### PR TITLE
fix (addon): #882 handle unload(reason="uninstall")

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -592,12 +592,10 @@ ActivityStreams.prototype = {
     };
 
     switch (reason){
-      // can be one of: disable/shutdown/upgrade/downgrade
-
-      // note that if the user uninstalls the addon, the reason will be set as
-      // "disable", see more here https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Listening_for_load_and_unload
+      // can be one of: uninstall/disable/shutdown/upgrade/downgrade
       case "disable":
-        this._tabTracker.handleUserEvent({event: "disable"});
+      case "uninstall":
+        this._tabTracker.handleUserEvent({event: reason});
         this._previewProvider.clearCache();
         this._unsetHomePage();
         defaultUnload();


### PR DESCRIPTION
@oyiptong turns out unload is called with `reason="uninstall"` when uninstalling. mdn and bugzilla are wrong or outdated.

r?

Fixes #882

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/884)
<!-- Reviewable:end -->
