### PR TITLE
fix(tests): Fixes #1557 mock PageWorker to remove null warning

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -53,6 +53,7 @@ const DEFAULT_OPTIONS = {
   recommendationTTL: 3600000, // every hour, get a new recommendation
   shareProvider: null,
   pageScraper: null,
+  pageWorker: null,
   searchProvider: null,
   recommendationProvider: null
 };
@@ -165,8 +166,13 @@ ActivityStreams.prototype = {
   },
 
   _setUpPageWorker(store) {
-    this._pageWorker = new PageWorker({store});
-    this._pageWorker.connect();
+    this._pageWorker = null;
+    if (!this.options.pageWorker) {
+      this._pageWorker = new PageWorker({store});
+      this._pageWorker.connect();
+    } else {
+      this._pageWorker = this.options.pageWorker;
+    }
   },
 
   _initializePerfMeter() {

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -116,7 +116,13 @@ function getTestActivityStream(options = {}) {
     _asyncParseAndSave() {}
   };
 
+  const mockPageWorker = {
+    connect() {},
+    destroy() {}
+  };
+
   options.pageScraper = mockPageScraper;
+  options.pageWorker = mockPageWorker;
   options.searchProvider = getTestSearchProvider();
   options.recommendationProvider = getTestRecommendationProvider();
   const testTabTracker = new TabTracker(options);


### PR DESCRIPTION
* Mocks out the PageWorker in ActivityStream tests
* Fixes warning ```this._pageWorker = null``` during tests