### PR TITLE
fix(content): #859 'Delete from History' should not be available for bookmarks

### DIFF
--- a/content-src/components/LinkMenu/LinkMenu.js
+++ b/content-src/components/LinkMenu/LinkMenu.js
@@ -34,7 +34,7 @@ const LinkMenu = React.createClass({
 
     // Don't add delete options for default links
     // that show up if your history is empty
-    if (isNotDefault) {
+    if (isNotDefault && !site.bookmarkGuid) {
       deleteOptions = [
         allowBlock && {
           ref: "dismiss",

--- a/content-test/components/LinkMenu.test.js
+++ b/content-test/components/LinkMenu.test.js
@@ -58,6 +58,13 @@ describe("LinkMenu", () => {
     assert.lengthOf(contextMenu.props.options, 4);
   });
 
+  it("should hide delete options for bookmarks", () => {
+    setup({site: {url: "https://foo.com", bookmarkGuid: "asdasd23123"}});
+    assert.isUndefined(contextMenu.refs.dismiss, "hide dismiss");
+    assert.isUndefined(contextMenu.refs.delete, "hide delete");
+    assert.lengthOf(contextMenu.props.options, 4);
+  });
+
   it("should hide dismiss option if allowBlock is false", () => {
     setup({allowBlock: false});
     assert.isUndefined(contextMenu.refs.dismiss, "hide dismiss");


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/883)
<!-- Reviewable:end -->
