### PR TITLE
feat(content): Add basic token matching for Timeline all/bookmark views with search in header.

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -40,6 +40,7 @@ const am = new ActionManager([
   "NOTIFY_ROUTE_CHANGE",
   "NOTIFY_PERFORMANCE",
   "NOTIFY_USER_EVENT",
+  "NOTIFY_FILTER_QUERY",
   "NOTIFY_OPEN_WINDOW",
   "NOTIFY_UPDATE_SEARCH_STRING",
   "NOTIFY_BLOCK_RECOMMENDATION",
@@ -238,6 +239,10 @@ function NotifyEvent(data) {
   return Notify("NOTIFY_USER_EVENT", data);
 }
 
+function NotifyFilterQuery(data) {
+  return Notify("NOTIFY_FILTER_QUERY", data);
+}
+
 function NotifyOpenWindow(data) {
   return Notify("NOTIFY_OPEN_WINDOW", data);
 }
@@ -272,6 +277,7 @@ am.defineActions({
   NotifyRouteChange,
   NotifyPerf,
   NotifyEvent,
+  NotifyFilterQuery,
   NotifyOpenWindow,
   NotifyUpdateSearchString,
   NotifyManageEngines,

--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -106,6 +106,18 @@ ActivityFeedItem.propTypes = {
   parsedUrl: React.PropTypes.shape({hostname: React.PropTypes.string})
 };
 
+function filterSites(filter, sites) {
+  if (!filter) {
+    return sites;
+  }
+
+  // Do a case-insensitive matching of all search terms finding tokens somewhere
+  // in the title or url.
+  const tokens = filter.trim().toLowerCase().split(/\s+/);
+  return sites.filter(site => tokens.every(token =>
+    `${site.title || site.provider_display || ""} ${site.url}`.toLowerCase().search(token) !== -1));
+}
+
 function groupSitesBySession(sites) {
   const sessions = [[]];
   sites.forEach((site, i) => {
@@ -171,7 +183,7 @@ const GroupedActivityFeed = React.createClass({
   },
   render() {
     let maxPreviews = this.props.maxPreviews;
-    const sites = this.props.sites
+    const sites = filterSites(this.props.filter, this.props.sites)
       .slice(0, this.props.length)
       .map(site => Object.assign({}, site, {dateDisplay: site[this.props.dateKey]}));
     const groupedSites = groupSitesByDate(sites);
@@ -220,6 +232,7 @@ const GroupedActivityFeed = React.createClass({
 
 GroupedActivityFeed.propTypes = {
   sites: React.PropTypes.array.isRequired,
+  filter: React.PropTypes.string,
   length: React.PropTypes.number,
   dateKey: React.PropTypes.string,
   page: React.PropTypes.string,

--- a/content-src/components/Header/Header.js
+++ b/content-src/components/Header/Header.js
@@ -1,4 +1,7 @@
 const React = require("react");
+const {connect} = require("react-redux");
+const {actions} = require("common/action-manager");
+const {justDispatch} = require("selectors/selectors");
 const {Link} = require("react-router");
 const classNames = require("classnames");
 
@@ -32,7 +35,13 @@ const Header = React.createClass({
           {props.links.map(link => <li key={link.to}><Link to={link.to}>{link.title}</Link></li>)}
         </ul>
       </section>
-      <section className="spacer" />
+      <section className="filter">
+        <input
+          onChange={e => props.dispatch(actions.NotifyFilterQuery(e.target.value))}
+          placeholder="Search your Activity Stream"
+          ref="filter"
+          type="search" />
+      </section>
       <section className="user-info">
         {props.userName && <span>
           {props.userName}
@@ -54,4 +63,5 @@ Header.propTypes = {
   disabled: React.PropTypes.bool
 };
 
-module.exports = Header;
+module.exports = connect(justDispatch)(Header);
+module.exports.Header = Header;

--- a/content-src/components/Header/Header.scss
+++ b/content-src/components/Header/Header.scss
@@ -25,7 +25,7 @@
       border-right: 1px solid darken($bg-grey, 5%);
       cursor: pointer;
       height: 100%;
-      padding-left: 20px;
+      padding-left: $header-section-spacing;
       position: relative;
       width: $header-nav-width;
 
@@ -40,13 +40,21 @@
       }
     }
 
-    &.spacer {
+    &.filter {
       flex-grow: 1;
+      padding-left: $header-section-spacing;
+
+      input {
+        @include search-input;
+        background: $search-glyph-image no-repeat 8px center / $search-glyph-size;
+        margin-left: $header-section-spacing;
+        max-width: $timeline-max-width;
+      }
     }
 
     &.user-info {
       font-size: 14px;
-      padding-right: 20px;
+      padding-right: $header-section-spacing;
 
       span {
         padding: 0 10px;

--- a/content-src/components/Search/Search.scss
+++ b/content-src/components/Search/Search.scss
@@ -129,20 +129,9 @@
   }
 
   input {
-    border-radius: $search-border-radius 0 0 $search-border-radius;
-    flex-grow: 1;
-    margin: 0;
-    padding: 6px 12px 8px $search-input-left-label-width;
-    border: 1px solid $search-input-border-color;
-    outline: none;
-    box-shadow: none;
-
-    &:focus {
-      z-index: 1;
-      border-color: $search-blue;
-      transition: box-shadow 150ms;
-      box-shadow: 0 0 0 0.5px $search-shadow;
-    }
+    @include search-input;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 
     &:focus + button {
       z-index: 1;
@@ -156,8 +145,7 @@
   }
 
   .search-label {
-    background: url('#{$image-path}glyph-search-16.svg') no-repeat center center;
-    background-size: 20px;
+    background: $search-glyph-image no-repeat center center / $search-glyph-size;
     position: absolute;
     top: 0;
     left: 0;

--- a/content-src/components/TimelinePage/TimelineBookmarks.js
+++ b/content-src/components/TimelinePage/TimelineBookmarks.js
@@ -11,11 +11,15 @@ const TimelineBookmarks = React.createClass({
       loadMoreAction={RequestMoreBookmarks}
       dateKey={"bookmarkDateCreated"}
       pageName={"TIMELINE_BOOKMARKS"}
-      Feed={props.Bookmarks} />);
+      Feed={props.Bookmarks}
+      Filter={props.Filter} />);
   }
 });
 
-TimelineBookmarks.propTypes = {Bookmarks: React.PropTypes.object.isRequired};
+TimelineBookmarks.propTypes = {
+  Filter: React.PropTypes.object.isRequired,
+  Bookmarks: React.PropTypes.object.isRequired
+};
 
 module.exports = connect(selectBookmarks)(TimelineBookmarks);
 

--- a/content-src/components/TimelinePage/TimelineFeed.js
+++ b/content-src/components/TimelinePage/TimelineFeed.js
@@ -75,10 +75,13 @@ const TimelineFeed = React.createClass({
   },
   render() {
     const props = this.props;
+    const query = (props.Filter && props.Filter.query) || "";
+    const showSpotlight = props.Spotlight && query === "";
     return (<section className="content" ref="scrollElement" onScroll={!props.Feed.isLoading && props.Feed.canLoadMore && this.loadMoreDataIfNeeded}>
       <div ref="wrapper" className={classNames("wrapper", "show-on-init", {on: props.Feed.init})}>
-        {props.Spotlight ? <Spotlight page={this.props.pageName} sites={props.Spotlight.rows} /> : null}
+        {showSpotlight ? <Spotlight page={this.props.pageName} sites={props.Spotlight.rows} /> : null}
         <GroupedActivityFeed
+          filter={query}
           sites={props.Feed.rows}
           page={props.pageName}
           dateKey={props.dateKey}

--- a/content-src/components/TimelinePage/TimelineHistory.js
+++ b/content-src/components/TimelinePage/TimelineHistory.js
@@ -12,12 +12,14 @@ const TimelineHistory = React.createClass({
       dateKey={"lastVisitDate"}
       pageName={"TIMELINE_ALL"}
       Feed={props.History}
+      Filter={props.Filter}
       Spotlight={props.Spotlight} />);
   }
 });
 
 TimelineHistory.propTypes = {
   Spotlight: React.PropTypes.object.isRequired,
+  Filter: React.PropTypes.object.isRequired,
   History: React.PropTypes.object.isRequired
 };
 module.exports = connect(selectHistory)(TimelineHistory);

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -41,6 +41,7 @@ module.exports = {
     "values": {},
     "error": false
   },
+  "Filter": {"query": ""},
   "Prefs": {
     "prefs": {},
     "error": false

--- a/content-src/reducers/Filter.js
+++ b/content-src/reducers/Filter.js
@@ -1,0 +1,17 @@
+const am = require("common/action-manager");
+
+// Track changes to the filtering of activity stream view.
+const INITIAL_STATE = {
+  // The query to filter content
+  query: ""
+};
+
+module.exports = function Filter(prevState = INITIAL_STATE, action) {
+  const state = Object.assign({}, prevState);
+  switch (action.type) {
+    case am.type("NOTIFY_FILTER_QUERY"):
+      state.query = action.data;
+      break;
+  }
+  return state;
+};

--- a/content-src/reducers/reducers.js
+++ b/content-src/reducers/reducers.js
@@ -3,6 +3,7 @@
 const setRowsOrError = require("reducers/SetRowsOrError");
 const setSearchContent = require("reducers/setSearchContent");
 const Experiments = require("reducers/Experiments");
+const Filter = require("reducers/Filter");
 const Prefs = require("reducers/Prefs");
 
 module.exports = {
@@ -13,5 +14,6 @@ module.exports = {
   WeightedHighlights: setRowsOrError("WEIGHTED_HIGHLIGHTS_REQUEST", "WEIGHTED_HIGHLIGHTS_RESPONSE"),
   Search: setSearchContent("SEARCH_STATE_RESPONSE", "SEARCH_UISTRINGS_RESPONSE", "SEARCH_SUGGESTIONS_RESPONSE", "SEARCH_CYCLE_CURRENT_ENGINE_RESPONSE"),
   Experiments,
+  Filter,
   Prefs
 };

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -109,11 +109,12 @@ module.exports.selectNewTabSites = createSelector(
 module.exports.selectHistory = createSelector(
   [
     selectSpotlight,
+    state => state.Filter,
     state => state.History,
     state => state.WeightedHighlights,
     state => state.Prefs.prefs.weightedHighlights
   ],
-  (Spotlight, History, WeightedHighlights, prefWeightedHighlights) => {
+  (Spotlight, Filter, History, WeightedHighlights, prefWeightedHighlights) => {
     let rows;
     if (prefWeightedHighlights) {
       rows = assignImageAndBackgroundColor(WeightedHighlights.rows);
@@ -123,10 +124,17 @@ module.exports.selectHistory = createSelector(
 
     return {
       Spotlight: Object.assign({}, Spotlight, {rows}),
+      Filter,
       History
     };
   }
 );
 
 // Timeline Bookmarks
-module.exports.selectBookmarks = state => ({Bookmarks: state.Bookmarks});
+module.exports.selectBookmarks = createSelector(
+  [
+    state => state.Filter,
+    state => state.Bookmarks
+  ],
+  (Filter, Bookmarks) => ({Filter, Bookmarks})
+);

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -1,3 +1,5 @@
+$image-path: 'img/';
+
 $bg-color: #FFF;
 $bg-grey: #FBFBFB;
 $very-light-grey: #EBEBEB;
@@ -31,6 +33,7 @@ $section-title-bottom-margin: 13px;
 $header-box-shadow: 0 4px 2px -3px rgba($black, 0.05);
 $header-nav-width: 250px;
 $header-border: solid 1px $header-border-color;
+$header-section-spacing: 20px;
 
 $tile-gutter: $base-gutter;
 $tile-width: 96px;
@@ -86,6 +89,8 @@ $search-shadow: rgba(96, 181, 255, 0.75);
 $search-button-grey: #FBFBFB;
 $search-button-border-color: #D4D4D4;
 $search-button-width: 64px;
+$search-glyph-image: url('#{$image-path}glyph-search-16.svg');
+$search-glyph-size: 20px;
 $search-text: #666;
 $search-section-background: #F7F7F7;
 $search-border-color: #EAEAEA;
@@ -106,8 +111,6 @@ $context-menu-outer-padding: 5px;
 $context-menu-item-padding: 3px 12px;
 
 $icon-size: 16px;
-
-$image-path: 'img/';
 
 $tooltip-height: 50px;
 $tooltip-background-color: #FFF3CE;
@@ -154,5 +157,22 @@ $tooltip-anchor-margin: -42px 0 0 -24px;
   &.active {
     background: $search-blue;
     color: $bg-color;
+  }
+}
+
+@mixin search-input {
+  border: 1px solid $search-input-border-color;
+  border-radius: $search-border-radius;
+  box-shadow: none;
+  flex-grow: 1;
+  margin: 0;
+  outline: none;
+  padding: 6px 12px 8px $search-input-left-label-width;
+
+  &:focus {
+    border-color: $search-blue;
+    box-shadow: 0 0 0 0.5px $search-shadow;
+    transition: box-shadow 150ms;
+    z-index: 1;
   }
 }

--- a/content-test/components/ActivityFeed.test.js
+++ b/content-test/components/ActivityFeed.test.js
@@ -202,6 +202,39 @@ describe("GroupedActivityFeed", () => {
   });
 });
 
+describe("GroupedActivityFeed filtered", () => {
+  function doFilter(filter) {
+    const sites = [faker.createSite({
+      moment: faker.moment(),
+      override: {
+        title: "the title goes here",
+        url: "https://www.domain.com/path"
+      }
+    })];
+    const instance = renderWithProvider(<GroupedActivityFeed sites={sites} filter={filter} />);
+    return TestUtils.scryRenderedDOMComponentsWithClass(instance, "activity-feed");
+  }
+
+  it("should filter on single words in title", () => {
+    assert.lengthOf(doFilter("title"), 1);
+  });
+  it("should filter on single words in url", () => {
+    assert.lengthOf(doFilter("domain"), 1);
+  });
+  it("should filter out non-matches", () => {
+    assert.lengthOf(doFilter("nothere"), 0);
+  });
+  it("should filter on multiple words", () => {
+    assert.lengthOf(doFilter("title domain"), 1);
+  });
+  it("should filter out partial matches", () => {
+    assert.lengthOf(doFilter("title nothere"), 0);
+  });
+  it("should filter case insensitively", () => {
+    assert.lengthOf(doFilter("TITLE"), 1);
+  });
+});
+
 describe("groupSitesBySession", () => {
   const testDate = 1456420000000;
   const minute = 60000;

--- a/content-test/components/Header.test.js
+++ b/content-test/components/Header.test.js
@@ -1,31 +1,31 @@
 /* globals describe, beforeEach, afterEach, it */
-const Header = require("components/Header/Header");
+const ConnectedHeader = require("components/Header/Header");
+const {Header} = ConnectedHeader;
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
-const {overrideConsoleError} = require("test/test-utils");
+const {overrideConsoleError, renderWithProvider} = require("test/test-utils");
 const fakeProps = {
   title: "Home",
   pathname: "/"
 };
 
 describe("Header", () => {
-  let node;
   let header;
   let el;
-  beforeEach(() => {
-    node = document.createElement("div");
-    header = ReactDOM.render(<Header {...fakeProps} />, node);
+  function setup(customProps = {}) {
+    const props = Object.assign({}, fakeProps, customProps);
+    const connected = renderWithProvider(<ConnectedHeader {...props} />);
+    header = TestUtils.findRenderedComponentWithType(connected, Header);
     el = ReactDOM.findDOMNode(header);
-  });
-  afterEach(() => {
-    ReactDOM.unmountComponentAtNode(node);
-  });
+  }
+
+  beforeEach(setup);
 
   it("should not throw if missing props", () => {
     assert.doesNotThrow(() => {
       const restore = overrideConsoleError();
-      ReactDOM.render(<Header />, node);
+      renderWithProvider(<ConnectedHeader />);
       restore();
     });
   });
@@ -45,14 +45,28 @@ describe("Header", () => {
   });
 
   it("should not show caret/arrow if props.disabled is true", () => {
-    header = ReactDOM.render(<Header {...fakeProps} disabled={true} />, node);
+    header = renderWithProvider(<Header {...fakeProps} disabled={true} />);
     assert.isTrue(header.refs.caret.hidden);
   });
 
   it("should not set showDropdown on click if props.disabled", () => {
-    header = ReactDOM.render(<Header {...fakeProps} disabled={true} />, node);
+    header = renderWithProvider(<Header {...fakeProps} disabled={true} />);
     TestUtils.Simulate.click(header.refs.clickElement);
     assert.isFalse(header.state.showDropdown);
+  });
+
+  it("should send search query event on filter change", done => {
+    const props = Object.assign({}, fakeProps, {
+      dispatch(action) {
+        assert.equal(action.type, "NOTIFY_FILTER_QUERY");
+        assert.equal(action.data, "hello");
+        done();
+      }
+    });
+    const instance = TestUtils.renderIntoDocument(<Header {...props} />);
+    let el = instance.refs.filter;
+    el.value = "hello";
+    TestUtils.Simulate.change(el);
   });
 
   describe("userImage", () => {
@@ -61,7 +75,9 @@ describe("Header", () => {
     });
 
     it("should have an img element if a user image is provided ", () => {
-      ReactDOM.render(<Header {...fakeProps} userImage="https://foo.com/user.jpg" />, node);
+      const connected = renderWithProvider(<Header {...fakeProps} userImage="https://foo.com/user.jpg" />);
+      header = TestUtils.findRenderedComponentWithType(connected, Header);
+      el = ReactDOM.findDOMNode(header);
       const imgEl = el.querySelector(".user-info img");
       assert.ok(imgEl);
       assert.include(imgEl.src, "https://foo.com/user.jpg");

--- a/content-test/components/TimelinePage.test.js
+++ b/content-test/components/TimelinePage.test.js
@@ -57,6 +57,7 @@ describe("Timeline", () => {
         canLoadMore: true,
         rows: mockData.History.rows
       },
+      Filter: {query: "hello"},
       dateKey: "lastVisitDate",
       pageName: "TIMELINE_ALL",
       loadMoreAction: () => {}
@@ -81,12 +82,20 @@ describe("Timeline", () => {
         const activityFeed = TestUtils.findRenderedComponentWithType(instance, GroupedActivityFeed);
         assert.equal(activityFeed.props.sites, fakeProps.Feed.rows);
         assert.equal(activityFeed.props.dateKey, fakeProps.dateKey);
+        assert.equal(activityFeed.props.filter, fakeProps.Filter.query);
       });
       it("should not render a Spotlight if Spotlight data is missing", () => {
         assert.lengthOf(TestUtils.scryRenderedComponentsWithType(instance, Spotlight), 0);
       });
-      it("should render a Spotlight if Spotlight data is provided", () => {
+      it("should not render a Spotlight if filtered", () => {
         setup({Spotlight: mockData.Highlights});
+        assert.lengthOf(TestUtils.scryRenderedComponentsWithType(instance, Spotlight), 0);
+      });
+      it("should render a Spotlight if Spotlight data is provided and no filter", () => {
+        setup({
+          Filter: {query: ""},
+          Spotlight: mockData.Highlights
+        });
         assert.ok(TestUtils.findRenderedComponentWithType(instance, Spotlight));
       });
     });


### PR DESCRIPTION
Fix #416. This approach does the filtering in content after passing the query string to a new notify action that gets selected by the timeline page views. Tests are updated to handle the now-connected Header in addition to new tests covering dispatching notify action, passing filter query from `TimelinePage`, and filtering in `GroupedActivityFeed` component. Styles are mostly reusing the input from the `Search` component, so refactored accordingly.

Todo: file followup performance bugs, ui tweaks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1199)
<!-- Reviewable:end -->
