### PR TITLE
fix(tests) Closes #1196 Intermittent SearchProvider failure

### DIFF
--- a/addon/main.js
+++ b/addon/main.js
@@ -1,7 +1,6 @@
 /* globals Task, ClientID */
 
 const {PlacesProvider} = require("addon/PlacesProvider");
-const {SearchProvider} = require("addon/SearchProvider");
 const {MetadataStore, METASTORE_NAME} = require("addon/MetadataStore");
 const {MetadataCache} = require("addon/MetadataCache");
 const {ActivityStreams} = require("addon/ActivityStreams");
@@ -25,7 +24,6 @@ Object.assign(exports, {
   main(options) {
     // options.loadReason can be install/enable/startup/upgrade/downgrade
     PlacesProvider.links.init();
-    SearchProvider.search.init();
     options.telemetry = false;
 
     Task.spawn(function*() {
@@ -97,6 +95,5 @@ Object.assign(exports, {
 
     MetadataCache.cache.uninit();
     PlacesProvider.links.uninit();
-    SearchProvider.search.uninit();
   }
 });

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -51,6 +51,36 @@ function doDump(object, trailer) {
   dump(JSON.stringify(object, null, 1) + trailer); // eslint-disable-line no-undef
 }
 
+function getTestSearchProvider() {
+  return {
+    init() {},
+    uninit() {},
+    on() {},
+    off() {},
+    get currentState() {
+      return {
+        engines: [],
+        currentEngine: this.currentEngine
+      };
+    },
+    get searchSuggestionUIStrings() {
+      return {
+        "searchHeader": "%S Search",
+        "searchForSomethingWith": "Search for",
+        "searchSettings": "Change Search Settings",
+        "searchPlaceholder": "Search the Web"
+      };
+    },
+    get currentEngine() {
+      return {
+        name: "",
+        iconBuffer: []
+      };
+    },
+    QueryInterface: {}
+  };
+}
+
 function getTestActivityStream(options = {}) {
   const mockMetadataStore = {
     asyncConnect() {return Promise.resolve();},
@@ -70,7 +100,9 @@ function getTestActivityStream(options = {}) {
     init() {},
     uninit() {}
   };
+
   options.pageScraper = mockPageScraper;
+  options.searchProvider = getTestSearchProvider();
   let mockApp = new ActivityStreams(mockMetadataStore, options);
   return mockApp;
 }

--- a/test/test-ActivityStreams-home-page.js
+++ b/test/test-ActivityStreams-home-page.js
@@ -18,6 +18,7 @@ exports["test activity stream loads on home page when appropriate"] = function(a
   assert.equal(`${url}#/`, prefService.get("browser.startup.homepage"));
 
   // Unload ActivityStream with reason="disable" and it should be unset.
+  app = getTestActivityStream({pageURL: url});
   app.unload("disable");
   assert.ok(!prefService.isSet("browser.startup.homepage"));
 

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -729,7 +729,9 @@ before(exports, function*() {
 });
 
 after(exports, () => {
-  app.unload();
+  if (!app._isUnloaded) {
+    app.unload();
+  }
 });
 
 require("sdk/test").run(exports);


### PR DESCRIPTION
* Mock the SearchProvider for tests that create an instance of ActivitySream
* Add a ```isUnloaded``` flag to ActivityStream to fix race condition of attempting to uninit when app is already destroyed (in ```test-TabTracker``` and ```test-ActivityStreams-home-page```)
* Make ```get currentState``` sync - it didn't need to be async
* Use the conventional way of creating an instance of searchProvider (create a ```this._searchProvider```)
* Pull it out of the scope of the addon, and into the scope of ActivityStream
* Clean up the SearchProvider
* Fix the SearchProvider tests 
    * Add a before/after
    * Fix deprecation warning about falling back to synchronous initialization of ```Services.search```
    * Create a proper handler for the observe test

Ran the tests a bunch of times with these changes and can't reproduce the intermittent for the 
SearchProvider failure. That being said, it's intermittent so..... ```¯\_(ツ)_/¯```