### PR TITLE
shield(metrics): Closes #1516 Add 'shield_variant' to pings

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -51,6 +51,7 @@ const DEFAULT_OPTIONS = {
   onRemoveWorker: null,
   placesCacheTimeout: 1800000, // every 30 minutes, rebuild/repopulate the cache
   recommendationTTL: 3600000, // every hour, get a new recommendation
+  shield_variant: "N/A",
   shareProvider: null,
   pageScraper: null,
   searchProvider: null,
@@ -505,7 +506,7 @@ ActivityStreams.prototype = {
   },
 
   _handleUserEvent({msg}) {
-    this._tabTracker.handleUserEvent(msg.data);
+    this._tabTracker.handleUserEvent(Object.assign(msg.data, {"shield_variant": this.options.shield_variant}));
   },
 
   _respondToRecommendationToggle() {

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -397,7 +397,7 @@ exports.test_TabTracker_action_pings = function*(assert) {
   app._handleUserEvent(eventData);
 
   let pingData = yield userEventPromise;
-  let additionalKeys = ["client_id", "addon_version", "locale", "action", "tab_id", "page"];
+  let additionalKeys = ["client_id", "addon_version", "locale", "action", "tab_id", "page", "shield_variant"];
   for (let key of additionalKeys) {
     assert.ok(pingData[key], `The ping has the additional key ${key}`);
   }
@@ -459,7 +459,7 @@ exports.test_TabTracker_unload_reason_with_user_action = function*(assert) {
     app._handleUserEvent(eventData);
 
     const eventPingData = yield userEventPromise;
-    const additionalKeys = ["client_id", "addon_version", "locale", "action", "tab_id", "page"];
+    const additionalKeys = ["client_id", "addon_version", "locale", "action", "tab_id", "page", "shield_variant"];
     for (let key of additionalKeys) {
       assert.ok(eventPingData[key], `The ping has the additional key ${key}`);
     }


### PR DESCRIPTION
* Add a ```shield_variant``` field to pings in order to track which variant we are in
* Give it a default value for non-shield users