### PR TITLE
Metadata store

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -16,6 +16,7 @@ const ss = require("sdk/simple-storage");
 const {Memoizer} = require("lib/Memoizer");
 const {PlacesProvider} = require("lib/PlacesProvider");
 const {SearchProvider} = require("lib/SearchProvider");
+const {MetadataStore} = require("lib/MetadataStore");
 const {TabTracker} = require("lib/TabTracker");
 const {PreviewProvider} = require("lib/PreviewProvider");
 const {TelemetrySender} = require("lib/TelemetrySender");
@@ -96,6 +97,7 @@ function ActivityStreams(options = {}) {
     this._experimentProvider.experimentId
   );
 
+  this._metadataStore = new MetadataStore();
   this._previewProvider = new PreviewProvider(this._tabTracker);
   this._populatingCache = {
     places: false,
@@ -574,6 +576,7 @@ ActivityStreams.prototype = {
       clearTimeout(this._previewCacheTimeoutID);
       clearTimeout(this._placesCacheTimeoutID);
       this._previewProvider.uninit();
+      this._metadataStore.asyncClose();
       NewTabURL.reset();
       Services.prefs.clearUserPref("places.favicons.optimizeToDimension");
       this.workers.clear();

--- a/lib/MetadataStore.js
+++ b/lib/MetadataStore.js
@@ -1,0 +1,380 @@
+ /* globals XPCOMUtils, Task, OS, Sqlite, PlacesUtils, NetUtil, Services */
+"use strict";
+
+const {Cu} = require("chrome");
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Sqlite.jsm");
+Cu.import("resource://gre/modules/NetUtil.jsm");
+Cu.import("resource://gre/modules/Timer.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "Task",
+                                  "resource://gre/modules/Task.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PlacesUtils",
+                                  "resource://gre/modules/PlacesUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "OS",
+                                  "resource://gre/modules/osfile.jsm");
+
+const METASTORE_NAME = "metadata.sqlite";
+
+const SQL_DDLS = [
+  `CREATE TABLE IF NOT EXISTS page_metadata (
+      id INTEGER PRIMARY KEY,
+      cache_key LONGVARCHAR UNIQUE,
+      places_url LONGVARCHAR,
+      title TEXT,
+      type VARCHAR(32),
+      description TEXT,
+      media_url LONGVARCHAR,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      expired_at LONG
+  )`,
+  `CREATE TABLE IF NOT EXISTS page_images (
+    id INTEGER PRIMARY KEY,
+    url LONGVARCHAR UNIQUE,
+    type INTEGER,
+    height INTEGER,
+    width INTEGER,
+    color VARCHAR(32)
+  )`,
+  `CREATE TABLE IF NOT EXISTS page_metadata_images (
+    metadata_id INTEGER,
+    image_id INTEGER,
+    FOREIGN KEY(metadata_id) REFERENCES page_metadata(id) ON DELETE CASCADE,
+    FOREIGN KEY(image_id) REFERENCES page_images(id) ON DELETE CASCADE
+  )`,
+  "CREATE UNIQUE INDEX IF NOT EXISTS page_metadata_cache_key_uniqueindex ON page_metadata (cache_key)",
+  "CREATE UNIQUE INDEX IF NOT EXISTS page_images_url_uniqueindex ON page_images (url)"
+];
+
+const SQL_LAST_INSERT_ROWID = "SELECT last_insert_rowid() AS lastInsertRowID";
+
+/**
+ * A place holder for the database migrations in the future
+ */
+const SQL_MIGRATIONS = [];
+
+const SQL_INSERT_METADATA = `INSERT INTO page_metadata
+  (cache_key, places_url, title, type, description, media_url, expired_at)
+  VALUES
+  (:cache_key, :places_url, :title, :type, :description, :media_url, :expired_at)`;
+
+const SQL_INSERT_IMAGES = `INSERT INTO page_images
+  (url, type, height, width, color)
+  VALUES
+  (:url, :type, :height, :width, :color)`;
+
+const SQL_INSERT_METADATA_IMAGES = `INSERT INTO page_metadata_images
+  (metadata_id, image_id) VALUES (?, ?)`;
+
+const SQL_SELECT_IMAGE_ID = "SELECT id FROM page_images WHERE url = ?";
+
+const SQL_DROPS = [
+  "DROP TABLE IF EXISTS page_metadata_images",
+  "DROP TABLE IF EXISTS page_metadata",
+  "DROP TABLE IF EXISTS page_images"
+];
+
+const SQL_DELETE_EXPIRED = "DELETE FROM page_metadata WHERE expired_at <= (CAST(strftime('%s', 'now') AS LONG)*1000)";
+
+/* Image type constants */
+const IMAGE_TYPES = {
+  "favicon": 1,
+  "favicon_rich": 2,
+  "preview": 3
+};
+
+function MetadataStore(path) {
+  this._path = path || OS.Path.join(OS.Constants.Path.localProfileDir, METASTORE_NAME);
+  this._conn = null;
+  this._dataExpiryJob = null;
+}
+
+MetadataStore.prototype = {
+  /**
+   * Creates the table schema for the metadata database. This function must be called
+   * after a database connection has been established
+   */
+  _asyncCreateTableSchema: Task.async(function*() {
+    try {
+      yield this._conn.executeTransaction(function*() {
+        for (let ddl of SQL_DDLS) {
+          yield this._conn.execute(ddl);
+        }
+        for (let migration of SQL_MIGRATIONS) {
+          yield this._conn.execute(migration);
+        }
+      }.bind(this));
+    } catch (e) {
+      Cu.reportError("MetadataStore failed to create tables.");
+      throw e;
+    }
+  }),
+
+  get transactionInProgress() {
+    return this._conn.transactionInProgress;
+  },
+
+  /**
+   * Creates a connection to the metadata database. It sets the journal mode
+   * to WAL, enables the foreign key support, and also creates the tables and
+   * indices if necessary
+   *
+   * Returns a promise that is resolved upon success, or rejected if an exception occurs
+   */
+  asyncConnect: Task.async(function*() {
+    if (this._conn) {
+      return;
+    }
+
+    try {
+      this._conn = yield Sqlite.openConnection({path: this._path});
+      yield this._conn.execute("PRAGMA journal_mode = WAL;");
+      yield this._conn.execute("PRAGMA foreign_keys = ON;");
+      yield this._asyncCreateTableSchema();
+    } catch (e) {
+      Cu.reportError("MetadataStore failed to create connection: " + e.message);
+      throw e;
+    }
+  }),
+
+  asyncClose: Task.async(function*() {
+    if (this._conn) {
+      yield this._conn.close();
+      this._conn = null;
+    }
+  }),
+
+  _getMetadataParameters(aRow) {
+    return {
+      cache_key: aRow.cache_key,
+      places_url: aRow.places_url,
+      title: aRow.title,
+      type: aRow.type || null,
+      description: aRow.description,
+      media_url: aRow.media.url || null,
+      expired_at: aRow.expired_at
+    };
+  },
+
+  _getFaviconParameters(aRow) {
+    return {
+      url: aRow.favicon_url,
+      type: IMAGE_TYPES.favicon,
+      height: 0,
+      width: 0,
+      color: this._rgbToHex(aRow.favicon_colors[0].color)
+    };
+  },
+
+  _getImageParameters(aRow) {
+    return {
+      url: aRow.url,
+      type: IMAGE_TYPES.preview,
+      height: aRow.height,
+      width: aRow.width,
+      color: this._rgbToHex(aRow.colors[0].color)
+    };
+  },
+
+  /**
+  * Convert a RGB array to the Hex form, e.g. [10, 1, 2] => #0A0102
+  */
+  _rgbToHex(rgb) {
+    return "#" + ((1 << 24) + (rgb[0] << 16) + (rgb[1] << 8) + rgb[2]).toString(16).slice(1).toUpperCase();
+  },
+
+  _asyncGetLastInsertRowID: Task.async(function*() {
+    let result = yield this._conn.execute(SQL_LAST_INSERT_ROWID);
+    return result[0].getResultByName("lastInsertRowID");
+  }),
+
+  _asyncGetImageIDByURL: Task.async(function*(url) {
+    let result = yield this._conn.executeCached(SQL_SELECT_IMAGE_ID, [url]);
+    return result[0].getResultByName("id");
+  }),
+
+  /**
+   * Inserts the metadata into the database. It consists of two tables,
+   * i.e. page_metadata for the regular meta information of the page, and
+   * page_images for the favicon and preview images.
+   *
+   * metaObjects, an array of metadata objects that currently generated by embed.ly
+   * Returns a promise that is resolved upon success, or rejected if an exception occurs
+   */
+  asyncInsert: Task.async(function*(metaObjects) {
+    const principal = Services.scriptSecurityManager.getSystemPrincipal();
+    for (let metaObject of metaObjects) {
+      yield this._conn.executeTransaction(function*() {
+        let metadata_id;
+        let image_ids = [];
+
+        /* attach favicon to places_url for Places */
+        PlacesUtils.favicons.setAndFetchFaviconForPage(
+          NetUtil.newURI(metaObject.places_url),
+          NetUtil.newURI(metaObject.favicon_url),
+          false,
+          PlacesUtils.favicons.FAVICON_LOAD_NON_PRIVATE,
+          null,
+          principal
+        );
+
+        /* 1. inserts it into page_metadata */
+        try {
+          let metadataBindings = this._getMetadataParameters(metaObject);
+          yield this._conn.executeCached(SQL_INSERT_METADATA, metadataBindings);
+          metadata_id = yield this._asyncGetLastInsertRowID();
+        } catch (e) {
+          Cu.reportError("MetadataStore failed to insert metadata: " + e.message);
+          throw e;
+        }
+
+        /* 2. inserts the favicon into page_images, handles the special case, in which
+         * the favicon already exsits */
+        let faviconBindings = this._getFaviconParameters(metaObject);
+        try {
+          yield this._conn.executeCached(SQL_INSERT_IMAGES, faviconBindings);
+          image_ids.push(yield this._asyncGetLastInsertRowID());
+        } catch (e) {
+          try {
+            image_ids.push(yield this._asyncGetImageIDByURL(faviconBindings.url));
+          } catch (e) {
+            Cu.reportError("MetadataStore failed to insert favicon: " + e.message);
+            throw e; /* force this transaction to rollback */
+          }
+        }
+
+        /* 3. inserts all the preview images */
+        for (let image of metaObject.images) {
+          let imageBindings = this._getImageParameters(image);
+          try {
+            yield this._conn.executeCached(SQL_INSERT_IMAGES, imageBindings);
+            image_ids.push(yield this._asyncGetLastInsertRowID());
+          } catch (e) {
+            try {
+              image_ids.push(yield this._asyncGetImageIDByURL(imageBindings.url));
+            } catch (e) {
+              Cu.reportError("MetadataStore failed to fetch the id of favicon: " + e.message);
+              throw e; /* force this transaction to rollback */
+            }
+          }
+        }
+
+        /* 4. inserts relations into the page_metadata_images */
+        for (let image_id of image_ids) {
+          yield this._conn.executeCached(SQL_INSERT_METADATA_IMAGES, [metadata_id, image_id]);
+        }
+      }.bind(this));
+    }
+  }),
+
+  /**
+   * Drops all the tables and the corresponding indices, the table schema remains
+   *
+   * Returns a promise that is resolved upon success, or rejected if an exception occurs
+   */
+  asyncDrop: Task.async(function*() {
+    try {
+      yield this._conn.executeTransaction(function*() {
+        for (let drop of SQL_DROPS) {
+          yield this._conn.execute(drop);
+        }
+      }.bind(this));
+      yield this._asyncCreateTableSchema();
+    } catch (e) {
+      Cu.reportError("MetadataStore failed to drop: " + e.message);
+      throw e;
+    }
+  }),
+
+  /**
+   * Executes arbitrary query against metadata database. For bulk insert, use
+   * asyncInsert function instead
+   *
+   * @param {String} aSql
+   *        SQL query to execute
+   * @param {Object} [optional] aOptions
+   *        aOptions.columns - an array of column names. if supplied the return
+   *        items will consists of objects keyed on column names. Otherwise
+   *        array of raw values is returned in the select order
+   *        aOptions.param - an object of SQL binding parameters
+   *        aOptions.callback - a callback to handle query raws
+   *
+   * Returns a promise with the array of retrieved items
+   */
+  asyncExecuteQuery: Task.async(function*(aSql, aOptions = {}) {
+    let {columns, params, callback} = aOptions;
+    let items = [];
+    let queryError = null;
+
+    yield this._conn.executeCached(aSql, params, aRow => {
+      try {
+        // check if caller wants to handle query raws
+        if (callback) {
+          callback(aRow);
+        }
+        // otherwise fill in the item and add items array
+        else {
+          let item = null;
+          // if columns array is given construct an object
+          if (columns && Array.isArray(columns)) {
+            item = {};
+            columns.forEach(column => {
+              item[column] = aRow.getResultByName(column);
+            });
+          } else {
+            // if no columns - make an array of raw values
+            item = [];
+            for (let i = 0; i < aRow.numEntries; i++) {
+              item.push(aRow.getResultByIndex(i));
+            }
+          }
+          items.push(item);
+        }
+      } catch (e) {
+        queryError = e;
+        throw StopIteration;
+      }
+    });
+    if (queryError) {
+      throw new Error(queryError);
+    }
+    return items;
+  }),
+
+  /**
+  * Enables the data expiry job. The database connection needs to
+  * be established prior to calling this function. Once it's triggered,
+  * any following calls will be ignored unless the user disables
+  * it by disableDataExpiryJob()
+  *
+  * @param {Number} interval
+  *        an time interval in millisecond for this cron job
+  */
+  enableDataExpiryJob(interval) {
+    if (!this._conn) {
+      throw new Error("The database connection is not open yet");
+    }
+
+    if (this._dataExpiryJob) {
+      return;
+    }
+
+    this._dataExpiryJob = setInterval(() => {
+      this._conn.execute(SQL_DELETE_EXPIRED).catch(error => {
+        // The delete might fail if a table dropping is being processed at
+        // the same time
+        Cu.reportError("Failed to delete expired metadata: " + error.message);
+      });
+    }, interval);
+  },
+
+  disableDataExpiryJob() {
+    if (this._dataExpiryJob) {
+      clearInterval(this._dataExpiryJob);
+      this._dataExpiryJob = null;
+    }
+  }
+};
+
+exports.MetadataStore = MetadataStore;

--- a/test/lib/MetastoreFixture.js
+++ b/test/lib/MetastoreFixture.js
@@ -1,0 +1,170 @@
+const favicon_colors = [
+  {
+    "color": [
+      223,
+      40,
+      22
+    ],
+    "weight": 0.0534667969
+  },
+  {
+    "color": [
+      249,
+      246,
+      247
+    ],
+    "weight": 0.0090332031
+  }
+];
+
+const images = [
+  {
+    "caption": null,
+    "colors": [
+      {
+        "color": [
+          0,
+          2,
+          18
+        ],
+        "weight": 0.5300292969
+      },
+      {
+        "color": [
+          0,
+          64,
+          117
+        ],
+        "weight": 0.056152343800000004
+      }
+    ],
+    "entropy": 5.39729713409,
+    "height": 360,
+    "size": 47722,
+    "url": "https://i.ytimg.com/vi/Q_CXUa8WfNM/hqdefault.jpg",
+    "width": 480
+  }
+];
+
+const favicon_colors_firefox = [
+  {
+    "color": [
+      70,
+      185,
+      230
+    ],
+    "weight": 0.049072265600000005
+  },
+  {
+    "color": [
+      0,
+      135,
+      197
+    ],
+    "weight": 0.0368652344
+  }
+];
+
+const images_firefox = [
+  {
+    "caption": null,
+    "colors": [
+      {
+        "color": [
+          0,
+          108,
+          168
+        ],
+        "weight": 0.3452148438
+      },
+      {
+        "color": [
+          0,
+          61,
+          107
+        ],
+        "weight": 0.1997070312
+      }
+    ],
+    "entropy": 4.85517735513,
+    "height": 627,
+    "size": 83964,
+    "url": "https://www.mozilla.org/media/img/firefox/firefox-independent-1200.5bd827ccf1ed.jpg",
+    "width": 1200
+  },
+  {
+    "caption": null,
+    "colors": [
+      {
+        "color": [
+          6,
+          7,
+          14
+        ],
+        "weight": 0.6301269531
+      },
+      {
+        "color": [
+          214,
+          143,
+          43
+        ],
+        "weight": 0.034667968800000004
+      },
+      {
+        "color": [
+          45,
+          133,
+          194
+        ],
+        "weight": 0.031005859400000002
+      }
+    ],
+    "entropy": 2.3233239714,
+    "height": 70,
+    "size": 9804,
+    "url": "https://www.mozilla.org/media/img/firefox/template/header-logo-inverse.510f97e92635.png",
+    "width": 185
+  }
+];
+
+const gMetadataFixture = [
+  {
+    cache_key: "https://www.mozilla.org/",
+    places_url: "https://www.mozilla.org/",
+    favicon_url: "https://www.mozilla.org/media/img/favicon.52506929be4c.ico",
+    description: "Did you know? Mozilla - the maker of Firefox - fights to keep the Internet a global public resource open and accessible to all.",
+    title: "We're building a better Internet",
+    media: {type: "video", url: "https://www.mozilla.org/media/video/mozilla.mp4"},
+    expired_at: 1475280000000, // "2016-10-01 00:00:00",
+    type: "html",
+    favicon_colors,
+    images
+  },
+  {
+    cache_key: "https://www.mozilla.org/en-US/firefox/new/",
+    places_url: "https://www.mozilla.org/en-US/firefox/new",
+    favicon_url: "https://www.mozilla.org/media/img/firefox/favicon.dc6635050bf5.ico",
+    description: "Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!",
+    title: "Browse Freely",
+    media: {type: "video", url: "https://www.mozilla.org/media/video/firefox.mp4"},
+    expired_at: 1475280000000, // "2016-10-01 00:00:00",
+    type: "html",
+    favicon_colors: favicon_colors_firefox,
+    images: images_firefox
+  },
+  {
+    cache_key: "https://www.mozilla.org/en-GB/firefox/new/",
+    places_url: "https://www.mozilla.org/en-GB/firefox/new",
+    favicon_url: "https://www.mozilla.org/media/img/firefox/favicon.dc6635050bf5.ico",
+    description: "Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!",
+    title: "Browse Freely",
+    media: {type: "video", url: "https://www.mozilla.org/media/video/firefox.mp4"},
+    expired_at: 1475280000000, // "2016-10-01 00:00:00",
+    type: "html",
+    favicon_colors: favicon_colors_firefox,
+    images: images_firefox
+  }
+];
+
+exports.metadataFixture = gMetadataFixture;

--- a/test/test-MetadataStore.js
+++ b/test/test-MetadataStore.js
@@ -1,0 +1,134 @@
+/* globals require, exports */
+"use strict";
+
+const {before, after, waitUntil} = require("sdk/test/utils");
+const {MetadataStore} = require("lib/MetadataStore.js");
+const {metadataFixture} = require("./lib/MetastoreFixture.js");
+
+const gMetadataStore = new MetadataStore();
+
+/**
+ * Description of the metadata fixture
+ *
+ * The metadata fixture is composed of 3 pages, i.e.
+ *   1. https://www.mozilla.org/
+ *   2. https://www.mozilla.org/en-US/firefox/new/
+ *   3. https://www.mozilla.org/en-GB/firefox/new/
+ * where the page #1 consists of 1 favicon and 1 image, whereas both
+ * page #2 and #3 share the same 1 favicon and 2 images, respectively
+ */
+
+/**
+ * This function could be used to ensure the "asyncDrop" actually commit
+ * the transaction. It appears that the transaction might be still in
+ * the uncommitted state despite its promise is resolved in Sqlite.jsm.
+ * Hence, it has to poll for the table info periodically to comfirm that
+ */
+function waitForDrop() {
+  return waitUntil(function*() {
+    if (gMetadataStore.transactionInProgress) {
+      return false;
+    }
+
+    try {
+      let nMetadata = yield gMetadataStore.asyncExecuteQuery(
+        "SELECT count(*) as count FROM page_metadata",
+        {"columns": ["count"]});
+      let nImages = yield gMetadataStore.asyncExecuteQuery(
+        "SELECT count(*) as count FROM page_images",
+        {"columns": ["count"]});
+      let nMetadataImages = yield gMetadataStore.asyncExecuteQuery(
+        "SELECT count(*) as count FROM page_metadata_images",
+        {"columns": ["count"]});
+      return !nMetadata[0].count &&
+        !nImages[0].count &&
+        !nMetadataImages[0].count;
+    } catch (e) {
+      /* ignore whatever error that makes the query above fail */
+      return false;
+    }
+  }, 10);
+}
+
+/**
+ * Test insert every single page separately
+ */
+exports.test_insert_single = function*(assert) {
+  for (let metadata of metadataFixture) {
+    yield gMetadataStore.asyncInsert([metadata]);
+
+    let items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata");
+    assert.equal(items.length, 1);
+    items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_images");
+    assert.equal(metadata.images.length + 1, items.length);
+    items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata_images");
+    assert.equal(metadata.images.length + 1, items.length);
+    yield gMetadataStore.asyncDrop();
+    yield waitForDrop();
+  }
+};
+
+exports.test_insert_twice = function*(assert) {
+  const metadata = metadataFixture[0];
+  yield gMetadataStore.asyncInsert([metadata]);
+
+  let items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata");
+  assert.equal(items.length, 1);
+  let error = false;
+  try {
+    yield gMetadataStore.asyncInsert([metadata]);
+  } catch (e) {
+    error = true;
+  }
+  assert.ok(error, "Re-insert the same page should be rejected!");
+  yield gMetadataStore.asyncDrop();
+  yield waitForDrop();
+};
+
+/**
+ * Test insert all the fixture pages, to test that page #2 and #3
+ * should share the same favicon and images instead of storing the
+ * same image twice
+ */
+exports.test_async_insert_all = function*(assert) {
+  yield gMetadataStore.asyncInsert(metadataFixture);
+
+  let items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata");
+  assert.equal(items.length, 3);
+  items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_images");
+  assert.equal(items.length, 5); // page #1(1 + 1) + page #2&#3(1 + 2)
+  items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata_images");
+  assert.deepEqual(items.length, 8);
+  assert.deepEqual(items[0], [1, 1]);
+  assert.deepEqual(items[1], [1, 2]);
+  assert.deepEqual(items[2], [2, 3]);
+  assert.deepEqual(items[3], [2, 4]);
+  assert.deepEqual(items[4], [2, 5]);
+  assert.deepEqual(items[5], [3, 3]);
+  assert.deepEqual(items[6], [3, 4]);
+  assert.deepEqual(items[7], [3, 5]);
+};
+
+exports.test_data_expiry = function*(assert) {
+  let item = Object.assign({}, metadataFixture[0]);
+  gMetadataStore.enableDataExpiryJob(100);
+  item.expired_at = Date.now();
+  yield gMetadataStore.asyncInsert([].concat(item, metadataFixture.slice(1, 3)));
+  yield waitUntil(() => {return true;}, 1000); // wait for the timer to trigger
+  let items = yield gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata");
+  assert.equal(items.length, 2, "It should have deleted the expired page");
+  gMetadataStore.disableDataExpiryJob();
+};
+
+before(exports, function*() {
+  yield gMetadataStore.asyncConnect();
+});
+
+after(exports, function*() {
+  yield gMetadataStore.asyncDrop();
+  yield waitForDrop();
+  yield waitUntil(() => {return !gMetadataStore.transactionInProgress;}, 10);
+  yield gMetadataStore.asyncClose();
+});
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
This is the first cut of metadata persistence implementation #863. It now supports:
* insertion of metadata, images(favicon and preview), and relations of those two
* table dropping
* data expiry (for metadata only, not for images yet)
* executeQuery (raw SQL statements)

To be added shortly:
* more specific query APIs (once we know how we want to query against those tables)
* data expiry for images

Also, table schema is open to change anytime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/899)
<!-- Reviewable:end -->
