### PR TITLE
fix (content): #1372 stopPropagation of LinkMenuButton click

### DIFF
--- a/content-src/components/ContextMenu/ContextMenu.js
+++ b/content-src/components/ContextMenu/ContextMenu.js
@@ -4,17 +4,16 @@ const ContextMenu = React.createClass({
   componentWillMount() {
     this.hideContext = () => {
       this.props.onUpdate(false);
-      window.removeEventListener("click", this.hideContext);
     };
-  },
-  componentWillUnmount() {
-    window.removeEventListener("click", this.hideContext);
   },
   componentDidUpdate(prevProps) {
     if (this.props.visible && !prevProps.visible) {
       setTimeout(() => {
         window.addEventListener("click", this.hideContext, false);
       }, 0);
+    }
+    if (!this.props.visible && prevProps.visible) {
+      window.removeEventListener("click", this.hideContext);
     }
   },
   render() {

--- a/content-src/components/LinkMenuButton/LinkMenuButton.js
+++ b/content-src/components/LinkMenuButton/LinkMenuButton.js
@@ -3,6 +3,7 @@ const React = require("react");
 const LinkMenuButton = React.createClass({
   render() {
     return (<button className="link-menu-button" onClick={e => {
+      e.preventDefault();
       this.props.onClick(e);
     }}>
       <span className="sr-only">Open context menu</span>

--- a/content-src/components/LinkMenuButton/LinkMenuButton.js
+++ b/content-src/components/LinkMenuButton/LinkMenuButton.js
@@ -3,8 +3,6 @@ const React = require("react");
 const LinkMenuButton = React.createClass({
   render() {
     return (<button className="link-menu-button" onClick={e => {
-      e.preventDefault();
-      e.stopPropagation();
       this.props.onClick(e);
     }}>
       <span className="sr-only">Open context menu</span>

--- a/content-src/components/LinkMenuButton/LinkMenuButton.js
+++ b/content-src/components/LinkMenuButton/LinkMenuButton.js
@@ -4,6 +4,7 @@ const LinkMenuButton = React.createClass({
   render() {
     return (<button className="link-menu-button" onClick={e => {
       e.preventDefault();
+      e.stopPropagation();
       this.props.onClick(e);
     }}>
       <span className="sr-only">Open context menu</span>


### PR DESCRIPTION
The issue was that `hideContext` was getting called and hiding the just shown context menu. This happens after sharing and also if you try to open a context menu while already having one open for another site. It's because `window.removeEventListener("click", this.hideContext);` wasn't called yet. There might be other ways to fix this?

@k88hudson r?

Fixes #1372
