### PR TITLE
fix(metadata-store): #1165 - Drop the migrations table in reset

### DIFF
--- a/addon/MetadataStore.js
+++ b/addon/MetadataStore.js
@@ -73,7 +73,8 @@ const SQL_SELECT_IMAGE_ID = "SELECT id FROM page_images WHERE url = ?";
 const SQL_DROPS = [
   "DROP TABLE IF EXISTS page_metadata_images",
   "DROP TABLE IF EXISTS page_metadata",
-  "DROP TABLE IF EXISTS page_images"
+  "DROP TABLE IF EXISTS page_images",
+  "DROP TABLE IF EXISTS migrations"
 ];
 
 const SQL_DELETE_EXPIRED = "DELETE FROM page_metadata WHERE expired_at <= (CAST(strftime('%s', 'now') AS LONG)*1000)";


### PR DESCRIPTION
@sarracini r?

Turns out it wasn't `sqlite.jsm` fault, it's mine. I should take the "credit" ;)

All the tests in your branch should pass now with this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1166)
<!-- Reviewable:end -->
