### PR TITLE
Consolidate action handlers

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -1,4 +1,4 @@
-/* globals NewTabURL, EventEmitter, XPCOMUtils, windowMediator, Task, Services */
+/* globals NewTabURL, EventEmitter, XPCOMUtils, Task, Services */
 
 "use strict";
 
@@ -19,14 +19,11 @@ const {TelemetrySender} = require("lib/TelemetrySender");
 const {PerfMeter} = require("lib/PerfMeter");
 const {AppURLHider} = require("lib/AppURLHider");
 const am = require("common/action-manager");
+const handlers = require("./handlers/handlers");
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource:///modules/NewTabURL.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-
-XPCOMUtils.defineLazyServiceGetter(this, "windowMediator",
-                                   "@mozilla.org/appshell/window-mediator;1",
-                                   "nsIWindowMediator");
 
 XPCOMUtils.defineLazyModuleGetter(this, "Task",
                                   "resource://gre/modules/Task.jsm");
@@ -103,50 +100,6 @@ ActivityStreams.prototype = {
     }
   },
 
-  /**
-   * Responds to places requests
-   */
-  _respondToPlacesRequests(msgName, params) {
-    let {msg, worker} = params;
-    switch (msgName) {
-      case am.type("TOP_FRECENT_SITES_REQUEST"):
-        this._memoized.getTopFrecentSites(msg.data).then(links => {
-          this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", worker, msg.meta);
-        });
-        break;
-      case am.type("RECENT_BOOKMARKS_REQUEST"):
-        this._memoized.getRecentBookmarks(msg.data).then(links => {
-          this._processAndSendLinks(links, "RECENT_BOOKMARKS_RESPONSE", worker, msg.meta);
-        });
-        break;
-      case am.type("RECENT_LINKS_REQUEST"):
-        this._memoized.getRecentLinks(msg.data).then(links => {
-          this._processAndSendLinks(links, "RECENT_LINKS_RESPONSE", worker, msg.meta);
-        });
-        break;
-      case am.type("HIGHLIGHTS_LINKS_REQUEST"):
-        this._memoized.getHighlightsLinks(msg.data).then(links => {
-          this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", worker, msg.meta);
-        });
-        break;
-      case am.type("NOTIFY_BOOKMARK_DELETE"):
-        PlacesProvider.links.asyncDeleteBookmark(msg.data);
-        break;
-      case am.type("NOTIFY_HISTORY_DELETE"):
-        PlacesProvider.links.deleteHistoryLink(msg.data);
-        break;
-      case am.type("NOTIFY_BLOCK_URL"):
-        PlacesProvider.links.blockURL(msg.data);
-        break;
-      case am.type("NOTIFY_UNBLOCK_URL"):
-        PlacesProvider.links.unblockURL(msg.data);
-        break;
-      case am.type("NOTIFY_UNBLOCK_ALL"):
-        PlacesProvider.links.unblockAll();
-        break;
-    }
-  },
-
   /*
    * Process the passed in links, save them, get from cache and response to content.
    */
@@ -158,31 +111,6 @@ ActivityStreams.prototype = {
     }
     const cachedLinks = this._previewProvider.getEnhancedLinks(processedLinks, previewsOnly);
     this.send(am.actions.Response(responseType, cachedLinks, {append}), worker);
