### PR TITLE
feat(content): add Remove Bookmark UI

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -86,6 +86,7 @@ const ActivityFeedItem = React.createClass({
         visible={this.state.showContextMenu}
         onUpdate={val => this.setState({showContextMenu: val})}
         url={site.url}
+        bookmarkGuid={site.bookmarkGuid}
         page={this.props.page}
         index={this.props.index}
         source={this.props.source}

--- a/content-src/components/DeleteMenu/DeleteMenu.js
+++ b/content-src/components/DeleteMenu/DeleteMenu.js
@@ -15,22 +15,34 @@ const DeleteMenu = React.createClass({
       }));
     }
   },
-  onDelete() {
+  onDeleteHistory() {
     this.props.dispatch(actions.NotifyHistoryDelete(this.props.url));
     this.userEvent("DELETE");
+  },
+  onDeleteBookmark() {
+    this.props.dispatch(actions.NotifyBookmarkDelete(this.props.bookmarkGuid));
+    this.userEvent("BOOKMARK_DELETE");
   },
   onBlock(url, index) {
     this.props.dispatch(actions.NotifyBlockURL(this.props.url));
     this.userEvent("BLOCK");
   },
   render() {
+    const menuOptions = [];
+
+    // Add the correct remove option for either a bookmark or a history link
+    if (this.props.bookmarkGuid) {
+      menuOptions.push({label: "Remove from Bookmarks", onClick: this.onDeleteBookmark});
+    } else {
+      menuOptions.push({label: "Remove from History", onClick: this.onDeleteHistory});
+    }
+
+    menuOptions.push({label: "Never show on this page", onClick: this.onBlock});
+
     return (<ContextMenu
       visible={this.props.visible}
       onUpdate={this.props.onUpdate}
-      options={[
-        {label: "Remove from History", onClick: this.onDelete},
-        {label: "Never show on this page", onClick: this.onBlock}
-      ]} />);
+      options={menuOptions} />);
   }
 });
 

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -74,6 +74,7 @@ const SpotlightItem = React.createClass({
         visible={this.state.showContextMenu}
         onUpdate={val => this.setState({showContextMenu: val})}
         url={site.url}
+        bookmarkGuid={site.bookmarkGuid}
         page={this.props.page}
         index={this.props.index}
         source={this.props.source}

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -55,6 +55,7 @@ const TopSites = React.createClass({
               visible={isActive}
               onUpdate={val => this.setState({showContextMenu: val})}
               url={site.url}
+              bookmarkGuid={site.bookmarkGuid}
               page={this.props.page}
               index={i}
               source="TOP_SITES"

--- a/content-src/reducers/SetRowsOrError.js
+++ b/content-src/reducers/SetRowsOrError.js
@@ -34,6 +34,9 @@ module.exports = function setRowsOrError(requestType, responseType) {
       case am.type("NOTIFY_HISTORY_DELETE"):
         state.rows = prevState.rows.filter(val => val.url !== action.data);
         break;
+      case am.type("NOTIFY_BOOKMARK_DELETE"):
+        state.rows = prevState.rows.filter(val => val.bookmarkGuid !== action.data);
+        break;
       default:
         return prevState;
     }

--- a/content-test/components/DeleteMenu.test.js
+++ b/content-test/components/DeleteMenu.test.js
@@ -11,6 +11,9 @@ const DEFAULT_PROPS = {
   visible: false
 };
 
+// Bookmark guid for testing
+const BOOKMARK_GUID = "testBookmark";
+
 // In the menu, the delete option is first,
 // and the block option is second.
 const DELETE_INDEX = 0;
@@ -47,7 +50,7 @@ describe("DeleteMenu", () => {
     const links = TestUtils.scryRenderedDOMComponentsWithClass(instance, "context-menu-link");
     assert.lengthOf(links, 2);
   });
-  it("should fire a delete event when Remove from History is clicked", done => {
+  it("should fire a delete history event when Remove from History is clicked", done => {
     setup(null, {
       dispatch(a) {
         if (a.type === "NOTIFY_HISTORY_DELETE") {
@@ -59,6 +62,20 @@ describe("DeleteMenu", () => {
     assert.equal(deleteLink.innerHTML, "Remove from History");
     TestUtils.Simulate.click(deleteLink);
   });
+  it("should fire a delete bookmark event when Remove from Bookmarks is clicked", done => {
+    setup({
+      bookmarkGuid: BOOKMARK_GUID,
+    }, {
+      dispatch(a) {
+        if (a.type === "NOTIFY_BOOKMARK_DELETE") {
+          assert.equal(a.data, BOOKMARK_GUID);
+          done();
+        }
+      }
+    });
+    assert.equal(deleteLink.innerHTML, "Remove from Bookmarks");
+    TestUtils.Simulate.click(deleteLink);
+  });
   it("should fire a user event for Remove from History", done => {
     setup({
       page: "NEW_TAB",
@@ -68,6 +85,25 @@ describe("DeleteMenu", () => {
       dispatch(a) {
         if (a.type === "NOTIFY_USER_EVENT") {
           assert.equal(a.data.event, "DELETE");
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "FEATURED");
+          assert.equal(a.data.action_position, 3);
+          done();
+        }
+      }
+    });
+    TestUtils.Simulate.click(deleteLink);
+  });
+  it("should fire a user event for Remove from Bookmarks", done => {
+    setup({
+      page: "NEW_TAB",
+      source: "FEATURED",
+      bookmarkGuid: BOOKMARK_GUID,
+      index: 3
+    }, {
+      dispatch(a) {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.event, "BOOKMARK_DELETE");
           assert.equal(a.data.page, "NEW_TAB");
           assert.equal(a.data.source, "FEATURED");
           assert.equal(a.data.action_position, 3);

--- a/content-test/reducers/SetRowsOrError.test.js
+++ b/content-test/reducers/SetRowsOrError.test.js
@@ -81,4 +81,13 @@ describe("setRowsOrError", () => {
     });
   })("NOTIFY_HISTORY_DELETE", "NOTIFY_BLOCK_URL");
 
+  ((event) => {
+    it(`should remove a row removed via ${event}`, () => {
+      const action = {type: event, data: "boorkmarkFOO"};
+      const prevRows = [{bookmarkGuid: "boorkmarkFOO"}, {bookmarkGuid: "boorkmarkBAR"}];
+      const state = reducer(Object.assign({}, setRowsOrError.DEFAULTS, {rows: prevRows}), action);
+      assert.deepEqual(state.rows, [{bookmarkGuid: "boorkmarkBAR"}]);
+    });
+  })("NOTIFY_BOOKMARK_DELETE", "NOTIFY_BLOCK_URL");
+
 });

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -244,7 +244,7 @@ ActivityStreams.prototype = {
     this.on(am.type("NOTIFY_BLOCK_URL"), this._respondToPlacesRequests);
     this.on(am.type("NOTIFY_UNBLOCK_URL"), this._respondToPlacesRequests);
     this.on(am.type("NOTIFY_UNBLOCK_ALL"), this._respondToPlacesRequests);
-    this.on(am.type("NOTIFY_HISTORY_DELETE"), this._respondToPlacesRequests);
+    this.on(am.type("NOTIFY_BOOKMARK_DELETE"), this._respondToPlacesRequests);
     this.on(am.type("SEARCH_STATE_REQUEST"), this._respondToSearchRequests);
     this.on(am.type("NOTIFY_PERFORM_SEARCH"), this._respondToSearchRequests);
     this.on(am.type("NOTIFY_ROUTE_CHANGE"), this._onRouteChange);
@@ -271,6 +271,7 @@ ActivityStreams.prototype = {
     this.off(am.type("NOTIFY_BLOCK_URL"), this._respondToPlacesRequests);
     this.off(am.type("NOTIFY_UNBLOCK_URL"), this._respondToPlacesRequests);
     this.off(am.type("NOTIFY_UNBLOCK_ALL"), this._respondToPlacesRequests);
+    this.off(am.type("NOTIFY_BOOKMARK_DELETE"), this._respondToPlacesRequests);
     this.off(am.type("SEARCH_STATE_REQUEST"), this._respondToSearchRequests);
     this.off(am.type("NOTIFY_PERFORM_SEARCH"), this._respondToSearchRequests);
     this.off(am.type("NOTIFY_ROUTE_CHANGE"), this._onRouteChange);


### PR DESCRIPTION
Fixes #659 
This still don't work on the Top Sites, since we don't get the bookmarkGuid for the top frecent sites. Should I file a follow up issue to fix this?
Note that I replaced a "NOTIFY_HISTORY_DELETE" event listener at the ActivityStream.js since it was duplicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/715)
<!-- Reviewable:end -->
