### PR TITLE
feat(metadata): Closes #1409 Create a page scraper

### DIFF
--- a/addon/MetadataStore.js
+++ b/addon/MetadataStore.js
@@ -492,6 +492,22 @@ MetadataStore.prototype = {
   }),
 
   /**
+   * Check if the link exists in the database by checking if it's cache key exists
+   *
+   * @param {String} key a cache key
+   *
+   * Returns a promise with the array of the retrieved metadata record
+   */
+  asyncCacheKeyExists: Task.async(function*(key) {
+    try {
+      let metadataLink = yield this.asyncExecuteQuery(`SELECT 1 FROM page_metadata WHERE cache_key = '${key}'`);
+      return metadataLink.length > 0;
+    } catch (e) {
+      return false;
+    }
+  }),
+
+  /**
   * Enables the data expiry job. The database connection needs to
   * be established prior to calling this function. Once it's triggered,
   * any following calls will be ignored unless the user disables

--- a/addon/PageScraper.js
+++ b/addon/PageScraper.js
@@ -1,0 +1,96 @@
+/* globals Services, Task */
+"use strict";
+
+const {MetadataParser} = require("addon/MetadataParser");
+const {Cu} = require("chrome");
+const options = require("@loader/options");
+
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Task.jsm");
+Cu.importGlobalProperties(["URL"]);
+
+const DEFAULT_OPTIONS = {
+  framescriptPath: new URL("data/page-scraper-content-script.js", options.prefixURI),
+  blacklist: ["about:", "localhost:", "resource://"]
+};
+
+function PageScraper(previewProvider, options = {}) {
+  this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+  this._previewProvider = previewProvider;
+  this._metadataParser = new MetadataParser();
+}
+
+/**
+ * Receives raw HTML from a page and sends it to a service to be parsed and the
+ * metadata extracted, and then stores that in the metadata DB. It takes an instance
+ * of PreviewProvider, since all the link processing takes places in PreviewProvider
+ */
+
+PageScraper.prototype = {
+  /**
+   * Check if the link is already in the metadata database. If not, parse the
+   * HTML and insert it in the metadata database
+   */
+  _asyncParseAndSave: Task.async(function*(rawHTML, url) {
+    let link = yield this._previewProvider.asyncLinkExist(url);
+    if (!link) {
+      let metadata;
+      try {
+        metadata = yield this._metadataParser.parseHTMLText(rawHTML, url);
+      } catch (e) {
+        Cu.reportError(`MetadataParser failed to parse ${url}`);
+      }
+      if (this._shouldSaveMetadata(metadata)) {
+        this._insertMetadata(metadata);
+      }
+    }
+  }),
+
+  /**
+   * Insert the metadata in the metadata database, along with it's source.
+   */
+  _insertMetadata(metadata) {
+    this._previewProvider.processAndInsertMetadata(metadata, "Local");
+  },
+
+  /**
+   * If metadata has neither a title, nor a favicon_url we do not want to insert
+   * it into the metadata DB
+   */
+  _shouldSaveMetadata(metadata) {
+    return (metadata && !!metadata.title && !!metadata.favicon_url);
+  },
+
+  /**
+   * Ensure that the page doesn't belong to a blacklist by checking that the
+   * url is not a substring of a restricted set of knows urls that should not
+   * collect metadata
+   */
+  _blacklistFilter(url) {
+    return (this.options.blacklist.every(item => url.indexOf(item) === -1));
+  },
+
+  /**
+   * Initialize the Page Scraper
+   */
+  init() {
+    Services.mm.loadFrameScript(this.options.framescriptPath, true);
+    Services.mm.addMessageListener("page-scraper-message", message => {
+      let {text, url} = message.data.data;
+      if (message.data.type === "PAGE_HTML" && this._blacklistFilter(url)) {
+        this._asyncParseAndSave(text, url);
+      }
+    });
+  },
+
+  /**
+   * Uninitialize the Page Scraper
+   */
+  uninit() {
+    Services.mm.removeMessageListener("page-scraper-message", this);
+    Services.mm.removeDelayedFrameScript(this.options.framescriptPath);
+  }
+};
+
+exports.PageScraper = PageScraper;

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -359,13 +359,32 @@ PreviewProvider.prototype = {
   },
 
   /**
-   * Do some pre-processing on the links before inserting them into the metadata
+   * Do some pre-processing on the link before inserting it into the metadata
    * DB and adding them to the metadata cache
    */
