### PR TITLE
fix(addon): #698 Don't send session pings for inactive tabs when closing the broswer window

### DIFF
--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -133,6 +133,7 @@ TabTracker.prototype = {
       this._tabData.session_duration = (Date.now() - this._tabData.start_time);
       delete this._tabData.start_time;
     }
+    delete this._tabData.active;
     Services.obs.notifyObservers(null, COMPLETE_NOTIF, JSON.stringify(this._tabData));
     this._clearTabData();
   },
@@ -177,6 +178,7 @@ TabTracker.prototype = {
       // URL stored in this._openTabs object keeps the previous URL after the tab.url
       // is replaced with a different page URL, as in click action of page reload
       this._openTabs[tab.id].url = tab.url;
+      this._openTabs[tab.id].active = true;
     }
   },
 
@@ -188,11 +190,19 @@ TabTracker.prototype = {
     }
     if (this.isActivityStreamsURL(tab.url)) {
       this.navigateAwayFromPage(tab, "unfocus");
+      this._openTabs[tab.id].active = false;
     }
   },
 
   logClose(tab) {
     if (this.isActivityStreamsURL(tab.url)) {
+      // check whether this tab is inactive or not, don't send the close ping
+      // if it's inactive as an "unfocus" one has already been sent by logDeactivate.
+      // Note that the test !tabs.activeTab won't work here when the user closes
+      // the window
+      if (!this._openTabs[tab.id].active) {
+        return;
+      }
       this.navigateAwayFromPage(tab, "close");
     }
     // get rid of that tab reference
@@ -200,7 +210,7 @@ TabTracker.prototype = {
   },
 
   onOpen(tab) {
-    this._openTabs[tab.id] = {tab: tab, url: tab.url};
+    this._openTabs[tab.id] = {tab: tab, url: tab.url, active: true};
 
     this.logReady = this.logReady.bind(this);
     this.logActivate = this.logActivate.bind(this);

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -244,6 +244,52 @@ exports.test_TabTracker_reactivating = function*(assert) {
   checkLoadUnloadReasons(assert, pingData, loadReasons, unloadReasons);
 };
 
+exports.test_TabTracker_close_window_with_multitabs = function*(assert) {
+  let pingData = [];
+  let openTabs = [];
+
+  let pingsSentPromise = createPingSentPromise(pingData, 2);
+
+  let tabsOpenedPromise = new Promise(resolve => {
+    let onOpen = function(tab) {
+      openTabs.push(tab);
+      if (openTabs.length === 2) {
+        tabs.removeListener("ready", onOpen);
+        resolve();
+      }
+    };
+
+    tabs.on("ready", onOpen);
+  });
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
+
+  tabs.open(ACTIVITY_STREAMS_URL);
+  // open another tab a bit later so that the first one could completely load
+  setTimeout(function() {
+    tabs.open(ACTIVITY_STREAMS_URL);
+  }, 1000);
+
+  yield tabsOpenedPromise;
+
+  // close both tabs
+  let tabClosedPromise = new Promise(resolve => {
+    for (let i in openTabs) {
+      openTabs[i].close(() => {
+        if (Number(i) === openTabs.length - 1) {
+          // We've closed the last tab
+          resolve();
+        }
+      });
+    }
+  });
+
+  yield tabClosedPromise;
+  yield pingsSentPromise;
+  let loadReasons = ["newtab", "newtab"];
+  let unloadReasons = ["unfocus", "close"];
+  checkLoadUnloadReasons(assert, pingData, loadReasons, unloadReasons);
+};
+
 exports.test_TabTracker_refresh = function*(assert) {
   let openTab;
   let numLoads = 0;


### PR DESCRIPTION
This fixes #698

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/726)
<!-- Reviewable:end -->
