### PR TITLE
bug(content): remove css that breaks timestamp alignment

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.scss
+++ b/content-src/components/ActivityFeed/ActivityFeed.scss
@@ -173,7 +173,6 @@
   align-items: baseline;
   display: flex;
   flex-grow: 1;
-  flex-wrap: wrap;
   overflow: hidden;
 
   .feed-description {


### PR DESCRIPTION
Fixes #815

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/826)
<!-- Reviewable:end -->
