### PR TITLE
feat(metadata): Closes #1409 Create a page scraper

### DIFF
--- a/addon/PageScraper.js
+++ b/addon/PageScraper.js
@@ -1,0 +1,77 @@
+/* globals Services, Task */
+"use strict";
+
+const {MetadataParser} = require("addon/MetadataParser");
+const {Cu} = require("chrome");
+const options = require("@loader/options");
+
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Task.jsm");
+Cu.importGlobalProperties(["URL"]);
+
+const DEFAULT_OPTIONS = {
+  metadataTTL: 3 * 24 * 60 * 60 * 1000, // 3 days for the metadata to live
+  framescriptPath: new URL("data/page-scraper-content-script.js", options.prefixURI),
+  blackList: ["about:", "localhost", "resource://"]
+};
+
+function PageScraper(previewProvider, options = {}) {
+  this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+  this._previewProvider = previewProvider;
+  this._metadataParser = new MetadataParser();
+}
+
+PageScraper.prototype = {
+  /**
+   * Check if the link is already in the metadata database. If not, parse the
+   *  HTML and insert it in the metadata database
+   */
+  _asyncParseAndSave: Task.async(function*(raw, url) {
+    let link = yield this._previewProvider.asyncDoesSingleLinkExist(url);
+    if (!link) {
+      let metadata = yield this._metadataParser.parseHTMLText(raw, url);
+      this._insertMetadata(metadata);
+    }
+  }),
+
+  /**
+   * Insert the metadata in the metadata database, along with it's source.
+   * Also add it to the metadata cache
+   */
+  _insertMetadata(metadata) {
+    if (Object.keys(metadata).length) {
+      this._previewProvider.processAndInsertMetadata([metadata], "Local");
+    }
+  },
+
+  /**
+   * Ensure that the page doesn't belong to a black list
+   */
+  _blackListFiter(url) {
+    return (this.options.blackList.every(item => url.indexOf(item) === -1));
+  },
+
+  /**
+   * Initialize the Page Scraper
+   */
+  init() {
+    Services.mm.loadFrameScript(this.options.framescriptPath, true);
+    Services.mm.addMessageListener("page-scraper-message", message => {
+      let {text, url} = message.data.data;
+      if (message.data.type === "PAGE_HTML" && this._blackListFiter(url)) {
+        this._asyncParseAndSave(text, url);
+      }
+    });
+  },
+
+  /**
+   * Uninitialize the Page Scraper
+   */
+  uninit() {
+    Services.mm.removeMessageListener("page-scraper-message", this);
+    Services.mm.removeDelayedFrameScript(this.options.framescriptPath);
+  }
+};
+
+exports.PageScraper = PageScraper;

--- a/test/test-PageScraper.js
+++ b/test/test-PageScraper.js
@@ -1,0 +1,95 @@
+/* globals require, exports */
+
+"use strict";
+
+const {before, after} = require("sdk/test/utils");
+const {PageScraper} = require("addon/PageScraper");
+const DUMMY_PARSED_METADATA = {metadata: "Some dummy metadata"};
+
+let gMetadataStore = [];
+let gPageScraper;
+let parseCallCount;
+
+const mockPreviewProvider = {
+  processLinks(link) {
+    return link.map(link => Object.assign({}, link, {cache_key: link.url, places_url: link.url}));
+  },
+  asyncDoesSingleLinkExist(url) {
+    let doesExists = false;
+    if (gMetadataStore[0]) {
+      gMetadataStore.forEach(item => {
+        if (item.url === url) {
+          doesExists = true;
+        }
+      });
+    }
+    return doesExists;
+  },
+  processAndInsertMetadata(metadata, source) {
+    const processedLink = this.processLinks(metadata);
+    this.insertMetadata(processedLink, source);
+  },
+  insertMetadata(metadata, source) {
+    const linkToInsert = Object.assign({}, metadata[0], {metadata_source: source});
+    gMetadataStore.push(linkToInsert);
+  }
+};
+
+exports.test_parse_and_save_HTML_only_once = function*(assert) {
+  let metadataObj = {
+    url: "https://www.foo.com",
+    metadata: DUMMY_PARSED_METADATA.metadata,
+    metadata_source: "Local"
+  };
+  // attempt to parse and save a page
+  yield gPageScraper._asyncParseAndSave(DUMMY_PARSED_METADATA, metadataObj.url);
+  let linksInserted = gMetadataStore[0];
+
+  // make sure we parsed and saved it in the DB
+  assert.equal(parseCallCount, 1, "we parsed the HTML once");
+  assert.equal(gMetadataStore.length, 1, "successfully inserted item into DB");
+  assert.equal(linksInserted.url, metadataObj.url, "parsed the correct url");
+  assert.equal(linksInserted.metadata, metadataObj.metadata, "extracted the correct metadata");
+  assert.equal(linksInserted.metadata_source, metadataObj.metadata_source, "attached the correct metadata_source");
+
+  // attempt to parse and save the same page as above
+  yield gPageScraper._asyncParseAndSave(DUMMY_PARSED_METADATA, metadataObj.url);
+
+  // we should NOT have parsed the page a second time, and the DB should be untouched
+  assert.equal(parseCallCount, 1, "we did not parse the same link again");
+  assert.deepEqual(gMetadataStore[0], linksInserted, "we did not insert the same link again");
+};
+
+exports.test_no_metadata_returned = function(assert) {
+  // the DB should be empty to start
+  const noMetadata = {};
+  assert.equal(gMetadataStore[0], undefined, "sanity check that our store is empty");
+
+  // try to insert some empty metadata and make sure that it didn't get inserted
+  gPageScraper._insertMetadata(noMetadata);
+  assert.equal(gMetadataStore[0], undefined, "we didn't insert the page with no metadata");
+
+  // insert some proper metadata and check that it correctly inserted
+  gPageScraper._insertMetadata(DUMMY_PARSED_METADATA);
+  assert.equal(gMetadataStore[0].metadata, DUMMY_PARSED_METADATA.metadata, "we did insert a page with metadata");
+};
+
+before(exports, () => {
+  parseCallCount = 0;
+  gPageScraper = new PageScraper(mockPreviewProvider, {framescriptPath: ""});
+  gPageScraper.init();
+  gPageScraper._metadataParser = {
+    parseHTMLText(raw, url) {
+      parseCallCount++;
+      return Promise.resolve({url, metadata: raw.metadata, cache_key: url});
+    }
+  };
+});
+
+after(exports, () => {
+  gPageScraper.uninit();
+  parseCallCount = 0;
+  gMetadataStore = [];
+});
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
* Create a PageSraper module (not instantiated anywhere yet)
    * Makes use of the MetadataParser to get metadata for links locally within page
    * Injects a frame script (not yet created) to get metadata for the page you're browsing
    * Has a blacklist for links NOT to get metadata for (can be added to)
    * Inserts metadata into the MetadataStore DB (and respectively to it's cache)
* Tests for PageScraper
* A function in PreviewProvider to check if the single page you're visiting already has metadata for it - in that case don't re-parse and re-compute metadata
* Tests for the addition of PreviewProvider's function