### PR TITLE
fix (addon): #1109, #1107 use separate window per provider and focus it on share

### DIFF
--- a/lib/ShareProvider.js
+++ b/lib/ShareProvider.js
@@ -108,7 +108,7 @@ function windowProperty(window, eventTracker) {
         if (size && size.height) {
           features = `${features},innerHeight=${size.height}`;
         }
-        window.open(shareEndpoint, "share-dialog", features);
+        window.open(shareEndpoint, `share-dialog-${provider.name}`, features).focus();
 
         eventTracker.handleUserEvent({
           event: "SHARE_FROM_TOOLBAR",


### PR DESCRIPTION
This fixes makes each provider have it's own window so you can have multiple share windows open at once. And it makes sure to focus the window on share if it was already open in the background.

r? @ncloudioj 

Fixes #1107 
Fixes #1109 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1117)
<!-- Reviewable:end -->
