### PR TITLE
fix(icon): Fix bad path to glyph-showmore-16.svg in icons.scss

### DIFF
--- a/content-src/styles/icons.scss
+++ b/content-src/styles/icons.scss
@@ -64,7 +64,7 @@
   }
 
   &.icon-showMore {
-    background-image: url('img/glyph-show-more-16.svg');
+    background-image: url('img/glyph-showmore-16.svg');
   }
 
   &.icon-timeline {


### PR DESCRIPTION
Fixes #1057

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1058)
<!-- Reviewable:end -->
