### PR TITLE
feat(metadata): Closes #1430 Init PageScraper and pref it off

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,12 @@
       "type": "string",
       "value": "weightedHighlights",
       "hidden": true
+    },
+    {
+      "name": "pageScraper",
+      "title": "Turn on page metadata scraper",
+      "type": "bool",
+      "value": false
     }
   ],
   "repository": "mozilla/activity-stream",

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -66,6 +66,11 @@ function getTestActivityStream(options = {}) {
   if (!options.mockShareProvider) {
     options.shareProvider = mockShareProvider;
   }
+  const mockPageScraper = {
+    init() {},
+    uninit() {}
+  };
+  options.pageScraper = mockPageScraper;
   let mockApp = new ActivityStreams(mockMetadataStore, options);
   return mockApp;
 }


### PR DESCRIPTION
* Creates an instance of PageScraper (pref'ed off)
* Creates a pref listener so that you can manually create an instance of PageScraper if you switch on ```extensions.@activity-streams.pageScraper``` to true.
* Adds the pref in ```package.json```
* Mocks out an instance of PageScraper for the tests