### PR TITLE
fix (addon): #1314 remove ShareProvider race condition workaround

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -280,9 +280,7 @@ ActivityStreams.prototype = {
 
     this._store.dispatch(am.actions.Response("PREFS_RESPONSE", simplePrefs.prefs));
 
-    // Share
-    // Note: there is a race condition here, which should be resolved in https://github.com/mozilla/activity-stream/issues/1314
-    this._store.dispatch(am.actions.Response("SHARE_PROVIDERS_RESPONSE", this._shareProvider.socialProviders || []));
+    this._store.dispatch(am.actions.Response("SHARE_PROVIDERS_RESPONSE", this._shareProvider.socialProviders));
   },
 
   _respondOpenWindow({msg}) {

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -101,7 +101,8 @@ function getTestActivityStream(options = {}) {
   };
   const mockShareProvider = {
     init() {},
-    uninit() {}
+    uninit() {},
+    socialProviders: []
   };
   if (!options.mockShareProvider) {
     options.shareProvider = mockShareProvider;


### PR DESCRIPTION
~~I haven't been able to trigger the race condition manually or via our tests after removing the workaround. So I just removed the workaround. We'll see if travis is happy.~~

UPDATE: I figured it out. The issue was with the mock provider used for testing.

r? @k88hudson 
