### PR TITLE
fix(addon): #454 Hide Load More if < 20 items on history

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -1,0 +1,13 @@
+module.exports = {
+  // How many items per query?
+  LINKS_QUERY_LIMIT: 20,
+
+  // Time interval for for frecent links query in milliseconds (72 hours).
+  FRECENT_RESULTS_TIME_LIMIT: 72 * 60 * 60 * 1000,
+
+  // Thresholds for highlights query
+  HIGHLIGHTS_THRESHOLDS: {
+    created: "-3 day",
+    visited: "-30 minutes",
+  }
+};

--- a/content-src/reducers/SetRowsOrError.js
+++ b/content-src/reducers/SetRowsOrError.js
@@ -8,7 +8,7 @@ const DEFAULTS = {
   canLoadMore: true
 };
 
-module.exports = function setRowsOrError(requestType, responseType) {
+module.exports = function setRowsOrError(requestType, responseType, querySize) {
   return (prevState = DEFAULTS, action) => {
     const state = {};
     const meta = action.meta || {};
@@ -25,7 +25,13 @@ module.exports = function setRowsOrError(requestType, responseType) {
           state.init = true;
           state.rows = meta.append ? prevState.rows.concat(action.data) : action.data;
           state.error = false;
+          // If there is no data, we definitely can't load more.
           if (!action.data || !action.data.length) {
+            state.canLoadMore = false;
+          }
+          // If the results returned are less than the query size,
+          // we should be on our last page of results.
+          else if (querySize && action.data.length < querySize) {
             state.canLoadMore = false;
           }
         }

--- a/content-src/reducers/reducers.js
+++ b/content-src/reducers/reducers.js
@@ -1,5 +1,6 @@
 const am = require("common/action-manager");
 const setRowsOrError = require("reducers/SetRowsOrError");
+const {LINKS_QUERY_LIMIT} = require("common/constants");
 
 function setSearchState(type) {
   return (prevState = {currentEngine: {}, error: false, init: false}, action) => {
@@ -30,8 +31,8 @@ function setSearchState(type) {
 
 module.exports = {
   TopSites: setRowsOrError("TOP_FRECENT_SITES_REQUEST", "TOP_FRECENT_SITES_RESPONSE"),
-  History: setRowsOrError("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE"),
-  Bookmarks: setRowsOrError("RECENT_BOOKMARKS_REQUEST", "RECENT_BOOKMARKS_RESPONSE"),
+  History: setRowsOrError("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE", LINKS_QUERY_LIMIT),
+  Bookmarks: setRowsOrError("RECENT_BOOKMARKS_REQUEST", "RECENT_BOOKMARKS_RESPONSE", LINKS_QUERY_LIMIT),
   Highlights: setRowsOrError("HIGHLIGHTS_LINKS_REQUEST", "HIGHLIGHTS_LINKS_RESPONSE"),
   Search: setSearchState("SEARCH_STATE_RESPONSE")
 };

--- a/content-test/reducers/SetRowsOrError.test.js
+++ b/content-test/reducers/SetRowsOrError.test.js
@@ -72,6 +72,37 @@ describe("setRowsOrError", () => {
     assert.deepEqual(state.rows, prevRows);
   });
 
+  it("should set canLoadMore to true by default", () => {
+    const action = {
+      type: RESPONSE_TYPE,
+      data: [{url: "a"}, {url: "b"}]
+    };
+    const state = reducer(undefined, action);
+    assert.isTrue(state.canLoadMore);
+  });
+
+  it("should set canLoadMore to false when data is missing", () => {
+    const state = reducer(undefined, {type: RESPONSE_TYPE});
+    assert.isFalse(state.canLoadMore);
+  });
+
+  it("should set canLoadMore to false when there are 0 items", () => {
+    const state = reducer(undefined, {type: RESPONSE_TYPE, data: []});
+    assert.isFalse(state.canLoadMore);
+  });
+
+  it("should set canLoadMore to false when the results are less than the querySize", () => {
+    reducer = setRowsOrError(REQUEST_TYPE, RESPONSE_TYPE, 3);
+    const state = reducer(undefined, {type: RESPONSE_TYPE, data: [{url: "a"}, {url: "b"}]});
+    assert.isFalse(state.canLoadMore);
+  });
+
+  it("should set canLoadMore to true when the results are equal to the querySize", () => {
+    reducer = setRowsOrError(REQUEST_TYPE, RESPONSE_TYPE, 3);
+    const state = reducer(undefined, {type: RESPONSE_TYPE, data: [{url: "a"}, {url: "b"}, {url: "c"}]});
+    assert.isTrue(state.canLoadMore);
+  });
+
   ((event) => {
     it(`should remove a row removed via ${event}`, () => {
       const action = {type: event, data: "http://foo.com"};

--- a/lib/PlacesProvider.js
+++ b/lib/PlacesProvider.js
@@ -28,11 +28,11 @@ XPCOMUtils.defineLazyGetter(this, "gPrincipal", function() {
   return Services.scriptSecurityManager.getNoAppCodebasePrincipal(uri);
 });
 
-// The maximum number of results PlacesProvider retrieves from history.
-const HISTORY_RESULTS_LIMIT = 20;
-
-// time interval for for frecent links query in milliseconds (72 hours).
-const FRECENT_RESULTS_TIME_LIMIT = 72 * 60 * 60 * 1000;
+const {
+  LINKS_QUERY_LIMIT,
+  FRECENT_RESULTS_TIME_LIMIT,
+  HIGHLIGHTS_THRESHOLDS
+} = require("../common/constants");
 
 const REV_HOST_BLACKLIST = [
   "moc.elgoog.www.",
@@ -45,11 +45,6 @@ const REV_HOST_BLACKLIST = [
   "oc.t.",
   ".",
 ].map(item => `'${item}'`);
-
-const HIGHLIGHTS_THRESHOLDS = {
-  created: "-3 day",
-  visited: "-30 minutes",
-};
 
 const PREF_BLOCKED_URLS = "query.blockedURLs";
 
@@ -333,8 +328,8 @@ Links.prototype = {
   _getHistoryLinks: Task.async(function*(options = {}) {
 
     let {limit, afterDate, beforeDate, order, ignoreBlocked} = options;
-    if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
-      limit = HISTORY_RESULTS_LIMIT;
+    if (!limit || limit.options > LINKS_QUERY_LIMIT) {
+      limit = LINKS_QUERY_LIMIT;
     }
 
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);
@@ -431,8 +426,8 @@ Links.prototype = {
   getTopFrecentSites: Task.async(function*(options = {}) {
 
     let {limit, ignoreBlocked} = options;
-    if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
-      limit = HISTORY_RESULTS_LIMIT;
+    if (!limit || limit.options > LINKS_QUERY_LIMIT) {
+      limit = LINKS_QUERY_LIMIT;
     }
 
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);
@@ -479,8 +474,8 @@ Links.prototype = {
    */
   getRecentBookmarks: Task.async(function*(options = {}) {
     let {limit, afterDate, beforeDate, ignoreBlocked} = options;
-    if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
-      limit = HISTORY_RESULTS_LIMIT;
+    if (!limit || limit.options > LINKS_QUERY_LIMIT) {
+      limit = LINKS_QUERY_LIMIT;
     }
 
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);
@@ -585,8 +580,8 @@ Links.prototype = {
   getHighlightsLinks: Task.async(function*(options = {}) {
 
     let {limit, ignoreBlocked} = options;
-    if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
-      limit = HISTORY_RESULTS_LIMIT;
+    if (!limit || limit.options > LINKS_QUERY_LIMIT) {
+      limit = LINKS_QUERY_LIMIT;
     }
 
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);


### PR DESCRIPTION
This fixes an issue where we still see the load more box if < 20 items are returned from the query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/739)
<!-- Reviewable:end -->