-  processAndInsertMetadata(links) {
-    const processedLinks = this._processLinks(links);
-    this.insertMetadata(processedLinks);
+  processAndInsertMetadata(link, metadataSource) {
+    const processedLink = this._processLinks([link]);
+    this.insertMetadata(processedLink, metadataSource);
   },
+
+  /**
+   * Check if a single link exists in the metadata DB
+   */
+  asyncLinkExist: Task.async(function*(url) {
+    let key = this._createCacheKey(url);
+    if (!key) {
+      return false;
+    }
+
+    // Hit the cache first and return true immediately if we have a hit
+    const metadataFromCache = MetadataCache.cache.get(key);
+    if (metadataFromCache) {
+      return true;
+    }
+
+    const linkExists = yield this._metadataStore.asyncCacheKeyExists(key);
+    return linkExists;
+  }),
 
   /**
    * Initialize Preview Provider

--- a/test/test-MetadataStore.js
+++ b/test/test-MetadataStore.js
@@ -174,6 +174,15 @@ exports.test_async_get_by_cache_key = function*(assert) {
   assert.equal(metaObjects.length, metadataFixture.length, "It should fetch all metadata records");
 };
 
+exports.test_async_get_single_link_by_cache_key = function*(assert) {
+  yield gMetadataStore.asyncInsert(metadataFixture);
+  let fixture = metadataFixture[0];
+  let linkExists = yield gMetadataStore.asyncCacheKeyExists(fixture.cache_key);
+  assert.equal(linkExists, true, "It should fetch one metadata record");
+  linkExists = yield gMetadataStore.asyncCacheKeyExists("idontexist.com/");
+  assert.equal(linkExists, false, "It should return an empty array since it doesn't exist");
+};
+
 exports.test_async_get_by_cache_key_in_special_cases = function*(assert) {
   yield gMetadataStore.asyncInsert(metadataFixture);
 

--- a/test/test-PageScraper.js
+++ b/test/test-PageScraper.js
@@ -1,0 +1,129 @@
+/* globals require, exports */
+
+"use strict";
+
+const {before, after} = require("sdk/test/utils");
+const {PageScraper} = require("addon/PageScraper");
+const DUMMY_PARSED_METADATA = {
+  metadata: "Some dummy metadata",
+  title: "Some dummy title",
+  favicon_url: "Some dummy favicon_url"
+};
+
+let gMetadataStore = [];
+let gPageScraper;
+let parseCallCount;
+
+const mockPreviewProvider = {
+  processLinks(link) {
+    return link.map(link => Object.assign({}, link, {cache_key: link.url, places_url: link.url}));
+  },
+  asyncLinkExist(url) {
+    let doesExists = false;
+    if (gMetadataStore[0]) {
+      gMetadataStore.forEach(item => {
+        if (item.url === url) {
+          doesExists = true;
+        }
+      });
+    }
+    return doesExists;
+  },
+  processAndInsertMetadata(metadata, source) {
+    const processedLink = this.processLinks([metadata]);
+    this.insertMetadata(processedLink, source);
+  },
+  insertMetadata(metadata, source) {
+    const linkToInsert = Object.assign({}, metadata[0], {metadata_source: source});
+    gMetadataStore.push(linkToInsert);
+  }
+};
+
+exports.test_parse_and_save_HTML_only_once = function*(assert) {
+  let metadataObj = {
+    url: "https://www.foo.com",
+    metadata: DUMMY_PARSED_METADATA.metadata,
+    metadata_source: "Local"
+  };
+  // attempt to parse and save a page
+  yield gPageScraper._asyncParseAndSave(DUMMY_PARSED_METADATA, metadataObj.url);
+  let linksInserted = gMetadataStore[0];
+
+  // make sure we parsed and saved it in the DB
+  assert.equal(parseCallCount, 1, "we parsed the HTML once");
+  assert.equal(gMetadataStore.length, 1, "successfully inserted item into DB");
+  assert.equal(linksInserted.url, metadataObj.url, "parsed the correct url");
+  assert.equal(linksInserted.metadata, metadataObj.metadata, "extracted the correct metadata");
+  assert.equal(linksInserted.metadata_source, metadataObj.metadata_source, "attached the correct metadata_source");
+
+  // attempt to parse and save the same page as above
+  yield gPageScraper._asyncParseAndSave(DUMMY_PARSED_METADATA, metadataObj.url);
+
+  // we should NOT have parsed the page a second time, and the DB should be untouched
+  assert.equal(parseCallCount, 1, "we did not parse the same link again");
+  assert.deepEqual(gMetadataStore[0], linksInserted, "we did not insert the same link again");
+};
+
+exports.test_no_metadata_returned = function*(assert) {
+  // the DB should be empty to start
+  const noMetadata = {title: null, favicon_url: null, url: "https://www.example.com"};
+  assert.equal(gMetadataStore[0], undefined, "sanity check that our store is empty");
+
+  // try to insert some empty metadata and make sure that it didn't get inserted
+  yield gPageScraper._asyncParseAndSave(noMetadata);
+  assert.equal(gMetadataStore[0], undefined, "we didn't insert the page with no metadata");
+
+  // insert some proper metadata and check that it correctly inserted
+  yield gPageScraper._asyncParseAndSave(DUMMY_PARSED_METADATA);
+  assert.equal(gMetadataStore[0].metadata, DUMMY_PARSED_METADATA.metadata, "we did insert a page with metadata");
+};
+
+exports.test_parse_html_rejects = function*(assert) {
+  // force the metadata parser to throw an execption
+  gPageScraper._metadataParser = {
+    parseHTMLText() {
+      return Promise.reject();
+    }
+  };
+  // the DB should be empty to start
+  assert.equal(gMetadataStore[0], undefined, "sanity check that our store is empty");
+
+  // try to insert some empty metadata and make sure that it didn't get inserted
+  yield gPageScraper._asyncParseAndSave({});
+  assert.equal(gMetadataStore[0], undefined, "we didn't insert the page with no metadata");
+};
+
+exports.test_blacklist = function(assert) {
+  let isAccepted;
+  let url = "https://www.accepted.com";
+  isAccepted = gPageScraper._blacklistFilter(url);
+  assert.equal(isAccepted, true, `${url} does not exist in the blacklist`);
+
+  url = "about:addons";
+  isAccepted = gPageScraper._blacklistFilter(url);
+  assert.equal(isAccepted, false, `${url} exists in the blacklist`);
+
+  url = "https://localhost:8080";
+  isAccepted = gPageScraper._blacklistFilter(url);
+  assert.equal(isAccepted, false, `${url} exists in the blacklist`);
+};
+
+before(exports, () => {
+  parseCallCount = 0;
+  gPageScraper = new PageScraper(mockPreviewProvider, {framescriptPath: ""});
+  gPageScraper.init();
+  gPageScraper._metadataParser = {
+    parseHTMLText(raw, url) {
+      parseCallCount++;
+      return Promise.resolve({title: raw.title, favicon_url: raw.favicon_url, url, metadata: raw.metadata, cache_key: url});
+    }
+  };
+});
+
+after(exports, () => {
+  gPageScraper.uninit();
+  parseCallCount = 0;
+  gMetadataStore = [];
+});
+
+require("sdk/test").run(exports);

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -50,6 +50,17 @@ const gMockMetadataStore = {
       });
     }
     return items;
