### PR TITLE
fix(content): #657 Restructure TopSite to remove stopPropagation

### DIFF
--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -44,13 +44,12 @@ const TopSites = React.createClass({
           return (<div className="tile-outer" key={site.guid || site.cacheKey || i}>
             <a onClick={() => this.onClick(i)} className={classNames("tile", {active: isActive})} href={site.url}>
               <SiteIcon className="tile-img-container" site={site} faviconSize={32} showTitle />
-              <LinkMenuButton onClick={(ev) => {
-                ev.preventDefault();
-                ev.stopPropagation();
-                this.setState({showContextMenu: true, activeTile: i});
-              }} />
               <div className="inner-border" />
             </a>
+            <LinkMenuButton onClick={(ev) => {
+              ev.preventDefault();
+              this.setState({showContextMenu: true, activeTile: i});
+            }} />
             <LinkMenu
               visible={isActive}
               onUpdate={val => this.setState({showContextMenu: val})}

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -9,6 +9,7 @@
 
   // This is a container for the delete menu
   .tile-outer {
+    @include link-menu-button;
     position: relative;
     display: inline-block;
     margin: 0 $tile-gutter 0 0;
@@ -19,7 +20,6 @@
 
   .tile {
     @include item-shadow;
-    @include link-menu-button;
     display: inline-flex;
     flex-shrink: 0;
     border-radius: $border-radius;


### PR DESCRIPTION
This patch fixes a weird issue where if you open a `ContextMenu` in Highlights and then open one in `TopSites`, the original one doesn't close. `stopPropagation` was messing with the window listener.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/924)
<!-- Reviewable:end -->
