### PR TITLE
fix(addon): #1033 Turn on the Multiprocess compatibility flag, correct the uses of addObserver, and avoid the use of shims.

### DIFF
--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -1,7 +1,7 @@
-/* globals Services, Locale */
+/* globals Services, Locale, XPCOMUtils */
 
 const tabs = require("sdk/tabs");
-const {Cu} = require("chrome");
+const {Ci, Cu} = require("chrome");
 const self = require("sdk/self");
 const {uuid} = require("sdk/util/uuid");
 const simplePrefs = require("sdk/simple-prefs");
@@ -9,6 +9,7 @@ const eventConstants = require("../common/event-constants");
 
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Locale.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
 const TELEMETRY_PREF = "telemetry";
 const COMPLETE_NOTIF = "tab-session-complete";
@@ -24,7 +25,6 @@ function TabTracker(trackableURLs, clientID, placesQueries, experimentId) {
   this._trackableURLs = trackableURLs;
   this._placesQueries = placesQueries;
   this.onOpen = this.onOpen.bind(this);
-  this.onPerfLoadComplete = this.onPerfLoadComplete.bind(this);
 
   this._onPrefChange = this._onPrefChange.bind(this);
   this.enabled = simplePrefs.prefs[TELEMETRY_PREF];
@@ -43,7 +43,7 @@ TabTracker.prototype = {
 
   _addListeners() {
     tabs.on("open", this.onOpen);
-    Services.obs.addObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
+    Services.obs.addObserver(this, PERF_LOG_COMPLETE_NOTIF, true);
   },
 
   _removeListeners() {
@@ -58,7 +58,7 @@ TabTracker.prototype = {
     tabs.removeListener("open", this.onOpen);
 
     if (this.enabled) {
-      Services.obs.removeObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
+      Services.obs.removeObserver(this, PERF_LOG_COMPLETE_NOTIF);
     }
   },
 
@@ -294,12 +294,17 @@ TabTracker.prototype = {
     this.enabled = newValue;
   },
 
-  onPerfLoadComplete: function(subject, topic, data) {
+  observe: function(subject, topic, data) {
     let eventData = JSON.parse(data);
     if (eventData.tabId === this._tabData.tab_id) {
       this._tabData.load_latency = eventData.events[eventData.events.length - 1].start;
     }
   },
+
+  QueryInterface: XPCOMUtils.generateQI([
+    Ci.nsIObserver,
+    Ci.nsISupportsWeakReference
+  ]),
 };
 
 exports.TabTracker = TabTracker;

--- a/lib/TelemetrySender.js
+++ b/lib/TelemetrySender.js
@@ -1,8 +1,9 @@
-/* globals Services */
+/* globals Services, XPCOMUtils */
 
-const {Cu} = require("chrome");
+const {Ci, Cu} = require("chrome");
 const simplePrefs = require("sdk/simple-prefs");
 Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]);
 
 const ENDPOINT_PREF = "telemetry.ping.endpoint";
@@ -21,13 +22,18 @@ function TelemetrySender() {
   simplePrefs.on(TELEMETRY_PREF, this._onPrefChange);
   simplePrefs.on(LOGGING_PREF, this._onPrefChange);
   if (this.enabled) {
-    Services.obs.addObserver(this, COMPLETE_NOTIF);
-    Services.obs.addObserver(this, ACTION_NOTIF);
-    Services.obs.addObserver(this, PERFORMANCE_NOTIF);
+    Services.obs.addObserver(this, COMPLETE_NOTIF, true);
+    Services.obs.addObserver(this, ACTION_NOTIF, true);
+    Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
   }
 }
 
 TelemetrySender.prototype = {
+  QueryInterface: XPCOMUtils.generateQI([
+    Ci.nsIObserver,
+    Ci.nsISupportsWeakReference
+  ]),
+
   observe(subject, topic, data) {
     if (topic === COMPLETE_NOTIF || topic === ACTION_NOTIF || topic === PERFORMANCE_NOTIF) {
       this._sendPing(data);
@@ -48,9 +54,9 @@ TelemetrySender.prototype = {
         Services.obs.removeObserver(this, ACTION_NOTIF);
         Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
       } else if (!this.enabled && newValue) {
-        Services.obs.addObserver(this, COMPLETE_NOTIF);
-        Services.obs.addObserver(this, ACTION_NOTIF);
-        Services.obs.addObserver(this, PERFORMANCE_NOTIF);
+        Services.obs.addObserver(this, COMPLETE_NOTIF, true);
+        Services.obs.addObserver(this, ACTION_NOTIF, true);
+        Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
       }
 
       this.enabled = newValue;
@@ -80,6 +86,8 @@ TelemetrySender.prototype = {
     try {
       if (this.enabled) {
         Services.obs.removeObserver(this, COMPLETE_NOTIF);
+        Services.obs.removeObserver(this, ACTION_NOTIF);
+        Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
       }
       simplePrefs.removeListener(TELEMETRY_PREF, this._onPrefChange);
       simplePrefs.removeListener(ENDPOINT_PREF, this._onPrefChange);

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
   "updateLink": "https://moz-activity-streams.s3.amazonaws.com/dist/activity-streams-latest.xpi",
   "updateURL": "https://moz-activity-streams.s3.amazonaws.com/dist/update.rdf",
   "permissions": {
+    "multiprocess": true,
     "private-browsing": true
   }
 }

--- a/test/lib/cachePromises.js
+++ b/test/lib/cachePromises.js
@@ -13,7 +13,7 @@ let makeCachePromise = (name) => {
         resolve();
       }
     };
-    Services.obs.addObserver(waitForCache, precacheNotif);
+    Services.obs.addObserver(waitForCache, precacheNotif, false);
   });
 };
 
@@ -30,7 +30,7 @@ let makeCountingCachePromise = (name, target) => {
         }
       }
     };
