### PR TITLE
fix(exceptions): Fixes #1667 add .catch to promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
   "plugins": [
     "json",
     "mozilla",
+    "promise",
     "react"
   ],
   "extends": [
@@ -31,6 +32,9 @@
     "mozilla/components-imports": 1,
     "mozilla/import-globals-from": 1,
     "mozilla/this-top-level-scope": 1,
+
+    "promise/param-names": 2,
+    "promise/catch-or-return": 2,
 
     "react/jsx-boolean-value": [2, "always"],
     "react/jsx-closing-bracket-location": [2, "after-props"],

--- a/addon/Memoizer.js
+++ b/addon/Memoizer.js
@@ -51,7 +51,7 @@ Memoizer.prototype = {
 
       if (this._cacheEnabled && !replace && this.hasRepr(key, repr)) {
         Services.obs.notifyObservers(null, `${key}-cache`, "hit");
-        return new Promise(resolve => resolve(this.getData(key, repr)));
+        return new Promise(resolve => resolve(this.getData(key, repr))).catch(err => Cu.reportError(err));
       }
       Services.obs.notifyObservers(null, `${key}-cache`, "miss");
       return Task.spawn(function*() {

--- a/addon/PageScraper.js
+++ b/addon/PageScraper.js
@@ -50,7 +50,11 @@ PageScraper.prototype = {
       }
 
       if (this._shouldSaveMetadata(metadata)) {
-        metadata.images = yield this._computeImageSize(metadata);
+        try {
+          metadata.images = yield this._computeImageSize(metadata);
+        } catch (e) {
+          Cu.reportError(`PageScraper failed to compute image size for ${url}`);
+        }
         this._insertMetadata(metadata);
         this._tabTracker.handlePerformanceEvent(event, "metadataParseSuccess", Date.now() - startTime);
       } else {

--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -227,7 +227,7 @@ Links.prototype = {
       if (type === Bookmarks.TYPE_BOOKMARK) {
         gLinks.getBookmark({id}).then(bookmark => {
           gLinks.emit("bookmarkAdded", bookmark);
-        });
+        }).catch(err => Cu.reportError(err));
       }
     },
 
@@ -241,7 +241,7 @@ Links.prototype = {
       if (type === Bookmarks.TYPE_BOOKMARK) {
         gLinks.getBookmark({id}).then(bookmark => {
           gLinks.emit("bookmarkChanged", bookmark);
-        });
+        }).catch(err => Cu.reportError(err));
       }
     },
 

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -176,10 +176,10 @@ PreviewProvider.prototype = {
         }
         getColor(link.favicon, link.url).then(color => {
           resolve(Object.assign({}, link, {favicon_color: color}));
-        }, () => resolve(link));
+        }, () => resolve(link)).catch(err => Cu.reportError(err));
       })
       )
-    );
+    ).catch(err => Cu.reportError(err));
   },
 
   /**
@@ -290,7 +290,7 @@ PreviewProvider.prototype = {
     requestQueue.forEach(requestBundle => {
       promises.push(this._asyncFetchAndStore(requestBundle, event));
     });
-    yield Promise.all(promises);
+    yield Promise.all(promises).catch(err => Cu.reportError(err));
   }),
 
   /**

--- a/addon/SearchProvider.js
+++ b/addon/SearchProvider.js
@@ -238,7 +238,7 @@ SearchProvider.prototype = {
         handleError: () => reject()
       };
       FormHistory.update(ops, callbacks);
-    });
+    }).catch(err => Cu.reportError(err));
     return result;
   }),
 

--- a/addon/ShareProvider.js
+++ b/addon/ShareProvider.js
@@ -276,7 +276,7 @@ ShareProvider.prototype = {
         }));
       }
       Services.prefs.setBoolPref("social.enabledByActivityStream", true);
-      yield Promise.all(promises);
+      yield Promise.all(promises).catch(err => Cu.reportError(err));
     }
   }),
 
@@ -304,7 +304,7 @@ ShareProvider.prototype = {
           });
         }));
       }
-      yield Promise.all(promises);
+      yield Promise.all(promises).catch(err => Cu.reportError(err));
       Services.prefs.clearUserPref("social.activeProviders");
       Services.prefs.clearUserPref("social.enabledByActivityStream");
     }

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -275,8 +275,12 @@ TabTracker.prototype = {
     tab.on("close", this.logClose);
 
     // update history and bookmark sizes
-    this._placesQueries.getHistorySize().then(size => {this._tabData.total_history_size = size;});
-    this._placesQueries.getBookmarksSize().then(size => {this._tabData.total_bookmarks = size;});
+    this._placesQueries.getHistorySize()
+      .then(size => {this._tabData.total_history_size = size;})
+      .catch(err => Cu.reportError(err));
+    this._placesQueries.getBookmarksSize()
+      .then(size => {this._tabData.total_bookmarks = size;})
+      .catch(err => Cu.reportError(err));
 
     // Some performance pings are sent before a tab is loaded. Let's make sure we have
     // session id available in advance for those pings.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "3.8.1",
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-mozilla": "0.2.3",
+    "eslint-plugin-promise": "3.3.0",
     "eslint-plugin-react": "6.4.1",
     "eslint-watch": "2.1.14",
     "eventemitter2": "2.1.3",

--- a/test/test-ActivityStreams-workers.js
+++ b/test/test-ActivityStreams-workers.js
@@ -90,7 +90,7 @@ after(exports, (name, assert, done) => {
   Promise.all([
     ...openTabs.map(tab => new Promise(resolve => tab.close(resolve))),
     new Promise(resolve => srv.stop(resolve))
-  ]).then(done);
+  ]).then(done).catch(err => {throw new Error(err);});
 });
 
 test.run(exports);

--- a/test/test-MetadataStore.js
+++ b/test/test-MetadataStore.js
@@ -306,7 +306,7 @@ exports.test_data_expiry = function*(assert) {
       if (items.length === expected) {
         isDeleted = true;
       }
-    });
+    }).catch(err => {throw new Error(err);});
     return false;
   }, 500);
 


### PR DESCRIPTION
Adding some catch enforcement
So this patch only enforces the catching of promises - we should file another PR for logging it to a central place, once we decide what that is, so that we can essentially mimic what sentry does.

@k88hudson r?