### PR TITLE
feat(highlights) - Min number of results

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -667,11 +667,10 @@ Links.prototype = {
 
   /**
    * Obtain a set of links to rank.
-   * Get MAX(all links visited in the past 4 days, last 20 links).
+   * Get all links visited in the past 4 days or default to last 20 links.
    * Last 20 links is used as fallback in case there is no recent history.
    *
    * @param {Object} options
-   *        {Integer} limit: Maximum number of results to return. Max 20
    *
    * @returns {Promise} Returns a promise with the array of links as payload.
    */

--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -679,34 +679,67 @@ Links.prototype = {
     let {ignoreBlocked} = options;
 
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);
+    let params = {limit: LINKS_QUERY_LIMIT};
 
-    let sqlQuery = `SELECT p.url as url,
-                           p.guid as guid,
-                           f.data as favicon,
-                           f.mime_type as mimeType,
-                           p.title as title,
-                           p.frecency as frecency,
-                           p.visit_count as visitCount,
-                           p.last_visit_date / 1000 as lastVisitDate,
-                           "history" as type,
-                           b.id as bookmarkId,
-                           b.guid as bookmarkGuid,
-                           b.title as bookmarkTitle,
-                           b.lastModified / 1000 as lastModified,
-                           b.dateAdded / 1000 as bookmarkDateCreated
-                    FROM moz_places p
-                    LEFT JOIN moz_bookmarks b
-                      ON b.fk = p.id
-                    LEFT JOIN moz_favicons f
-                      ON p.favicon_id = f.id
-                    WHERE datetime(p.last_visit_date / 1000 / 1000, 'unixepoch') > datetime('now', '${HIGHLIGHTS_THRESHOLDS.ageLimit}')
-                    AND p.url NOT IN (${blockedURLs})
-                    AND p.title NOT NULL
-                    AND p.rev_host NOT IN (${REV_HOST_BLACKLIST})`;
+    let sqlQuery = `SELECT DISTINCT * FROM (
+                      SELECT * FROM (
+                        SELECT p.url as url,
+                          p.guid as guid,
+                          f.data as favicon,
+                          f.mime_type as mimeType,
+                          p.title as title,
+                          p.frecency as frecency,
+                          p.visit_count as visitCount,
+                          p.last_visit_date / 1000 as lastVisitDate,
+                          "history" as type,
+                          b.id as bookmarkId,
+                          b.guid as bookmarkGuid,
+                          b.title as bookmarkTitle,
+                          b.lastModified / 1000 as lastModified,
+                          b.dateAdded / 1000 as bookmarkDateCreated
+                        FROM moz_places p
+                        LEFT JOIN moz_bookmarks b
+                          ON b.fk = p.id
+                        LEFT JOIN moz_favicons f
+                          ON p.favicon_id = f.id
+                        AND p.url NOT IN (${blockedURLs})
+                        AND p.title NOT NULL
+                        AND p.rev_host NOT IN (${REV_HOST_BLACKLIST})
+                        ORDER BY p.last_visit_date DESC
+                        LIMIT :limit
+                      )
+                      UNION ALL
+                      SELECT * FROM (
+                        SELECT p.url as url,
+                          p.guid as guid,
+                          f.data as favicon,
+                          f.mime_type as mimeType,
+                          p.title as title,
+                          p.frecency as frecency,
+                          p.visit_count as visitCount,
+                          p.last_visit_date / 1000 as lastVisitDate,
+                          "history" as type,
+                          b.id as bookmarkId,
+                          b.guid as bookmarkGuid,
+                          b.title as bookmarkTitle,
+                          b.lastModified / 1000 as lastModified,
+                          b.dateAdded / 1000 as bookmarkDateCreated
+                        FROM moz_places p
+                        LEFT JOIN moz_bookmarks b
+                          ON b.fk = p.id
+                        LEFT JOIN moz_favicons f
+                          ON p.favicon_id = f.id
+                        WHERE datetime(p.last_visit_date / 1000 / 1000, 'unixepoch') > datetime('now', '${HIGHLIGHTS_THRESHOLDS.ageLimit}')
+                        AND p.url NOT IN (${blockedURLs})
+                        AND p.title NOT NULL
+                        AND p.rev_host NOT IN (${REV_HOST_BLACKLIST})
+                      )
+                    )`;
 
     let links = yield this.executePlacesQuery(sqlQuery, {
       columns: ["bookmarkId", "bookmarkTitle", "bookmarkGuid", "bookmarkDateCreated", "url", "guid", "title",
-        "lastVisitDate", "frecency", "visitCount", "type", "lastModified", "favicon", "mimeType"]
+        "lastVisitDate", "frecency", "visitCount", "type", "lastModified", "favicon", "mimeType"],
+      params
     });
 
     links = this._faviconBytesToDataURI(links);


### PR DESCRIPTION
Fixes #1275 

The query should fetch past 4 days of results OR past 20 results so that we have something to show to a user if he's been away from Firefox recently.