### PR TITLE
Experimental localization support with L20n

### DIFF
--- a/bin/generate-html.js
+++ b/bin/generate-html.js
@@ -15,6 +15,10 @@ function template(rawOptions) {
     <title>${options.title}</title>
     <link rel="stylesheet" href="${options.baseUrl}main.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+
+    <meta name="defaultLanguage" content="en-US">
+    <meta name="availableLanguages" content="en-US, pl">
+    <link rel="localization" href="./locales/{locale}/app.properties">
   </head>
   <body>
     <div id="root"></div>

--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -3,7 +3,7 @@ const {connect} = require("react-redux");
 const {justDispatch} = require("selectors/selectors");
 const {actions} = require("common/action-manager");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
-const {prettyUrl, getRandomFromTimestamp} = require("lib/utils");
+const {prettyUrl, getRandomFromTimestamp, l10n} = require("lib/utils");
 const moment = require("moment");
 const classNames = require("classnames");
 
@@ -40,8 +40,11 @@ const ActivityFeedItem = React.createClass({
 
     let dateLabel = "";
     if (date && this.props.showDate) {
+      // TODO how to implement this in L20n?
+      // See http://momentjs.com/docs/#/displaying/calendar-time/
       dateLabel = moment(date).calendar();
     } else if (date) {
+      // TODO use Intl's DateTimeFormat
       dateLabel = moment(date).format("h:mm A");
     }
 
@@ -155,8 +158,8 @@ const GroupedActivityFeed = React.createClass({
       });
     const groupedSites = groupSitesByDate(sites);
     return (<div className="grouped-activity-feed">
-      {sites.length > 0 && this.props.title &&
-        <h3 className="section-title">{this.props.title}</h3>
+      {sites.length > 0 && this.props.title && this.props["data-l10n-id"] &&
+        <h3 className="section-title" {...l10n(this.props)}>{this.props.title}</h3>
       }
       {Array.from(groupedSites.keys()).map(date => {
         return (<div key={date}>

--- a/content-src/components/Header/Header.js
+++ b/content-src/components/Header/Header.js
@@ -1,5 +1,6 @@
 const React = require("react");
 const {Link} = require("react-router");
+const {l10n} = require("lib/utils");
 
 const Header = React.createClass({
   getDefaultProps() {
@@ -15,11 +16,11 @@ const Header = React.createClass({
       <section className="nav" onClick={() => this.setState({showDropdown: !this.state.showDropdown})}>
         <h1>
           <span hidden={!props.icon} className={`icon fa ${props.icon}`} />
-          <span>{props.title}</span>
+          <span {...l10n(props)}>{props.title}</span>
           <span className="arrow fa fa-chevron-down" />
         </h1>
         <ul className="nav-picker" hidden={!this.state.showDropdown}>
-          {props.links.map(link => <li key={link.to}><Link to={link.to}>{link.title}</Link></li>)}
+          {props.links.map(link => <li key={link.to}><Link to={link.to} {...l10n(link)}>{link.title}</Link></li>)}
         </ul>
       </section>
       <section className="spacer" />

--- a/content-src/components/LoadMore/LoadMore.js
+++ b/content-src/components/LoadMore/LoadMore.js
@@ -1,17 +1,19 @@
 const React = require("react");
 const Loader = require("components/Loader/Loader");
 const {Link} = require("react-router");
+const {l10n} = require("lib/utils");
 
 const LoadMore = React.createClass({
   getDefaultProps() {
     return {
+      "data-l10n-id": "load-more-label",
       label: "See more"
     };
   },
   render() {
     const link = this.props.to ?
-      (<Link to={this.props.to}><span className="fa fa-chevron-down" /> {this.props.label}</Link>) :
-      (<a href="#" onClick={e => { e.preventDefault(); this.props.onClick(); }}>
+      (<Link to={this.props.to} {...l10n(this.props)}><span className="fa fa-chevron-down" /> {this.props.label}</Link>) :
+      (<a href="#" onClick={e => { e.preventDefault(); this.props.onClick(); }} {...l10n(this.props)}>
           <span className="fa fa-chevron-down" /> {this.props.label}
         </a>);
     return (<div hidden={this.props.hidden}>

--- a/content-src/components/Loader/Loader.js
+++ b/content-src/components/Loader/Loader.js
@@ -8,7 +8,7 @@ const Loader = React.createClass({
   },
   render() {
     return (<div className="loader" hidden={!this.props.show}>
-      <div className="spinner"/> Loading...
+      <div data-l10n-id="loader-spinner" className="spinner"/> Loading...
     </div>);
   }
 });

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -14,7 +14,10 @@ const NewTabPage = React.createClass({
     this.props.dispatch(actions.NotifyPerformSearch(value));
   },
   componentDidMount() {
-    document.title = "New Tab";
+    document.l10n.setAttributes(
+      document.head.querySelector("title"),
+      "new-tab-title"
+    );
   },
   componentDidUpdate() {
     if (this.props.isReady) {
@@ -39,7 +42,7 @@ const NewTabPage = React.createClass({
           </section>
 
           <section>
-            <GroupedActivityFeed title="Recent Activity" sites={props.TopActivity.rows} length={6} />
+            <GroupedActivityFeed data-l10n-id="new-tab-feed-title" title="Recent Activity" sites={props.TopActivity.rows} length={6} />
           </section>
         </div>
       </div>

--- a/content-src/components/Search/Search.js
+++ b/content-src/components/Search/Search.js
@@ -15,7 +15,7 @@ const Search = React.createClass({
   render() {
     return (<form className="search-wrapper">
       <span className="search-label fa fa-search" />
-      <input ref="input" type="search" placeholder="Search" required />
+      <input data-l10n-id="search-input" ref="input" type="search" placeholder="Search" required />
       <button ref="button" onClick={() => this.doSearch(this.refs.input.value)}>
         <span className="fa fa-arrow-right" />
       </button>

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -5,6 +5,7 @@ const {actions} = require("common/action-manager");
 const moment = require("moment");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const classNames = require("classnames");
+const {l10n} = require("lib/utils");
 
 const DEFAULT_LENGTH = 3;
 
@@ -21,15 +22,31 @@ const SpotlightItem = React.createClass({
     const description = site.description;
     const isPortrait = image.height > image.width;
 
-    let contextMessage;
+    let l10nData;
     if (site.bookmarkDateCreated) {
-      contextMessage = `Bookmarked ${moment(site.bookmarkDateCreated).fromNow()}`;
+      l10nData = {
+        "data-l10n-id": "spotlight-context-bookmarked-relative",
+        "data-l10n-args": {
+          // TODO Use Intl's RelativeTimeFormat
+          fromNow: moment(site.bookmarkDateCreated).fromNow()
+        }
+      };
     } else if (site.lastVisitDate) {
-      contextMessage = `Visited ${moment(site.lastVisitDate).fromNow()}`;
+      l10nData = {
+        "data-l10n-id": "spotlight-context-visited-relative",
+        "data-l10n-args": {
+          // TODO Use Intl's RelativeTimeFormat
+          fromNow: moment(site.lastVisitDate).fromNow()
+        }
+      };
     } else if (site.type === "bookmark") {
-      contextMessage = "Bookmarked recently";
+      l10nData = {
+        "data-l10n-id": "spotlight-context-bookmarked-recently",
+      };
     } else {
-      contextMessage = "Visited recently";
+      l10nData = {
+        "data-l10n-id": "spotlight-context-visited-recently",
+      };
     }
 
     return (<li className="spotlight-item">
@@ -43,7 +60,7 @@ const SpotlightItem = React.createClass({
               {site.title}
             </h4>
             <p className="spotlight-description" ref="description">{description}</p>
-            <div className="spotlight-context" ref="contextMessage">{contextMessage}</div>
+            <div {...l10n(l10nData)} className="spotlight-context" ref="contextMessage"></div>
           </div>
         </div>
         <div className="inner-border" />
@@ -76,7 +93,7 @@ const Spotlight = React.createClass({
       blankSites.push(<li className="spotlight-item spotlight-placeholder" key={`blank-${i}`} />);
     }
     return (<section className="spotlight">
-      <h3 className="section-title">Featured</h3>
+      <h3 data-l10n-id="spotlight-title" className="section-title">Featured</h3>
       <ul>
         {sites.map(site => <SpotlightItem key={site.url} onDelete={this.onDelete} {...site} />)}
         {blankSites}

--- a/content-src/components/TimelinePage/TimelineBookmarks.js
+++ b/content-src/components/TimelinePage/TimelineBookmarks.js
@@ -19,9 +19,9 @@ const TimelineBookmarks = React.createClass({
     const props = this.props;
     return (<div className="wrapper">
       <Spotlight sites={props.Spotlight.rows} />
-      <GroupedActivityFeed title="Just now" sites={props.Bookmarks.rows} length={20} dateKey="bookmarkDateCreated" />
+      <GroupedActivityFeed data-l10n-id="timeline-bookmarks-feed-title" title="Just now" sites={props.Bookmarks.rows} length={20} dateKey="bookmarkDateCreated" />
       <LoadMore loading={props.Bookmarks.isLoading} hidden={!props.Bookmarks.canLoadMore || !props.Bookmarks.rows.length} onClick={this.getMore}
-        label="See more activity"/>
+        data-l10n-id="timeline-bookmarks-load-more" label="See more activity"/>
     </div>);
   }
 });

--- a/content-src/components/TimelinePage/TimelineHistory.js
+++ b/content-src/components/TimelinePage/TimelineHistory.js
@@ -19,9 +19,9 @@ const TimelineHistory = React.createClass({
     const props = this.props;
     return (<div className="wrapper">
       <Spotlight sites={props.Spotlight.rows} />
-      <GroupedActivityFeed title="Just now" sites={props.History.rows} />
+      <GroupedActivityFeed data-l10n-id="timeline-history-feed-title" title="Just now" sites={props.History.rows} />
       <LoadMore loading={props.History.isLoading} hidden={!props.History.canLoadMore || !props.History.rows.length} onClick={this.getMore}
-        label="See more activity"/>
+        data-l10n-id="timeline-history-load-more" label="See more activity"/>
     </div>);
   }
 });

--- a/content-src/components/TimelinePage/TimelinePage.js
+++ b/content-src/components/TimelinePage/TimelinePage.js
@@ -2,31 +2,37 @@ const React = require("react");
 const {Link} = require("react-router");
 const classNames = require("classnames");
 const Header = require("components/Header/Header");
+const {l10n} = require("lib/utils");
 
 const TimelinePage = React.createClass({
   componentDidMount() {
-    document.title = "Activity Stream";
+    document.l10n.setAttributes(
+      document.head.querySelector("title"),
+      "timeline-page-title"
+    );
   },
   render() {
     const props = this.props;
     const pathname = props.location && props.location.pathname;
     const navItems = [
-      {title: "All", to: "/timeline", active: true, icon: "fa-firefox"},
-      {title: "Bookmarks", to: "/timeline/bookmarks", icon: "fa-star"}
+      {title: "All", "data-l10n-id": "timeline-page-all", to: "/timeline", active: true, icon: "fa-firefox"},
+      {title: "Bookmarks", "data-l10n-id": "timeline-page-bookmarks", to: "/timeline/bookmarks", icon: "fa-star"}
     ];
     return (<div className="outer-wrapper">
       <Header
         title="Activity Stream"
+        data-l10n-id="timeline-page-header"
         icon="fa-timeline"
         pathname={pathname}
-        links={[{title: "Home", to: "/"}]} />
+        links={[{title: "Home", "data-l10n-id": "timeline-page-home", to: "/"}]} />
       <main className="timeline">
         <nav className="sidebar" onScroll={this.onScroll}>
           <ul>
             {navItems.map(item => {
               return (<li key={item.to}>
                 <Link to={item.to} className={classNames({active: item.to === pathname})}>
-                  <span className={`fa ${item.icon}`} /> <span className="link-title">{item.title}</span>
+                  <span className={`fa ${item.icon}`} />
+                  <span {...l10n(item)} className="link-title">{item.title}</span>
                 </Link>
               </li>);
             })}

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -19,7 +19,7 @@ const TopSites = React.createClass({
       blankSites.push(<div className="tile tile-placeholder" key={`blank-${i}`} />);
     }
     return (<section className="top-sites">
-      <h3 className="section-title">Top Sites</h3>
+      <h3 data-l10n-id="top-sites-title" className="section-title">Top Sites</h3>
       <div className="tiles-wrapper">
         {sites.map((site) => {
           return (<a key={site.url} className="tile" href={site.url}>

--- a/content-src/lib/utils.js
+++ b/content-src/lib/utils.js
@@ -79,5 +79,18 @@ module.exports = {
   getRandomFromTimestamp(percent, site) {
     const n = (site.lastVisitDate || site.bookmarkDateCreated || Math.round(Math.random() * 100)) % 100;
     return n <= percent * 100;
+  },
+
+  // before: data-l10n-id={this.props['data-l10n-id']}
+  // after:  {...l10n(this.props)}
+  l10n(props) {
+    return Object.keys(props).filter(
+      key => key.startsWith("data-l10n-")
+    ).reduce(
+      (l10nProps, key) => Object.assign({}, l10nProps, {
+        [key]: key === "data-l10n-args" ?
+          JSON.stringify(props[key]) : props[key]
+      }), {}
+    );
   }
 };

--- a/content-src/static/locales/en-US/app.properties
+++ b/content-src/static/locales/en-US/app.properties
@@ -1,0 +1,26 @@
+load-more-label = See more
+
+loader-spinner = Loading…
+
+new-tab-title = New Tab
+new-tab-feed-title = Recent Activity
+
+search-input.placeholder = Search
+
+spotlight-title = Featured
+spotlight-context-bookmarked-relative = Bookmarked {{ fromNow }}
+spotlight-context-visited-relative = Visited {{ fromNow }}
+spotlight-context-bookmarked-recently = Bookmarked recently
+spotlight-context-visited-recently = Visited recently
+
+timeline-page-title = Activity Stream
+timeline-page-header = Activity Stream
+timeline-page-home = Home
+timeline-page-all = All
+timeline-page-bookmarks = Bookmarks
+timeline-history-feed-title = Just now
+timeline-history-load-more = See more activity
+timeline-bookmarks-feed-title = Just now
+timeline-bookmarks-load-more = See more activity
+
+top-sites-title = Top Sites

--- a/content-src/static/locales/pl/app.properties
+++ b/content-src/static/locales/pl/app.properties
@@ -1,0 +1,26 @@
+load-more-label = Zobacz więcej
+
+loader-spinner = Trwa ładowanie…
+
+new-tab-title = Nowa karta
+new-tab-feed-title = Ostatnia aktywność
+
+search-input.placeholder = Wyszukaj
+
+spotlight-title = Wybrana aktywność
+spotlight-context-bookmarked-relative = Dodano zakładkę {{ fromNow }}
+spotlight-context-visited-relative = Odwiedzono {{ fromNow }}
+spotlight-context-bookmarked-recently = Niedawno dodano zakładkę
+spotlight-context-visited-recently = Niedawno odwiedzono
+
+timeline-page-title = Strumień aktywności
+timeline-page-header = Strumień aktywności
+timeline-page-home = Strona główna
+timeline-page-all = Wszystko
+timeline-page-bookmarks = Zakładki
+timeline-history-feed-title = Przed chwilą
+timeline-history-load-more = Zobacz więcej aktywności
+timeline-bookmarks-feed-title = Przed chwilą
+timeline-bookmarks-load-more = Zobacz więcej aktywności
+
+top-sites-title = Najczęstsze

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "classnames": "2.2.3",
     "fancy-dedupe": "0.1.0",
     "history": "1.17.0",
+    "l20n": "^3.5.1",
     "moment": "2.11.2",
     "react": "0.14.7",
     "react-dom": "0.14.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,8 @@ module.exports = {
     vendor: [
       "react",
       "react-dom",
-      "moment"
+      "moment",
+      "l20n"
     ]
   },
   output: {
@@ -62,7 +63,8 @@ module.exports = {
       "selectors": absolute("./content-src/selectors"),
       "lib": absolute("./content-src/lib"),
       "strings": absolute("./strings"),
-      "test": absolute("./content-test")
+      "test": absolute("./content-test"),
+      "l20n": absolute("./node_modules/l20n/dist/compat/web/l20n.js")
     }
   },
   module: {


### PR DESCRIPTION
I was able to get L20n to work with Activity Streams.

![stream1](https://cloud.githubusercontent.com/assets/265818/14188918/12f993d2-f78b-11e5-8125-a5303f43b543.png)
![stream2](https://cloud.githubusercontent.com/assets/265818/14188923/16f80bd0-f78b-11e5-90b9-797cae39730a.png)

This is highly experimental and part of my exploration into what it would take to use L20n in Firefox Desktop with React.  In this attempt, I'm simply reusing L20n's Mutation Observer to get notified when React re-renders elements with `data-l10n-id` and `data-l10n-args` attributes.

I've outlined other possible approaches in https://github.com/stasm/l20n-react-experiments/ with parts of the conversation happening in https://groups.google.com/d/msg/mozilla.tools.l10n/XtxHgBEokCA/onHthNvtBgAJ.  This PR is an invitation to join the discussion :)

cc @zbraniecki @Pike

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/429)
<!-- Reviewable:end -->