-  },
-
-  _respondToSearchRequests(msgName, params) {
-    let {msg, worker} = params;
-    switch (msgName) {
-      case am.type("SEARCH_STATE_REQUEST"):
-        SearchProvider.search.state.then(state => {
-          this.send(am.actions.Response("SEARCH_STATE_RESPONSE", state), worker);
-        });
-        break;
-      case am.type("NOTIFY_PERFORM_SEARCH"):
-        SearchProvider.search.state.then(state => {
-          let win = windowMediator.getMostRecentWindow("navigator:browser");
-          let gBrowser = win.getBrowser();
-          let browser = gBrowser.selectedBrowser;
-          let searchData = {
-            engineName: state.currentEngine.name,
-            searchString: msg.data,
-            healthReportKey: "d",
-            searchPurpose: "d"
-          };
-          SearchProvider.search.performSearch(browser, searchData);
-        });
-        break;
-    }
   },
 
   /**
@@ -209,13 +137,9 @@ ActivityStreams.prototype = {
     this.broadcast(am.actions.Response("RECEIVE_CURRENT_ENGINE"), data);
   },
 
-  _handleUserEvent(eventName, data) {
-    this._tabTracker.handleUserEvent(data.msg.data);
-  },
-
-  _onRouteChange(eventName, data) {
+  _onRouteChange(data) {
     if (data) {
-      this._tabTracker.handleRouteChange(tabs.activeTab, data.msg.data);
+      this._tabTracker.handleRouteChange(tabs.activeTab, data);
     }
     this._appURLHider.maybeHideURL(tabs.activeTab);
   },
@@ -226,10 +150,6 @@ ActivityStreams.prototype = {
   _setupListeners() {
     this._handlePlacesChanges = this._handlePlacesChanges.bind(this);
     this._handleCurrentEngineChanges = this._handleCurrentEngineChanges.bind(this);
-    this._respondToPlacesRequests = this._respondToPlacesRequests.bind(this);
-    this._respondToSearchRequests = this._respondToSearchRequests.bind(this);
-    this._onRouteChange = this._onRouteChange.bind(this);
-    this._handleUserEvent = this._handleUserEvent.bind(this);
     PlacesProvider.links.on("deleteURI", this._handlePlacesChanges);
     PlacesProvider.links.on("clearHistory", this._handlePlacesChanges);
     PlacesProvider.links.on("linkChanged", this._handlePlacesChanges);
@@ -238,20 +158,6 @@ ActivityStreams.prototype = {
     PlacesProvider.links.on("bookmarkRemoved", this._handlePlacesChanges);
     PlacesProvider.links.on("bookmarkChanged", this._handlePlacesChanges);
     SearchProvider.search.on("browser-search-engine-modified", this._handleCurrentEngineChanges);
-
-    this.on(am.type("TOP_FRECENT_SITES_REQUEST"), this._respondToPlacesRequests);
-    this.on(am.type("HIGHLIGHTS_LINKS_REQUEST"), this._respondToPlacesRequests);
-    this.on(am.type("RECENT_BOOKMARKS_REQUEST"), this._respondToPlacesRequests);
-    this.on(am.type("RECENT_LINKS_REQUEST"), this._respondToPlacesRequests);
-    this.on(am.type("NOTIFY_HISTORY_DELETE"), this._respondToPlacesRequests);
-    this.on(am.type("NOTIFY_BLOCK_URL"), this._respondToPlacesRequests);
-    this.on(am.type("NOTIFY_UNBLOCK_URL"), this._respondToPlacesRequests);
-    this.on(am.type("NOTIFY_UNBLOCK_ALL"), this._respondToPlacesRequests);
-    this.on(am.type("NOTIFY_BOOKMARK_DELETE"), this._respondToPlacesRequests);
-    this.on(am.type("SEARCH_STATE_REQUEST"), this._respondToSearchRequests);
-    this.on(am.type("NOTIFY_PERFORM_SEARCH"), this._respondToSearchRequests);
-    this.on(am.type("NOTIFY_ROUTE_CHANGE"), this._onRouteChange);
-    this.on(am.type("NOTIFY_USER_EVENT"), this._handleUserEvent);
   },
 
   /**
@@ -266,19 +172,6 @@ ActivityStreams.prototype = {
     PlacesProvider.links.off("bookmarkRemoved", this._handlePlacesChanges);
     PlacesProvider.links.off("bookmarkChanged", this._handlePlacesChanges);
     SearchProvider.search.off("browser-search-engine-modified", this._handleCurrentEngineChanges);
-
-    this.off(am.type("TOP_FRECENT_SITES_REQUEST"), this._respondToPlacesRequests);
-    this.off(am.type("RECENT_BOOKMARKS_REQUEST"), this._respondToPlacesRequests);
-    this.off(am.type("RECENT_LINKS_REQUEST"), this._respondToPlacesRequests);
-    this.off(am.type("NOTIFY_HISTORY_DELETE"), this._respondToPlacesRequests);
-    this.off(am.type("NOTIFY_BLOCK_URL"), this._respondToPlacesRequests);
-    this.off(am.type("NOTIFY_UNBLOCK_URL"), this._respondToPlacesRequests);
-    this.off(am.type("NOTIFY_UNBLOCK_ALL"), this._respondToPlacesRequests);
-    this.off(am.type("NOTIFY_BOOKMARK_DELETE"), this._respondToPlacesRequests);
-    this.off(am.type("SEARCH_STATE_REQUEST"), this._respondToSearchRequests);
-    this.off(am.type("NOTIFY_PERFORM_SEARCH"), this._respondToSearchRequests);
-    this.off(am.type("NOTIFY_ROUTE_CHANGE"), this._onRouteChange);
-    this.off(am.type("NOTIFY_USER_EVENT"), this._handleUserEvent);
   },
 
   /**
@@ -415,12 +308,18 @@ ActivityStreams.prototype = {
             this._removeWorker(worker);
           }
           this._perfMeter.log(worker.tab, msg.type, msg.data);
-          this.emit(msg.type, {msg, worker});
+          this._applyHandlers(msg, worker);
         });
       },
       onError: err => {
         Cu.reportError(err);
       }
+    });
+  },
+
+  _applyHandlers(...args) {
+    handlers.forEach(handler => {
+      handler.apply(this, args);
     });
   },
 

--- a/lib/handlers/handlers.js
+++ b/lib/handlers/handlers.js
@@ -1,0 +1,16 @@
+const am = require("common/action-manager");
+
+module.exports = [
+  function(action) {
+    switch (action.type) {
+      case am.type("NOTIFY_USER_EVENT"):
+        this._tabTracker.handleUserEvent(action.data);
+        break;
+      case am.type("NOTIFY_ROUTE_CHANGE"):
+        this._onRouteChange(action.data);
+        break;
+    }
+  },
+  require("./places").handler,
+  require("./search").handler
+];

--- a/lib/handlers/places.js
+++ b/lib/handlers/places.js
@@ -1,0 +1,42 @@
+const am = require("common/action-manager");
+const {PlacesProvider} = require("lib/PlacesProvider");
+
+exports.handler = function PlacesHandler(action, worker) {
+  switch (action.type) {
+    case am.type("TOP_FRECENT_SITES_REQUEST"):
+      this._memoized.getTopFrecentSites(action.data).then(links => {
+        this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", worker, action.meta);
+      });
+      break;
+    case am.type("RECENT_BOOKMARKS_REQUEST"):
+      this._memoized.getRecentBookmarks(action.data).then(links => {
+        this._processAndSendLinks(links, "RECENT_BOOKMARKS_RESPONSE", worker, action.meta);
+      });
+      break;
+    case am.type("RECENT_LINKS_REQUEST"):
+      this._memoized.getRecentLinks(action.data).then(links => {
+        this._processAndSendLinks(links, "RECENT_LINKS_RESPONSE", worker, action.meta);
+      });
+      break;
+    case am.type("HIGHLIGHTS_LINKS_REQUEST"):
+      this._memoized.getHighlightsLinks(action.data).then(links => {
+        this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", worker, action.meta);
+      });
+      break;
+    case am.type("NOTIFY_BOOKMARK_DELETE"):
+      PlacesProvider.links.asyncDeleteBookmark(action.data);
+      break;
+    case am.type("NOTIFY_HISTORY_DELETE"):
+      PlacesProvider.links.deleteHistoryLink(action.data);
+      break;
+    case am.type("NOTIFY_BLOCK_URL"):
+      PlacesProvider.links.blockURL(action.data);
+      break;
+    case am.type("NOTIFY_UNBLOCK_URL"):
+      PlacesProvider.links.unblockURL(action.data);
+      break;
+    case am.type("NOTIFY_UNBLOCK_ALL"):
+      PlacesProvider.links.unblockAll();
+      break;
+  }
+};

--- a/lib/handlers/search.js
+++ b/lib/handlers/search.js
@@ -1,0 +1,33 @@
+/* globals XPCOMUtils, windowMediator */
+
+const am = require("common/action-manager");
+const {SearchProvider} = require("lib/SearchProvider");
+const {Cu} = require("chrome");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+XPCOMUtils.defineLazyServiceGetter(this, "windowMediator",
+                                   "@mozilla.org/appshell/window-mediator;1",
+                                   "nsIWindowMediator");
+
+exports.handler = function SearchHandler(action, worker) {
+  switch (action.type) {
+    case am.type("SEARCH_STATE_REQUEST"):
+      SearchProvider.search.state.then(state => {
+        this.send(am.actions.Response("SEARCH_STATE_RESPONSE", state), worker);
+      });
+      break;
+    case am.type("NOTIFY_PERFORM_SEARCH"):
+      SearchProvider.search.state.then(state => {
+        let win = windowMediator.getMostRecentWindow("navigator:browser");
+        let gBrowser = win.getBrowser();
+        let browser = gBrowser.selectedBrowser;
+        let searchData = {
+          engineName: state.currentEngine.name,
+          searchString: action.data,
+          healthReportKey: "d",
+          searchPurpose: "d"
+        };
+        SearchProvider.search.performSearch(browser, searchData);
+      });
+      break;
+  }
+};


### PR DESCRIPTION
I was thinking something like this might be a better pattern for handling and responding to messages from content, since this way:

- removes several bug vectors (forgetting to add/remove event listeners, bind each handler)
- consolidates the location for adding a new listener to a single place (`lib/handlers/handler.js`)
- slight change to the function signature

Suggestions welcome 👍 

What do you think? @oyiptong @rlr @sarracini @emtwo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/761)
<!-- Reviewable:end -->
