### PR TITLE
fix(addon): #796 Fix delete observer notification

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -47,6 +47,7 @@ const DEFAULT_OPTIONS = {
 };
 
 const PLACES_CHANGES_EVENTS = [
+  "deleteURI",
   "clearHistory",
   "linkChanged",
   "manyLinksChanged",


### PR DESCRIPTION
Fixes an issue where deleting history items stopped working

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/807)
<!-- Reviewable:end -->
