### PR TITLE
shield(addon): Closes #1541 Pull TelemetrySender out of ActivityStream scope

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -18,7 +18,6 @@ const {SearchProvider} = require("addon/SearchProvider");
 const {ShareProvider} = require("addon/ShareProvider");
 const {PreviewProvider} = require("addon/PreviewProvider");
 const {RecommendationProvider} = require("addon/RecommendationProvider");
-const {TelemetrySender} = require("addon/TelemetrySender");
 const {PerfMeter} = require("addon/PerfMeter");
 const {AppURLHider} = require("addon/AppURLHider");
 const am = require("common/action-manager");
@@ -70,7 +69,7 @@ const PLACES_CHANGES_EVENTS = [
 
 const HOME_PAGE_PREF = "browser.startup.homepage";
 
-function ActivityStreams(metadataStore, tabTracker, options = {}) {
+function ActivityStreams(metadataStore, tabTracker, telemetrySender, options = {}) {
   this.options = Object.assign({}, DEFAULT_OPTIONS, options);
   EventEmitter.decorate(this);
 
@@ -94,7 +93,7 @@ function ActivityStreams(metadataStore, tabTracker, options = {}) {
   this._memoizer = new Memoizer();
   this._memoized = this._get_memoized(this._memoizer);
 
-  this._telemetrySender = new TelemetrySender();
+  this._telemetrySender = telemetrySender;
 
   this._experimentProvider = new ExperimentProvider(
     options.clientID,

--- a/addon/main.js
+++ b/addon/main.js
@@ -4,6 +4,7 @@
 const {PlacesProvider} = require("addon/PlacesProvider");
 const {MetadataStore, METASTORE_NAME} = require("addon/MetadataStore");
 const {MetadataCache} = require("addon/MetadataCache");
+const {TelemetrySender} = require("addon/TelemetrySender");
 const {TabTracker} = require("addon/TabTracker");
 const {ActivityStreams} = require("addon/ActivityStreams");
 const {setTimeout, clearTimeout} = require("sdk/timers");
@@ -32,6 +33,7 @@ Object.assign(exports, {
       const clientID = yield ClientID.getClientID();
       options.clientID = clientID;
       const tabTracker = new TabTracker(clientID);
+      const telemetrySender = new TelemetrySender();
 
       if (options.loadReason === "upgrade") {
         yield this.migrateMetadataStore();
@@ -42,7 +44,7 @@ Object.assign(exports, {
       } catch (e) {
         this.reconnectMetadataStore();
       }
-      app = new ActivityStreams(metadataStore, tabTracker, options);
+      app = new ActivityStreams(metadataStore, tabTracker, telemetrySender, options);
     }.bind(this));
   },
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const {Cc, Ci, Cu, components} = require("chrome");
+const {TelemetrySender} = require("addon/TelemetrySender");
 const {TabTracker} = require("addon/TabTracker");
 const {ActivityStreams} = require("addon/ActivityStreams");
 const {stack: Cs} = components;
@@ -119,7 +120,8 @@ function getTestActivityStream(options = {}) {
   options.searchProvider = getTestSearchProvider();
   options.recommendationProvider = getTestRecommendationProvider();
   const testTabTracker = new TabTracker(options.clientID);
-  let mockApp = new ActivityStreams(mockMetadataStore, testTabTracker, options);
+  const testTelemetrySender = new TelemetrySender();
+  let mockApp = new ActivityStreams(mockMetadataStore, testTabTracker, testTelemetrySender, options);
   return mockApp;
 }
 


### PR DESCRIPTION
* Pulls ```TelemetrySender``` out of scope of Activity Stream so the shield study can use it too to send pings
* Update tests accordingly 