### PR TITLE
chore(lint): Remove no-vendor-prefix rule for sasslint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -21,6 +21,7 @@ rules:
   no-ids: 0
   no-important: 0
   no-qualifying-elements: 0
+  no-vendor-prefixes: 0
   no-warn: 1
   placeholder-in-extend: 2
   property-sort-order: 0


### PR DESCRIPTION
I don't think this is a common issue we need to check for, and it's annoying seeing the warning every time.