### PR TITLE
fix(addon): Remove the frame-src definition as it is now obsolete.

### DIFF
--- a/bin/generate-html.js
+++ b/bin/generate-html.js
@@ -9,7 +9,7 @@ const defaults = {
 function template(rawOptions) {
   const options = Object.assign({}, defaults, rawOptions || {});
   const csp = options.csp === "on" ?
-    "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'self'; img-src http: https: data:; style-src 'self' 'unsafe-inline'; child-src 'self' https://*.youtube.com https://*.vimeo.com; frame-src 'self' https://*.youtube.com https://*.vimeo.com\">" :
+    "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'self'; img-src http: https: data:; style-src 'self' 'unsafe-inline'; child-src 'self' https://*.youtube.com https://*.vimeo.com\">" :
     "";
   return `<!doctype html>
 <html lang="en-us">


### PR DESCRIPTION
According to [devmo](https://developer.mozilla.org/docs/Web/Security/CSP/CSP_policy_directives) and the [implementation bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1045891), `child-src` was introduced in Firefox 45.

Currently the CSP lists both `child-src` and `frame-src`, however, as activity stream's minimum version is FF 45, all that needs to be listed is `child-src`.

This will also avoid the obsolete warning that is seen on the console when a new tab is opened.