### PR TITLE
fix(addon): #716 Don't send session pings for tabs that finish loading in the background.

### DIFF
--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -138,7 +138,9 @@ TabTracker.prototype = {
   },
 
   logReady(tab) {
-    if (this.isActivityStreamsURL(tab.url)) {
+    // If an inactive tab is done loading, we don't care. It's session would have
+    // already ended, likely with an 'unfocus' unload reason.
+    if (this.isActivityStreamsURL(tab.url) && tabs.activeTab.id === tab.id) {
       if (!this._tabData.url) {
         this._tabData.url = tab.url;
         this._tabData.tab_id = tab.id;

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -61,7 +61,9 @@ function checkLoadUnloadReasons(assert, pingData, expectedLoadReasons, expectedU
     for (let key of expectedKeys) {
       assert.notEqual(ping[key], undefined, `${key} is an attribute in our tab data.`);
     }
-    assert.notEqual(ping.session_duration, 0, "session_duration is not 0");
+    if (ping.load_reason !== "none") {
+      assert.notEqual(ping.session_duration, 0, "session_duration is not 0");
+    }
   }
 }
 
@@ -123,6 +125,57 @@ exports.test_TabTracker_open_close_tab = function*(assert) {
 
   let secondsOpen = pingData.session_duration;
   assert.ok(secondsOpen > 0, "The tab should have stayed open for more than 0 seconds");
+};
+
+exports.test_TabTracker_unfocus_unloaded_tab = function*(assert) {
+  let openTabs = [];
+  let pingData = [];
+
+  let pingsSentPromise = createPingSentPromise(pingData, 3);
+
+  let tabsOpenedPromise = new Promise(resolve => {
+    let onOpen = function(tab) {
+      openTabs.push(tab);
+      if (openTabs.length === 2) {
+        tabs.removeListener("ready", onOpen);
+        resolve();
+      }
+    };
+
+    tabs.on("ready", onOpen);
+  });
+
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
+
+  tabs.open(ACTIVITY_STREAMS_URL);
+
+  // Open the second tab on the next event loop tick to ensure the first
+  // tab opened but didn't have time to load.
+  setTimeout(() => {
+    tabs.open(ACTIVITY_STREAMS_URL);
+  }, 0);
+
+  // Wait until both tabs have opened
+  yield tabsOpenedPromise;
+
+  // Close both tabs.
+  let tabClosedPromise = new Promise(resolve => {
+    for (let i in openTabs) {
+      openTabs[i].close(() => {
+        if (Number(i) === openTabs.length - 1) {
+          // We've closed the last tab
+          resolve();
+        }
+      });
+    }
+  });
+
+  yield tabClosedPromise;
+  yield pingsSentPromise;
+
+  let loadReasons = ["none", "newtab", "focus"];
+  let unloadReasons = ["unfocus", "close", "close"];
+  checkLoadUnloadReasons(assert, pingData, loadReasons, unloadReasons);
 };
 
 exports.test_TabTracker_reactivating = function*(assert) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/717)
<!-- Reviewable:end -->
