### PR TITLE
chore(addon): #1509 - Host the add-on release channel via Test Pilot

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,8 +256,8 @@
     "__": "# NOTE: THESE SCRIPTS ARE COMPILED!!! EDIT yamscripts.yml instead!!!"
   },
   "title": "Activity Stream",
-  "updateLink": "https://moz-activity-streams.s3.amazonaws.com/dist/activity-streams-latest.xpi",
-  "updateURL": "https://moz-activity-streams.s3.amazonaws.com/dist/update.rdf",
+  "updateLink": "https://testpilot.firefox.com/files/activitystream/latest",
+  "updateURL": "https://testpilot.firefox.com/files/activitystream/updates.json",
   "permissions": {
     "multiprocess": true,
     "private-browsing": true


### PR DESCRIPTION
This fixes #1509. This appears to be the easiest solution by far after exploring other workarounds. See more details at #1509.

Note that we are only moving the `release` to the Test Pilot channel, everything else remains the same (i.e. being hosted in A-S S3 bucket) for the `dev` and `prerelease`. 