### PR TITLE
fix(highlights): Use the same limit for bookmarks as history and let weighter decide

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -634,7 +634,7 @@ Links.prototype = {
 
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);
 
-    let params = {limitBookmarks: 1, limitHistory: (limit - 1)};
+    let params = {limitBookmarks: limit, limitHistory: limit};
 
     let sqlQuery = `SELECT DISTINCT * FROM (
                       SELECT * FROM (


### PR DESCRIPTION
Fix #1555 by getting the same number of results for bookmarks and history then letting the weighting algorithm decide which to show. We don't need to arbitrarily limit bookmarks to 1 as we now show more than 3 results.

r?@k88hudson 