### PR TITLE
fix(content): #978 Put the active class on the tile-outer container instead of on the tile link.

### DIFF
--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -41,8 +41,8 @@ const TopSites = React.createClass({
       <div className="tiles-wrapper">
         {sites.map((site, i) => {
           const isActive = this.state.showContextMenu && this.state.activeTile === i;
-          return (<div className="tile-outer" key={site.guid || site.cache_key || i}>
-            <a onClick={() => this.onClick(i)} className={classNames("tile", {active: isActive})} href={site.url}>
+          return (<div className={classNames("tile-outer", {active: isActive})} key={site.guid || site.cache_key || i}>
+            <a onClick={() => this.onClick(i)} className="tile" href={site.url}>
               <SiteIcon className="tile-img-container" site={site} faviconSize={32} showTitle />
               <div className="inner-border" />
             </a>

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -64,6 +64,13 @@ describe("TopSites", () => {
       const menu = TestUtils.scryRenderedComponentsWithType(topSites, LinkMenu)[0];
       assert.equal(menu.props.visible, true);
     });
+
+    it("should make the tile active when link menu button is clicked", () => {
+      const button = ReactDOM.findDOMNode(TestUtils.scryRenderedComponentsWithType(topSites, LinkMenuButton)[0]);
+      TestUtils.Simulate.click(button);
+      const tileOuter = el.querySelector(".tile-outer");
+      assert.include(tileOuter.className, "active");
+    });
   });
 
 });


### PR DESCRIPTION
fix #978 r?@k88hudson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/997)
<!-- Reviewable:end -->
