### PR TITLE
feat(addon): Local color analysis for favicons

### DIFF
--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -13,6 +13,11 @@ const DEFAULT_FAVICON_BG_COLOR = [150, 150, 150];
 module.exports.justDispatch = (() => ({}));
 
 function getBackgroundRGB(site) {
+
+  // This is from firefox
+  if (site.favicon_color) {
+    return site.favicon_color;
+  }
   if (site.favicon_colors && site.favicon_colors[0] && site.favicon_colors[0].color) {
     return site.favicon_colors[0].color;
   }

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -170,8 +170,12 @@ ActivityStreams.prototype = {
       this._previewProvider.asyncSaveLinks(processedLinks, event);
     }
     const cachedLinks = this._previewProvider.getEnhancedLinks(processedLinks, previewsOnly);
-    this._handlePerformanceEvent(event, processedLinks, cachedLinks);
-    this.send(am.actions.Response(responseType, cachedLinks, {append}), worker);
+    this._previewProvider.getFaviconColors(cachedLinks)
+      .then(links => {
+        this._handlePerformanceEvent(event, processedLinks, cachedLinks);
+        this.send(am.actions.Response(responseType, links, {append}), worker);
+      });
+
   },
 
   _respondToSearchRequests(msgName, params) {

--- a/lib/ColorAnalyzerProvider.js
+++ b/lib/ColorAnalyzerProvider.js
@@ -1,0 +1,19 @@
+const {Cu, Cc, Ci} = require("chrome");
+
+Cu.import("resource://gre/modules/Services.jsm");
+
+const ColorAnalyzer = Cc["@mozilla.org/places/colorAnalyzer;1"].
+                      getService(Ci.mozIColorAnalyzer);
+
+exports.getColor = function getColor(url) {
+  return new Promise((resolve, reject) => {
+    ColorAnalyzer.findRepresentativeColor({spec: url}, function(ok, number) {
+      if (ok) {
+        const rgb = [(number >> 16) & 0xFF, (number >> 8) & 0xFF, number & 0xFF];
+        resolve(rgb);
+      } else {
+        reject(new Error("There was an error processing this image"));
+      }
+    });
+  });
+};

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -6,6 +6,7 @@ const ss = require("sdk/simple-storage");
 const simplePrefs = require("sdk/simple-prefs");
 const self = require("sdk/self");
 const {TippyTopProvider} = require("lib/TippyTopProvider");
+const {getColor} = require("lib/ColorAnalyzerProvider");
 
 const EMBEDLY_PREF = "embedly.endpoint";
 const EMBEDLY_VERSION_QUERY = "?addon_version=";
@@ -179,6 +180,22 @@ PreviewProvider.prototype = {
         const cacheKey = this._createCacheKey(sanitizedURL);
         return Object.assign({}, link, {sanitizedURL, cacheKey});
       });
+  },
+
+  getFaviconColors(links) {
+    return Promise.all(
+      links.map(link => {
+        return new Promise(resolve => {
+          if (!link.favicon) {
+            return resolve(link);
+          }
+          getColor(link.favicon)
+            .then(color => {
+              resolve(Object.assign({}, link, {favicon_color: color}));
+            }, () => resolve(link));
+        });
+      })
+    );
   },
 
   /**

--- a/test/resources/colors.js
+++ b/test/resources/colors.js
@@ -1,0 +1,15 @@
+exports.colors = [
+  {
+    rgb: [255, 255, 255],
+    uri: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4////fwAJ+wP9CNHoHgAAAABJRU5ErkJggg=="
+  },
+  {
+    rgb: [0, 0, 0],
+    uri: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg=="
+  },
+  {
+    // pink
+    rgb: [249, 103, 103],
+    uri: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4mZ7+HwAG6wLHDjjvLgAAAABJRU5ErkJggg=="
+  }
+];

--- a/test/test-ColorAnalyzerProvider.js
+++ b/test/test-ColorAnalyzerProvider.js
@@ -1,0 +1,21 @@
+const test = require("sdk/test");
+const {getColor} = require("lib/ColorAnalyzerProvider");
+const {colors} = require("./resources/colors");
+
+exports["test getColor"] = function*(assert) {
+  for (let i in colors) {
+    const color = colors[i];
+    const result = yield getColor(color.uri);
+    assert.deepEqual(result, color.rgb, `color should be ${color.rgb.join(", ")}`);
+  }
+};
+
+exports["test getColor errors"] = function*(assert) {
+  try {
+    yield getColor("badURIhahaha");
+  } catch (e) {
+    assert.equal(e.message, "There was an error processing this image", "should throw the right error");
+  }
+};
+
+test.run(exports);


### PR DESCRIPTION
This is a WIP, I want to add caching for color analysis and change the logic about where it gets done as well before merging this, but it seems to be working pretty well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/793)
<!-- Reviewable:end -->
