### PR TITLE
feat(content): Add redux flow to recommendations

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -42,7 +42,9 @@ const am = new ActionManager([
   "NOTIFY_UPDATE_SEARCH_STRING",
   "NOTIFY_BLOCK_RECOMMENDATION",
   "NOTIFY_TOGGLE_RECOMMENDATIONS",
-  "RECEIVE_RECOMMENDATION_TOGGLE"
+  "RECEIVE_RECOMMENDATION_TOGGLE",
+  "PREFS_REQUEST",
+  "PREFS_RESPONSE"
 ]);
 
 // This is a a set of actions that have sites in them,
@@ -126,6 +128,10 @@ function RequestMoreRecentLinks(beforeDate) {
 
 function RequestHighlightsLinks() {
   return RequestExpect("HIGHLIGHTS_LINKS_REQUEST", "HIGHLIGHTS_LINKS_RESPONSE");
+}
+
+function RequestInitialPrefs() {
+  return RequestExpect("PREFS_REQUEST", "PREFS_RESPONSE");
 }
 
 function RequestSearchState() {
@@ -235,6 +241,7 @@ am.defineActions({
   RequestRecentLinks,
   RequestMoreRecentLinks,
   RequestHighlightsLinks,
+  RequestInitialPrefs,
   RequestSearchState,
   RequestSearchStrings,
   RequestSearchSuggestions,

--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -11,6 +11,8 @@ const Base = React.createClass({
 
     this.props.dispatch(actions.RequestHighlightsLinks());
 
+    this.props.dispatch(actions.RequestInitialPrefs());
+
     this.props.dispatch(actions.RequestBookmarks());
 
     this.props.dispatch(actions.RequestSearchState());

--- a/content-src/reducers/SetRowsOrError.js
+++ b/content-src/reducers/SetRowsOrError.js
@@ -64,6 +64,10 @@ module.exports = function setRowsOrError(requestType, responseType, querySize) {
           }
         });
         break;
+      case am.type("PREFS_RESPONSE"):
+      case am.type("RECEIVE_RECOMMENDATION_TOGGLE"):
+        state.recommendationShown = action.data.recommendationStatus;
+        break;
       case am.type("NOTIFY_BLOCK_URL"):
       case am.type("NOTIFY_HISTORY_DELETE"):
         state.rows = prevState.rows.filter(val => val.url !== action.data);

--- a/content-test/reducers/SetRowsOrError.test.js
+++ b/content-test/reducers/SetRowsOrError.test.js
@@ -165,4 +165,15 @@ describe("setRowsOrError", () => {
     assert.deepEqual(state.rows, [{url: "http://bar.com", bookmarkGuid: "boorkmarkBAR"}]);
   });
 
+  it("should set the 'recommendationShown' status on RECEIVE_RECOMMENDATION_TOGGLE", () => {
+    const action = {type: "RECEIVE_RECOMMENDATION_TOGGLE", data: {recommendationStatus: false}};
+    const state = reducer(undefined, action);
+    assert.isFalse(state.recommendationShown);
+  });
+
+  it("should get the inital 'recommendationShown' status when prefs are requested", () => {
+    const action = {type: "PREFS_RESPONSE", data: {recommendationStatus: true}};
+    const state = reducer(undefined, action);
+    assert.isTrue(state.recommendationShown);
+  });
 });

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -284,6 +284,10 @@ ActivityStreams.prototype = {
     this.send(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data), worker);
   },
 
+  _respondToInitialPrefsRequest() {
+    this.broadcast(am.actions.Response("PREFS_RESPONSE", {recommendationStatus: simplePrefs.prefs.recommendations}));
+  },
+
   /**
    * Handles changes to places
    */
@@ -339,6 +343,8 @@ ActivityStreams.prototype = {
         return this._handleUserEvent(args);
       case am.type("EXPERIMENTS_REQUEST"):
         return this._respondToExperimentsRequest(args);
+      case am.type("PREFS_REQUEST"):
+        return this._respondToInitialPrefsRequest();
       case am.type("NOTIFY_TOGGLE_RECOMMENDATIONS"):
         return this._respondToRecommendationToggle();
     }

--- a/lib/RecommendationProvider.js
+++ b/lib/RecommendationProvider.js
@@ -137,8 +137,8 @@ RecommendationProvider.prototype = {
     */
   uninit() {
     clearTimeout(this._pocketTimeoutID);
-    this._recommendedContent = new Set();
-    this._blockedRecommendedContent = [];
+    this._recommendedContent = [];
+    this._blockedRecommendedContent = new Set();
     this._currentRecommendation = null;
   }
 };


### PR DESCRIPTION
This change:
1. adds the redux part to actually show recommendations. 
2. fixes a typo I had in RecommendationProvider which went unnoticed because it was never being invoked until now


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/938)
<!-- Reviewable:end -->
