### PR TITLE
fix(addon): #1139 Add error handling for colorAnalyzer

### DIFF
--- a/addon/ColorAnalyzerProvider.js
+++ b/addon/ColorAnalyzerProvider.js
@@ -6,13 +6,17 @@ const ColorAnalyzer = Cc["@mozilla.org/places/colorAnalyzer;1"].getService(Ci.mo
 
 exports.getColor = function getColor(url) {
   return new Promise((resolve, reject) => {
-    ColorAnalyzer.findRepresentativeColor({spec: url}, (ok, number) => {
-      if (ok) {
-        const rgb = [(number >> 16) & 0xFF, (number >> 8) & 0xFF, number & 0xFF];
-        resolve(rgb);
-      } else {
-        reject(new Error("There was an error processing this image"));
-      }
-    });
+    try {
+      ColorAnalyzer.findRepresentativeColor({spec: url}, (ok, number) => {
+        if (ok) {
+          const rgb = [(number >> 16) & 0xFF, (number >> 8) & 0xFF, number & 0xFF];
+          resolve(rgb);
+        } else {
+          reject(new Error("There was an error processing this image"));
+        }
+      });
+    } catch (e) {
+      reject(e);
+    }
   });
 };


### PR DESCRIPTION
This closes #1139

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1198)
<!-- Reviewable:end -->
