### PR TITLE
WIP feat(shield): Instrument tiles page for session and search/click-related events

### DIFF
--- a/addon/main.js
+++ b/addon/main.js
@@ -7,6 +7,7 @@ const {MetadataCache} = require("addon/MetadataCache");
 const {TelemetrySender} = require("addon/TelemetrySender");
 const {TabTracker} = require("addon/TabTracker");
 const {ActivityStreams} = require("addon/ActivityStreams");
+const {PageMod} = require("sdk/page-mod");
 const {setTimeout, clearTimeout} = require("sdk/timers");
 const {Cu} = require("chrome");
 
@@ -23,6 +24,65 @@ let app = null;
 let metadataStore = null;
 let connectRetried = 0;
 
+/**
+ * Instrument various events from the new tab page.
+ */
+function NewTabInstrumenter(tabTracker, telemetrySender) {
+  this._tabTracker = tabTracker;
+  this._telemetrySender = telemetrySender;
+}
+
+NewTabInstrumenter.prototype = {
+  init() {
+    let reportEvent = (event, data = {}) => {
+      let payload = Object.assign({event}, data);
+      this._tabTracker.handleUserEvent(payload);
+    };
+
+    // Instrument tile actions, e.g., click
+    this._dlp = Cu.import("resource:///modules/DirectoryLinksProvider.jsm", {}).DirectoryLinksProvider;
+    this._dlp._reportSitesAction = this._dlp.reportSitesAction;
+    this._dlp.reportSitesAction = function(sites, action, action_position) {
+      if (action.search(/^(click|block|pin|unpin)$/) === 0) {
+        reportEvent(action.toUpperCase(), {
+          action_position,
+          source: sites[action_position].link.type.toUpperCase()
+        });
+      }
+      return this._reportSitesAction(sites, action, action_position);
+    };
+
+    // Instrument search actions
+    this._pageMod = new PageMod({
+      attachTo: ["existing", "top"],
+      contentScript: `addEventListener("ContentSearchClient", ({detail}) => {
+        if (detail.type === "Search") self.port.emit("search", detail.data)
+      });`,
+      include: "about:newtab",
+      onAttach(worker) {
+        worker.port.on("search", () => reportEvent("SEARCH"));
+      }
+    });
+
+    // Instrument new tab sessions
+    this._tabTracker.init(["about:newtab"], {
+      getBookmarksSize() {
+        return Promise.resolve(0);
+      },
+      getHistorySize() {
+        return Promise.resolve(0);
+      }
+    });
+  },
+
+  unload() {
+    this._dlp.reportSitesAction = this._dlp._reportSitesAction;
+    this._pageMod.destroy();
+    this._tabTracker.uninit();
+    this._telemetrySender.uninit();
+  }
+};
+
 Object.assign(exports, {
   main(options) {
     // options.loadReason can be install/enable/startup/upgrade/downgrade
@@ -35,6 +95,11 @@ Object.assign(exports, {
       const tabTracker = new TabTracker(clientID);
       const telemetrySender = new TelemetrySender();
 
+      // XXX figure out when to turn on instrumenter
+      if (true) {
+        app = new NewTabInstrumenter(tabTracker, telemetrySender);
+      }
+      else {
       if (options.loadReason === "upgrade") {
         yield this.migrateMetadataStore();
       }
@@ -45,6 +110,8 @@ Object.assign(exports, {
         this.reconnectMetadataStore();
       }
       app = new ActivityStreams(metadataStore, tabTracker, telemetrySender, options);
+      }
+
       try {
         app.init();
       } catch (e) {

--- a/common/event-constants.js
+++ b/common/event-constants.js
@@ -1,5 +1,6 @@
 const DEFAULT_PAGE = "NEW_TAB";
 const urlPatternToPageMap = new Map([
+  [/^about:newtab/, "TILES"],
   [/\/timeline$/, "TIMELINE_ALL"],
   [/\/timeline\/bookmarks$/, "TIMELINE_BOOKMARKS"]
 ]);


### PR DESCRIPTION
Fix #1570. Don't merge as it has dummy logic to turn on instrumenting. This shield-specific stuff should probably should stay off of `master` anyway.

Implements the ping structure described in #1523.

Currently blocked on #1516 to determine `shield_variant` that'll be used to turn on instrumenter or activity stream.