-    Services.obs.addObserver(waitForCache, precacheNotif);
+    Services.obs.addObserver(waitForCache, precacheNotif, false);
   });
 };
 

--- a/test/test-ActivityStreams-places-caching.js
+++ b/test/test-ActivityStreams-places-caching.js
@@ -51,7 +51,7 @@ let makeNotifsPromise = (cacheStatus) => {
     };
 
     for (let notif of notifSet) {
-      Services.obs.addObserver(observer, notif);
+      Services.obs.addObserver(observer, notif, false);
     }
   });
 };
@@ -199,7 +199,7 @@ exports["test rebuilds don't clobber each other"] = function*(assert) {
       notifCount++;
     }
   };
-  Services.obs.addObserver(countNotif, notif);
+  Services.obs.addObserver(countNotif, notif, false);
 
   // phase 1: add history visit and count
   placesCachePromise = makeCachePromise("places");

--- a/test/test-PerfMeter.js
+++ b/test/test-PerfMeter.js
@@ -37,7 +37,7 @@ function openTestTab(openUrl, notifyEvent) {
     }
 
     if (notifyEvent) {
-      Services.obs.addObserver(onNotify, notifyEvent);
+      Services.obs.addObserver(onNotify, notifyEvent, false);
     }
 
     // open the page in timeout, to make it fire after we return
@@ -51,7 +51,7 @@ function prefSetter(value) {
       Services.obs.removeObserver(onPrefChange, "performance-pref-changed");
       resolve();
     }
-    Services.obs.addObserver(onPrefChange, "performance-pref-changed");
+    Services.obs.addObserver(onPrefChange, "performance-pref-changed", false);
     simplePrefs.prefs["performance.log"] = value;
   });
 }
@@ -128,7 +128,7 @@ exports.test_PerfMeter_events = function*(assert) {
       Services.obs.removeObserver(onNotify, "performance-log-complete");
       resolve();
     }
-    Services.obs.addObserver(onNotify, "performance-log-complete");
+    Services.obs.addObserver(onNotify, "performance-log-complete", false);
     tabData.tab.reload();
   });
 
@@ -268,7 +268,7 @@ exports.test_PerfMeter_tab_restore = function*(assert) {
       Services.obs.removeObserver(onNotify, "performance-log-complete");
       resolve(tab);
     }
-    Services.obs.addObserver(onNotify, "performance-log-complete");
+    Services.obs.addObserver(onNotify, "performance-log-complete", false);
     tab = gBrowser.addTab(appUrl);
   });
 
@@ -285,7 +285,7 @@ exports.test_PerfMeter_tab_restore = function*(assert) {
       Services.obs.removeObserver(onRestore, "sessionstore-debug-tab-restored");
       resolve(tab);
     }
-    Services.obs.addObserver(onRestore, "sessionstore-debug-tab-restored");
+    Services.obs.addObserver(onRestore, "sessionstore-debug-tab-restored", false);
     tab = SessionStore.undoCloseTab(browserWindow);
   });
 
@@ -296,7 +296,7 @@ exports.test_PerfMeter_tab_restore = function*(assert) {
       Services.obs.removeObserver(onNotify, "performance-log-complete");
       resolve();
     }
-    Services.obs.addObserver(onNotify, "performance-log-complete");
+    Services.obs.addObserver(onNotify, "performance-log-complete", false);
 
     tab.linkedBrowser.goBack();
   });

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -30,7 +30,7 @@ function createPingSentPromise(pingData, expectedPingCount) {
         }
       }
     }
