### PR TITLE
chore (addon): Add python virtual env to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ data/content/
 logs/
 firefox/
 lib/vendor.bundle.js
+activity-streams-env/


### PR DESCRIPTION
As we're using fab to do the addon deploy, eslint will check the json assets in the Python virtual environment by mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1047)
<!-- Reviewable:end -->
