### PR TITLE
fix (addon): #849 only reset back home page on disable

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -575,7 +575,6 @@ ActivityStreams.prototype = {
       clearTimeout(this._placesCacheTimeoutID);
       this._previewProvider.uninit();
       NewTabURL.reset();
-      this._unsetHomePage();
       Services.prefs.clearUserPref("places.favicons.optimizeToDimension");
       this.workers.clear();
       this._removeListeners();
@@ -600,6 +599,7 @@ ActivityStreams.prototype = {
       case "disable":
         this._tabTracker.handleUserEvent({event: "disable"});
         this._previewProvider.clearCache();
+        this._unsetHomePage();
         defaultUnload();
         break;
       default:

--- a/test/test-ActivityStreams-home-page.js
+++ b/test/test-ActivityStreams-home-page.js
@@ -13,15 +13,19 @@ exports["test activity stream loads on home page when appropriate"] = function*(
   // By default, the home page should be set to ActivityStream.
   assert.equal(url + "#/", prefService.get("browser.startup.homepage"));
 
-  // Unload ActivityStream and it should be unset.
+  // Unload ActivityStream and the home page should still be ours.
   app.unload();
+  assert.equal(url + "#/", prefService.get("browser.startup.homepage"));
+
+  // Unload ActivityStream with reason="disable" and it should be unset.
+  app.unload("disable");
   assert.ok(!prefService.isSet("browser.startup.homepage"));
 
   // If the pref is already overriden, ActivityStream shouldn't change it.
   prefService.set("browser.startup.homepage", "https://example.com");
   app = new ActivityStreams({pageURL: url});
   assert.equal("https://example.com", prefService.get("browser.startup.homepage"));
-  app.unload();
+  app.unload("disable");
   assert.equal("https://example.com", prefService.get("browser.startup.homepage"));
 
   // If we override the pref and the user changes it back to about:home,


### PR DESCRIPTION
r? @sarracini or @oyiptong 

Basically, we don't reset the home page back on unload unless the user is disabling (uninstalling).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/878)
<!-- Reviewable:end -->