-    Services.obs.addObserver(observe, "tab-session-complete");
+    Services.obs.addObserver(observe, "tab-session-complete", false);
   });
 }
 
@@ -58,10 +58,10 @@ function checkLoadUnloadReasons(assert, pingData, expectedLoadReasons, expectedU
         expectedKeys = EXPECTED_KEYS;
         delete ping.load_latency;
     }
-    assert.equal(Object.keys(ping).length, expectedKeys.length, "We have as many attributes as we expect");
     for (let key of expectedKeys) {
       assert.notEqual(ping[key], undefined, `${key} is an attribute in our tab data.`);
     }
+    assert.equal(Object.keys(ping).length, expectedKeys.length, "We have as many attributes as we expect");
     if (ping.load_reason !== "none") {
       assert.notEqual(ping.session_duration, 0, "session_duration is not 0");
     }
@@ -78,7 +78,7 @@ function waitForPageLoadAndSessionComplete() {
         });
       }, 10);
     }
-    Services.obs.addObserver(onPageLoaded, "performance-log-complete");
+    Services.obs.addObserver(onPageLoaded, "performance-log-complete", false);
   }
   return waitSessionComplete(onShow);
 }
@@ -105,7 +105,7 @@ function waitSessionComplete(onShow) {
       }
     }
 
-    Services.obs.addObserver(onSessionComplete, "tab-session-complete");
+    Services.obs.addObserver(onSessionComplete, "tab-session-complete", false);
   });
 }
 
@@ -392,7 +392,7 @@ exports.test_TabTracker_action_pings = function*(assert) {
         resolve(JSON.parse(data));
       }
     }
-    Services.obs.addObserver(observe, "user-action-event");
+    Services.obs.addObserver(observe, "user-action-event", false);
   });
 
   let eventData = {
@@ -443,7 +443,7 @@ exports.test_TabTracker_unload_reason_with_user_action = function*(assert) {
           resolve(JSON.parse(data));
         }
       }
-      Services.obs.addObserver(observe, "user-action-event");
+      Services.obs.addObserver(observe, "user-action-event", false);
     });
 
     let eventData = {
@@ -486,7 +486,7 @@ exports.test_TabTracker_performance_action_pings = function*(assert) {
         resolve(JSON.parse(data));
       }
     }
-    Services.obs.addObserver(observe, "performance-event");
+    Services.obs.addObserver(observe, "performance-event", false);
   });
 
   let eventData1 = {
@@ -535,7 +535,7 @@ exports.test_TabTracker_handleRouteChange = function*(assert) {
       Services.obs.removeObserver(observe, "tab-session-complete");
       resolve(JSON.parse(data));
     }
-    Services.obs.addObserver(observe, "tab-session-complete");
+    Services.obs.addObserver(observe, "tab-session-complete", false);
     app._tabTracker.onOpen(tabData);
     app._tabTracker.handleRouteChange(tabData, {isFirstLoad: false});
   });
@@ -575,7 +575,7 @@ exports.test_TabTracker_History_And_Bookmark_Reporting = function*(assert) {
       Services.obs.removeObserver(onCacheComplete, "activity-streams-places-cache-complete");
       resolve();
     }
-    Services.obs.addObserver(onCacheComplete, "activity-streams-places-cache-complete");
+    Services.obs.addObserver(onCacheComplete, "activity-streams-places-cache-complete", false);
     app._handlePlacesChanges("bookmark");
   });
 
@@ -609,7 +609,7 @@ exports.test_TabTracker_session_reports = function*(assert) {
       pingCounter++;
     }
   }
-  Services.obs.addObserver(pingBumper, "tab-session-complete");
+  Services.obs.addObserver(pingBumper, "tab-session-complete", false);
 
   // open the non-realted page
   tabs.open("http://www.example.com");
@@ -659,7 +659,7 @@ exports.test_TabTracker_disable_ping = function*(assert) {
         resolve(JSON.parse(data));
       }
     }
-    Services.obs.addObserver(observe, "user-action-event");
+    Services.obs.addObserver(observe, "user-action-event", false);
   });
 
   // manually trigger the "disable" or "uninstall" event


### PR DESCRIPTION
This seems to get us enough to turn on the multiprocess compatibility flag and to avoid the use of the shims (which may impact performance in e10s mode).

Most of the work here is to correct the uses of `Services.obs.addObserver` this is meant to take [three arguments](https://dxr.mozilla.org/mozilla-central/rev/0ba72e8027cfcbcbf3426770ac264a7ade2af090/xpcom/ds/nsIObserverService.idl#25), but for some reason with the shims / non-e10s we were getting away with two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1042)
<!-- Reviewable:end -->