+  },
+  asyncCacheKeyExists(key) {
+    let exists = false;
+    if (gMetadataStore[0]) {
+      gMetadataStore[0].forEach(item => {
+        if (key === item.cache_key) {
+          exists = true;
+        }
+      });
+    }
+    return exists;
   }
 };
 const gMockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
@@ -188,19 +199,29 @@ exports.test_process_links = function(assert) {
 };
 
 exports.test_process_and_insert_links = function(assert) {
-  const fakeData = [
-    {"url": "http://example.com/1", "title": "blah"},
-    {"url": "http://example.com/2", "title": "blah"}
-  ];
+  const fakeData = {"url": "http://example.com/1", "title": "Title for example.com/1"};
 
   // process and insert the links
-  gPreviewProvider.processAndInsertMetadata(fakeData);
+  gPreviewProvider.processAndInsertMetadata(fakeData, "metadata_source");
+  assert.equal(gMetadataStore[0].length, 1, "saved one item");
 
-  assert.equal(gMetadataStore[0].length, 2, "saved two items");
-  assert.equal(gMetadataStore[0][0].url, fakeData[0].url, "first site was saved as expected");
-  assert.equal(gMetadataStore[0][0].cache_key, "example.com/1", "we added a cache_key for the first site");
-  assert.equal(gMetadataStore[0][1].url, fakeData[1].url, "second site was saved as expected");
-  assert.equal(gMetadataStore[0][1].cache_key, "example.com/2", "we added a cache_key for the second site");
+  // check the first site inserted in the metadata DB
+  assert.equal(gMetadataStore[0][0].url, fakeData.url, "site was saved as expected");
+  assert.equal(gMetadataStore[0][0].cache_key, "example.com/1", "we added a cache_key for the site");
+  assert.equal(gMetadataStore[0][0].metadata_source, "metadata_source", "we added a metadata_source for the site");
+  assert.equal(gMetadataStore[0][0].title, fakeData.title, "we added the title from the metadata for the site");
+};
+
+exports.test_look_for_link_in_DB = function*(assert) {
+  // the first time we check the link will not be in the DB
+  const urlObject = {url: "https://www.dontexist.com", cache_key: "dontexist.com"};
+  let doesLinkExist = yield gPreviewProvider.asyncLinkExist(urlObject.url);
+  assert.equal(doesLinkExist, false, "link doesn't exist at first");
+
+  // insert the link and check again, this time it will be in the DB
+  gPreviewProvider.processAndInsertMetadata(urlObject);
+  doesLinkExist = yield gPreviewProvider.asyncLinkExist(urlObject.url);
+  assert.equal(doesLinkExist, true, "link does exist this time around");
 };
 
 exports.test_dedupe_urls = function(assert) {


### PR DESCRIPTION
* Create a PageSraper module (not instantiated anywhere yet)
    * Makes use of the MetadataParser to get metadata for links locally within page 
    * Injects a frame script (not yet created) to get metadata for the page you're browsing
    * Has a blacklist for links NOT to get metadata for (can be added to)
    * Inserts metadata into the MetadataStore DB (and respectively to it's cache)
* Tests for PageScraper
* A function in PreviewProvider to check if the single page you're visiting already has metadata for it - in that case don't re-parse and re-compute metadata
* Tests for the addition of PreviewProvider's function

Fixes #1409 