### PR TITLE
Add generic override globals function and Task shim

### DIFF
--- a/content-test/index.js
+++ b/content-test/index.js
@@ -1,17 +1,17 @@
 const req = require.context(".", true, /\.test.js$/);
 const files = req.keys();
+const globals = require("shims/_utils/globals");
 const {overrideGlobals, overrideConsoleError} = require("test/test-utils");
 
 // This exposes sinon assertions to chai.assert
 sinon.assert.expose(assert, {prefix: ""});
-
 
 describe("ActivtyStreams", () => {
   let restores;
   before(() => {
     restores = [
       overrideConsoleError(message => {throw new Error(message);}),
-      overrideGlobals()
+      overrideGlobals(globals)
     ];
   });
   after(() => {

--- a/content-test/index.js
+++ b/content-test/index.js
@@ -1,31 +1,21 @@
 const req = require.context(".", true, /\.test.js$/);
 const files = req.keys();
-const {overrideConsoleError} = require("test/test-utils");
+const {overrideGlobals, overrideConsoleError} = require("test/test-utils");
 
 // This exposes sinon assertions to chai.assert
 sinon.assert.expose(assert, {prefix: ""});
 
+
 describe("ActivtyStreams", () => {
-  let restore;
-  let originalAlert;
-  let originalConfirm;
-  let originalServices;
+  let restores;
   before(() => {
-    originalAlert = window.alert;
-    window.alert = () => {};
-    restore = overrideConsoleError(message => {
-      throw new Error(message);
-    });
-    originalConfirm = window.confirm;
-    window.confirm = () => true;
-    originalServices = global.Services;
-    global.Services = {obs: {notifyObservers: sinon.spy()}};
+    restores = [
+      overrideConsoleError(message => {throw new Error(message);}),
+      overrideGlobals()
+    ];
   });
   after(() => {
-    restore();
-    window.alert = originalAlert;
-    window.confirm = originalConfirm;
-    global.Services = originalServices;
+    restores.forEach(fn => fn());
   });
 
   files.forEach(file => req(file));

--- a/content-test/meta/globals.test.js
+++ b/content-test/meta/globals.test.js
@@ -1,0 +1,31 @@
+/* globals Task, Services */
+describe("globals", () => {
+  describe("Services", () => {
+    it("should exist", () => {
+      assert.ok(Services);
+    });
+    it("should have a notifyObservers method", () => {
+      assert.isFunction(Services.obs.notifyObservers);
+    });
+  });
+  describe("Task", () => {
+    it("should exist", () => {
+      assert.ok(Task);
+    });
+    it("should have a working .spawn method", done => {
+      Task.spawn(function*() {
+        const result = yield new Promise(resolve => resolve(42));
+        assert.equal(result, 42);
+        done();
+      });
+    });
+    it("should have a working .async method", done => {
+      const fn = Task.async(function*() {
+        const result = yield new Promise(resolve => resolve(42));
+        assert.equal(result, 42);
+        done();
+      });
+      fn();
+    });
+  });
+});

--- a/content-test/test-utils.js
+++ b/content-test/test-utils.js
@@ -4,7 +4,6 @@ const {Provider} = require("react-redux");
 const mockData = require("lib/fake-data");
 const {selectNewTabSites} = require("selectors/selectors");
 const TestUtils = require("react-addons-test-utils");
-const globalShims = require("shims/_utils/globals");
 
 const DEFAULT_STORE = {
   getState: () => mockData,
@@ -37,7 +36,7 @@ function overrideConsoleError(onError = () => {}) {
   };
 }
 
-function overrideGlobals () {
+function overrideGlobals(globalShims) {
   const originalGlobals = {};
   const keys = Object.keys(globalShims);
   keys.forEach(key => {
@@ -45,7 +44,7 @@ function overrideGlobals () {
     global[key] = globalShims[key];
   });
   return function resetGlobals() {
-    Object.keys(globalShims).forEach(key => {
+    keys.forEach(key => {
       originalGlobals[key] = global[key];
     });
   };

--- a/content-test/test-utils.js
+++ b/content-test/test-utils.js
@@ -4,6 +4,7 @@ const {Provider} = require("react-redux");
 const mockData = require("lib/fake-data");
 const {selectNewTabSites} = require("selectors/selectors");
 const TestUtils = require("react-addons-test-utils");
+const globalShims = require("shims/_utils/globals");
 
 const DEFAULT_STORE = {
   getState: () => mockData,
@@ -36,11 +37,26 @@ function overrideConsoleError(onError = () => {}) {
   };
 }
 
+function overrideGlobals () {
+  const originalGlobals = {};
+  const keys = Object.keys(globalShims);
+  keys.forEach(key => {
+    originalGlobals[key] = global[key];
+    global[key] = globalShims[key];
+  });
+  return function resetGlobals() {
+    Object.keys(globalShims).forEach(key => {
+      originalGlobals[key] = global[key];
+    });
+  };
+}
+
 module.exports = {
   rawMockData: mockData,
   mockData: Object.assign({}, mockData, selectNewTabSites(mockData)),
   createMockProvider,
   renderWithProvider,
   faker: require("test/faker"),
-  overrideConsoleError
+  overrideConsoleError,
+  overrideGlobals
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-transform-strict-mode": "6.11.3",
     "babel-preset-react": "6.11.1",
     "chai": "3.5.0",
+    "co-task": "1.0.0",
     "conventional-changelog-cli": "1.2.0",
     "cpx": "1.5.0",
     "eslint": "3.5.0",

--- a/shims/_utils/globals.js
+++ b/shims/_utils/globals.js
@@ -1,0 +1,5 @@
+module.exports = {
+  alert: () => {},
+  confirm: () => {},
+  Services: {obs: {notifyObservers: sinon.spy()}}
+};

--- a/shims/_utils/globals.js
+++ b/shims/_utils/globals.js
@@ -1,5 +1,10 @@
+const Task = require("co-task");
 module.exports = {
+  // These are so we don't interupt the browser by an alert/confirm window
   alert: () => {},
-  confirm: () => {},
-  Services: {obs: {notifyObservers: sinon.spy()}}
+  confirm: () => true,
+
+  // These are Firefox globals that are often used
+  Services: {obs: {notifyObservers: sinon.spy()}},
+  Task
 };


### PR DESCRIPTION
This PR adds overrides for globals in test utils, as well as a shim for `Task`. see `globals.test.js` for examples of usage.