### PR TITLE
chore(gitignore): Ignore .update.rdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ firefox/
 config.yml
 .amo_config.json
 common/vendor.js
+*.update.rdf


### PR DESCRIPTION
When we run `npm run package` it's kind of annoying that these get added and not ignored. Can we just gitignore it? I'm doing this a lot for remote testing on windows.