### PR TITLE
fix (addon): #1111 don't add shareplane to toolbar on activation

### DIFF
--- a/lib/ShareProvider.js
+++ b/lib/ShareProvider.js
@@ -135,6 +135,10 @@ const Overlay = {
       if (win.SocialShare.shareButton) {
         win.SocialShare.shareButton.removeAttribute("hidden");
       }
+
+      // unmonkeypatch SocialActivationListener.receiveMessage
+      win.SocialActivationListener.receiveMessage = win.SocialActivationListener.originalReceiveMessage;
+      delete win.SocialActivationListener.originalReceiveMessage;
     }
   },
   observe: window => {
@@ -146,6 +150,44 @@ const Overlay = {
     if (window.SocialShare.shareButton) {
       window.SocialShare.shareButton.setAttribute("hidden", "true");
     }
+
+    // monkeypatch SocialActivationListener.receiveMessage
+    window.SocialActivationListener.originalReceiveMessage = window.SocialActivationListener.receiveMessage;
+    window.SocialActivationListener.receiveMessage = function(aMessage) {
+      // NOTE: This is a patched version of SocialActivationListener.receiveMessage
+      // that doesn't install the shareplane button to the toolbar when a new provider
+      // is activated.
+      // original code is at mozilla-central/source/browser/base/content/browser-social.js
+      let data = aMessage.json;
+      let browser = aMessage.target;
+      data.window = window;
+      const {
+        gBrowser,
+        Social,
+        SocialShare,
+        SocialSidebar
+      } = window;
+      // if the source if the message is the share panel, we do a one-click
+      // installation. The source of activations is controlled by the
+      // social.directories preference
+      let options;
+      if (browser === SocialShare.iframe && Services.prefs.getBoolPref("social.share.activationPanelEnabled")) {
+        options = {bypassContentCheck: true, bypassInstallPanel: true};
+      }
+
+      Social.installProvider(data, manifest => {
+        Social.activateFromOrigin(manifest.origin, provider => {
+          if (provider.sidebarURL) {
+            SocialSidebar.show(provider.origin);
+          }
+          if (provider.postActivationURL) {
+            // if activated from an open share panel, we load the landing page in
+            // a background tab
+            gBrowser.loadOneTab(provider.postActivationURL, {inBackground: SocialShare.panel.state === "open"});
+          }
+        });
+      }, options);
+    };
   }
 };
 

--- a/lib/ShareProvider.js
+++ b/lib/ShareProvider.js
@@ -159,7 +159,6 @@ const Overlay = {
       // is activated.
       // original code is at mozilla-central/source/browser/base/content/browser-social.js
       let data = aMessage.json;
-      let browser = aMessage.target;
       data.window = window;
       const {
         gBrowser,
@@ -167,13 +166,6 @@ const Overlay = {
         SocialShare,
         SocialSidebar
       } = window;
-      // if the source if the message is the share panel, we do a one-click
-      // installation. The source of activations is controlled by the
-      // social.directories preference
-      let options;
-      if (browser === SocialShare.iframe && Services.prefs.getBoolPref("social.share.activationPanelEnabled")) {
-        options = {bypassContentCheck: true, bypassInstallPanel: true};
-      }
 
       Social.installProvider(data, manifest => {
         Social.activateFromOrigin(manifest.origin, provider => {
@@ -186,7 +178,7 @@ const Overlay = {
             gBrowser.loadOneTab(provider.postActivationURL, {inBackground: SocialShare.panel.state === "open"});
           }
         });
-      }, options);
+      }, {});
     };
   }
 };

--- a/lib/ShareProvider.js
+++ b/lib/ShareProvider.js
@@ -163,15 +163,11 @@ const Overlay = {
       const {
         gBrowser,
         Social,
-        SocialShare,
-        SocialSidebar
+        SocialShare
       } = window;
 
       Social.installProvider(data, manifest => {
         Social.activateFromOrigin(manifest.origin, provider => {
-          if (provider.sidebarURL) {
-            SocialSidebar.show(provider.origin);
-          }
           if (provider.postActivationURL) {
             // if activated from an open share panel, we load the landing page in
             // a background tab

--- a/lib/ShareProvider.js
+++ b/lib/ShareProvider.js
@@ -162,8 +162,7 @@ const Overlay = {
       data.window = window;
       const {
         gBrowser,
-        Social,
-        SocialShare
+        Social
       } = window;
 
       Social.installProvider(data, manifest => {
@@ -171,7 +170,7 @@ const Overlay = {
           if (provider.postActivationURL) {
             // if activated from an open share panel, we load the landing page in
             // a background tab
-            gBrowser.loadOneTab(provider.postActivationURL, {inBackground: SocialShare.panel.state === "open"});
+            gBrowser.loadOneTab(provider.postActivationURL, {inBackground: false});
           }
         });
       }, {});


### PR DESCRIPTION
@mixedpuppy r? and if you have any tips on how to trigger what the activations page does in a test, I'll add one. I tried but couldn't trigger the scenario where the shareplane gets added to the toolbar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1122)
<!-- Reviewable:end -->
