### PR TITLE
fix (content): #891 wait for content bridge to be setup before render

### DIFF
--- a/content-src/main.js
+++ b/content-src/main.js
@@ -17,4 +17,13 @@ const Root = React.createClass({
   }
 });
 
-ReactDOM.render(<Root />, document.getElementById("root"));
+function renderRootWhenAddonIsReady() {
+  if (window.navigator.activity_streams_addon) {
+    ReactDOM.render(<Root />, document.getElementById("root"));
+  } else {
+    // If the content bridge to the addon isn't set up yet, try again soon.
+    setTimeout(renderRootWhenAddonIsReady, 50);
+  }
+}
+
+renderRootWhenAddonIsReady();

--- a/data/content-bridge.js
+++ b/data/content-bridge.js
@@ -2,8 +2,6 @@
 
 "use strict";
 
-unsafeWindow.navigator.activity_streams_addon = true;
-
 window.addEventListener("content-to-addon", function(event) {
   self.port.emit("content-to-addon", JSON.parse(event.detail));
 }, false);
@@ -22,3 +20,5 @@ window.addEventListener("pagehide", function() {
 document.onreadystatechange = function() {
   self.port.emit("content-to-addon", {type: "NOTIFY_PERFORMANCE", data: "DOC_READY_STATE=" + document.readyState});
 };
+
+unsafeWindow.navigator.activity_streams_addon = true;


### PR DESCRIPTION
There are some cases where we end up dispatching actions before the content bridge is set up, so the addon side never receives the initial messages to get data. Then the actions time out and the user is stuck hanging tight...

It only seems to happen in some cases when firing up Firefox with the Activity Stream page open. Happens more with e10s disabled. See issue for more details. I was able to reliably reproduce by having Firefox open my home page on startup. I would install the addon, make sure it was working, close Firefox, reopen Firefox, it still worked, close Firefox, reopen Firefox and then it was busted. Obviously it was a painful troubleshooting/debugging session.

r? @k88hudson 

Fixes #891

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/896)
<!-- Reviewable:end -->
