### PR TITLE
test(addon): Reduce useless jpm test output

### DIFF
--- a/dev-prefs.json
+++ b/dev-prefs.json
@@ -1,4 +1,5 @@
 {
+  "javascript.options.strict": false,
   "xpinstall.signatures.required": false,
   "extensions.@activity-streams.sdk.console.logLevel": "info",
   "extensions.@activity-streams.telemetry.ping.endpoint": "https://onyx_tiles.stage.mozaws.net/v3/links/activity-stream",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "pretest": "npm run bundle && npm run copyTestImages && npm run copyTopSitesJson",
     "test:lint": "eslint . && jscs . && sass-lint -v -q",
     "test:checkbinary": "echo \"JPM_FIREFOX_BINARY: ${JPM_FIREFOX_BINARY}\"",
-    "test:jpm": "jpm test -b ${JPM_FIREFOX_BINARY:-\"firefox\"} --prefs ./test-prefs.json",
+    "test:jpm": "jpm test -b ${JPM_FIREFOX_BINARY:-\"firefox\"} --prefs ./test-prefs.json -v",
     "test:karma": "NODE_ENV=test karma start",
     "posttest": "cat logs/reports/coverage/text-summary.txt",
     "tdd": "npm run test:karma -- --no-single-run --browsers Chrome",

--- a/test-prefs.json
+++ b/test-prefs.json
@@ -1,5 +1,6 @@
 {
   "xpinstall.signatures.required": false,
+  "javascript.options.strict": false,
   "extensions.@activity-streams.sdk.console.logLevel": "info",
   "extensions.@activity-streams.performance.log": false,
   "extensions.@activity-streams.previews.enabled": false,

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -45,7 +45,7 @@ scripts:
     lint: eslint . && jscs . && sass-lint -v -q
     checkbinary: echo "JPM_FIREFOX_BINARY: ${JPM_FIREFOX_BINARY}"
     # test:jpm: Run jpm tests
-    jpm: jpm test -b ${JPM_FIREFOX_BINARY:-"firefox"} --prefs ./test-prefs.json
+    jpm: jpm test -b ${JPM_FIREFOX_BINARY:-"firefox"} --prefs ./test-prefs.json -v
     # test:karma: Run content tests only
     karma: NODE_ENV=test karma start
     post: cat logs/reports/coverage/text-summary.txt


### PR DESCRIPTION
This will hide a whole bunch of javascript warnings and show the pass/fail state of each test (way more interesting info).

We could optionally not have `-v` if it's too much info

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/789)
<!-- Reviewable:end -->
