### PR TITLE
fix (content): #604 remove custom titles from GroupedActivityFeed

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -183,12 +183,9 @@ const GroupedActivityFeed = React.createClass({
     const groupedSites = groupSitesByDate(sites);
     let globalCount = -1;
     return (<div className="grouped-activity-feed">
-      {sites.length > 0 && this.props.title &&
-        <h3 ref="title" className="section-title">{this.props.title}</h3>
-      }
       {Array.from(groupedSites.keys()).map((date, dateIndex) => {
         return (<div className="group" key={date}>
-          {this.props.showDateHeadings && dateIndex > 0 &&
+          {this.props.showDateHeadings &&
             <h3 className="section-title">{moment(date).startOf("day").calendar(null, CALENDAR_HEADINGS)}</h3>
           }
           {groupedSites.get(date).map((sites, outerIndex) => {
@@ -217,7 +214,6 @@ const GroupedActivityFeed = React.createClass({
 GroupedActivityFeed.propTypes = {
   sites: React.PropTypes.array.isRequired,
   length: React.PropTypes.number,
-  title: React.PropTypes.string,
   dateKey: React.PropTypes.string,
   page: React.PropTypes.string,
   showDateHeadings: React.PropTypes.bool

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -68,7 +68,8 @@ const NewTabPage = React.createClass({
           </section>
 
           <section>
-            <GroupedActivityFeed title="Recent Activity" sites={props.TopActivity.rows} length={MAX_TOP_ACTIVITY_ITEMS} page={PAGE_NAME} />
+            <h3 ref="title" className="section-title">Recent Activity</h3>
+            <GroupedActivityFeed sites={props.TopActivity.rows} length={MAX_TOP_ACTIVITY_ITEMS} page={PAGE_NAME} />
           </section>
 
           <section className="bottom-links-container">

--- a/content-src/components/TimelinePage/TimelineBookmarks.js
+++ b/content-src/components/TimelinePage/TimelineBookmarks.js
@@ -26,7 +26,6 @@ const TimelineBookmarks = React.createClass({
     const props = this.props;
     return (<div className={classNames("wrapper", "show-on-init", {on: props.Bookmarks.init})}>
       <GroupedActivityFeed
-        title="Just now"
         sites={props.Bookmarks.rows}
         length={20}
         dateKey="bookmarkDateCreated"

--- a/content-src/components/TimelinePage/TimelineHistory.js
+++ b/content-src/components/TimelinePage/TimelineHistory.js
@@ -28,7 +28,6 @@ const TimelineHistory = React.createClass({
     return (<div className={classNames("wrapper", "show-on-init", {on: props.History.init})}>
       <Spotlight page={PAGE_NAME} sites={props.Spotlight.rows} />
       <GroupedActivityFeed
-        title="Just now"
         sites={props.History.rows}
         page={PAGE_NAME}
         showDateHeadings={true} />

--- a/content-test/components/ActivityFeed.test.js
+++ b/content-test/components/ActivityFeed.test.js
@@ -144,10 +144,11 @@ describe("GroupedActivityFeed", function() {
     it("should show date headings if showDateHeadings is true", () => {
       const item = renderWithProvider(<GroupedActivityFeed showDateHeadings={true} sites={sites} />);
       const titles = TestUtils.scryRenderedDOMComponentsWithClass(item, "section-title");
-      assert.lengthOf(titles, 3);
-      assert.equal(titles[0].innerHTML, "Yesterday");
-      assert.equal(titles[1].innerHTML, m3.format("[Last] dddd"));
-      assert.equal(titles[2].innerHTML, m4.format("dddd MMMM D, YYYY"));
+      assert.lengthOf(titles, 4);
+      assert.equal(titles[0].innerHTML, "Today");
+      assert.equal(titles[1].innerHTML, "Yesterday");
+      assert.equal(titles[2].innerHTML, m3.format("[Last] dddd"));
+      assert.equal(titles[3].innerHTML, m4.format("dddd MMMM D, YYYY"));
     });
     it("should not show date headings if showDateHeadings is false", () => {
       const item = renderWithProvider(<GroupedActivityFeed showDateHeadings={false} sites={sites} />);


### PR DESCRIPTION
r? @k88hudson 

What do you think of this? The New Tab page will keep the "Recent Activity" but the Timeline pages will show "Today"/"Yesterday"/etc instead of "Just now".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/710)
<!-- Reviewable:end -->
