### PR TITLE
feat(content): Add dismiss button for timeline filtering

### DIFF
--- a/content-src/components/Header/Header.js
+++ b/content-src/components/Header/Header.js
@@ -13,7 +13,10 @@ const Header = React.createClass({
     };
   },
   getInitialState() {
-    return {showDropdown: false};
+    return {
+      filterQuery: "",
+      showDropdown: false
+    };
   },
   onClick() {
     if (this.props.disabled) {
@@ -21,8 +24,12 @@ const Header = React.createClass({
     }
     this.setState({showDropdown: !this.state.showDropdown});
   },
+  updateFilter(query) {
+    this.setState({filterQuery: query});
+    this.props.dispatch(actions.NotifyFilterQuery(query));
+  },
   render() {
-    const props = this.props;
+    const {props, state} = this;
     return (<header className="head">
 
       <section ref="clickElement" className={classNames("nav", {"disabled": props.disabled})} onClick={this.onClick}>
@@ -31,16 +38,21 @@ const Header = React.createClass({
           <span>{props.title}</span>
           <span ref="caret" hidden={props.disabled} className="arrow" />
         </h1>
-        <ul ref="dropdown" className="nav-picker" hidden={!this.state.showDropdown}>
+        <ul ref="dropdown" className="nav-picker" hidden={!state.showDropdown}>
           {props.links.map(link => <li key={link.to}><Link to={link.to}>{link.title}</Link></li>)}
         </ul>
       </section>
       <section className="filter">
         <input
-          onChange={e => props.dispatch(actions.NotifyFilterQuery(e.target.value))}
+          onChange={e => this.updateFilter(e.target.value)}
           placeholder="Search your Activity Stream"
           ref="filter"
-          type="search" />
+          type="search"
+          value={state.filterQuery} />
+        {state.filterQuery && <span
+          className="icon icon-dismiss"
+          onClick={() => this.updateFilter("")}
+          ref="filterDismiss" />}
       </section>
       <section className="user-info">
         {props.userName && <span>

--- a/content-src/components/Header/Header.scss
+++ b/content-src/components/Header/Header.scss
@@ -50,6 +50,19 @@
         margin-left: $header-section-spacing;
         max-width: $timeline-max-width;
       }
+
+      .icon-dismiss {
+        border: 1px solid $icon-color;
+        border-radius: $icon-size;
+        cursor: pointer;
+        margin-left: -24px;
+        opacity: 0.5;
+        z-index: 1;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
     }
 
     &.user-info {

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -111,6 +111,7 @@ $context-menu-outer-padding: 5px;
 $context-menu-item-padding: 3px 12px;
 
 $icon-size: 16px;
+$icon-color: #4D4D4D;
 
 $tooltip-height: 50px;
 $tooltip-background-color: #FFF3CE;

--- a/content-test/components/Header.test.js
+++ b/content-test/components/Header.test.js
@@ -69,6 +69,38 @@ describe("Header", () => {
     TestUtils.Simulate.change(el);
   });
 
+  it("should update state on filter change", () => {
+    assert.equal(header.state.filterQuery, "");
+
+    let el = header.refs.filter;
+    el.value = "hello";
+    TestUtils.Simulate.change(el);
+
+    assert.equal(header.state.filterQuery, "hello");
+  });
+
+  it("should not have a filter dismiss by default", () => {
+    assert.isUndefined(header.refs.filterDismiss);
+  });
+
+  it("should have a filter dismiss on filter change", () => {
+    let el = header.refs.filter;
+    el.value = "hello";
+    TestUtils.Simulate.change(el);
+
+    assert.ok(header.refs.filterDismiss);
+  });
+
+  it("should clear search on dismiss", () => {
+    let el = header.refs.filter;
+    el.value = "hello";
+    TestUtils.Simulate.change(el);
+    TestUtils.Simulate.click(header.refs.filterDismiss);
+
+    assert.isUndefined(header.refs.filterDismiss);
+    assert.equal(header.state.filterQuery, "");
+  });
+
   describe("userImage", () => {
     it("should not have an img element if no user image is provided", () => {
       assert.isNull(el.querySelector(".user-info img"));


### PR DESCRIPTION
Fix #1260. Adds just the dismiss button as the other items from the mock are outdated. Uses the existing dismiss icon. Adds tests for the new state and shared updating logic. r?@sarracini 