### PR TITLE
fix vertical text cropping in items (#1526)

### DIFF
--- a/content-src/components/HighlightContext/HighlightContext.scss
+++ b/content-src/components/HighlightContext/HighlightContext.scss
@@ -1,5 +1,5 @@
 .highlight-context {
-  padding: $spotlight-padding;
+  padding: $spotlight-info-default-padding $spotlight-info-default-padding 11px;
   position: absolute;
   bottom: 0;
   left: 0;

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -41,12 +41,9 @@ const SpotlightItem = React.createClass({
     const description = site.description || site.url;
     const isPortrait = image.height > image.width;
 
-    // XXX The precedence here is the same as SpotlightFeedItem (now gone) was.
     // We may want to reconsider this as part of
     // https://github.com/mozilla/activity-stream/issues/1473
-    const feedName = site.provider_name ?
-      site.provider_name.toLowerCase() :
-      site.provider_display;
+    const providerName = site.provider_name ? site.provider_name.toLowerCase() : "";
     const style = {};
 
     if (imageUrl) {
@@ -62,8 +59,8 @@ const SpotlightItem = React.createClass({
         <div className="spotlight-details">
           <div className="spotlight-info">
             <div className="spotlight-text">
-              <div className="spotlight-feedname">
-                {feedName}
+              <div className="spotlight-provider-name">
+                {providerName}
               </div>
               <h4 ref="title" className="spotlight-title">{site.title}</h4>
               <p className="spotlight-description" ref="description">{description}</p>

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -48,6 +48,7 @@
   > a {
     display: block;
     color: inherit;
+    height: 100%;
   }
 
   .spotlight-image {
@@ -87,7 +88,7 @@
   }
 
   .spotlight-info {
-    padding: $spotlight-padding;
+    padding: $spotlight-info-top-padding $spotlight-info-default-padding;
   }
 
   .spotlight-text {

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -71,7 +71,7 @@
     top: $spotlight-icon-gutter;
   }
 
-  .spotlight-feedname {
+  .spotlight-provider-name {
     color: $mid-light-grey;
     font-size: 10px;
   }

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -73,14 +73,12 @@
 
   .spotlight-feedname {
     color: $mid-light-grey;
-    line-height: 1.8;
     font-size: 10px;
   }
 
   .spotlight-title {
     margin: 0 0 $spotlight-title-margin-bottom;
     font-size: inherit;
-    line-height: 1.3;
     word-wrap: break-word;
   }
 
@@ -95,6 +93,10 @@
   .spotlight-text {
     max-height: $spotlight-text-height;
     overflow: hidden;
+
+    // absolute units because this is inherited to lines with smaller font
+    // heights that are still visually compatible with this
+    line-height: 18px;
   }
 
   .spotlight-description {

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -66,7 +66,7 @@ $spotlight-padding: $base-gutter / 2;
 $spotlight-item-height: 270px;
 $spotlight-item-width: ($wrapper-max-width - $base-gutter * 2) / 3;
 $spotlight-img-height: 130px;
-$spotlight-text-height: 86px;
+$spotlight-text-height: 90px;
 $spotlight-font-size: 12px;
 $spotlight-icon-height: 35px;
 $spotlight-icon-width: 35px;

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -62,8 +62,14 @@ $feed-hover-color: rgba($black, 0.06);
 $feed-line-color: rgba($black, 0.05);
 $feed-circle-color: #CECECE;
 
-$spotlight-padding: $base-gutter / 2;
-$spotlight-item-height: 270px;
+$spotlight-info-default-padding: ($base-gutter / 2);
+
+// The top-padding needs to be less because a smaller font is used
+// immediately under it, so the default padding makes it visually appear to
+// have too much whitespace above.
+$spotlight-info-top-padding: ($base-gutter / 2) - 4;
+
+$spotlight-item-height: 262px;
 $spotlight-item-width: ($wrapper-max-width - $base-gutter * 2) / 3;
 $spotlight-img-height: 130px;
 $spotlight-text-height: 90px;

--- a/content-test/components/Spotlight.story.js
+++ b/content-test/components/Spotlight.story.js
@@ -76,6 +76,26 @@ storiesOf("Highlight Item", module)
     site.bestImage = site.images[0];
     return (<Container><SpotlightItem {...site} /></Container>);
   })
+  .add("Title overflows text area", () => {
+    const site = createSite({images: 1});
+    site.bestImage = site.images[0];
+    site.title = "The Most Awesome Aggregator Site You're Ever Going To See On The Entire English-Speaking Part World Wide Web";
+    return (<Container><SpotlightItem {...site} /></Container>);
+  })
+  .add("Title + desc overflows text area", () => {
+    const site = createSite({images: 1});
+    site.bestImage = site.images[0];
+    site.title = "The Most Awesome Aggregator Site You're Ever Going To See";
+    site.description = "The quick brown fox jumps over the laziest dog";
+    return (<Container><SpotlightItem {...site} /></Container>);
+  })
+  .add("Missing provider_{name,display} metadata", () => {
+    const site = createSite({images: 1});
+    site.bestImage = site.images[0];
+    delete site.provider_name;
+    delete site.provider_display;
+    return (<Container><SpotlightItem {...site} /></Container>);
+  })
   .add("Missing an image", () => {
     const site = createSite({images: 0});
     return (<Container><SpotlightItem {...site} /></Container>);

--- a/content-test/components/Spotlight.story.js
+++ b/content-test/components/Spotlight.story.js
@@ -89,11 +89,10 @@ storiesOf("Highlight Item", module)
     site.description = "The quick brown fox jumps over the laziest dog";
     return (<Container><SpotlightItem {...site} /></Container>);
   })
-  .add("Missing provider_{name,display} metadata", () => {
+  .add("Missing provider_name metadata", () => {
     const site = createSite({images: 1});
     site.bestImage = site.images[0];
     delete site.provider_name;
-    delete site.provider_display;
     return (<Container><SpotlightItem {...site} /></Container>);
   })
   .add("Missing an image", () => {


### PR DESCRIPTION
fix(Highlights): fix vertical text cropping & layout in individual items (closes #1526)

The easiest way to test is to do:

npm run bundle
npm run storybook
(browse to localhost:9001)

and look over the various Highlight Item stories