### PR TITLE
feat(addon): #935 Track highlight source in click pings

### DIFF
--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -104,6 +104,7 @@ const Spotlight = React.createClass({
         page: this.props.page,
         source: "FEATURED",
         action_position: index,
+        highlight_type: site.type,
         url: site.recommended ? site.url : null,
         recommender_type: site.recommended ? site.recommender_type : null
       }));

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -41,6 +41,7 @@ describe("Spotlight", function() {
           assert.equal(a.data.page, "NEW_TAB");
           assert.equal(a.data.source, "FEATURED");
           assert.equal(a.data.action_position, 0);
+          assert.equal(a.data.highlight_type, fakeSpotlightItems[0].type);
           assert.equal(a.data.url, null);
           assert.equal(a.data.recommender_type, null);
           done();
@@ -56,6 +57,7 @@ describe("Spotlight", function() {
           assert.equal(a.data.page, "NEW_TAB");
           assert.equal(a.data.source, "FEATURED");
           assert.equal(a.data.action_position, 0);
+          assert.equal(a.data.highlight_type, fakeSpotlightItems[0].type);
           assert.equal(a.data.url, fakeRecommendation.url);
           assert.equal(a.data.recommender_type, fakeRecommendation.recommender_type);
           done();


### PR DESCRIPTION
fix #935. This adds the highlight source to the click pings.

The related change for the data pipeline will be made in Splice and Infernyx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1003)
<!-- Reviewable:end -->
