### PR TITLE
feat(addon): set browser pref to store bigger favicons

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -54,6 +54,8 @@ function ActivityStreams(options = {}) {
   this._setupButton();
   NewTabURL.override(`${this.options.pageURL}#/`);
 
+  Services.prefs.setIntPref("places.favicons.optimizeToDimension", 64);
+
   this._appURLHider = new AppURLHider(this.appURLs);
   this._perfMeter = new PerfMeter(this.appURLs);
 
@@ -516,6 +518,7 @@ ActivityStreams.prototype = {
       clearTimeout(this._placesCacheTimeoutID);
       this._previewProvider.uninit();
       NewTabURL.reset();
+      Services.prefs.clearUserPref("places.favicons.optimizeToDimension");
       this.workers.clear();
       this._removeListeners();
       this._pagemod.destroy();


### PR DESCRIPTION
Fixes #731 

I'm not sure we need tests for this. What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/792)
<!-- Reviewable:end -->
