### PR TITLE
chore(performance): Only set state if differences were found

### DIFF
--- a/addon/PageWorker.js
+++ b/addon/PageWorker.js
@@ -2,6 +2,7 @@ const {Page} = require("sdk/page-worker");
 const {data} = require("sdk/self");
 const {LOCAL_STORAGE_KEY} = require("common/constants");
 const {ADDON_TO_CONTENT} = require("common/event-constants");
+const watch = require("common/vendor")("redux-watch");
 
 class PageWorker {
   constructor({store} = {}) {
@@ -25,9 +26,13 @@ class PageWorker {
       contentScriptFile: data.url("content-bridge.js"),
       contentScriptWhen: "start"
     });
+
+    // Note: watch only calls the callback (this._onDispatch) if something on
+    // the state object actually changed
+    const w = watch(this._store.getState);
     // Note: According to the redux docs, calling .subscribe on a store
     // returns a function which will unsubscribe
-    this._unsubscribe = this._store.subscribe(this._onDispatch);
+    this._unsubscribe = this._store.subscribe(w(this._onDispatch));
   }
   destroy() {
     if (this._page) {

--- a/common/reducers/Filter.js
+++ b/common/reducers/Filter.js
@@ -11,7 +11,8 @@ module.exports = function Filter(prevState = INITIAL_STATE, action) {
   switch (action.type) {
     case am.type("NOTIFY_FILTER_QUERY"):
       state.query = action.data || "";
-      break;
+      return state;
+    default:
+      return prevState;
   }
-  return state;
 };

--- a/common/vendor-src.js
+++ b/common/vendor-src.js
@@ -4,12 +4,14 @@
 // require("common/vendor")("my-dependency");
 
 const vendorModules = {
+  "deep-diff": require("deep-diff"),
   "redux": require("redux"),
   "redux-thunk": require("redux-thunk"),
   "seedrandom": require("seedrandom"),
   "url-parse": require("url-parse"),
   "DoublyLinkedList": require("DoublyLinkedList/doubly-linked-list").DoublyLinkedList,
-  "PageMetadataParser": require("page-metadata-parser")
+  "PageMetadataParser": require("page-metadata-parser"),
+  "redux-watch": require("redux-watch")
 };
 
 module.exports = function vendor(moduleName) {

--- a/content-test/common/reducers/equality.test.js
+++ b/content-test/common/reducers/equality.test.js
@@ -1,0 +1,35 @@
+const createStore = require("common/create-store");
+const {actions} = require("common/action-manager");
+const {createRows} = require("test/faker");
+
+describe("Reducer equality", () => {
+  let store;
+  function dispatchRows(type, length = 10) {
+    store.dispatch(actions.Response(type, createRows({length})));
+  }
+  beforeEach(() => {
+    store = createStore({logger: false});
+  });
+  it("should return a reference", () => {
+    assert.equal(store.getState(), store.getState());
+  });
+  it("should dispatch rows", () => {
+    dispatchRows("TOP_FRECENT_SITES_RESPONSE", 6);
+    const newState = store.getState();
+    assert.equal(newState.TopSites.rows.length, 6);
+  });
+  it("should not modify other unrelated state", () => {
+    const oldState = store.getState();
+    dispatchRows("TOP_FRECENT_SITES_RESPONSE", 6);
+    const newState = store.getState();
+    assert.equal(newState.Highlights, oldState.Highlights);
+  });
+  it("should not modify any state for unused actions", () => {
+    const oldState = store.getState();
+    store.dispatch(actions.Notify("NOTIFY_PERFORMANCE", {}));
+    const newState = store.getState();
+    Object.keys(oldState).forEach(key => {
+      assert.equal(newState[key], oldState[key], key);
+    });
+  });
+});

--- a/content-test/common/reducers/reducers.test.js
+++ b/content-test/common/reducers/reducers.test.js
@@ -2,8 +2,11 @@ const createStore = require("common/create-store");
 const {actions} = require("common/action-manager");
 const {createRows} = require("test/faker");
 
-describe("Reducer equality", () => {
+// These tests ensure that all our reducers
+// do not unintentionally create new objects
+describe("Reducers", () => {
   let store;
+  // Dispatch a fake action that contains an array of links
   function dispatchRows(type, length = 10) {
     store.dispatch(actions.Response(type, createRows({length})));
   }
@@ -11,9 +14,9 @@ describe("Reducer equality", () => {
     store = createStore({logger: false});
   });
   it("should return a reference", () => {
-    assert.equal(store.getState(), store.getState());
+    assert.strictEqual(store.getState(), store.getState());
   });
-  it("should dispatch rows", () => {
+  it("should cause a state change for a related reducer", () => {
     dispatchRows("TOP_FRECENT_SITES_RESPONSE", 6);
     const newState = store.getState();
     assert.equal(newState.TopSites.rows.length, 6);
@@ -22,7 +25,7 @@ describe("Reducer equality", () => {
     const oldState = store.getState();
     dispatchRows("TOP_FRECENT_SITES_RESPONSE", 6);
     const newState = store.getState();
-    assert.equal(newState.Highlights, oldState.Highlights);
+    assert.strictEqual(newState.Highlights, oldState.Highlights);
   });
   it("should not modify any state for unused actions", () => {
     const oldState = store.getState();

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "redux": "3.6.0",
     "redux-logger": "2.6.1",
     "redux-thunk": "2.1.0",
+    "redux-watch": "1.1.1",
     "reselect": "2.5.4",
     "seedrandom": "2.4.2",
     "url-parse": "1.1.3"


### PR DESCRIPTION
This PR changes the page worker behaviour so that it only saves a new copy of the redux state if anything has changed.