### PR TITLE
feat(topsites): Show shorter top sites label without top level domain

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -470,6 +470,14 @@ Links.prototype = {
     });
 
     links = this._faviconBytesToDataURI(links);
+    links = links.map(link => {
+      try {
+        link.eTLD = Services.eTLD.getPublicSuffix(Services.io.newURI(link.url, null, null));
+      } catch (e) {
+        link.eTLD = "";
+      }
+      return link;
+    });
     return links.filter(link => LinkChecker.checkLoadURI(link.url));
   }),
 

--- a/content-src/selectors/siteMetadataSelectors.js
+++ b/content-src/selectors/siteMetadataSelectors.js
@@ -8,7 +8,12 @@ function selectSiteProperties(site) {
   const metadataFavicon = site.favicons && site.favicons[0] && site.favicons[0].url;
   const favicon = site.favicon_url || metadataFavicon || site.favicon;
   const parsedUrl = site.parsedUrl || urlParse(site.url || "");
-  const label = prettyUrl(parsedUrl.hostname);
+
+  // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
+  const eTLDLength = (site.eTLD || "").length;
+  const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
+  const label = prettyUrl(parsedUrl.hostname).slice(0, eTLDExtra);
+
   return {favicon, parsedUrl, label};
 }
 

--- a/content-test/selectors/colorSelectors.test.js
+++ b/content-test/selectors/colorSelectors.test.js
@@ -49,6 +49,7 @@ describe("colorSelectors", () => {
 
   describe("selectSiteIcon", () => {
     const siteWithFavicon = {
+      eTLD: "com",
       url: "http://foo.com",
       favicon_url: "http://foo.com/favicon.ico",
       favicon: "http://foo.com/favicon-16.ico",
@@ -108,8 +109,8 @@ describe("colorSelectors", () => {
       const lightColor = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_colors: [{color: [200, 200, 200]}]}));
       assert.equal(lightColor.fontColor, "black");
     });
-    it("should add a label (hostname)", () => {
-      assert.equal(state.label, "foo.com");
+    it("should add a label (hostname without eTLD)", () => {
+      assert.equal(state.label, "foo");
     });
   });
 

--- a/content-test/selectors/siteMetadataSelectors.test.js
+++ b/content-test/selectors/siteMetadataSelectors.test.js
@@ -82,10 +82,15 @@ describe("siteMetadataSelectors", () => {
 
       assert.ok(result.parsedUrl);
     });
-    it("should set label prop", () => {
+    it("should set label prop without eTLD set", () => {
       let result = selectSiteProperties(validSpotlightSite);
 
-      assert.ok(result.label);
+      assert.equal(result.label, "cnn.com");
+    });
+    it("should set label prop with eTLD set", () => {
+      let result = selectSiteProperties(Object.assign({}, validSpotlightSite, {eTLD: "com"}));
+
+      assert.equal(result.label, "cnn");
     });
   });
 });

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -64,6 +64,7 @@ exports.test_Links_getTopFrecentSites = function*(assert) {
   links = yield provider.getTopFrecentSites();
   assert.equal(links.length, 1, "adding a visit yields a link");
   assert.equal(links[0].url, testURI.spec, "added visit corresponds to added url");
+  assert.equal(links[0].eTLD, "com", "added visit mozilla.com has 'com' eTLD");
 };
 
 exports.test_Links_getTopFrecentSites_Order = function*(assert) {


### PR DESCRIPTION
Fix #1376 by using Services.eTLD to get the effective top level domain of a top frecent site url. Use that eTLD to remove it from the displayed hostname label.

r?@piatra 