### PR TITLE
Dedupe URLs before sending them to content side

### DIFF
--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -92,7 +92,9 @@ module.exports.selectNewTabSites = createSelector(
     let topHighlights = spotlightRows;
     if (prefWeightedHighlights) {
       const weightedRows = WeightedHighlights.rows.concat(WeightedHighlights.init ? firstRunData.Highlights : []);
-      topHighlights = assignImageAndBackgroundColor(weightedRows);
+      topHighlights = dedupe.group([
+        topSitesRows,
+        assignImageAndBackgroundColor(weightedRows)])[1];
     }
 
     return {

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -224,7 +224,7 @@ describe("selectors", () => {
     });
     it("should render the correct Spotlight items for weightedHighlights", () => {
       let weightedHighlights = {
-        WeightedHighlights: {rows: [{url: "http://foo.com"}, {url: "http://www.foo.com"}]},
+        WeightedHighlights: {rows: [{url: "http://foo.com"}, {url: "http://www.bar.com"}]},
         Prefs: {prefs: {weightedHighlights: true}}
       };
 
@@ -244,6 +244,15 @@ describe("selectors", () => {
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
       assert.equal(state.Spotlight.rows.length, firstRunData.Highlights.length);
+    });
+    it("should dedupe weighted highlights results", () => {
+      let weightedHighlights = {
+        WeightedHighlights: {rows: [{url: "http://foo.com"}, {url: "http://www.foo.com"}]},
+        Prefs: {prefs: {weightedHighlights: true}}
+      };
+
+      state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
+      assert.equal(state.Spotlight.rows.length, 1);
     });
   });
 });


### PR DESCRIPTION
Fixed #1244 moves dedupe and lib/utils to /common

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1246)
<!-- Reviewable:end -->
