### PR TITLE
fix(content): #838 Search keyword is removed after navigating with the arrow keys through the search suggestion dropdown

### DIFF
--- a/content-src/components/Search/Search.js
+++ b/content-src/components/Search/Search.js
@@ -122,6 +122,17 @@ const Search = React.createClass({
       case "ArrowUp":
         if (index > -1) {
           newIndex--;
+
+          // if we've reached the top of the suggestions list and press 'up' once more,
+          // we keep the table visible but display the origial search string. This
+          // behaviour is meant to match about:newtab
+          if (newIndex === -1) {
+            this.setState({focus: true});
+            this.props.dispatch(actions.NotifyUpdateSearchString(originalSearchString));
+            newSuggestionIndex = -1;
+            newIndex = -1;
+            break;
+          }
           if (index < numSuggestions) {
             // We are in suggestions, move on up.
             newSuggestionIndex--;
@@ -229,6 +240,13 @@ const Search = React.createClass({
       activeEngineIndex: newEngineIndex
     });
   },
+
+  onMouseMove(newIndex) {
+    this.setState({
+      activeIndex: newIndex,
+      activeSuggestionIndex: newIndex,
+    });
+  },
   render() {
     const {currentEngine, searchString, suggestions, formHistory, engines} = this.props;
     let suggestionsIdIndex = 0;
@@ -259,8 +277,10 @@ const Search = React.createClass({
           {formHistory.map(suggestion => {
             const active = (this.state.activeSuggestionIndex === suggestionsIdIndex);
             const activeEngine = this.getActiveEngine();
-            return (<li key={suggestion} role="presentation">
-                  <a id={"history-search-suggestions-" + suggestionsIdIndex++ }
+            const suggestionIndex = suggestionsIdIndex++;
+            return (<li key={suggestion} role="option">
+                  <a id={"history-search-suggestions-" + suggestionIndex }
+                     onMouseMove={() => this.onMouseMove(suggestionIndex)}
                      className={active ? "active" : ""} role="option"
                      aria-selected={active} onClick={() => this.performSearch({engineName: activeEngine, searchString: suggestion})}>
                      <div id="historyIcon" className={active ? "active" : ""}></div>{suggestion}</a>
@@ -273,8 +293,10 @@ const Search = React.createClass({
           {suggestions.map(suggestion => {
             const active = (this.state.activeSuggestionIndex === suggestionsIdIndex);
             const activeEngine = this.getActiveEngine();
-            return (<li key={suggestion} role="presentation">
-            <a ref={suggestion} id={"search-suggestions-" + suggestionsIdIndex++ }
+            const suggestionIndex = suggestionsIdIndex++;
+            return (<li key={suggestion} role="option">
+            <a ref={suggestion} id={"search-suggestions-" + suggestionIndex }
+              onMouseMove={() => this.onMouseMove(suggestionIndex)}
               className={active ? "active" : ""} role="option"
               aria-selected={active}
               onClick={() => this.performSearch({engineName: activeEngine, searchString: suggestion})}>{suggestion}</a>

--- a/content-test/components/Search.test.js
+++ b/content-test/components/Search.test.js
@@ -366,4 +366,22 @@ describe("Search", () => {
     instance.setState({focus: true, activeSuggestionIndex: -1, activeIndex: -1, activeEngineIndex: -1});
     TestUtils.Simulate.click(instance.refs.Yahoo);
   });
+
+  it("should keep the drop down visible and display the original search string when no suggestion is selected", () => {
+    const props = {
+      searchString: "h",
+      suggestions: ["hello", "hi"]
+    };
+    setup(props);
+    // make sure the drop down is 'visible', set the active suggestion to the first
+    // available suggestion, and move up one time.
+    instance.setState({focus: true, activeSuggestionIndex: 0, activeIndex: 0});
+    TestUtils.Simulate.keyDown(instance.refs.searchInput, {key: "ArrowUp"});
+    // the drop down should still be visible, but we want to display the original search string
+    // and reset all the indices to -1
+    assert.equal(instance.state.focus, true);
+    assert.equal(instance.state.searchString, "h");
+    assert.equal(instance.state.activeSuggestionIndex, -1);
+    assert.equal(instance.state.activeIndex, -1);
+  });
 });


### PR DESCRIPTION
the onMouseMove stuff is to prevent the double selection stuff that was going on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/890)
<!-- Reviewable:end -->
