### PR TITLE
Refactor cache updating strategy

### DIFF
--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -5,7 +5,6 @@ const {Cu} = require("chrome");
 const ss = require("sdk/simple-storage");
 const simplePrefs = require("sdk/simple-prefs");
 const self = require("sdk/self");
-const {setTimeout, clearTimeout} = require("sdk/timers");
 const {TippyTopProvider} = require("lib/TippyTopProvider");
 
 const EMBEDLY_PREF = "embedly.endpoint";
@@ -32,7 +31,6 @@ const DEFAULT_OPTIONS = {
   cacheCleanupPeriod: 86400000, // a cache clearing job runs at most once every 24 hours
   cacheRefreshAge: 259200000, // refresh a link every 3 days
   cacheTTL: 2592000000, // cached items expire if they haven't been accessed in 30 days
-  cacheUpdateInterval: 3600000, // a cache update job runs every hour
   proxyMaxLinks: 25, // number of links embedly proxy accepts per request
   initFresh: false,
 };
@@ -43,11 +41,9 @@ function PreviewProvider(tabTracker, options = {}) {
   this._tippyTopProvider = new TippyTopProvider();
   this._tabTracker = tabTracker;
   this.init();
-  this._runPeriodicUpdate();
 }
 
 PreviewProvider.prototype = {
-  _updateTimeout: null,
 
   /**
    * Clean-up the preview cache
@@ -89,13 +85,10 @@ PreviewProvider.prototype = {
           break;
         case ENABLED_PREF:
           if (this.enabled) {
-            // if disabling, remove cache and update
-            this._clearPeriodicUpdate();
             this.clearCache();
           } else {
-            // if enabling, create cache and start updating
+            // if enabling, create cache
             ss.storage.embedlyData = {};
-            this._runPeriodicUpdate();
           }
           this.enabled = simplePrefs.prefs[ENABLED_PREF];
           break;
@@ -224,12 +217,29 @@ PreviewProvider.prototype = {
   },
 
   /**
+   * Determine if a cached link has expired
+   */
+  isLinkExpired(link) {
+    const cachedLink = ss.storage.embedlyData[link.cacheKey];
+    if (!cachedLink) {
+      return false;
+    }
+    let currentTime = Date.now();
+    return (currentTime - cachedLink.refreshTime) > this.options.cacheRefreshAge;
+  },
+
+  /**
    * Request links from embedly, optionally filtering out known links
    */
   asyncSaveLinks: Task.async(function*(links, event = {}, newOnly = true, updateAccessTime = true) {
+    let linksList = this._uniqueLinks(links)
+      .filter(link => link)
+      // If a request is in progress, don't re-request it
+      .filter(link => !this._alreadyRequested.has(link.cacheKey))
+      // If we already have the link in the cache, don't request it again...
+      // ... UNLESS it has expired
+      .filter(link => !newOnly || !ss.storage.embedlyData[link.cacheKey] || this.isLinkExpired(link));
 
-    // optionally filter out known links, and links which already have a request in process
-    let linksList = this._uniqueLinks(links).filter(link => link && (!newOnly || !ss.storage.embedlyData[link.cacheKey]) && !this._alreadyRequested.has(link.cacheKey));
     linksList.forEach(link => this._alreadyRequested.add(link.cacheKey));
 
     let requestQueue = [];
@@ -244,35 +254,6 @@ PreviewProvider.prototype = {
     });
     yield Promise.all(promises);
   }),
-
-  /**
-   * Asynchronously update links
-   */
-  asyncUpdateLinks: Task.async(function*() {
-    let links = [];
-    let currentTime = Date.now();
-    for (let key in ss.storage.embedlyData) {
-      let link = ss.storage.embedlyData[key];
-      if (!link.refreshTime || (currentTime - link.refreshTime) > this.options.cacheRefreshAge) {
-        links.push(link);
-      }
-    }
-    const event = this._tabTracker.generateEvent({source: "UPDATE_LINKS"});
-    let linksToUpdate = this.processLinks(links);
-    yield this.asyncSaveLinks(linksToUpdate, event, false, false);
-    Services.obs.notifyObservers(null, "activity-streams-preview-cache-update", null);
-  }),
-
-  /**
-   * Runs a periodic update
-   */
-  _runPeriodicUpdate() {
-    this._updateTimeout = setTimeout(() => {
-      this.asyncUpdateLinks().then(() => {
-        this._runPeriodicUpdate();
-      });
-    }, this.options.cacheUpdateInterval);
-  },
 
   /**
    * Makes the necessary requests to embedly to get data for each link
@@ -359,19 +340,9 @@ PreviewProvider.prototype = {
   },
 
   /**
-   * Clear update timeout
-   */
-  _clearPeriodicUpdate() {
-    if (this._updateTimeout) {
-      clearTimeout(this._updateTimeout);
-    }
-  },
-
-  /**
    * Uninit the preview provider
    */
   uninit() {
-    this._clearPeriodicUpdate();
     simplePrefs.off("", this._onPrefChange);
     this._alreadyRequested = new Set();
   },


### PR DESCRIPTION
This patch removes the `_runPeriodicUpdate` function and replaces it with a strategy where when links from a query are sent to `asyncSaveLinks`, they are re-requested if they have expired.

This will eliminate unnecessary update requests for items in the cache that won't ever be needed again/requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/787)
<!-- Reviewable:end -->
