### PR TITLE
Refactor New Tab / Highlight selectors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -118,7 +118,7 @@
     "no-catch-shadow": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,
-    "no-confusing-arrow": 2,
+    "no-confusing-arrow": [2, {"allowParens": true}],
     "no-console": 1,
     "no-const-assign": 2,
     "no-constant-condition": 2,

--- a/common/constants.js
+++ b/common/constants.js
@@ -2,6 +2,9 @@ module.exports = {
   // How many items per query?
   LINKS_QUERY_LIMIT: 20,
 
+  // Number of top sites
+  TOP_SITES_LENGTH: 6,
+
   // Number of large Highlight tiles, pre-weighted hightlights.  Should go away
   // when unweighted highlights go away.
   SPOTLIGHT_DEFAULT_LENGTH: 3,

--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -1,6 +1,7 @@
 const React = require("react");
 const {connect} = require("react-redux");
-const {selectNewTabSites, selectSpotlight} = require("selectors/selectors");
+const {selectNewTabSites} = require("selectors/selectors");
+const {selectSpotlight} = require("selectors/oldSpotlightSelectors");
 const {SpotlightItem} = require("components/Spotlight/Spotlight");
 const GroupedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const TopSites = require("components/TopSites/TopSites");

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -54,11 +54,11 @@ const NewTabPage = React.createClass({
   render() {
     const props = this.props;
     const recommendationLabel = "Show Trending Highlights";
-    const recommendationIcon = props.Spotlight.recommendationShown ? "check" : "   ";
+    const recommendationIcon = props.Highlights.recommendationShown ? "check" : "   ";
     const showRecommendationOption = props.showRecommendationOption;
 
     const spotlightLength =
-      this.props.Spotlight.weightedHighlights ? WEIGHTED_HIGHLIGHTS_LENGTH :
+      this.props.Highlights.weightedHighlights ? WEIGHTED_HIGHLIGHTS_LENGTH :
       SPOTLIGHT_DEFAULT_LENGTH;
     return (<main className="new-tab">
       <div className="new-tab-wrapper">
@@ -79,10 +79,10 @@ const NewTabPage = React.createClass({
 
           <section>
             <Spotlight page={PAGE_NAME} length={spotlightLength}
-              sites={props.Spotlight.rows} />
+              sites={props.Highlights.rows} />
           </section>
 
-          { props.Spotlight.weightedHighlights ? null : this.renderRecentActivity() }
+          { props.Highlights.weightedHighlights ? null : this.renderRecentActivity() }
 
           <section className="bottom-links-container">
             <span className="link-wrapper-right">
@@ -110,7 +110,7 @@ const NewTabPage = React.createClass({
 
 NewTabPage.propTypes = {
   TopSites: React.PropTypes.object.isRequired,
-  Spotlight: React.PropTypes.object.isRequired,
+  Highlights: React.PropTypes.object.isRequired,
   TopActivity: React.PropTypes.object.isRequired,
   dispatch: React.PropTypes.func.isRequired
 };

--- a/content-src/selectors/colorSelectors.js
+++ b/content-src/selectors/colorSelectors.js
@@ -6,6 +6,14 @@ const {prettyUrl, getBlackOrWhite, toRGBString, getRandomColor} = require("lib/u
 const DEFAULT_FAVICON_BG_COLOR = [150, 150, 150];
 const BACKGROUND_FADE = 0.5;
 
+/**
+ * getBackgroundRGB - Selects the best background colour as RGB based on metadata.
+ *                    If none can be determined, returns a random color based on the label,
+ *                    or as a last resort, a default color.
+ *
+ * @param  {obj} site  A site object (with metadata)
+ * @return {array}     An RGB colour as an array of numbers. E.g. [150, 150, 150]
+ */
 function getBackgroundRGB(site) {
   // This is from firefox
   if (site.favicon_color) {
@@ -24,6 +32,14 @@ function getBackgroundRGB(site) {
   return favicon ? DEFAULT_FAVICON_BG_COLOR : getRandomColor(label);
 }
 
+/**
+ * assignImageAndBackgroundColor - Calculates the best image and background color for each site in an array of sites
+ *
+ * @param  {arr} rows  An array of sites
+ * @return {arr}       An array of sites, where each site has two additional properties:
+ *                    .bestImage         an image object (e.g. {url: "http://foo.com/image.jpg"})
+ *                    .backgroundColor  an array representing an RGB background color (e.g. [150, 150, 150])
+ */
 function assignImageAndBackgroundColor(rows) {
   return rows.map(site => {
     const newProps = {};
@@ -39,6 +55,16 @@ function assignImageAndBackgroundColor(rows) {
   });
 }
 
+/**
+ * selectSiteIcon
+ *
+ * @return {obj} An object of props for the SiteIcon component
+ *    .url {str} The url of the site
+ *    .favicon {str} The url of the favicon image for the site
+ *    .backgroundColor {arr} an array representing an RGB background color (e.g. [150, 150, 150])
+ *    .fontColor {arr} an array representing an RGB font color, either black ([0, 0, 0]) or white ([255, 255, 255])
+ *    .label {str} A pretty url based on the hostname of the site
+ */
 const selectSiteIcon = createSelector(
   site => site,
   site => {

--- a/content-src/selectors/getHighlightContextFromSite.js
+++ b/content-src/selectors/getHighlightContextFromSite.js
@@ -1,5 +1,15 @@
 const {FIRST_RUN_TYPE} = require("lib/first-run-data");
 
+/**
+ * getHighlightContextFromSite - Returns an object with details about the origin of the Highlight
+ *                               and what to display in the "context" message (on the Highlight component)
+ *
+ * @param  {obj} site A site (with metadata)
+ * @return {obj}
+ *     .label {str} The message to be displayed at the bottom of the Highlight component
+ *     .type {str} An indicator of the origin/type of the highlight. One of:
+ *                 recommended, firstRun, bookmark, synced, open, or history
+ */
 module.exports = function getHighlightContextFromSite(site) {
   const result = {};
 

--- a/content-src/selectors/oldSpotlightSelectors.js
+++ b/content-src/selectors/oldSpotlightSelectors.js
@@ -1,0 +1,39 @@
+const firstRunData = require("lib/first-run-data");
+const {createSelector} = require("reselect");
+const {assignImageAndBackgroundColor} = require("selectors/colorSelectors");
+
+function isValidSpotlightSite(site) {
+  return (site.bestImage &&
+    site.title &&
+    site.description &&
+    site.title !== site.description);
+}
+
+module.exports.selectSpotlight = createSelector(
+  [
+    state => state.Highlights,
+    state => state.Prefs.prefs.recommendations,
+    state => state.Experiments.values.weightedHighlights
+  ],
+  (Highlights, recommendationShown, isNewHighlights) => {
+    // Only concat first run data if init is true
+    const highlightRows = Highlights.rows.concat(Highlights.init ? firstRunData.Highlights : []);
+    let rows = assignImageAndBackgroundColor(highlightRows)
+      .sort((site1, site2) => {
+        const site1Valid = isValidSpotlightSite(site1);
+        const site2Valid = isValidSpotlightSite(site2);
+        if (site2.type === firstRunData.FIRST_RUN_TYPE) {
+          return -1;
+        } else if (site1.type === firstRunData.FIRST_RUN_TYPE) {
+          return 1;
+        } else if (site1Valid && site2Valid) {
+          return 0;
+        } else if (site2Valid) {
+          return 1;
+        }
+        return -1;
+      });
+
+    return Object.assign({}, Highlights, {rows, recommendationShown, isNewHighlights});
+  }
+);

--- a/content-src/selectors/selectAndDedupe.js
+++ b/content-src/selectors/selectAndDedupe.js
@@ -1,0 +1,31 @@
+const dedupe = require("lib/dedupe");
+
+/**
+ * Dedupe items and appends defaults if result length is smaller than required.
+ *
+ * @param {Array} group
+ * @param {Array} group.sites - sites to process.
+ * @param {Array} group.dedupe - sites to dedupe against.
+ * @param {Number} group.max - required number of items.
+ * @param {Array} group.defaults - default values to use.
+ * @returns {Array}
+ */
+module.exports = function selectAndDedupe(group) {
+  return group.reduce((result, options, index, arr) => {
+    let current;
+    if (result.length) {
+      const previous = result.reduce((prev, current) => prev.concat(current), []);
+      current = dedupe.group([previous, options.sites])[1];
+    } else {
+      current = dedupe.one(options.sites);
+    }
+    if (options.defaults) {
+      current = current.concat(options.defaults);
+    }
+    if (options.max && current.length > options.max) {
+      current = current.slice(0, options.max);
+    }
+    result.push(current);
+    return result;
+  }, []);
+};

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -132,7 +132,7 @@ module.exports.selectNewTabSites = createSelector(
 
     return {
       TopSites: Object.assign({}, TopSites, {rows: topSitesRows}),
-      Spotlight: Object.assign({}, Spotlight, {rows: spotlightRows, weightedHighlights: prefWeightedHighlights}),
+      Highlights: Object.assign({}, Spotlight, {rows: spotlightRows, weightedHighlights: prefWeightedHighlights}),
       TopActivity: Object.assign({}, History, {rows: historyRows}),
       isReady: TopSites.init && History.init && Spotlight.init && Experiments.init && WeightedHighlights.init,
       showRecommendationOption: Experiments.values.recommendedHighlight

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -1,144 +1,58 @@
-const dedupe = require("lib/dedupe");
 const {createSelector} = require("reselect");
 const firstRunData = require("lib/first-run-data");
+const selectAndDedupe = require("selectors/selectAndDedupe");
 const {assignImageAndBackgroundColor} = require("selectors/colorSelectors");
-const {
-  SPOTLIGHT_DEFAULT_LENGTH,
-  WEIGHTED_HIGHLIGHTS_LENGTH
-} = require("common/constants");
-
-const TOP_SITES_LENGTH = module.exports.TOP_SITES_LENGTH = 6;
-
-module.exports.justDispatch = (() => ({}));
-
-function isValidSpotlightSite(site) {
-  return (site.bestImage &&
-    site.title &&
-    site.description &&
-    site.title !== site.description);
-}
+const {selectSpotlight} = require("selectors/oldSpotlightSelectors");
+const {SPOTLIGHT_DEFAULT_LENGTH, WEIGHTED_HIGHLIGHTS_LENGTH, TOP_SITES_LENGTH} = require("common/constants");
 
 /**
- * Dedupe items and appends defaults if result length is smaller than required.
- *
- * @param {Array} options.sites - sites to process.
- * @param {Array} options.dedupe - sites to dedupe against.
- * @param {Number} options.max - required number of items.
- * @param {Array} options.defaults - default values to use.
- * @returns {Array}
+ * justDispatch - This can be used just to add the dispatch function to the props of a component
  */
-const selectAndDedupe = module.exports.selectAndDedupe = options => {
-  let rows = dedupe.group([
-    options.dedupe,
-    options.sites])[1];
+module.exports.justDispatch = (() => ({}));
 
-  if (rows.length < options.max && options.defaults) {
-    rows = rows.concat(options.defaults);
-  }
-
-  return rows.slice(0, options.max);
-};
-
-const selectWeightedHighlights = module.exports.selectWeightedHighlights = createSelector(
-  [
-    state => state.WeightedHighlights
-  ],
-  WeightedHighlights => Object.assign({}, WeightedHighlights, {rows: assignImageAndBackgroundColor(WeightedHighlights.rows)})
-);
-
-const selectSpotlight = module.exports.selectSpotlight = createSelector(
-  [
-    state => state.Highlights,
-    state => state.Prefs.prefs.recommendations,
-    selectWeightedHighlights,
-    state => state.Experiments.values.weightedHighlights
-  ],
-  (Highlights, recommendationShown, WeightedHighlights, prefWeightedHighlights) => {
-    let rows;
-    if (prefWeightedHighlights) {
-      rows = WeightedHighlights.rows;
-    } else {
-      // Only concat first run data if init is true
-      const highlightRows = Highlights.rows.concat(Highlights.init ? firstRunData.Highlights : []);
-      rows = assignImageAndBackgroundColor(highlightRows)
-        .sort((site1, site2) => {
-          const site1Valid = isValidSpotlightSite(site1);
-          const site2Valid = isValidSpotlightSite(site2);
-          if (site2.type === firstRunData.FIRST_RUN_TYPE) {
-            return -1;
-          } else if (site1.type === firstRunData.FIRST_RUN_TYPE) {
-            return 1;
-          } else if (site1Valid && site2Valid) {
-            return 0;
-          } else if (site2Valid) {
-            return 1;
-          }
-          return -1;
-        });
-    }
-
-    return Object.assign({}, Highlights, {rows, recommendationShown, prefWeightedHighlights});
-  }
-);
-
-const selectTopSites = module.exports.selectTopSites = createSelector(
-  [
-    state => state.TopSites
-  ],
-  TopSites => Object.assign({}, TopSites, {
-    rows: dedupe.one(TopSites.rows
-      // Add first run stuff to the end if init has already happened
-      .concat(TopSites.init ? firstRunData.TopSites : []))
-  })
-);
-
+/**
+ * selectNewTabSites
+ *
+ * @return {obj}
+ *    .TopSites {obj} State object for Top Sites
+ *    .Highlights {obj} State object for Highlights, including a boolean .weightedHighlights indicating whether it is in the experiment or not
+ *    .TopActivity {obj} State object (empty for weightedHighlights experiment)
+ *    .isReady {bool} Do we have all the required data to display New Tab?
+ *    .showRecommendationOption {bool} Should we show the option to turn recommendations off/on?
+ */
 module.exports.selectNewTabSites = createSelector(
   [
-    selectWeightedHighlights,
     state => state.Experiments.values.weightedHighlights,
-    selectTopSites,
-    state => state.History,
-    selectSpotlight,
+    state => (state.Experiments.values.weightedHighlights ? state.WeightedHighlights : selectSpotlight(state)),
+    state => state.TopSites,
+    state => (state.Experiments.values.weightedHighlights ? Object.assign({}, state.History, {rows: []}) : state.History),
     state => state.Experiments
   ],
-  (WeightedHighlights, prefWeightedHighlights, TopSites, History, Spotlight, Experiments) => {
-    // Remove duplicates
-    // Note that we have to limit the length of topsites, spotlight so we
-    // don't dedupe against stuff that isn't shown
-    let [topSitesRows, spotlightRows] = dedupe.group([TopSites.rows.slice(0, TOP_SITES_LENGTH), Spotlight.rows]);
-
-    // Find the index of the recommendation. If we have an index, find that recommendation and put it
-    // in the third highlights spot
-    let recommendation = spotlightRows.findIndex(element => element.recommended);
-    if (recommendation >= 0) {
-      spotlightRows.splice(2, 0, spotlightRows.splice(recommendation, 1)[0]);
-    }
-    spotlightRows = spotlightRows.slice(0,
-      prefWeightedHighlights ? WEIGHTED_HIGHLIGHTS_LENGTH :
-      SPOTLIGHT_DEFAULT_LENGTH);
-    const historyRows = dedupe.group([
-      topSitesRows,
-      spotlightRows,
-      History.rows])[2];
-
-    if (prefWeightedHighlights) {
-      spotlightRows = selectAndDedupe({
-        dedupe: topSitesRows,
-        sites: WeightedHighlights.rows,
-        max: WEIGHTED_HIGHLIGHTS_LENGTH,
+  (isNewHighlights, Highlights, TopSites, History, Experiments) => {
+    const [topSitesRows, highlightsRows, historyRows] = selectAndDedupe([
+      {
+        sites: TopSites.rows,
+        max: TOP_SITES_LENGTH,
+        defaults: firstRunData.TopSites
+      },
+      {
+        sites: isNewHighlights ? assignImageAndBackgroundColor(Highlights.rows) : Highlights.rows,
+        max: isNewHighlights ? WEIGHTED_HIGHLIGHTS_LENGTH : SPOTLIGHT_DEFAULT_LENGTH,
         defaults: assignImageAndBackgroundColor(firstRunData.Highlights)
-      });
-    }
-
+      },
+      {sites: History.rows}
+    ]);
     return {
       TopSites: Object.assign({}, TopSites, {rows: topSitesRows}),
-      Highlights: Object.assign({}, Spotlight, {rows: spotlightRows, weightedHighlights: prefWeightedHighlights}),
+      Highlights: Object.assign({}, Highlights, {rows: highlightsRows, weightedHighlights: isNewHighlights}),
       TopActivity: Object.assign({}, History, {rows: historyRows}),
-      isReady: TopSites.init && History.init && Spotlight.init && Experiments.init && WeightedHighlights.init,
+      isReady: TopSites.init && Highlights.init && History.init && Experiments.init,
       showRecommendationOption: Experiments.values.recommendedHighlight
     };
   }
 );
 
-// Share Providers
+/**
+ * selectShareProviders - for the Share component
+ */
 module.exports.selectShareProviders = state => ({ShareProviders: state.ShareProviders});

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -38,7 +38,7 @@ describe("NewTabPage", () => {
 
   it("should render Spotlight components with correct data", () => {
     const spotlightSites = TestUtils.findRenderedComponentWithType(instance, Spotlight);
-    assert.equal(spotlightSites.props.sites, fakeProps.Spotlight.rows);
+    assert.equal(spotlightSites.props.sites, fakeProps.Highlights.rows);
   });
 
   it("should render GroupedActivityFeed with correct data", () => {

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -9,7 +9,7 @@ const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const {mockData, faker, renderWithProvider} = require("test/test-utils");
-const fakeSpotlightItems = mockData.Spotlight.rows;
+const fakeSpotlightItems = mockData.Highlights.rows;
 const fakeSiteWithImage = faker.createSite();
 
 fakeSiteWithImage.bestImage = fakeSiteWithImage.images[0];

--- a/content-test/faker.js
+++ b/content-test/faker.js
@@ -1,7 +1,7 @@
 const faker = require("faker");
 const moment = require("moment");
 const tiptop = require("tippy-top-sites");
-const {selectSpotlight} = require("selectors/selectors");
+const {selectSpotlight} = require("selectors/oldSpotlightSelectors");
 
 const BASE_TIP_TOP_FAVICON_URL = "favicons/images/";
 

--- a/content-test/index.js
+++ b/content-test/index.js
@@ -1,4 +1,4 @@
-const req = require.context(".", true, /\.test.js$/);
+const req = require.context(".", true, /\.test\.js$/);
 const files = req.keys();
 const globals = require("shims/_utils/globals");
 const {overrideGlobals, overrideConsoleError} = require("test/test-utils");

--- a/content-test/selectors/oldSpotlightSelectors.test.js
+++ b/content-test/selectors/oldSpotlightSelectors.test.js
@@ -1,0 +1,105 @@
+const {rawMockData: fakeState} = require("test/test-utils");
+const firstRunData = require("lib/first-run-data");
+
+const validSpotlightSite = {
+  "title": "man throws alligator in wendys wptv dnt cnn",
+  "url": "http://www.cnn.com/videos/tv/2016/02/09/man-throws-alligator-in-wendys-wptv-dnt.cnn",
+  "description": "A Florida man faces multiple charges for throwing an alligator through a Wendy's drive-thru window. CNN's affiliate WPTV reports.",
+  "lastVisitDate": 1456426160465,
+  "images": [{
+    "url": "http://i2.cdn.turner.com/cnnnext/dam/assets/160209053130-man-throws-alligator-in-wendys-wptv-dnt-00004611-large-169.jpg",
+    "height": 259,
+    "width": 460,
+    "entropy": 3.98714569089,
+    "size": 14757
+  }]
+};
+
+const {selectSpotlight} = require("selectors/oldSpotlightSelectors");
+describe("selectSpotlight", () => {
+  let state = selectSpotlight(fakeState);
+
+  function setup(custom) {
+    state = selectSpotlight(Object.assign({}, fakeState, custom));
+    return state;
+  }
+
+  beforeEach(() => setup());
+
+  // Tests that provided sites are sorted to the bottom, because they don't
+  // match the conditions for spotlight to use them
+  function assertInvalidSite(site) {
+    const invalidSite = Object.assign({}, validSpotlightSite, site);
+    const result = setup({Highlights: {init: true, rows: [invalidSite, validSpotlightSite]}});
+    assert.lengthOf(result.rows, 2 + firstRunData.Highlights.length);
+    assert.equal(result.rows[0].url, validSpotlightSite.url);
+    assert.equal(result.rows[1].url, invalidSite.url);
+  }
+  it("should have the same properties as Highlights plus recommendationShown", () => {
+    Object.keys(fakeState.Highlights).forEach(prop => assert.property(state, prop));
+    assert.property(state, "recommendationShown");
+  });
+  it("should set recommendationShown based on prefs.recommendations", () => {
+    setup({Prefs: {prefs: {recommendations: true}}});
+    assert.isTrue(state.recommendationShown);
+  });
+  it("should add a bestImage for each item", () => {
+    state.rows.forEach(site => {
+      assert.property(site, "bestImage");
+      assert.isObject(site.bestImage);
+      assert.property(site.bestImage, "url");
+    });
+  });
+  it("should add a backgroundColor for items that dont have an image", () => {
+    const site = {
+      url: "https://foo.com",
+      favicon_colors: [{color: [11, 11, 11]}]
+    };
+    const results = setup({Highlights: {rows: [site]}});
+    assert.deepEqual(results.rows[0].backgroundColor, "rgba(11, 11, 11, 0.4)");
+  });
+  it("should use site.background_color for items that dont have an image if it exists", () => {
+    const site = {
+      url: "https://foo.com",
+      background_color: "#111111",
+      favicon_colors: [{color: [11, 11, 11]}]
+    };
+    const results = setup({Highlights: {rows: [site]}});
+    assert.equal(results.rows[0].backgroundColor, "#111111");
+  });
+  it("should use a fallback bg color if no favicon_colors are available", () => {
+    const site = {url: "https://foo.com"};
+    const results = setup({Highlights: {rows: [site]}});
+    assert.ok(results.rows[0].backgroundColor, "should have a bg color");
+  });
+  it("should include first run items if init is true and Highlights is empty", () => {
+    const results = setup({Highlights: {init: true, rows: []}});
+    firstRunData.Highlights.forEach((item, i) => {
+      assert.equal(results.rows[i].url, item.url);
+    });
+  });
+  it("should not include first run items if init is false", () => {
+    const results = setup({Highlights: {init: false, rows: []}});
+    assert.lengthOf(results.rows, 0);
+  });
+  it("should sort sites that do not have a title to the end", () => {
+    assertInvalidSite({title: null});
+  });
+  it("should sort sites that do not have a description to the end", () => {
+    assertInvalidSite({description: null});
+  });
+  it("should sort sites for which the title equals the description to the end", () => {
+    assertInvalidSite({
+      title: "foo",
+      description: "foo"
+    });
+  });
+  it("should sort sites that do not have an images prop or an empty array to the end", () => {
+    assertInvalidSite({images: null});
+    assertInvalidSite({images: []});
+  });
+  it("should append History sites to the end", () => {
+    assertInvalidSite({images: null});
+    assertInvalidSite({images: []});
+  });
+});

--- a/content-test/selectors/selectAndDedupe.test.js
+++ b/content-test/selectors/selectAndDedupe.test.js
@@ -1,0 +1,55 @@
+const selectAndDedupe = require("selectors/selectAndDedupe");
+
+const urlToSite = url => ({url});
+
+describe("selectAndDedupe", () => {
+  it("should dedupe items", () => {
+    const result = selectAndDedupe([
+      {sites: [{url: "http://www.mozilla.org"}]},
+      {sites: [{url: "http://www.mozilla.org"}, {url: "http://www.firefox.org"}]},
+      {sites: [{url: "http://www.mozilla.org"}, {url: "http://www.firefox.org"}, {url: "http://www.blah.org"}]}
+    ]);
+    assert.lengthOf(result, 3);
+    assert.deepEqual(result[0], [{url: "http://www.mozilla.org"}]);
+    assert.deepEqual(result[1], [{url: "http://www.firefox.org"}]);
+    assert.deepEqual(result[2], [{url: "http://www.blah.org"}]);
+  });
+  it("should slice the results based on `max` argument (defaults should not be added)", () => {
+    const result = selectAndDedupe([
+      {
+        sites: ["http://www.mozilla.org", "http://www.firefox.com"].map(urlToSite),
+        max: 1,
+        defaults: ["http://foo.com"].map(urlToSite)
+      },
+      {sites: []}
+    ]);
+
+    assert.equal(result[0].length, 1);
+    assert.equal(result[0][0].url, "http://www.mozilla.org");
+  });
+  it("should append defaults if result length is under the specified limit", () => {
+    const defaults = ["http://foo.com", "http://bar.com"].map(urlToSite);
+    const result = selectAndDedupe([
+      {
+        sites: ["http://www.mozilla.org", "http://www.firefox.com"].map(urlToSite),
+        max: 5,
+        defaults
+      },
+      {sites: []}
+    ]);
+    assert.equal(result[0].length, 4);
+  });
+  it("should slice the results based on `max` argument (combined with defaults)", () => {
+    const defaults = ["http://foo.com", "http://bar.com"].map(urlToSite);
+    const result = selectAndDedupe([
+      {
+        sites: ["http://www.mozilla.org", "http://www.firefox.com"].map(urlToSite),
+        max: 3,
+        defaults
+      },
+      {sites: []}
+    ]);
+
+    assert.equal(result[0].length, 3);
+  });
+});

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -163,7 +163,7 @@ describe("selectors", () => {
     });
     it("should return the right properties", () => {
       [
-        "Spotlight",
+        "Highlights",
         "TopActivity",
         "TopSites",
         "showRecommendationOption"
@@ -171,11 +171,11 @@ describe("selectors", () => {
         assert.property(state, prop);
       });
     });
-    it("should use first 3 items of selectSpotlight for Spotlight", () => {
-      assert.lengthOf(state.Spotlight.rows, SPOTLIGHT_DEFAULT_LENGTH);
+    it("should use first 3 items of selectSpotlight for Highlights", () => {
+      assert.lengthOf(state.Highlights.rows, SPOTLIGHT_DEFAULT_LENGTH);
     });
-    it("should dedupe TopSites, Spotlight, and TopActivity", () => {
-      const groups = [state.TopSites.rows, state.Spotlight.rows, state.TopActivity.rows];
+    it("should dedupe TopSites, Highlights, and TopActivity", () => {
+      const groups = [state.TopSites.rows, state.Highlights.rows, state.TopActivity.rows];
       assert.deepEqual(groups, dedupe.group(groups));
     });
     it("should not give showRecommendationOption if we are not in the experiment", () => {
@@ -196,11 +196,11 @@ describe("selectors", () => {
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
-      assert.property(state.Spotlight, "weightedHighlights");
-      assert.isTrue(state.Spotlight.weightedHighlights);
-      assert.equal(state.Spotlight.rows.length, weightedHighlights.WeightedHighlights.rows.length + firstRunData.Highlights.length);
+      assert.property(state.Highlights, "weightedHighlights");
+      assert.isTrue(state.Highlights.weightedHighlights);
+      assert.equal(state.Highlights.rows.length, weightedHighlights.WeightedHighlights.rows.length + firstRunData.Highlights.length);
       for (let i = 0; i < weightedHighlights.WeightedHighlights.rows.length; i++) {
-        assert.equal(state.Spotlight.rows[i].url, weightedHighlights.WeightedHighlights.rows[i].url);
+        assert.equal(state.Highlights.rows[i].url, weightedHighlights.WeightedHighlights.rows[i].url);
       }
     });
     it("should render first run highlights of fresh profiles", () => {
@@ -210,8 +210,8 @@ describe("selectors", () => {
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
-      assert.equal(state.Spotlight.rows.length, firstRunData.Highlights.length);
-      state.Spotlight.rows.forEach((row, i) => {
+      assert.equal(state.Highlights.rows.length, firstRunData.Highlights.length);
+      state.Highlights.rows.forEach((row, i) => {
         assert.equal(row.url, firstRunData.Highlights[i].url);
       });
     });
@@ -222,8 +222,8 @@ describe("selectors", () => {
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
-      assert.equal(state.Spotlight.rows.length, 5);
-      assert.equal(state.Spotlight.rows[2].url, firstRunData.Highlights[0].url);
+      assert.equal(state.Highlights.rows.length, 5);
+      assert.equal(state.Highlights.rows[2].url, firstRunData.Highlights[0].url);
     });
     it("should dedupe weighted highlights results", () => {
       let weightedHighlights = {
@@ -232,7 +232,7 @@ describe("selectors", () => {
       };
 
       state = selectNewTabSites(Object.assign({}, fakeState, weightedHighlights));
-      assert.equal(state.Spotlight.rows.length, 1 + firstRunData.Highlights.length);
+      assert.equal(state.Highlights.rows.length, 1 + firstRunData.Highlights.length);
     });
   });
   describe("selectWeightedHighlights", () => {


### PR DESCRIPTION
This patch simplifies the selectors used for Highlights by:

- Renaming "Spotlight" to "Highlights"
- putting some of the old stuff related to pre-weighted highlights into isolated, separate selectors (in `oldSpotlightSelectors.js`)
- simplifying deduping code (with a refactor of `selectAndDedupe`)
- adding detailed comments for most selectors