### PR TITLE
Tooltip hints for Highlights, TopSites

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -20,6 +20,7 @@ function loadStories() {
   require("../content-test/components/Spotlight-unweighted.story");
   require("../content-test/components/Spotlight.story");
   require("../content-test/components/ContextMenu.story");
+  require("../content-test/components/Hint.story");
   // require as many stories as you need.
 }
 

--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -50,7 +50,9 @@ const am = new ActionManager([
   "SHARE_PROVIDERS_RESPONSE",
   "NOTIFY_SHARE_URL",
   "NOTIFY_COPY_URL",
-  "NOTIFY_EMAIL_URL"
+  "NOTIFY_EMAIL_URL",
+  "ENABLE_ALL_HINTS",
+  "DISABLE_HINT"
 ]);
 
 // This is a a set of actions that have sites in them,
@@ -259,6 +261,14 @@ function NotifyShareUrl(url, title, provider) {
   return Notify("NOTIFY_SHARE_URL", {url, title, provider});
 }
 
+function DisableHint(id) {
+  return Notify("DISABLE_HINT", id);
+}
+
+function ShowAllHints() {
+  return Notify("ENABLE_ALL_HINTS");
+}
+
 am.defineActions({
   Notify,
   Response,
@@ -294,7 +304,9 @@ am.defineActions({
   RequestShareProviders,
   NotifyCopyUrl,
   NotifyEmailUrl,
-  NotifyShareUrl
+  NotifyShareUrl,
+  ShowAllHints,
+  DisableHint
 });
 
 module.exports = am;

--- a/common/reducers/Hints.js
+++ b/common/reducers/Hints.js
@@ -1,0 +1,16 @@
+const am = require("common/action-manager");
+
+module.exports = (prevState = {}, action) => {
+  let state;
+  switch (action.type) {
+    case am.type("DISABLE_HINT"):
+      state = {};
+      // action.data should be the id of a hint, as defined in props.id on the Hint component
+      state[action.data] = false;
+      return Object.assign({}, prevState, state);
+    case am.type("ENABLE_ALL_HINTS"):
+      return {};
+    default:
+      return prevState;
+  }
+};

--- a/common/reducers/SetRowsOrError.js
+++ b/common/reducers/SetRowsOrError.js
@@ -5,7 +5,8 @@ const DEFAULTS = {
   error: false,
   init: false,
   isLoading: false,
-  canLoadMore: true
+  canLoadMore: true,
+  showHint: true
 };
 
 module.exports = function setRowsOrError(requestType, responseType, querySize) {

--- a/common/reducers/reducers.js
+++ b/common/reducers/reducers.js
@@ -6,6 +6,7 @@ const Experiments = require("./Experiments");
 const Filter = require("./Filter");
 const Prefs = require("./Prefs");
 const ShareProviders = require("./ShareProviders");
+const Hints = require("./Hints");
 
 module.exports = {
   TopSites: setRowsOrError("TOP_FRECENT_SITES_REQUEST", "TOP_FRECENT_SITES_RESPONSE"),
@@ -16,5 +17,6 @@ module.exports = {
   Experiments,
   Filter,
   Prefs,
-  ShareProviders
+  ShareProviders,
+  Hints
 };

--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -6,6 +6,7 @@ const GroupedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const TopSites = require("components/TopSites/TopSites");
 const faker = require("test/faker");
 const sizeof = require("object-sizeof");
+const {ShowAllHints} = require("common/action-manager").actions;
 
 // Only include this in DEVELOPMENT builds
 let JSONTree;
@@ -51,6 +52,11 @@ const DebugPage = React.createClass({
           <p><a className="btn" href={downloadState} download="activity-stream-state.json">Download current state to file</a></p>
           <textarea value={plainText} />
           <Viewer {...this.props} />
+        </section>
+
+        <section>
+          <h2>Tooltip Hints</h2>
+          <button className="btn" onClick={() => this.props.dispatch(ShowAllHints())}>Show all tooltip hints</button>
         </section>
 
         <section>

--- a/content-src/components/DebugPage/DebugPage.scss
+++ b/content-src/components/DebugPage/DebugPage.scss
@@ -4,10 +4,17 @@
   }
 
   .btn {
-    color: $dark-grey;
-    border: 1px solid $dark-grey;
+    color: $white;
+    border: 0;
+    background-color: $link-blue;
     padding: 5px 10px;
     border-radius: 8px;
+    cursor: pointer;
+
+    &:hover,
+    &:active {
+      background-color: lighten($link-blue, 20%);
+    }
   }
 
   label {

--- a/content-src/components/Hint/Hint.js
+++ b/content-src/components/Hint/Hint.js
@@ -1,0 +1,68 @@
+const React = require("react");
+const {connect} = require("react-redux");
+const {DisableHint} = require("common/action-manager").actions;
+
+/**
+ * Hint - A component for helping onboard users to different features
+ *        It displays a small bit of text that, if clicked, shows a tooltip with
+ *        a description of the feature
+ */
+const Hint = React.createClass({
+  getDefaultProps() {
+    return {disabled: false};
+  },
+  getInitialState() {
+    return {active: false};
+  },
+  hide() {
+    this.setState({active: false});
+  },
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.active && !prevState.active) {
+      // Timeout needed or else this.hide will be triggered from onClickPrompt
+      setTimeout(() => {
+        window.addEventListener("click", this.hide, false);
+      }, 0);
+    }
+    if (!this.state.active && prevState.active) {
+      window.removeEventListener("click", this.hide);
+    }
+  },
+  componentWillUnmount() {
+    window.removeEventListener("click", this.hide);
+  },
+  onClickPrompt(e) {
+    e.preventDefault();
+    this.setState({active: !this.state.active});
+  },
+  onDisable(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({active: false});
+    this.props.dispatch(DisableHint(this.props.id));
+  },
+  render() {
+    // Note: refs are for testing hooks
+    return (<div className="hint-container" hidden={this.props.disabled} ref="container">
+      <span className="tooltip-tip" />
+      &ndash; <a className="prompt" href="#" onClick={this.onClickPrompt} ref="prompt"> What&rsquo;s this?</a>
+      <div className="explanation" hidden={!this.state.active} ref="explanation">
+        <h3 ref="title">{this.props.title}</h3>
+        <p ref="body">{this.props.body}</p>
+        <button className="close-button" onClick={this.onDisable} ref="closeButton">
+          <h4>Okay, got it!</h4>
+          <p>Don&rsquo;t show this tip again</p>
+        </button>
+      </div>
+    </div>);
+  }
+});
+
+Hint.propTypes = {
+  id: React.PropTypes.string.isRequired,
+  title: React.PropTypes.string.isRequired,
+  body: React.PropTypes.string.isRequired
+};
+
+module.exports = connect((state, props) => ({disabled: state.Hints[props.id] === false}))(Hint);
+module.exports.Hint = Hint;

--- a/content-src/components/Hint/Hint.scss
+++ b/content-src/components/Hint/Hint.scss
@@ -1,0 +1,92 @@
+.hint-container {
+  display: inline-block;
+  position: relative;
+  // This is needed to push the child component(i.e. the explanation above other stuff in the container)
+  z-index: $hint-z-index;
+
+  // This is the link that if clicked, opens the explanation
+  .prompt {
+    color: inherit;
+    opacity: 0.8;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  // This is the box that shows up when you click the prompt
+  .explanation {
+    font-size: $hint-font-size;
+    box-shadow: 0 5px 10px $faintest-black;
+    line-height: $hint-line-height;
+    border: 1px solid $hint-border-color;
+    width: $hint-box-width;
+    border-radius: $hint-border-radius;
+    padding: $hint-padding;
+    background: $white;
+    position: absolute;
+    left: 100%;
+    margin-left: $hint-offset-left;
+    top: -$hint-offset-top;
+
+    // This is the little triangle on the tooltip
+    &::before {
+      content: '';
+      position: absolute;
+      top: $hint-offset-top - 1;
+      left: -($hint-offset-left / 2);
+      width: $hint-offset-left;
+      height: $hint-offset-left;
+      background-color: $white;
+      display: block;
+      transform: rotate(45deg);
+      border: 1px solid $hint-border-color;
+      border-right-style: none;
+      border-top-style: none;
+    }
+
+    h3 {
+      color: $hint-title-color;
+      font-size: $hint-title-font-size;
+      line-height: 1.1;
+      font-weight: 500;
+      margin: 0 0 10px;
+    }
+
+    p {
+      color: $hint-body-color;
+      margin: 0 0 15px;
+    }
+
+    .close-button {
+      display: block;
+      width: 100%;
+      padding: $hint-button-padding;
+      border: 0;
+      text-align: center;
+      background-color: $hint-button-color;
+      border-radius: $hint-border-radius;
+      cursor: pointer;
+
+      &:hover {
+        background-color: lighten($hint-button-color, 10%);
+      }
+
+      h4,
+      p {
+        font-weight: normal;
+        margin: 0;
+        color: $white;
+      }
+
+      h4 {
+        font-size: $hint-button-font-size;
+        margin-bottom: 3px;
+      }
+
+      p {
+        opacity: 0.6;
+      }
+    }
+  }
+}

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -74,7 +74,7 @@ const NewTabPage = React.createClass({
 
         <div className={classNames("show-on-init", {on: this.props.isReady})}>
           <section>
-            <TopSites page={PAGE_NAME} sites={props.TopSites.rows} />
+            <TopSites page={PAGE_NAME} sites={props.TopSites.rows} showHint={props.TopSites.showHint} />
           </section>
 
           <section>

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -7,9 +7,11 @@ const SiteIcon = require("components/SiteIcon/SiteIcon");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
 const HighlightContext = require("components/HighlightContext/HighlightContext");
+const Hint = require("components/Hint/Hint");
 const classNames = require("classnames");
 
 const {SPOTLIGHT_DEFAULT_LENGTH} = require("common/constants");
+const HIGHLIGHTS_HINT_TEXT = "Find your way back to the great articles, videos, and other pages you’ve discovered on the web.";
 
 const SpotlightItem = React.createClass({
   getInitialState() {
@@ -128,7 +130,7 @@ const Spotlight = React.createClass({
     const sites = this.props.sites.slice(0, this.props.length);
 
     return (<section className="spotlight">
-      <h3 className="section-title">Highlights</h3>
+      <h3 className="section-title">Highlights <Hint id="highlights_hint" title="Highlights" body={HIGHLIGHTS_HINT_TEXT} /></h3>
       <ul className="spotlight-list">
         {sites.map((site, i) => <SpotlightItem
           index={i}

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -6,7 +6,10 @@ const classNames = require("classnames");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
+const Hint = require("components/Hint/Hint");
+
 const DEFAULT_LENGTH = 6;
+const TOP_SITES_HINT_TEXT = "Get right to the sites you visit most: click on a tile to open or hover to share, bookmark or delete.";
 
 const TopSites = React.createClass({
   getInitialState() {
@@ -34,7 +37,7 @@ const TopSites = React.createClass({
   render() {
     const sites = this.props.sites.slice(0, this.props.length);
     return (<section className="top-sites">
-      <h3 className="section-title">Top Sites</h3>
+      <h3 className="section-title">Top Sites <Hint id="top_sites_hint" title="Top Sites" body={TOP_SITES_HINT_TEXT} /></h3>
       <div className="tiles-wrapper">
         {sites.map((site, i) => {
           const isActive = this.state.showContextMenu && this.state.activeTile === i;
@@ -64,6 +67,7 @@ const TopSites = React.createClass({
 TopSites.propTypes = {
   length: React.PropTypes.number,
   page: React.PropTypes.string.isRequired,
+  showHint: React.PropTypes.bool,
   sites: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       url: React.PropTypes.string.isRequired,

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -51,5 +51,6 @@ module.exports = {
         "origin": "https://myspace.com"
       }
     ]
-  }
+  },
+  "Hints": {}
 };

--- a/content-src/main.scss
+++ b/content-src/main.scss
@@ -90,3 +90,4 @@ a {
 @import './components/MediaPreview/MediaPreview';
 @import './components/HighlightContext/HighlightContext';
 @import './components/Tooltip/Tooltip';
+@import './components/Hint/Hint';

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -121,6 +121,22 @@ $tooltip-anchor-width: 8px;
 $tooltip-anchor-height: 8px;
 $tooltip-anchor-margin: -42px 0 0 -24px;
 
+$hint-z-index: 10000;
+$hint-border-color: #E0E0E0;
+$hint-font-size: 12px;
+$hint-padding: 20px;
+$hint-line-height: 1.6;
+$hint-box-width: 280px;
+$hint-border-radius: 4px;
+$hint-offset-left: 16px;
+$hint-offset-top: 25px;
+$hint-title-color: #3D3D3D;
+$hint-title-font-size: 18px;
+$hint-body-color: #2B2B2B;
+$hint-button-color: #2083F2;
+$hint-button-padding: 8px;
+$hint-button-font-size: 15px;
+
 @mixin item-shadow {
   box-shadow: $item-shadow;
 

--- a/content-test/common/reducers/Hints.test.js
+++ b/content-test/common/reducers/Hints.test.js
@@ -1,0 +1,17 @@
+const Hints = require("common/reducers/Hints");
+const {ShowAllHints, DisableHint} = require("common/action-manager").actions;
+
+describe("Hints reducer", () => {
+  it("should have the correct initial state", () => {
+    const state = Hints(undefined, {});
+    assert.deepEqual(state, {});
+  });
+  it("should reset Hints to {} on an ENABLE_ALL_HINTS action", () => {
+    const state = Hints({foo: false, blah: false}, ShowAllHints());
+    assert.deepEqual(state, {});
+  });
+  it("should add [id]: false on a DISABLE_HINT action", () => {
+    const state = Hints({blah: false}, DisableHint("foo"));
+    assert.deepEqual(state, {blah: false, foo: false});
+  });
+});

--- a/content-test/components/Hint.story.js
+++ b/content-test/components/Hint.story.js
@@ -1,0 +1,23 @@
+const React = require("react");
+const {storiesOf, action} = require("@kadira/storybook");
+const {Hint} = require("components/Hint/Hint");
+
+const logAction = action("redux action");
+const Container = React.createClass({
+  getInitialState: () => ({disabled: false}),
+  // This is a replacement for what would normally be handled by redux
+  dispatch(a) {
+    logAction(a);
+    this.setState({disabled: true});
+  },
+  render() {
+    return (<div style={{padding: 30}}>
+      Something <Hint id="foo" title="Something" body="This is something." disabled={this.state.disabled} dispatch={this.dispatch} />
+    </div>);
+  }
+});
+
+module.exports = Container;
+
+storiesOf("Hint", module)
+  .add("Basic example", () => <Container />);

--- a/content-test/components/Hint.test.js
+++ b/content-test/components/Hint.test.js
@@ -1,0 +1,133 @@
+const React = require("react");
+const TestUtils = require("react-addons-test-utils");
+const {renderWithProvider} = require("test/test-utils");
+const ConnectedHint = require("components/Hint/Hint");
+const {Hint} = ConnectedHint;
+const {DisableHint} = require("common/action-manager").actions;
+
+describe("Hint", () => {
+  let instance;
+
+  function setup(custom = {}) {
+    const props = Object.assign({id: "foo", title: "foo", body: "bar"}, custom);
+    instance = TestUtils.renderIntoDocument(<Hint {...props} />);
+  }
+
+  beforeEach(setup);
+
+  it("should render the component", () => {
+    TestUtils.isCompositeComponentWithType(instance, Hint);
+  });
+
+  describe("default state", () => {
+    it("should show the container by default", () => {
+      assert.equal(instance.refs.container.hidden, false);
+    });
+    it("should show the prompt by default", () => {
+      assert.equal(instance.refs.prompt.hidden, false);
+    });
+    it("should hide the explanation by default", () => {
+      assert.equal(instance.refs.explanation.hidden, true);
+    });
+  });
+
+  describe("props", () => {
+    it("should hide the container if props.disabled is true", () => {
+      setup({id: "foo", disabled: true});
+      assert.equal(instance.refs.container.hidden, true);
+    });
+    it("should render props.title", () => {
+      setup({id: "foo", title: "Everglade"});
+      assert.equal(instance.refs.title.innerHTML, "Everglade");
+    });
+    it("should render props.body", () => {
+      setup({id: "foo", body: "Bloop"});
+      assert.equal(instance.refs.body.innerHTML, "Bloop");
+    });
+  });
+
+  describe("state", () => {
+    it("should show the explanation if state.active is true", () => {
+      instance.setState({active: true});
+      assert.equal(instance.refs.explanation.hidden, false);
+    });
+    it("should hide the explanation if state.active is false", () => {
+      instance.setState({active: false});
+      assert.equal(instance.refs.explanation.hidden, true);
+    });
+    it("should set state.active = true if the prompt is clicked", () => {
+      assert.equal(instance.state.active, false);
+      TestUtils.Simulate.click(instance.refs.prompt);
+      assert.equal(instance.state.active, true);
+    });
+  });
+
+  describe("disable button", () => {
+    let dispatch;
+    beforeEach(() => {
+      dispatch = sinon.spy();
+      setup({id: "foo", dispatch});
+      instance.setState({active: true});
+    });
+    it("should set active = false if the close button is clicked", () => {
+      TestUtils.Simulate.click(instance.refs.closeButton);
+      assert.equal(instance.state.active, false);
+    });
+    it("should dispatch a disable action if the close button is clicked", () => {
+      TestUtils.Simulate.click(instance.refs.closeButton);
+      assert.calledWith(dispatch, DisableHint("foo"));
+    });
+  });
+
+  describe("connected state", () => {
+    it("should set props.disabled to false if Hints[props.id] is undefined", () => {
+      const connected = renderWithProvider(<ConnectedHint id="foo" title="foo" body="blah" />, {getState: () => ({Hints: {}})});
+      instance = TestUtils.findRenderedComponentWithType(connected, Hint);
+      assert.equal(instance.props.disabled, false);
+    });
+    it("should set props.disabled to true if Hints[props.id] is false", () => {
+      const connected = renderWithProvider(<ConnectedHint id="foo" title="foo" body="blah" />, {getState: () => ({Hints: {foo: false}})});
+      instance = TestUtils.findRenderedComponentWithType(connected, Hint);
+      assert.equal(instance.props.disabled, true);
+    });
+  });
+
+  describe("window listeners", () => {
+    let clock;
+    beforeEach(() => {
+      sinon.spy(window, "addEventListener");
+      sinon.spy(window, "removeEventListener");
+      clock = sinon.useFakeTimers();
+    });
+    afterEach(() => {
+      window.addEventListener.restore();
+      window.removeEventListener.restore();
+      clock.restore();
+    });
+    it("should set active = false when this.hide is called", () => {
+      instance.setState({active: true});
+      instance.hide();
+      assert.equal(instance.state.active, false);
+    });
+    it("should attach a window listener when active is set to true", () => {
+      instance.setState({active: true});
+      instance.setState({foo: true});
+      clock.tick(1);
+      assert.calledOnce(window.addEventListener);
+      assert.calledWithExactly(window.addEventListener, "click", instance.hide, false);
+    });
+    it("should remove window listener when active is set to false", () => {
+      instance.setState({active: true});
+      instance.setState({foo: true});
+      instance.setState({active: false});
+      assert.calledOnce(window.removeEventListener);
+      assert.calledWithExactly(window.removeEventListener, "click", instance.hide);
+    });
+    it("should remove window listener when component is unmounted", () => {
+      instance.setState({active: true});
+      instance.componentWillUnmount();
+      assert.calledOnce(window.removeEventListener);
+      assert.calledWithExactly(window.removeEventListener, "click", instance.hide);
+    });
+  });
+});


### PR DESCRIPTION
This patch adds:
- a `Hint` component (see comps here: https://mozilla.invisionapp.com/share/8F8V2GX3S#/screens)
- `Hint`s for Top Sites and Highlights
- a `Hints` reducer, to store (and persist) disabled hints 
- a button on the Debug page that can enable all of the hints again

To test it, please try:
- clicking on the "What's this?" text next to the Top Sites and Highlights titles on New Tab
- click on the blue button inside the hint (it should make the "What's this" text disappear)
- open another new tab, make sure "What's this" is still gone
- go to the debug page, and click the `Show all Tooltip Hints` button, and see if all the "What's this" reappear