### PR TITLE
Bug 1264 missing image size

### DIFF
--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -221,11 +221,11 @@ class Baseline {
   extractImage(images) {
     const image = getBestImage(images);
 
-    if (!image) {
+    if (!image || !image.width || !image.height) {
       return 0;
     }
 
-    return Math.min(image.size, 1e5);
+    return Math.min(image.width * image.height, 1e5);
   }
 
   /**

--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -221,6 +221,7 @@ class Baseline {
   extractImage(images) {
     const image = getBestImage(images);
 
+    // Sanity check: validate that an image exists and we have dimensions before trying to compute size.
     if (!image || !image.width || !image.height) {
       return 0;
     }

--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -59,7 +59,7 @@ class Baseline {
   normalize(features) {
     return Object.keys(this.normalizeFeatures).reduce((acc, key) => {
       const {min, max} = this.normalizeFeatures[key];
-      if (max !== min) { // No division by 0.
+      if (max > min) { // No division by 0.
         let delta = max - min;
         acc[key] = (features[key] - min) / delta;
       }

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -125,7 +125,7 @@ module.exports.selectNewTabSites = createSelector(
         dedupe: topSitesRows,
         sites: WeightedHighlights.rows,
         max: BOTTOM_HIGHLIGHTS_LENGTH + TOP_HIGHLIGHTS_LENGTH,
-        defaults: firstRunData.Highlights
+        defaults: assignImageAndBackgroundColor(firstRunData.Highlights)
       });
     }
 
@@ -151,7 +151,12 @@ module.exports.selectHistory = createSelector(
   (Spotlight, Filter, History, WeightedHighlights, prefWeightedHighlights) => {
     let rows;
     if (prefWeightedHighlights) {
-      rows = WeightedHighlights.rows;
+      rows = selectAndDedupe({
+        sites: WeightedHighlights.rows,
+        dedupe: [],
+        max: TOP_HIGHLIGHTS_LENGTH,
+        defaults: assignImageAndBackgroundColor(firstRunData.Highlights)
+      });
     } else {
       rows = dedupe.one(Spotlight.rows);
     }

--- a/content-test/common/Baseline.test.js
+++ b/content-test/common/Baseline.test.js
@@ -212,11 +212,26 @@ describe("Baseline", () => {
 
       assert.equal(result.features.description, entry.description.length);
     });
-    it("should set description to 0 if it's the same as the url", () => {
-      entry.description = entry.url;
-      const result = baseline.extractFeatures(entry);
 
-      assert.equal(result.features.description, 0);
+    it("should call `normalizeTimestamp`", () => {
+      const stub = sandbox.stub(baseline, "normalizeTimestamp");
+      baseline.extractFeatures(entry);
+
+      sinon.assert.calledOnce(stub);
+    });
+
+    it("should call `extractDescriptionLength`", () => {
+      const stub = sandbox.stub(baseline, "extractDescriptionLength");
+      baseline.extractFeatures(entry);
+
+      sinon.assert.calledOnce(stub);
+    });
+
+    it("should call `extractImage`", () => {
+      const stub = sandbox.stub(baseline, "extractImage");
+      baseline.extractFeatures(entry);
+
+      sinon.assert.calledOnce(stub);
     });
 
     it("should select min", () => {
@@ -299,6 +314,12 @@ describe("Baseline", () => {
 
       assert.isNumber(result.features.idf);
       assert.isTrue(Number.isFinite(result.features.idf));
+    });
+    it("should call `extractDescriptionLength`", () => {
+      const stub = sandbox.stub(baseline, "extractDescriptionLength");
+      baseline.extractFeatures(entry);
+
+      sinon.assert.calledWithExactly(stub, entry);
     });
   });
 

--- a/content-test/common/Baseline.test.js
+++ b/content-test/common/Baseline.test.js
@@ -128,9 +128,13 @@ describe("Baseline", () => {
     assert.equal(baseline.extractImage({images: [{}]}), 0);
   });
 
+  it("should return 0 for when images don't have width or height", () => {
+    assert.equal(baseline.extractImage({images: [{url: "foo"}]}), 0);
+  });
+
   it("should extract image size", () => {
-    const images = [{size: 42, width: 300, height: 300, url: "bar"}];
-    assert.equal(baseline.extractImage(images), 42);
+    const images = [{width: 300, height: 300, url: "bar"}];
+    assert.equal(baseline.extractImage(images), 300 * 300);
   });
 
   it("should return the same number of items after sort", () => {


### PR DESCRIPTION
Fix for #1264, new metadata service does not return image size. Feature value ends up being `undefined` and therefore the final score is NaN. Using `width x height` to replace image size.

Small updates to the test as well to ensure all feature extraction methods provide defaults and that all function calls are made, because one test was actually making assertions on a stubbed method.