### PR TITLE
shield(addon): Closes #1482 Pull tabTracker out of ActivitySteam scope

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -17,7 +17,6 @@ const {Memoizer} = require("addon/Memoizer");
 const {PlacesProvider} = require("addon/PlacesProvider");
 const {SearchProvider} = require("addon/SearchProvider");
 const {ShareProvider} = require("addon/ShareProvider");
-const {TabTracker} = require("addon/TabTracker");
 const {PreviewProvider} = require("addon/PreviewProvider");
 const {RecommendationProvider} = require("addon/RecommendationProvider");
 const {TelemetrySender} = require("addon/TelemetrySender");
@@ -72,7 +71,7 @@ const PLACES_CHANGES_EVENTS = [
 
 const HOME_PAGE_PREF = "browser.startup.homepage";
 
-function ActivityStreams(metadataStore, options = {}) {
+function ActivityStreams(metadataStore, tabTracker, options = {}) {
   this.options = Object.assign({}, DEFAULT_OPTIONS, options);
   EventEmitter.decorate(this);
 
@@ -105,12 +104,8 @@ function ActivityStreams(metadataStore, options = {}) {
   );
   this._experimentProvider.init();
 
-  this._tabTracker = new TabTracker(
-    this.appURLs,
-    options.clientID,
-    this._memoized,
-    this._experimentProvider.experimentId
-  );
+  this._tabTracker = tabTracker;
+  this._tabTracker.init(this.appURLs, this._memoized, this._experimentProvider.experimentId);
 
   this._previewProvider = new PreviewProvider(this._tabTracker, metadataStore, this._experimentProvider);
 

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -1,4 +1,5 @@
 /* globals Services, Locale, XPCOMUtils */
+"use strict";
 
 const tabs = require("sdk/tabs");
 const {Ci, Cu} = require("chrome");
@@ -19,13 +20,9 @@ const PERFORMANCE_NOTIF = "performance-event";
 const RATING_NOTIF = "metadata-rating-event";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
 
-function TabTracker(trackableURLs, clientID, placesQueries, experimentId) {
+function TabTracker(clientID) {
   this._tabData = {};
-
   this._clientID = clientID;
-  this._experimentID = experimentId;
-  this._trackableURLs = trackableURLs;
-  this._placesQueries = placesQueries;
   this.onOpen = this.onOpen.bind(this);
 
   this._onPrefChange = this._onPrefChange.bind(this);
@@ -41,6 +38,12 @@ TabTracker.prototype = {
 
   get tabData() {
     return this._tabData;
+  },
+
+  init(trackableURLs, placesQueries, experimentId) {
+    this._trackableURLs = trackableURLs;
+    this._placesQueries = placesQueries;
+    this._experimentID = experimentId;
   },
 
   _addListeners() {

--- a/addon/main.js
+++ b/addon/main.js
@@ -1,8 +1,10 @@
 /* globals Task, ClientID */
+"use strict";
 
 const {PlacesProvider} = require("addon/PlacesProvider");
 const {MetadataStore, METASTORE_NAME} = require("addon/MetadataStore");
 const {MetadataCache} = require("addon/MetadataCache");
+const {TabTracker} = require("addon/TabTracker");
 const {ActivityStreams} = require("addon/ActivityStreams");
 const {setTimeout, clearTimeout} = require("sdk/timers");
 const {Cu} = require("chrome");
@@ -27,7 +29,10 @@ Object.assign(exports, {
     options.telemetry = false;
 
     Task.spawn(function*() {
-      options.clientID = yield ClientID.getClientID();
+      const clientID = yield ClientID.getClientID();
+      options.clientID = clientID;
+      const tabTracker = new TabTracker(clientID);
+
       if (options.loadReason === "upgrade") {
         yield this.migrateMetadataStore();
       }
@@ -37,7 +42,7 @@ Object.assign(exports, {
       } catch (e) {
         this.reconnectMetadataStore();
       }
-      app = new ActivityStreams(metadataStore, options);
+      app = new ActivityStreams(metadataStore, tabTracker, options);
     }.bind(this));
   },
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const {Cc, Ci, Cu, components} = require("chrome");
+const {TabTracker} = require("addon/TabTracker");
 const {ActivityStreams} = require("addon/ActivityStreams");
 const {stack: Cs} = components;
 
@@ -117,7 +118,8 @@ function getTestActivityStream(options = {}) {
   options.pageScraper = mockPageScraper;
   options.searchProvider = getTestSearchProvider();
   options.recommendationProvider = getTestRecommendationProvider();
-  let mockApp = new ActivityStreams(mockMetadataStore, options);
+  const testTabTracker = new TabTracker(options.clientID);
+  let mockApp = new ActivityStreams(mockMetadataStore, testTabTracker, options);
   return mockApp;
 }
 


### PR DESCRIPTION
* Pull TabTracker out of ActivityStream scope
* Put it in the scope of ```main.js```
* Update tests to reflect this change