### PR TITLE
switch timing uses of Date.now to performance.now wrapper for better accuracy 

### DIFF
--- a/addon/PerfMeter.js
+++ b/addon/PerfMeter.js
@@ -5,6 +5,8 @@ Cu.import("resource://gre/modules/Services.jsm");
 const tabs = require("sdk/tabs");
 const simplePrefs = require("sdk/simple-prefs");
 
+const {absPerf} = require("common/AbsPerf");
+
 const VALID_TELEMETRY_TAGS = new Set([
   "TAB_READY",
   "WORKER_ATTACHED",
@@ -116,7 +118,7 @@ PerfMeter.prototype = {
     let item = {tag: "TAB_OPEN", start: 0};
     this._tabs[tab.id] = {
       tab,
-      openAt: Date.now(),
+      openAt: absPerf.now(),
       events: [item],
       requests: new Map(),
       workerWasAttached: false
@@ -147,14 +149,14 @@ PerfMeter.prototype = {
             {tag: "TAB_READY", start: 0}
           ];
           tabData.requests = new Map();
-          tabData.openAt = Date.now();
+          tabData.openAt = absPerf.now();
         }
         tabData.workerWasAttached = true;
       }
 
       let item = {
         tag,
-        start: Date.now() - tabData.openAt,
+        start: absPerf.now() - tabData.openAt,
         data
       };
 

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -7,6 +7,7 @@ const self = require("sdk/self");
 const {TippyTopProvider} = require("addon/TippyTopProvider");
 const {getColor} = require("addon/ColorAnalyzerProvider");
 const {MetadataCache} = require("addon/MetadataCache");
+const {absPerf} = require("common/AbsPerf");
 
 const ENABLED_PREF = "previews.enabled";
 const METADATA_SOURCE_PREF = "metadataSource";
@@ -314,9 +315,9 @@ PreviewProvider.prototype = {
     this._tabTracker.handlePerformanceEvent(event, "embedlyProxyRequestSentCount", newLinks.length);
     try {
       // Make network call when enabled and record how long the network call took
-      const startNetworkCall = Date.now();
+      const startNetworkCall = absPerf.now();
       let response = yield this._asyncGetLinkData(linkURLs);
-      const endNetworkCall = Date.now();
+      const endNetworkCall = absPerf.now();
       this._tabTracker.handlePerformanceEvent(event, "embedlyProxyRequestTime", endNetworkCall - startNetworkCall);
 
       if (response.ok) {

--- a/addon/RecommendationProvider.js
+++ b/addon/RecommendationProvider.js
@@ -2,6 +2,7 @@
 "use strict";
 const {Cu} = require("chrome");
 const {setTimeout, clearTimeout} = require("sdk/timers");
+const {absPerf} = require("common/AbsPerf");
 const simplePrefs = require("sdk/simple-prefs");
 
 const POCKET_API_URL = "pocket.endpoint";
@@ -82,9 +83,9 @@ RecommendationProvider.prototype = {
   asyncSetRecommendedContent: Task.async(function*() {
     try {
       let event = this._tabTracker.generateEvent();
-      let startNetworkCall = Date.now();
+      let startNetworkCall = absPerf.now();
       let response = yield this._asyncGetRecommendationsFromPocket();
-      let endNetworkCall = Date.now();
+      let endNetworkCall = absPerf.now();
       this._tabTracker.handlePerformanceEvent(event, "pocketProxyRequestTime", endNetworkCall - startNetworkCall);
       if (response.ok) {
         let responseJson = yield response.json();

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -6,6 +6,7 @@ const self = require("sdk/self");
 const {uuid} = require("sdk/util/uuid");
 const simplePrefs = require("sdk/simple-prefs");
 const eventConstants = require("../common/event-constants");
+const {absPerf} = require("common/AbsPerf");
 
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Locale.jsm");
@@ -177,7 +178,7 @@ TabTracker.prototype = {
       return;
     }
     if (this._tabData.start_time) {
-      this._tabData.session_duration = (Date.now() - this._tabData.start_time);
+      this._tabData.session_duration = (absPerf.now() - this._tabData.start_time);
       delete this._tabData.start_time;
     }
     delete this._tabData.active;
@@ -231,7 +232,7 @@ TabTracker.prototype = {
       // we need to restore tab_id and url, because they could have been errased
       // by a call navigateAwayFromPage() caused by another tab
       this._initTabSession(tab, this._tabData.load_reason || "focus");
-      this._tabData.start_time = Date.now();
+      this._tabData.start_time = absPerf.now();
 
       // URL stored in this._openTabs object keeps the previous URL after the tab.url
       // is replaced with a different page URL, as in click action of page reload

--- a/common/AbsPerf.js
+++ b/common/AbsPerf.js
@@ -1,0 +1,34 @@
+/* globals Services */
+"use strict";
+
+let usablePerfObj;
+
+// if we're running in an addon module
+if (typeof Window === "undefined") {
+  const {Cu} = require("chrome");
+  Cu.import("resource://gre/modules/Services.jsm");
+
+  // Borrow the high-resolution timer from the hidden window....
+  usablePerfObj = Services.appShell.hiddenDOMWindow.performance;
+} else { // we must be running in content space
+  usablePerfObj = performance;
+}
+
+function _AbsPerf() {
+}
+_AbsPerf.prototype = {
+  /**
+   * returns Performance.now as the absolute number milliseconds since the
+   * UNIX epoch, instead of since performance.timing.navigationStart.  We need
+   * to be able to do math with timestamps obtained both in chrome (from the
+   * hidden window) and in content.
+   */
+  now: function now() {
+    return usablePerfObj.timing.navigationStart + usablePerfObj.now();
+  }
+};
+
+module.exports = {
+  absPerf: new _AbsPerf(),  // a singleton
+  _AbsPerf
+};

--- a/common/AbsPerf.js
+++ b/common/AbsPerf.js
@@ -18,13 +18,19 @@ function _AbsPerf() {
 }
 _AbsPerf.prototype = {
   /**
-   * returns Performance.now as the absolute number milliseconds since the
-   * UNIX epoch, instead of since performance.timing.navigationStart.  We need
-   * to be able to do math with timestamps obtained both in chrome (from the
-   * hidden window) and in content.
+   * Drop in replacement for Date.now, using performance.now to get monotonic
+   * high resolution timing.  Useful since we need to be able to do math with
+   * timestamps obtained both in chrome (from the hidden window) and in
+   * content.  At some point, we may want to replace/augment this with
+   * something that returns even higher precision (non-integer ms, since
+   * Performance.now is supposed to offer 5us granularity).
+   *
+   * @return {Number} Milliseconds since the UNIX epoch, rounded to the nearest
+   * integer.
+   *
    */
   now: function now() {
-    return usablePerfObj.timing.navigationStart + usablePerfObj.now();
+    return Math.round(usablePerfObj.timing.navigationStart + usablePerfObj.now());
   }
 };
 

--- a/content-test/common/AbsPerf.test.js
+++ b/content-test/common/AbsPerf.test.js
@@ -9,11 +9,26 @@ describe("_AbsPerf", () => {
   });
 
   describe("#now", () => {
-    it("should return a number < performance.timing.navigationStart + performance.now()", () => {
+    it("should return a number", () => {
       let n = absPerf.now();
 
       assert.isNumber(n);
-      assert.isBelow(n, performance.timing.navigationStart + performance.now());
+    });
+
+    it("should return an integer", () => {
+      let n = absPerf.now();
+
+      assert(n % 1 === 0);
+    });
+
+    // +1 is to account for possible rounding up.
+    it("should return a value <= Math.round(performance.timing.navigationStart + performance.now())", () => {
+      let n = absPerf.now();
+
+      // since the following statement runs later than the call to absPerf.now,
+      // the result of absPerf.now, even with rounding, better not be more.
+      assert.isAtMost(n,
+         Math.round(performance.timing.navigationStart + performance.now()));
     });
   });
 });

--- a/content-test/common/AbsPerf.test.js
+++ b/content-test/common/AbsPerf.test.js
@@ -1,0 +1,19 @@
+/* globals beforeEach, describe, it */
+const {_AbsPerf} = require("common/AbsPerf");
+
+let absPerf;
+
+describe("_AbsPerf", () => {
+  beforeEach(() => {
+    absPerf = new _AbsPerf();
+  });
+
+  describe("#now", () => {
+    it("should return a number < performance.timing.navigationStart + performance.now()", () => {
+      let n = absPerf.now();
+
+      assert.isNumber(n);
+      assert.isBelow(n, performance.timing.navigationStart + performance.now());
+    });
+  });
+});


### PR DESCRIPTION
This PR switches the various timing uses of Date.now (except for httpd.js, which seems to be an external module, and I'd be surprised if we care about the timing there).

One can test some data collection by adding this to dev-prefs.json

```json
  "extensions.@activity-streams.performance.log": true
```

On my relative new Macbook Pro, opening and closing 8 new tabs on master without this patch yielded this for NEWTAB_RENDER:

```
SIZE=8 MEAN=519.63 STD=31.69 MEDIAN=514.5
```

with the commits in this PR, it yielded

```
SIZE=8 MEAN=526.43 STD=30.83 MEDIAN=511.6549072265625
```

Which I would guess is not statistically significant.  That said, I'd also expect that it'll come in handing for we're timing smaller things, plus it avoids the occasional "NTP clock shift" issues.

Note that this change will effect all performance logging that uses PerfMeter, making our new, slightly more accurate numbers theoretically hard to compare against the existing data.  CC @emtwo 