### PR TITLE
chore (package): Remove history package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "classnames": "2.2.5",
     "fancy-dedupe": "0.1.0",
     "get-youtube-id": "1.0.0",
-    "history": "2.1.2",
     "lodash.debounce": "4.0.8",
     "moment": "2.15.0",
     "react": "15.3.1",


### PR DESCRIPTION
we stopped using `history` in d6c0aed3abcb83305564ccd0b5c73ba2fefb1815