### PR TITLE
fix(framescript): Don't wait for load before sending metadata

### DIFF
--- a/data/page-scraper-content-script.js
+++ b/data/page-scraper-content-script.js
@@ -20,7 +20,7 @@ DOMFetcher.prototype = {
   _addWindowListeners(event) {
     let window = event.target.defaultView;
     if (window === this.cfmm.content) {
-      window.addEventListener("load", this._sendContentMessage, false);
+      this._sendContentMessage();
     }
   },
 


### PR DESCRIPTION
Don't listen for load event - send metadata as soon as we get DOMContentLoaded