### PR TITLE
chore(addon): Closes #1007 Add type for recommendations

### DIFF
--- a/lib/RecommendationProvider.js
+++ b/lib/RecommendationProvider.js
@@ -68,7 +68,8 @@ RecommendationProvider.prototype = {
       return Object.assign({}, {
         url: allowedRecommendations[index].url,
         recommended: true,
-        recommender_type: "pocket-trending"});
+        recommender_type: "pocket-trending",
+        type: "recommended"});
     }
     return null;
   },

--- a/test/test-RecommendationProvider.js
+++ b/test/test-RecommendationProvider.js
@@ -139,6 +139,7 @@ exports.test_random_recommendation = function(assert) {
   assert.equal(recommendation.url, fakeRecommendedContent[0].url, "we picked the correct url");
   assert.ok(recommendation.recommended, "it's been stamped as a recommended url");
   assert.ok(recommendation.recommender_type, "it's been stamped with a recommender type");
+  assert.equal(recommendation.type, "recommended", "it's been stamped with a type");
 
   // getting a random recommendation should return null if there are no recommendations to show
   fakeRecommendedContent = [];


### PR DESCRIPTION
uses ```recommended``` as type, to be consistent with the type naming in ```content-src/HighlightContext/types.js``` @ncloudioj  r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1063)
<!-- Reviewable:end -->
