### PR TITLE
Create higlights experiment

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -137,7 +137,7 @@ function ActivityStreams(metadataStore, options = {}) {
   this._prefsProvider.init();
   // This is instantiated with a recommender based on weights if pref is true. Used to score highlights.
   this._baselineRecommender = null;
-  if (simplePrefs.prefs.weightedHighlights) {
+  if (this._experimentProvider.data.weightedHighlights) {
     this._loadRecommender();
   }
 

--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -72,7 +72,8 @@ const DebugPage = React.createClass({
                 {selectSpotlight({
                   Highlights: this.props.raw[this.state.dataSource],
                   WeightedHighlights: this.props.raw[this.state.dataSource],
-                  Prefs: this.props.raw.Prefs
+                  Prefs: this.props.raw.Prefs,
+                  Experiments: this.props.raw.Experiments
                 }).rows.map((item, i) =>
                   (<SpotlightItem key={i} {...item} />))
                 }

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -51,7 +51,7 @@ const selectSpotlight = module.exports.selectSpotlight = createSelector(
     state => state.Prefs.prefs.recommendations,
     state => state.Prefs.prefs.metadataRatingSystem,
     selectWeightedHighlights,
-    state => state.Prefs.prefs.weightedHighlights
+    state => state.Experiments.values.weightedHighlights
   ],
   (Highlights, recommendationShown, metadataRating, WeightedHighlights, prefWeightedHighlights) => {
     let rows;
@@ -95,7 +95,7 @@ const selectTopSites = module.exports.selectTopSites = createSelector(
 module.exports.selectNewTabSites = createSelector(
   [
     selectWeightedHighlights,
-    state => state.Prefs.prefs.weightedHighlights,
+    state => state.Experiments.values.weightedHighlights,
     selectTopSites,
     state => state.History,
     selectSpotlight,
@@ -146,7 +146,7 @@ module.exports.selectHistory = createSelector(
     state => state.Filter,
     state => state.History,
     selectWeightedHighlights,
-    state => state.Prefs.prefs.weightedHighlights
+    state => state.Experiments.values.weightedHighlights
   ],
   (Spotlight, Filter, History, WeightedHighlights, prefWeightedHighlights) => {
     let rows;

--- a/content-test/faker.js
+++ b/content-test/faker.js
@@ -133,6 +133,7 @@ function createSpotlightItem(options = {}) {
   return selectSpotlight({
     Highlights: {rows: [site]},
     WeightedHighlights: {rows: [site]},
+    Experiments: {values: {}},
     Prefs: {prefs: {}}
   }).rows[0];
 }

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -178,7 +178,7 @@ describe("selectors", () => {
   });
   describe("selectHistory weightedHighlights pref is true", () => {
     let state;
-    let fakeStateWithWeights = Object.assign({}, fakeState, {Prefs: {prefs: {weightedHighlights: true}}});
+    let fakeStateWithWeights = Object.assign({}, fakeState, {Experiments: {values: {weightedHighlights: true}}});
     beforeEach(() => {
       state = selectHistory(fakeStateWithWeights);
     });
@@ -230,7 +230,7 @@ describe("selectors", () => {
           rows: [{url: "http://foo1.com"}, {url: "http://www.foo2.com"}, {url: "http://www.foo3.com"},
             {url: "http://foo4.com"}, {url: "http://www.foo5.com"}, {url: "http://www.foo6.com"}]
         },
-        Prefs: {prefs: {weightedHighlights: true}}
+        Experiments: {values: {weightedHighlights: true}}
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
@@ -244,7 +244,7 @@ describe("selectors", () => {
     it("should render first run highlights of fresh profiles", () => {
       let weightedHighlights = {
         WeightedHighlights: {rows: [], init: true},
-        Prefs: {prefs: {weightedHighlights: true}}
+        Experiments: {values: {weightedHighlights: true}}
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
@@ -256,7 +256,7 @@ describe("selectors", () => {
     it("should append First Run data if less or equal to MIN_HIGHLIGHTS_LENGTH", () => {
       let weightedHighlights = {
         WeightedHighlights: {rows: [{url: "http://foo.com"}, {url: "http://www.bar.com"}], init: true},
-        Prefs: {prefs: {weightedHighlights: true}}
+        Experiments: {values: {weightedHighlights: true}}
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
@@ -266,7 +266,7 @@ describe("selectors", () => {
     it("should dedupe weighted highlights results", () => {
       let weightedHighlights = {
         WeightedHighlights: {rows: [{url: "http://foo.com"}, {url: "http://www.foo.com"}], init: true},
-        Prefs: {prefs: {weightedHighlights: true}}
+        Experiments: {values: {weightedHighlights: true}}
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));

--- a/dev-prefs.json
+++ b/dev-prefs.json
@@ -4,6 +4,5 @@
   "extensions.@activity-streams.sdk.console.logLevel": "info",
   "extensions.@activity-streams.telemetry.ping.endpoint": "https://onyx_tiles.stage.mozaws.net/v3/links/activity-stream",
   "extensions.@activity-streams.embedly.endpoint": "https://embedly-proxy.services.mozilla.com/v2/extract",
-  "extensions.@activity-streams.weightedHighlights": true,
   "extensions.@activity-streams.metadataRatingSystem": true
 }

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
       "name": "experimentOverrides",
       "title": "Sets which experiment(s) are turned on, if defined (use comma separated values)",
       "type": "string",
-      "value": "",
+      "value": "weightedHighlights",
       "hidden": true
     }
   ],

--- a/test-prefs.json
+++ b/test-prefs.json
@@ -5,5 +5,6 @@
   "extensions.@activity-streams.performance.log": false,
   "extensions.@activity-streams.previews.enabled": false,
   "extensions.@activity-streams.telemetry": true,
-  "extensions.@activity-streams.telemetry.ping.endpoint": "https://onyx_tiles.stage.mozaws.net/v3/links/activity-stream"
+  "extensions.@activity-streams.telemetry.ping.endpoint": "https://onyx_tiles.stage.mozaws.net/v3/links/activity-stream",
+  "extensions.@activity-streams.experimentOverrides": ""
 }


### PR DESCRIPTION
This pull requests creates a weighted highlights experiment and turns it on for everyone.

Some questions:
- [x] right now it's turning weighted highlights on addon side and generating them but the pref is still read via the PrefsProvider. How should we leverage between pref provider and experiments provider?
- [x] pref event listeners are still present in the code. Are they a problem with the current override system? https://github.com/mozilla/activity-stream/blob/30e3fc0d152e326cd151eac98f967b44adf57566/addon/ActivityStreams.js#L485

cc @k88hudson 