### PR TITLE
fix (addon): #769 stop caching when afterDate or beforeDate provided

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -150,24 +150,29 @@ ActivityStreams.prototype = {
    * Responds to places requests
    */
   _respondToPlacesRequests({msg, worker}) {
+    let provider = this._memoized;
+    if (msg.data && (msg.data.afterDate || msg.data.beforeDate)) {
+      // Only use the Memoizer cache for the default first page of data.
+      provider = PlacesProvider.links;
+    }
     switch (msg.type) {
       case am.type("TOP_FRECENT_SITES_REQUEST"):
-        this._memoized.getTopFrecentSites(msg.data).then(links => {
+        provider.getTopFrecentSites(msg.data).then(links => {
           this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", worker, msg.meta);
         });
         break;
       case am.type("RECENT_BOOKMARKS_REQUEST"):
-        this._memoized.getRecentBookmarks(msg.data).then(links => {
+        provider.getRecentBookmarks(msg.data).then(links => {
           this._processAndSendLinks(links, "RECENT_BOOKMARKS_RESPONSE", worker, msg.meta);
         });
         break;
       case am.type("RECENT_LINKS_REQUEST"):
-        this._memoized.getRecentLinks(msg.data).then(links => {
+        provider.getRecentLinks(msg.data).then(links => {
           this._processAndSendLinks(links, "RECENT_LINKS_RESPONSE", worker, msg.meta);
         });
         break;
       case am.type("HIGHLIGHTS_LINKS_REQUEST"):
-        this._memoized.getHighlightsLinks(msg.data).then(links => {
+        provider.getHighlightsLinks(msg.data).then(links => {
           this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", worker, msg.meta);
         });
         break;


### PR DESCRIPTION
We shouldn't cache places queries if `afterDate` or `beforeDate` are provided because we have no way to replace/invalidate them on history changes. Those queries only happen when scrolling down through the feed and are much less likely to be repeated anyway.

r? @oyiptong 

Fixes #769

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/851)
<!-- Reviewable:end -->
