### PR TITLE
fix(content): Disable search for current release

### DIFF
--- a/content-src/components/Header/Header.scss
+++ b/content-src/components/Header/Header.scss
@@ -49,6 +49,9 @@
         background: $search-glyph-image no-repeat 8px center / $search-glyph-size;
         margin-left: $header-section-spacing;
         max-width: $timeline-max-width;
+
+        // GH#1305: Temporarily disable for current release
+        display: none;
       }
 
       .icon-dismiss {


### PR DESCRIPTION
Fix #1305. Visually hide the search input box without affecting tests. r?@k88hudson 