### PR TITLE
feature(Highlights): force on weightedHighlights for everyone

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,7 +5,6 @@ const {configure} = require("@kadira/storybook");
 require("../data/content/main.css");
 
 function loadStories() {
-  require("../content-test/components/Spotlight-unweighted.story");
   require("../content-test/components/Spotlight.story");
   require("../content-test/components/ContextMenu.story");
   require("../content-test/components/Hint.story");

--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -108,7 +108,7 @@ ActivityStreams.prototype = {
     this._initializePageScraper(this._experimentProvider, this._previewProvider, this._tabTracker);
     this._initializeRecommendationProvider(this._experimentProvider, this._previewProvider, this._tabTracker);
     this._initializeShareProvider(this._tabTracker);
-    initializePromises.push(this._initializeBaselineRecommender(this._experimentProvider));
+    initializePromises.push(this._initializeBaselineRecommender());
     this._initializePrefProvider();
 
     this._setupPageMod();
@@ -189,13 +189,11 @@ ActivityStreams.prototype = {
     this._memoized = this._get_memoized(this._memoizer);
   },
 
-  _initializeBaselineRecommender(experimentProvider) {
-    // This is instantiated with a recommender based on weights if pref is true. Used to score highlights.
+  _initializeBaselineRecommender() {
+    // This is instantiated with a recommender based on weights which
+    // is used to score highlights.
     this._baselineRecommender = null;
-    if (experimentProvider.data.weightedHighlights) {
-      return this._loadRecommender();
-    }
-    return Promise.resolve();
+    return this._loadRecommender();
   },
 
   _initializePreviewProvier(experimentProvider, metadataStore, tabTracker) {
@@ -321,7 +319,6 @@ ActivityStreams.prototype = {
 
   /**
    * Instantiate the recommender that scores the highlights items.
-   * Called when weightedHighlights prefs is toggled to true.
    * @private
    */
   _loadRecommender() {
@@ -569,20 +566,18 @@ ActivityStreams.prototype = {
   },
 
   /**
-   * Listen for changes to weighted highlights pref or associated options.
+   * Listen for changes to weighted highlights prefs.
    *
    * @param {String} prefName - name of the pref that changed.
    * @private
    */
   _weightedHiglightsListeners(prefName) {
-    // Update the feature weights only if we are doing weighted highlights.
-    if (prefName === "weightedHighlightsCoefficients" && simplePrefs.prefs.weightedHighlights) {
+    // Update the feature weights
+    if (prefName === "weightedHighlightsCoefficients") {
       let highlightsCoefficients = this._loadWeightedHighlightsCoefficients();
       this._baselineRecommender.updateOptions({highlightsCoefficients});
     }
-    if (prefName === "weightedHighlights") {
-      this._loadRecommender();
-    }
+    this._loadRecommender();
   },
 
   /**

--- a/content-src/selectors/oldSpotlightSelectors.js
+++ b/content-src/selectors/oldSpotlightSelectors.js
@@ -13,7 +13,7 @@ module.exports.selectSpotlight = createSelector(
   [
     state => state.Highlights,
     state => state.Prefs.prefs.recommendations,
-    state => state.Experiments.values.weightedHighlights
+    state => true
   ],
   (Highlights, recommendationShown, isNewHighlights) => {
     // Only concat first run data if init is true

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -2,7 +2,6 @@ const {createSelector} = require("reselect");
 const firstRunData = require("lib/first-run-data");
 const selectAndDedupe = require("selectors/selectAndDedupe");
 const {assignImageAndBackgroundColor} = require("selectors/colorSelectors");
-const {selectSpotlight} = require("selectors/oldSpotlightSelectors");
 const {SPOTLIGHT_DEFAULT_LENGTH, WEIGHTED_HIGHLIGHTS_LENGTH, TOP_SITES_LENGTH} = require("common/constants");
 
 /**
@@ -22,10 +21,10 @@ module.exports.justDispatch = (() => ({}));
  */
 module.exports.selectNewTabSites = createSelector(
   [
-    state => state.Experiments.values.weightedHighlights,
-    state => (state.Experiments.values.weightedHighlights ? state.WeightedHighlights : selectSpotlight(state)),
+    state => true,
+    state => state.WeightedHighlights, // XXXdmose remove selectSpotlight code itself for #1611
     state => state.TopSites,
-    state => (state.Experiments.values.weightedHighlights ? Object.assign({}, state.History, {rows: []}) : state.History),
+    state => Object.assign({}, state.History, {rows: []}), // XXXdmose remove state.History and whatever code implemented that #1611
     state => state.Experiments
   ],
   (isNewHighlights, Highlights, TopSites, History, Experiments) => {

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -41,7 +41,7 @@ describe("NewTabPage", () => {
     assert.equal(spotlightSites.props.sites, fakeProps.Highlights.rows);
   });
 
-  it("should render GroupedActivityFeed with correct data", () => {
+  it.skip("should render GroupedActivityFeed with correct data", () => { // XXXdmose - remove in #1611
     const activityFeed = TestUtils.findRenderedComponentWithType(instance, GroupedActivityFeed);
     assert.equal(activityFeed.props.sites, fakeProps.TopActivity.rows);
   });
@@ -128,7 +128,7 @@ describe("NewTabPage", () => {
       const deleteLink = TestUtils.scryRenderedDOMComponentsWithClass(item, "context-menu-link")[0];
       TestUtils.Simulate.click(deleteLink);
     });
-    it("should have the correct page, source, index for activity feed", done => {
+    it.skip("should have the correct page, source, index for activity feed", done => {  // XXXdmose remove for #1611
       setupConnected(a => {
         if (a.type === "NOTIFY_USER_EVENT") {
           assert.equal(a.data.page, "NEW_TAB");

--- a/content-test/components/Spotlight.story.js
+++ b/content-test/components/Spotlight.story.js
@@ -39,21 +39,10 @@ const Container = props => (
 // unclear reasons.  Presumably something to do with faker, tippy-top-sites,
 // lorempixel (used by faker for the images), or Spotlight (aka Highlight)
 // itself.
-
-// Compute the weighted fake spotlight rows.
-// XXX should we be assigning to rawMockData?
-
-// After the code stops checking Experiments.values.weightedHighlights,
-// this next line can go away:
-rawMockData.Experiments.values.weightedHighlights = true;
-
-// If/when weightedHighlights become the default, we can update fake-data.js
-// and remove this line too.
-rawMockData.WeightedHighlights.weightedHighlights = true;
 let mockData = Object.assign({}, rawMockData, selectNewTabSites(rawMockData));
 let fakeSpotlightItems = mockData.Highlights.rows;
 
-storiesOf("Highlight List (weighted)", module)
+storiesOf("Highlight List", module)
   .add("All valid properties", () =>
     <Container>
       <Spotlight length={WEIGHTED_HIGHLIGHTS_LENGTH} page="SPOTLIGHT_STORYBOOK" sites={fakeSpotlightItems} />

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -133,7 +133,7 @@ describe("selectors", () => {
       });
     });
 
-    describe("old Highlights", () => {
+    describe.skip("old Highlights", () => { // XXXdmose remove in #1611
       it("should have highlights of SPOTLIGHT_DEFAULT_LENGTH", () => {
         setup(undefined, false);
         assert.lengthOf(state.Highlights.rows, SPOTLIGHT_DEFAULT_LENGTH);

--- a/experiments.json
+++ b/experiments.json
@@ -31,7 +31,7 @@
   },
   "weightedHighlights": {
     "name": "Weighted Highlights",
-    "active": true,
+    "active": false,
     "description": "Use weighted highlights instead of the query based ones.",
     "control": {
       "value": false,


### PR DESCRIPTION
This PR forces on the weightedHighlights for all activity-stream users.  This is the lowest-risk way to get it turned on for the Shield study.  After this lands, #1611 can be moved out of La Mauricie and into Mount Revelstoke, where another PR will tear out the non-weighted code entirely so that that issue can be closed.

The main things to test here is that 

npm run test
the XPI generated by 'npm run package'
npm run firefox

all default to the weighted highlights in a new profile.

r? @sarracini 