### PR TITLE
fix(tests): Fixes #1197 Intermittent RecommendationProvider failure

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -56,7 +56,8 @@ const DEFAULT_OPTIONS = {
   recommendationTTL: 3600000, // every hour, get a new recommendation
   shareProvider: null,
   pageScraper: null,
-  searchProvider: null
+  searchProvider: null,
+  recommendationProvider: null
 };
 
 const PLACES_CHANGES_EVENTS = [
@@ -129,14 +130,7 @@ function ActivityStreams(metadataStore, options = {}) {
 
   this._asyncBuildPlacesCache();
 
-  // Only create RecommendationProvider if they are in the experiment
-  if (this._experimentProvider.data.recommendedHighlight) {
-    this._recommendationProvider = new RecommendationProvider(this._previewProvider, this._tabTracker);
-    if (simplePrefs.prefs.recommendations) {
-      this._recommendationProvider.asyncSetRecommendedContent();
-    }
-    this._refreshRecommendations(this.options.recommendationTTL);
-  }
+  this._initializeRecommendationProvider();
 
   if (this.options.shareProvider) {
     this._shareProvider = this.options.shareProvider;
@@ -297,6 +291,22 @@ ActivityStreams.prototype = {
         url: msg.data.url,
         isPrivate: msg.data.isPrivate
       });
+    }
+  },
+
+  _initializeRecommendationProvider() {
+    // Only create RecommendationProvider if they are in the experiment
+    if (this._experimentProvider.data.recommendedHighlight) {
+      if (!this.options.recommendationProvider) {
+        this._recommendationProvider = new RecommendationProvider(this._previewProvider, this._tabTracker);
+      } else {
+        this._recommendationProvider = this.options.recommendationProvider;
+      }
+      this._recommendationProvider.init();
+      if (simplePrefs.prefs.recommendations) {
+        this._recommendationProvider.asyncSetRecommendedContent();
+      }
+      this._refreshRecommendations(this.options.recommendationTTL);
     }
   },
 

--- a/addon/RecommendationProvider.js
+++ b/addon/RecommendationProvider.js
@@ -16,13 +16,8 @@ Cu.importGlobalProperties(["fetch"]);
 
 function RecommendationProvider(previewProvider, tabTracker, options = {}) {
   this.options = Object.assign({}, DEFAULT_TIMEOUTS, options);
-  this._recommendedContent = [];
-  this._blockedRecommendedContent = new Set();
-  this._currentRecommendation = null;
-  this._pocketEndpoint = simplePrefs.prefs[POCKET_API_URL];
   this._previewProvider = previewProvider;
   this._tabTracker = tabTracker;
-  this._asyncUpdateRecommendations(this.options.pocketTimeout);
 }
 
 RecommendationProvider.prototype = {
@@ -132,6 +127,16 @@ RecommendationProvider.prototype = {
         this.asyncSetRecommendedContent();
         this._asyncUpdateRecommendations(pocketTimeout);
       }, pocketTimeout);
+    }
+  },
+
+  init() {
+    this._recommendedContent = [];
+    this._blockedRecommendedContent = new Set();
+    this._currentRecommendation = null;
+    this._pocketEndpoint = simplePrefs.prefs[POCKET_API_URL];
+    if (this.options.pocketTimeout) {
+      this._asyncUpdateRecommendations(this.options.pocketTimeout);
     }
   },
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -51,6 +51,16 @@ function doDump(object, trailer) {
   dump(JSON.stringify(object, null, 1) + trailer); // eslint-disable-line no-undef
 }
 
+function getTestRecommendationProvider() {
+  return {
+    init() {},
+    asyncSetRecommendedContent() {},
+    setBlockedRecommendation() {},
+    getRecommendation() {},
+    uninit() {}
+  };
+}
+
 function getTestSearchProvider() {
   return {
     init() {},
@@ -105,6 +115,7 @@ function getTestActivityStream(options = {}) {
 
   options.pageScraper = mockPageScraper;
   options.searchProvider = getTestSearchProvider();
+  options.recommendationProvider = getTestRecommendationProvider();
   let mockApp = new ActivityStreams(mockMetadataStore, options);
   return mockApp;
 }

--- a/test/test-RecommendationProvider.js
+++ b/test/test-RecommendationProvider.js
@@ -161,7 +161,8 @@ before(exports, () => {
     }
   };
   const mockTabTracker = {handleUserEvent() {}, generateEvent() {}, handlePerformanceEvent() {}};
-  gRecommendationProvider = new RecommendationProvider(mockPreviewProvider, mockTabTracker);
+  gRecommendationProvider = new RecommendationProvider(mockPreviewProvider, mockTabTracker, {pocketTimeout: null});
+  gRecommendationProvider.init();
 });
 
 after(exports, () => {


### PR DESCRIPTION
Problem: since we were calling the function ```_asyncUpdateRecommendations``` which makes a network request in the constructor, every time we were creating an instance of RecommendationProvider we were risking making a network call if that function executed without a network connection. 
Fix: Make an init function and only call that function if we have a timeout (which we set to null in the tests) & mock it out for when we create an instance of Activity Streams

** Also had to move the initialization of recommendationProvider into a separate function because the linter was complaining that ActivityStream's constructor is too big lol **