### PR TITLE
fix(addon): #638 Dedupe history for embedly only

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -196,7 +196,7 @@ const GroupedActivityFeed = React.createClass({
               {sites.map((site, i) => {
                 globalCount++;
                 return (<ActivityFeedItem
-                    key={site.cacheKey || i}
+                    key={i}
                     onClick={this.onClickFactory(globalCount)}
                     onShare={this.onShareFactory(globalCount)}
                     showImage={getRandomFromTimestamp(0.2, site)}

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -166,8 +166,6 @@ PreviewProvider.prototype = {
   _uniqueLinks(links) {
     let dedupedLinks = new Map();
     links.forEach(link => {
-      link.sanitizedURL = this._sanitizeURL(link.url);
-      link.cacheKey = this._createCacheKey(link.sanitizedURL);
       if (!dedupedLinks.has(link.cacheKey)) {
         dedupedLinks.set(link.cacheKey, link);
       }
@@ -176,11 +174,17 @@ PreviewProvider.prototype = {
   },
 
   /**
-    * Process the raw links that come in
+    * Process the raw links that come in,
+    * adds a sanitizeURL and cacheKey
     */
   processLinks(links) {
-    let sites = this._uniqueLinks(links.filter(this._URLFilter(URL_FILTERS)));
-    return sites;
+    return links
+      .filter(this._URLFilter(URL_FILTERS))
+      .map(link => {
+        const sanitizedURL = this._sanitizeURL(link.url);
+        const cacheKey = this._createCacheKey(sanitizedURL);
+        return Object.assign({}, link, {sanitizedURL, cacheKey});
+      });
   },
 
   /**
@@ -215,9 +219,11 @@ PreviewProvider.prototype = {
    * Request links from embedly, optionally filtering out known links
    */
   asyncSaveLinks: Task.async(function*(links, newOnly = true, updateAccessTime = true) {
+
     // optionally filter out known links, and links which already have a request in process
-    let linksList = links.filter(link => link && (!newOnly || !ss.storage.embedlyData[link.cacheKey]) && !this._alreadyRequested.has(link.cacheKey));
+    let linksList = this._uniqueLinks(links).filter(link => link && (!newOnly || !ss.storage.embedlyData[link.cacheKey]) && !this._alreadyRequested.has(link.cacheKey));
     linksList.forEach(link => this._alreadyRequested.add(link.cacheKey));
+
     let requestQueue = [];
     let promises = [];
     while (linksList.length !== 0) {

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -277,6 +277,25 @@ exports.test_sanitize_urls = function*(assert) {
   assert.equal(expectedUrl, sanitizedUrl, "%s doesn't cause unhandled exception");
 };
 
+exports.test_process_links = function*(assert) {
+  const fakeData = [
+    {"url": "http://foo.com/#foo", "title": "blah"},
+    {"url": "http://foo.com/#bar", "title": "blah"},
+    {"url": "http://www.foo.com/", "title": "blah"},
+    {"url": "https://foo.com/", "title": "blah"}
+  ];
+
+  const processedLinks = gPreviewProvider.processLinks(fakeData);
+
+  assert.equal(fakeData.length, processedLinks.length, "should not deduplicate or remove any links");
+
+  processedLinks.forEach((link, i) => {
+    assert.equal(link.url, fakeData[i].url, "each site has its original url");
+    assert.ok(link.sanitizedURL, "links have sanitizedURLs");
+    assert.ok(link.cacheKey, "links have cacheKeys");
+  });
+};
+
 exports.test_dedupe_urls = function*(assert) {
   const fakeData = [
     {"url": "http://foo.com/", "title": "blah"},
@@ -299,8 +318,6 @@ exports.test_dedupe_urls = function*(assert) {
   ];
 
   uniqueLinks.forEach((link, i) => {
-    assert.ok(link.sanitizedURL, "each site has a 'sanitizedURL' field");
-    assert.ok(link.cacheKey, "each site has a 'cacheKey' field");
     assert.ok(link.url, "each site has it's original url");
     assert.equal(link.url, expectedUrls[i].url, "links have been deduped");
   });


### PR DESCRIPTION
- leaves all history items and their URLs intact
- only dedupes items when they are sent to embedly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/711)
<!-- Reviewable:end -->
