### PR TITLE
feat(content): #870 Turn recommendations on as experiment

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -42,7 +42,9 @@ const am = new ActionManager([
   "NOTIFY_UPDATE_SEARCH_STRING",
   "NOTIFY_BLOCK_RECOMMENDATION",
   "NOTIFY_TOGGLE_RECOMMENDATIONS",
-  "RECEIVE_RECOMMENDATION_TOGGLE"
+  "RECEIVE_RECOMMENDATION_TOGGLE",
+  "PREFS_REQUEST",
+  "PREFS_RESPONSE"
 ]);
 
 // This is a a set of actions that have sites in them,
@@ -126,6 +128,10 @@ function RequestMoreRecentLinks(beforeDate) {
 
 function RequestHighlightsLinks() {
   return RequestExpect("HIGHLIGHTS_LINKS_REQUEST", "HIGHLIGHTS_LINKS_RESPONSE");
+}
+
+function RequestInitialPrefs() {
+  return RequestExpect("PREFS_REQUEST", "PREFS_RESPONSE");
 }
 
 function RequestSearchState() {
@@ -235,6 +241,7 @@ am.defineActions({
   RequestRecentLinks,
   RequestMoreRecentLinks,
   RequestHighlightsLinks,
+  RequestInitialPrefs,
   RequestSearchState,
   RequestSearchStrings,
   RequestSearchSuggestions,

--- a/common/event-constants.js
+++ b/common/event-constants.js
@@ -24,7 +24,8 @@ const constants = {
     "SHARE",
     "UNBLOCK",
     "UNBLOCK_ALL",
-    "TOGGLE_RECOMMENDATION"
+    "TOGGLE_RECOMMENDATION",
+    "NEW_RECOMMENDATION"
   ]),
   sources: new Set([
     "TOP_SITES",

--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -11,6 +11,8 @@ const Base = React.createClass({
 
     this.props.dispatch(actions.RequestHighlightsLinks());
 
+    this.props.dispatch(actions.RequestInitialPrefs());
+
     this.props.dispatch(actions.RequestBookmarks());
 
     this.props.dispatch(actions.RequestSearchState());

--- a/content-src/components/LinkMenu/LinkMenu.js
+++ b/content-src/components/LinkMenu/LinkMenu.js
@@ -8,17 +8,20 @@ const LinkMenu = React.createClass({
   getDefaultProps() {
     return {
       visible: false,
-      allowBlock: true
+      allowBlock: true,
+      site: {}
     };
   },
   userEvent(event) {
-    const {page, source, index, dispatch} = this.props;
+    const {page, source, index, dispatch, site} = this.props;
     if (page && source) {
       let payload = {
         event,
         page: page,
         source: source,
-        action_position: index
+        action_position: index,
+        url: site.recommended ? site.url : null,
+        recommender_type: site.recommended ? site.recommender_type : null
       };
       dispatch(actions.NotifyEvent(payload));
     }
@@ -116,7 +119,9 @@ LinkMenu.propTypes = {
   // This is for events
   page: React.PropTypes.string,
   source: React.PropTypes.string,
-  index: React.PropTypes.number
+  index: React.PropTypes.number,
+  url: React.PropTypes.string,
+  recommender_type: React.PropTypes.string
 };
 
 module.exports = connect(({Experiments}) => {

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -18,16 +18,19 @@ const NewTabPage = React.createClass({
   getInitialState() {
     return {
       showSettingsMenu: false,
-      renderedOnce: false
+      renderedOnce: false,
+      showRecommendations: true,
     };
   },
   toggleRecommendation() {
     this.props.dispatch(actions.NotifyEvent({
       event: "TOGGLE_RECOMMENDATION",
-      page: PAGE_NAME
+      page: PAGE_NAME,
+      showRecommendations: !this.state.showRecommendations
     }));
     this.props.dispatch(actions.NotifyToggleRecommendations());
     this.props.dispatch(actions.RequestHighlightsLinks());
+    this.setState({showRecommendations: !this.state.showRecommendations});
   },
   componentDidMount() {
     document.title = "New Tab";

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -134,7 +134,9 @@ const Spotlight = React.createClass({
         event: "CLICK",
         page: this.props.page,
         source: "FEATURED",
-        action_position: index
+        action_position: index,
+        url: site.recommended ? site.url : null,
+        recommender_type: site.recommended ? site.recommender_type : null
       }));
       if (site.recommended) {
         this.props.dispatch(actions.NotifyBlockRecommendation(site.url));

--- a/content-src/reducers/Experiments.js
+++ b/content-src/reducers/Experiments.js
@@ -1,5 +1,5 @@
 const definitions = require("../../experiments.json");
-const defaultState = {values: {}, error: false};
+const defaultState = {values: {}, error: false, init: false};
 
 // Start with control values
 Object.keys(definitions).forEach(key => {
@@ -19,6 +19,7 @@ module.exports = function Experiments(prevState = defaultState, action) {
     };
   } else {
     return {
+      init: true,
       error: false,
       values: action.data
     };

--- a/content-src/reducers/SetRowsOrError.js
+++ b/content-src/reducers/SetRowsOrError.js
@@ -64,6 +64,10 @@ module.exports = function setRowsOrError(requestType, responseType, querySize) {
           }
         });
         break;
+      case am.type("PREFS_RESPONSE"):
+      case am.type("RECEIVE_RECOMMENDATION_TOGGLE"):
+        state.recommendationShown = action.data.recommendationStatus;
+        break;
       case am.type("NOTIFY_BLOCK_URL"):
       case am.type("NOTIFY_HISTORY_DELETE"):
         state.rows = prevState.rows.filter(val => val.url !== action.data);

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -94,9 +94,10 @@ module.exports.selectNewTabSites = createSelector(
   [
     selectTopSites,
     state => state.History,
-    selectSpotlight
+    selectSpotlight,
+    state => state.Experiments
   ],
-  (TopSites, History, Spotlight) => {
+  (TopSites, History, Spotlight, Experiments) => {
 
     // Remove duplicates
     // Note that we have to limit the length of topsites, spotlight so we
@@ -119,7 +120,8 @@ module.exports.selectNewTabSites = createSelector(
       TopSites: Object.assign({}, TopSites, {rows: topSitesRows}),
       Spotlight: Object.assign({}, Spotlight, {rows: spotlightRows}),
       TopActivity: Object.assign({}, History, {rows: historyRows}),
-      isReady: TopSites.init && History.init && Spotlight.init
+      isReady: TopSites.init && History.init && Spotlight.init && Experiments.init,
+      showRecommendationOption: Experiments.values.recommendedHighlight
     };
   }
 );

--- a/content-src/static/img/glyph-pocket-16.svg
+++ b/content-src/static/img/glyph-pocket-16.svg
@@ -7,7 +7,6 @@
     path {
       fill: #999999;
     }
-
   </style>
 
 

--- a/content-src/styles/icons.scss
+++ b/content-src/styles/icons.scss
@@ -78,5 +78,4 @@
   &.icon-pocket {
     background-image: url('img/glyph-pocket-16.svg');
   }
-
 }

--- a/content-test/components/LinkMenu.test.js
+++ b/content-test/components/LinkMenu.test.js
@@ -146,7 +146,7 @@ describe("LinkMenu", () => {
     function checkBlockRecommendation(options) {
       it(`should ${options.ref} recommendation`, done => {
         let count = 0;
-        setup({site: {url: "https://foo.com", recommended: true}}, {dispatch(action) {
+        setup({site: {url: "https://foo.com", recommender_type: "pocket-trending", recommended: true}}, {dispatch(action) {
           if (action.type === options.event) {
             assert.deepEqual(action.data, options.eventData, "event data");
             count++;
@@ -156,6 +156,8 @@ describe("LinkMenu", () => {
             assert.equal(action.data.page, DEFAULT_PROPS.page);
             assert.equal(action.data.source, DEFAULT_PROPS.source);
             assert.equal(action.data.action_position, DEFAULT_PROPS.index);
+            assert.equal(action.data.url, "https://foo.com");
+            assert.equal(action.data.recommender_type, "pocket-trending");
             count++;
           }
           if (count === 2) {

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -61,6 +61,11 @@ describe("NewTabPage", () => {
       TestUtils.Simulate.click(instance.refs.settingsLink);
       assert.equal(instance.refs.settingsMenu.props.visible, true);
     });
+    it("should show the setting button if we have recommendations", () => {
+      let fakePropsWithRecommendations = Object.assign({}, mockData, {showRecommendationOption: true});
+      instance = renderWithProvider(<NewTabPage {...fakePropsWithRecommendations} dispatch={() => {}} />);
+      assert.equal(instance.refs.settingsLink.hidden, false);
+    });
   });
 
   describe("hide recommendations", () => {

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -32,17 +32,37 @@ describe("Spotlight", function() {
   });
 
   describe("actions", () => {
-    it("should fire a click event an item is clicked", done => {
+    it("should fire a click event an item is clicked without a url or recommender type if it is not a recommendation", done => {
       function dispatch(a) {
         if (a.type === "NOTIFY_USER_EVENT") {
           assert.equal(a.data.event, "CLICK");
           assert.equal(a.data.page, "NEW_TAB");
           assert.equal(a.data.source, "FEATURED");
           assert.equal(a.data.action_position, 0);
+          assert.equal(a.data.url, null);
+          assert.equal(a.data.recommender_type, null);
           done();
         }
       }
       instance = renderWithProvider(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSpotlightItems} />);
+      TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
+    });
+    it("should fire a click event an item is clicked with url and recommender type when site is a recommendation", done => {
+      function dispatch(a) {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.event, "CLICK");
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "FEATURED");
+          assert.equal(a.data.action_position, 0);
+          assert.equal(a.data.url, fakeRecommendation.url);
+          assert.equal(a.data.recommender_type, fakeRecommendation.recommender_type);
+          done();
+        }
+      }
+      let fakeSitesWithRecommendation = fakeSpotlightItems;
+      let fakeRecommendation =  {url: "http://example.com", recommender_type: "pocket-trending", recommended: true};
+      fakeSitesWithRecommendation[0] = Object.assign({}, fakeSitesWithRecommendation[0], fakeRecommendation);
+      instance = renderWithProvider(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSitesWithRecommendation} />);
       TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
     });
   });

--- a/content-test/reducers/SetRowsOrError.test.js
+++ b/content-test/reducers/SetRowsOrError.test.js
@@ -165,4 +165,15 @@ describe("setRowsOrError", () => {
     assert.deepEqual(state.rows, [{url: "http://bar.com", bookmarkGuid: "boorkmarkBAR"}]);
   });
 
+  it("should set the 'recommendationShown' status on RECEIVE_RECOMMENDATION_TOGGLE", () => {
+    const action = {type: "RECEIVE_RECOMMENDATION_TOGGLE", data: {recommendationStatus: false}};
+    const state = reducer(undefined, action);
+    assert.isFalse(state.recommendationShown);
+  });
+
+  it("should get the inital 'recommendationShown' status when prefs are requested", () => {
+    const action = {type: "PREFS_RESPONSE", data: {recommendationStatus: true}};
+    const state = reducer(undefined, action);
+    assert.isTrue(state.recommendationShown);
+  });
 });

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -184,7 +184,8 @@ describe("selectors", () => {
       [
         "Spotlight",
         "TopActivity",
-        "TopSites"
+        "TopSites",
+        "showRecommendationOption"
       ].forEach(prop => {
         assert.property(state, prop);
       });
@@ -195,6 +196,14 @@ describe("selectors", () => {
     it("should dedupe TopSites, Spotlight, and TopActivity", () => {
       const groups = [state.TopSites.rows, state.Spotlight.rows, state.TopActivity.rows];
       assert.deepEqual(groups, dedupe.group(groups));
+    });
+    it("should not give showRecommendationOption if we are not in the experiment", () => {
+      assert.deepEqual(state.showRecommendationOption, undefined);
+    });
+    it("should give a showRecommendationOption if we are in the experiment", () => {
+      const experimentsData = {Experiments: {values: {recommendedHighlight: true}}};
+      state = selectNewTabSites(Object.assign({}, fakeState, experimentsData));
+      assert.isTrue(state.showRecommendationOption);
     });
   });
   describe("selectSiteIcon", () => {

--- a/content-test/test-utils.js
+++ b/content-test/test-utils.js
@@ -38,7 +38,7 @@ function overrideConsoleError(onError = () => {}) {
 
 module.exports = {
   rawMockData: mockData,
-  mockData: Object.assign({}, mockData, selectNewTabSites(mockData), {showRecommendationOption: true}),
+  mockData: Object.assign({}, mockData, selectNewTabSites(mockData)),
   createMockProvider,
   renderWithProvider,
   faker: require("test/faker"),

--- a/experiments.json
+++ b/experiments.json
@@ -27,5 +27,19 @@
       "threshold": 0.5,
       "description": "Block is first, delete is second"
     }
+  },
+  "recommendedHighlight": {
+    "name": "Recommended Highlights",
+    "description": "Show a recommendation from Pocket to the user",
+    "control": {
+      "value": false,
+      "description": "Do not show a recommendation"
+    },
+    "variant": {
+      "id": "exp-002-recommended-highlights",
+      "value": true,
+      "threshold": 0.3,
+      "description": "Show a recommendation in the third highlights spot"
+    }
   }
 }

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -112,7 +112,7 @@ function ActivityStreams(metadataStore, options = {}) {
 
   // Only create RecommendationProvider if they are in the experiment
   if (this._experimentProvider.data.recommendedHighlight) {
-    this._recommendationProvider = new RecommendationProvider(this._previewProvider);
+    this._recommendationProvider = new RecommendationProvider(this._previewProvider, this._tabTracker);
     if (simplePrefs.prefs.recommendations) {
       this._recommendationProvider.asyncSetRecommendedContent();
     }

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -284,6 +284,10 @@ ActivityStreams.prototype = {
     this.send(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data), worker);
   },
 
+  _respondToInitialPrefsRequest() {
+    this.broadcast(am.actions.Response("PREFS_RESPONSE", {recommendationStatus: simplePrefs.prefs.recommendations}));
+  },
+
   /**
    * Handles changes to places
    */
@@ -339,6 +343,8 @@ ActivityStreams.prototype = {
         return this._handleUserEvent(args);
       case am.type("EXPERIMENTS_REQUEST"):
         return this._respondToExperimentsRequest(args);
+      case am.type("PREFS_REQUEST"):
+        return this._respondToInitialPrefsRequest();
       case am.type("NOTIFY_TOGGLE_RECOMMENDATIONS"):
         return this._respondToRecommendationToggle();
     }

--- a/lib/RecommendationProvider.js
+++ b/lib/RecommendationProvider.js
@@ -7,7 +7,7 @@ const simplePrefs = require("sdk/simple-prefs");
 const POCKET_API_URL = "pocket.endpoint";
 
 const DEFAULT_TIMEOUTS = {
-  pocketTimeout: 60000, // every 10 minutes, refresh the Pocket recommendations
+  pocketTimeout: 60 * 60 * 1000, // every 1 hour, refresh the Pocket recommendations
 };
 
 Cu.import("resource://gre/modules/Task.jsm");

--- a/lib/RecommendationProvider.js
+++ b/lib/RecommendationProvider.js
@@ -137,8 +137,8 @@ RecommendationProvider.prototype = {
     */
   uninit() {
     clearTimeout(this._pocketTimeoutID);
-    this._recommendedContent = new Set();
-    this._blockedRecommendedContent = [];
+    this._recommendedContent = [];
+    this._blockedRecommendedContent = new Set();
     this._currentRecommendation = null;
   }
 };

--- a/lib/RecommendationProvider.js
+++ b/lib/RecommendationProvider.js
@@ -13,13 +13,14 @@ const DEFAULT_TIMEOUTS = {
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.importGlobalProperties(["fetch"]);
 
-function RecommendationProvider(previewProvider, options = {}) {
+function RecommendationProvider(previewProvider, tabTracker, options = {}) {
   this.options = Object.assign({}, DEFAULT_TIMEOUTS, options);
   this._recommendedContent = [];
   this._blockedRecommendedContent = new Set();
   this._currentRecommendation = null;
   this._pocketEndpoint = simplePrefs.prefs[POCKET_API_URL];
   this._previewProvider = previewProvider;
+  this._tabTracker = tabTracker;
   this._asyncUpdateRecommendations(this.options.pocketTimeout);
 }
 
@@ -39,7 +40,21 @@ RecommendationProvider.prototype = {
       return this._currentRecommendation;
     }
     this._currentRecommendation = this._getRandomRecommendation();
+    this._handleNewRecommendationEvent(this._currentRecommendation);
     return this._currentRecommendation;
+  },
+
+  /**
+    * Handle the NEW_RECOMMENDATION event
+    */
+  _handleNewRecommendationEvent(currentRecommendation) {
+    let url = currentRecommendation ? currentRecommendation.url : null;
+    let recommenderType = currentRecommendation ? currentRecommendation.recommender_type : null;
+    this._tabTracker.handleUserEvent({
+      event: "NEW_RECOMMENDATION",
+      url: url,
+      recommender_type: recommenderType
+    });
   },
 
   /**
@@ -52,17 +67,23 @@ RecommendationProvider.prototype = {
       return Object.assign({}, {
         url: allowedRecommendations[index].url,
         timestamp: allowedRecommendations[index].timestamp,
-        recommended: true});
+        recommended: true,
+        recommender_type: "pocket-trending"});
     }
     return null;
   },
 
   /**
     * Fetches Pocket recommendations and saves them to a global list of recommended content
+    * and collect some metrics on the network latency
     */
   asyncSetRecommendedContent: Task.async(function*() {
     try {
+      let event = this._tabTracker.generateEvent();
+      let startNetworkCall = Date.now();
       let response = yield this._asyncGetRecommendationsFromPocket();
+      let endNetworkCall = Date.now();
+      this._tabTracker.handlePerformanceEvent(event, "pocketProxyRequestTime", endNetworkCall - startNetworkCall);
       if (response.ok) {
         let responseJson = yield response.json();
         if (responseJson.urls.length > 0) {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
       "name": "recommendations",
       "title": "Show me recommendations",
       "type": "bool",
-      "value": false
+      "value": true
     }
   ],
   "repository": "mozilla/activity-stream",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
       "name": "pocket.endpoint",
       "title": "Pocket Endpoint",
       "type": "string",
-      "value": "",
+      "value": "https://embedly-proxy.services.mozilla.com/v2/recommendations",
       "hidden": true
     },
     {

--- a/test/test-RecommendationProvider.js
+++ b/test/test-RecommendationProvider.js
@@ -139,6 +139,7 @@ exports.test_random_recommendation = function*(assert) {
   assert.equal(recommendation.url, fakeRecommendedContent[0].url, "we picked the correct url");
   assert.equal(recommendation.timestamp, fakeRecommendedContent[0].timestamp, "it has the correct timestamp");
   assert.ok(recommendation.recommended, "it's been stamped as a recommended url");
+  assert.ok(recommendation.recommender_type, "it's been stamped with a recommender type");
 
   // getting a random recommendation should return null if there are no recommendations to show
   fakeRecommendedContent = [];
@@ -157,7 +158,8 @@ before(exports, function*() {
       return a;
     }
   };
-  gRecommendationProvider = new RecommendationProvider(mockPreviewProvider);
+  const mockTabTracker = {handleUserEvent: function() {}, generateEvent: function() {}, handlePerformanceEvent: function() {}};
+  gRecommendationProvider = new RecommendationProvider(mockPreviewProvider, mockTabTracker);
 });
 
 after(exports, function*() {


### PR DESCRIPTION
This sets up recommendations as an experiment and flips the pref on
Last patch for #870 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/906)
<!-- Reviewable:end -->
