### PR TITLE
feat(metadata) Closes #1410 Create a metadata parser

### DIFF
--- a/addon/MetadataParser.js
+++ b/addon/MetadataParser.js
@@ -1,0 +1,47 @@
+/* globals require, exports */
+"use strict";
+
+const {getMetadata} = require("common/vendor")("PageMetadataParser");
+const {Cc, Ci} = require("chrome");
+
+function MetadataParser() {
+}
+
+MetadataParser.prototype = {
+  /**
+   * Parse the outerHTML
+   */
+  _getDocumentObject(text) {
+    const parser = Cc["@mozilla.org/xmlextras/domparser;1"]
+                  .createInstance(Ci.nsIDOMParser);
+    return parser.parseFromString(text, "text/html");
+  },
+
+  /**
+   * Format the data so the metadata DB receives it
+   */
+  _formatData(data, url) {
+    const images = data.image_url ? [{url: data.image_url, height: 500, width: 500}] : [];
+    const formattedData = {
+      url,
+      images,
+      original_url: data.original_url,
+      title: data.title,
+      description: data.description,
+      favicon_url: data.icon_url
+    };
+    return formattedData;
+  },
+
+  /**
+   * Parse HTML, get the metadata from it, and format it
+   */
+  parseHTMLText(raw, url) {
+    return new Promise(resolve => {
+      const doc = this._getDocumentObject(raw);
+      resolve(this._formatData(getMetadata(doc, url), url));
+    });
+  }
+};
+
+exports.MetadataParser = MetadataParser;

--- a/common/vendor-src.js
+++ b/common/vendor-src.js
@@ -8,7 +8,8 @@ const vendorModules = {
   "redux-thunk": require("redux-thunk"),
   "seedrandom": require("seedrandom"),
   "url-parse": require("url-parse"),
-  "DoublyLinkedList": require("DoublyLinkedList/doubly-linked-list").DoublyLinkedList
+  "DoublyLinkedList": require("DoublyLinkedList/doubly-linked-list").DoublyLinkedList,
+  "PageMetadataParser": require("page-metadata-parser")
 };
 
 module.exports = function vendor(moduleName) {

--- a/content-test/addon/MetadataParser.test.js
+++ b/content-test/addon/MetadataParser.test.js
@@ -1,0 +1,77 @@
+/* globals assert, require */
+"use strict";
+const createMetadataParser = require("inject!addon/MetadataParser");
+const TEST_TITLE = "Test Page";
+const TEST_ICON = "https://www.foo.com/icon.png";
+const TEST_IMAGE = "https://www.foo.com/image.png";
+const TEST_DESCRIPTION = "This is a description";
+const TEST_HTML = `<html>
+  <head>
+    <title>${TEST_TITLE}</title>
+    <link rel="shortcut icon" type="image/x-icon" href="${TEST_ICON}" />
+    <meta property="og:description" content="${TEST_DESCRIPTION}" />
+    <meta property="og:image" content="${TEST_IMAGE}" />
+  </head>
+ </html>`;
+
+describe("MetadataParser", () => {
+  const {MetadataParser} = createMetadataParser({
+    "common/vendor.bundle": {url: {resolve(url) {return url;}}},
+    "chrome": {
+      Cc: {"@mozilla.org/xmlextras/domparser;1": {createInstance: () => new DOMParser()}},
+      Ci: {nsIDOMParser: {}}
+    }
+  });
+  const metadataParser = new MetadataParser();
+
+  it("should get the document object", () => {
+    const result = metadataParser._getDocumentObject(TEST_HTML);
+    assert.ok(result);
+    assert.equal(result.querySelector("title").textContent, "Test Page");
+  });
+
+  it("should format the data properly", () => {
+    const originalUrl = "https://www.foo.com";
+    const incomingData = {
+      "description": "Some description",
+      "icon_url": "//www.foo.com/icon.png",
+      "image_url": "//www.foo.com/image.png",
+      "title": "Some title",
+      "url": "https:///"
+    };
+    const expectedFormattedData = {
+      "url": originalUrl,
+      "images": [{"url": incomingData.image_url, "height": 500, "width": 500}],
+      "title": incomingData.title,
+      "description": incomingData.description,
+      "favicon_url": incomingData.icon_url
+    };
+    // format the data so the MetadataStore can store it properly
+    const formattedData = metadataParser._formatData(incomingData, originalUrl);
+
+    assert.equal(formattedData.url, expectedFormattedData.url);
+    assert.deepEqual(formattedData.images, expectedFormattedData.images);
+    assert.equal(formattedData.title, expectedFormattedData.title);
+    assert.equal(formattedData.description, expectedFormattedData.description);
+    assert.equal(formattedData.favicon_url, expectedFormattedData.favicon_url);
+  });
+
+  it("should parse HTML text", () => {
+    const url = "https://foo.com";
+    const expectedResult = {
+      url,
+      "images": [{"url": TEST_IMAGE, "height": 500, "width": 500}],
+      "title": TEST_TITLE,
+      "favicon_url": TEST_ICON,
+      "description": TEST_DESCRIPTION
+    };
+    return metadataParser.parseHTMLText(TEST_HTML, url).then(result => {
+      assert.ok(result);
+      assert.equal(result.url, expectedResult.url);
+      assert.equal(result.title, expectedResult.title);
+      assert.equal(result.description, expectedResult.description);
+      assert.deepEqual(result.images, expectedResult.images);
+      assert.equal(result.favicon_url, TEST_ICON);
+    });
+  });
+});

--- a/content-test/meta/shims/chrome.test.js
+++ b/content-test/meta/shims/chrome.test.js
@@ -17,6 +17,12 @@ describe("Chrome", () => {
       assert.isTrue(instance.Cu.import.isSinonProxy);
     });
   });
+  describe("#Ci", () => {
+    it("should have a .nsIDOMParser spy", () => {
+      assert.property(instance.Ci, "nsIDOMParser");
+      assert.isTrue(instance.Ci.nsIDOMParser.isSinonProxy);
+    });
+  });
   describe("chrome", () => {
     it("should be an instance of Chrome", () => {
       assert.instanceOf(chrome, Chrome);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "moment": "2.15.1",
     "react": "15.3.2",
     "react-dom": "15.3.2",
+    "page-metadata-parser": "^0.4.2",
     "react-json-inspector": "7.0.0",
     "react-redux": "4.4.5",
     "react-router": "2.8.0",

--- a/shims/chrome.js
+++ b/shims/chrome.js
@@ -1,8 +1,8 @@
 class Chrome {
   constructor() {
     this.Cc = {};
-    this.Cu = {import: sinon.spy()};
-    this.Ci = {};
+    this.Cu = {import: sinon.spy(), importGlobalProperties: sinon.spy()};
+    this.Ci = {nsIDOMParser: sinon.spy()};
   }
 }
 module.exports = new Chrome();


### PR DESCRIPTION
* Creates a MetadataParser module (not actually used anywhere yet)
    * Receieves a DOM, parses it
    * Gets metdata for that DOM (from remote service)
    * Formats it correctly for the metadataStore to insert it correctly 
* Module calls into remote page-metadata-parser service
* Import the page-metadata-parser package
* Tests for MetadataParser
* Adds relevant shims for MetadataParser