### PR TITLE
MetadataParser and PageScraper

### DIFF
--- a/data/page-scraper-content-script.js
+++ b/data/page-scraper-content-script.js
@@ -1,0 +1,14 @@
+function sendData() {
+  const text = document.documentElement.innerHTML;
+  const url = document.documentURI;
+  self.port.emit("message", {type: "PAGE_HTML", data: {text, url}});
+}
+
+sendData();
+if (document.readyState === "complete") {
+  sendData();
+} else {
+  window.addEventListener("load", sendData);
+}
+
+window.addEventListener("pagehide", sendData);

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -24,6 +24,7 @@ const {AppURLHider} = require("lib/AppURLHider");
 const am = require("common/action-manager");
 const {CONTENT_TO_ADDON, ADDON_TO_CONTENT} = require("common/event-constants");
 const {ExperimentProvider} = require("lib/ExperimentProvider");
+const {PageScraper} = require("lib/PageScraper");
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource:///modules/NewTabURL.jsm");
@@ -97,6 +98,7 @@ function ActivityStreams(metadataStore, options = {}) {
   );
 
   this._previewProvider = new PreviewProvider(this._tabTracker, metadataStore);
+  this._pageScraper = new PageScraper();
 
   this._populatingCache = {
     places: false,
@@ -580,6 +582,7 @@ ActivityStreams.prototype = {
       this.workers.clear();
       this._removeListeners();
       this._pagemod.destroy();
+      this._pageScraper.unload();
       this._button.destroy();
       this._tabTracker.uninit();
       this._telemetrySender.uninit();

--- a/lib/MetadataParser.js
+++ b/lib/MetadataParser.js
@@ -1,0 +1,91 @@
+/* globals Task */
+
+"use strict";
+
+const {getMetadata} = require("lib/vendor.bundle").PageMetadataParser;
+const {resolve} = require("lib/vendor.bundle").url;
+const {Cc, Ci, Cu} = require("chrome");
+const {Page} = require("sdk/page-worker");
+
+Cu.import("resource://gre/modules/Task.jsm");
+Cu.importGlobalProperties(["URL"]);
+
+function getDocumentObject(text) {
+  const parser = Cc["@mozilla.org/xmlextras/domparser;1"]
+                .createInstance(Ci.nsIDOMParser);
+  return parser.parseFromString(text, "text/html");
+}
+
+function createCacheKey(url) {
+  url = new URL(url);
+  let key = url.host.replace(/www\.?/, "");
+  key = key + url.pathname + (url.search || "");
+  return key.toString();
+}
+
+function tempFixUrls(data, baseUrl) {
+  function resolveUrl(url) {
+    if (!url) {
+      return url;
+    }
+    url = resolve(baseUrl, url);
+    return url.replace(/^\/\//, "https://");
+  }
+  data.image_url = resolveUrl(data.image_url);
+  data.icon_url = resolveUrl(data.icon_url);
+  data.url = resolveUrl(data.url || baseUrl);
+  return data;
+}
+
+// The metadata parser is a different format right now
+// we need to temporarily convert it
+function tempToEmbedlyFormat(data, url) {
+  const {title, type, description, icon_url, image_url} = tempFixUrls(data, url);
+  return {
+
+    // These are needed for MetadataStore
+    places_url: url,
+    cache_key: createCacheKey(url),
+
+    title,
+    type,
+    description,
+    images: image_url ? [{url: image_url, height: 300, width: 300}] : [],
+    favicon_url: icon_url,
+    url
+  };
+}
+
+function parseHTMLText(raw, url) {
+  return new Promise(resolve => {
+    const doc = getDocumentObject(raw);
+    resolve(tempToEmbedlyFormat(getMetadata(doc), url));
+  });
+}
+
+const parseByURL = Task.async(function*(url) {
+  let page;
+  const text = yield new Promise((resolve, reject) => {
+    page = Page({
+      contentScript: "self.postMessage(document.body.innerHTML);",
+      contentURL: url,
+      contentScriptWhen: "ready",
+      onMessage(message) {
+        resolve(message);
+      }
+    });
+  });
+  page.destroy();
+
+  return yield parseHTMLText(text, url);
+});
+
+module.exports = Object.assign(module.exports, {
+  parseHTMLText,
+  parseByURL,
+  getDocumentObject,
+
+  // Temp stuff
+  tempFixUrls,
+  tempToEmbedlyFormat
+});

--- a/lib/PageScraper.js
+++ b/lib/PageScraper.js
@@ -1,0 +1,79 @@
+/* globals XPCOMUtils, Services, EventEmitter */
+"use strict";
+
+const simplePrefs = require("sdk/simple-prefs");
+const {PageMod} = require("sdk/page-mod");
+const {data} = require("sdk/self");
+const {parseHTMLText} = require("lib/MetadataParser");
+const {Cu} = require("chrome");
+
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyGetter(this, "EventEmitter", function() {
+  const {EventEmitter} = Cu.import("resource://devtools/shared/event-emitter.js", {});
+  return EventEmitter;
+});
+
+class PageScraper {
+  constructor() {
+    EventEmitter.decorate(this);
+    this.pageMod = null;
+    this.enabled = false;
+
+    simplePrefs.on(PageScraper.PAGE_SCRAPER_PREF, () => {
+      const newEnabledValue = simplePrefs.prefs[PageScraper.PAGE_SCRAPER_PREF];
+      if (newEnabledValue && !this.enabled) {
+        this.load();
+      } else if (!newEnabledValue && this.enabled) {
+        this.unload();
+      }
+    });
+    if (simplePrefs.prefs[PageScraper.PAGE_SCRAPER_PREF]) {
+      this.load();
+    }
+  }
+  parseAndSave(raw, url) {
+    parseHTMLText(raw, url)
+      .then(metadata => {
+        // Todo: save in store
+        console.log(metadata); // eslint-disable-line no-console
+        Services.obs.notifyObservers(null, PageScraper.PAGE_PARSED_NOTIF, JSON.stringify(metadata));
+      });
+  }
+  observe(subject, topic, data) {
+    this.emit(topic, data);
+  }
+  load() {
+    if (this.pageMod) {
+      return;
+    }
+    Services.obs.addObserver(this, PageScraper.PAGE_PARSED_NOTIF);
+    this.pageMod = PageMod({
+      include: "*",
+      attachTo: ["existing", "top"],
+      contentScriptFile: data.url("page-scraper-content-script.js"),
+      onAttach: worker => {
+        worker.port.on("message", action => {
+          if (action.type === "PAGE_HTML") {
+            this.parseAndSave(action.data.text, action.data.url);
+          }
+        });
+      }
+    });
+    this.enabled = true;
+  }
+  unload() {
+    if (this.enabled) {
+      Services.obs.removeObserver(this, PageScraper.PAGE_PARSED_NOTIF);
+      this.pageMod.destroy();
+    }
+    this.pageMod = null;
+    this.enabled = false;
+  }
+}
+
+PageScraper.PAGE_SCRAPER_PREF = "page.scraper";
+PageScraper.PAGE_PARSED_NOTIF = "page-scraper-page-parsed";
+
+exports.PageScraper = PageScraper;

--- a/lib/vendor-src.js
+++ b/lib/vendor-src.js
@@ -9,5 +9,7 @@ try {
 }
 
 platform_exports = Object.assign(platform_exports, {
-  SeedRandom: require("seedrandom")
+  SeedRandom: require("seedrandom"),
+  PageMetadataParser: require("page-metadata-parser"),
+  url: require("url")
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "history": "1.17.0",
     "lodash.debounce": "4.0.6",
     "moment": "2.11.2",
+    "page-metadata-parser": "^0.2.0",
     "react": "0.14.8",
     "react-dom": "0.14.8",
     "react-json-inspector": "6.1.3",
@@ -143,6 +144,12 @@
       "title": "Show me recommendations",
       "type": "bool",
       "value": true
+    },
+    {
+      "name": "page.scraper",
+      "title": "Turn on page metadata scraper",
+      "type": "bool",
+      "value": false
     }
   ],
   "repository": "mozilla/activity-stream",

--- a/test/test-MetadataParser.js
+++ b/test/test-MetadataParser.js
@@ -1,0 +1,47 @@
+const test = require("sdk/test");
+const {
+  getDocumentObject,
+  tempFixUrls,
+  parseHTMLText,
+  parseByURL
+} = require("lib/MetadataParser");
+
+const TEST_HTML = `<html>
+  <head>
+    <title>Test Page</title>
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+</html>`;
+
+exports["test getDocumentObject"] = assert => {
+  const result = getDocumentObject(TEST_HTML);
+  assert.ok(result, "creates a document object");
+  assert.equal(result.querySelector("title").textContent, "Test Page", "document.querySelector works");
+};
+
+exports["test tempFixUrls"] = assert => {
+  const result = tempFixUrls({
+    image_url: "blah.jpg",
+    icon_url: "//blah.com/favicon.png",
+    url: "http://foo.com"
+  }, "//foo.com");
+  assert.ok(result, "returns a metadata object");
+  assert.equal(result.image_url, "https://foo.com/blah.jpg", "resolves image_url, relative urls");
+  assert.equal(result.icon_url, "https://blah.com/favicon.png", "resolves image_url, protocol relative urls");
+  assert.equal(result.url, "http://foo.com/", "resolves url, leaves absolute urls alone");
+};
+
+exports["test parseHTMLText"] = function*(assert) {
+  const result = yield parseHTMLText(TEST_HTML, "https://foo.com");
+  assert.ok(result, "Returns a metadata object");
+  assert.equal(result.title, "Test Page", "title is Test Page");
+  assert.equal(result.favicon_url, "https://foo.com/favicon.ico", "favicon is https://foo.com/favicon.ico");
+};
+
+exports["test parseByURL"] = function*(assert) {
+  const result = yield parseByURL("http://example.com");
+  assert.ok(result, "Returns a metadata object");
+  assert.ok(result.url, "http://example.com");
+};
+
+test.run(exports);

--- a/test/test-PageScraper.js
+++ b/test/test-PageScraper.js
@@ -1,0 +1,28 @@
+const test = require("sdk/test");
+const {before, after} = require("sdk/test/utils");
+const {PageScraper} = require("lib/PageScraper");
+const simplePrefs = require("sdk/simple-prefs");
+
+let ps;
+let prevPrefValue;
+
+function setPref(value) {
+  simplePrefs.prefs[PageScraper.PAGE_SCRAPER_PREF] = value;
+}
+
+exports["test PageScraper"] = assert => {
+  assert.ok(ps.pageMod, "has .pageMod");
+};
+
+before(exports, () => {
+  prevPrefValue = simplePrefs.prefs[PageScraper.PAGE_SCRAPER_PREF];
+  ps = new PageScraper();
+  setPref(true);
+});
+
+after(exports, () => {
+  ps.unload();
+  setPref(prevPrefValue);
+});
+
+test.run(exports);


### PR DESCRIPTION
This patch adds metadata parsing and page scraping. There are two parts:
- a `MetadataParser`, which takes a url or a raw html as text
- a `PageScraper` which uses `MetadataParser` to parse pages as they are loaded in the browser. By default it is pref'ed off.

It's not yet hooked up to the metadata db since it kind of depends on implementing update/insert, and I figured it would be better as a subsequent patch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/904)
<!-- Reviewable:end -->
