### PR TITLE
chore(build): Only run git hook on push not commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "tdd": "npm run test:karma -- --no-single-run --browsers Chrome",
     "package": "npm run bundle && jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi",
     "travis": "npm run test",
-    "precommit": "npm run test:lint && npm run yamscripts",
+    "prepush": "npm run test:lint && npm run yamscripts",
     "help": "yamscripts help",
     "yamscripts": "yamscripts compile",
     "__": "# NOTE: THESE SCRIPTS ARE COMPILED!!! EDIT yamscripts.yml instead!!!"

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -63,5 +63,4 @@ scripts:
 
   # This is just to make sure we don't make commits with failing tests
   # or uncompiled yamscripts.yml. Run automatically with husky.
-  precommit: =>test:lint && =>yamscripts
-  # prepush: =>test
+  prepush: =>test:lint && =>yamscripts


### PR DESCRIPTION
Since lint is taking quite a long time with all the extra files, let's run our hook on `push` not `commit`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/893)
<!-- Reviewable:end -->
