### PR TITLE
fix (addon): #1013 only send tab data if there is an active tab

### DIFF
--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -115,6 +115,11 @@ TabTracker.prototype = {
   },
 
   handlePerformanceEvent(eventData, eventName, value) {
+    if (!tabs.activeTab) {
+      // short circuit out if there is no active tab
+      return;
+    }
+
     let payload = Object.assign({}, eventData);
     payload.action = "activity_stream_performance";
     payload.tab_id = tabs.activeTab.id;


### PR DESCRIPTION
Should Fix #1013 and #1022

r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1031)
<!-- Reviewable:end -->
