### PR TITLE
fix(metadatastore): #1577: Add parameterized query

### DIFF
--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -243,8 +243,7 @@ PreviewProvider.prototype = {
   }),
 
   /**
-   * Find the metadata for each link in the database. Note that it'll try to fetch items
-   * from the cache before querying the metadata store
+   * Find the metadata for each link in the database
    */
   _asyncFindItemsInDB: Task.async(function*(links) {
     let cacheKeys = [];
@@ -256,7 +255,13 @@ PreviewProvider.prototype = {
     });
 
     // Hit the database for the missing keys
-    const linksMetadata = yield this._metadataStore.asyncGetMetadataByCacheKey(cacheKeys);
+    let linksMetadata;
+    try {
+      linksMetadata = yield this._metadataStore.asyncGetMetadataByCacheKey(cacheKeys);
+    } catch (e) {
+      Cu.reportError(`Failed to fetch metadata: ${e.message}`);
+      return [];
+    }
     return linksMetadata;
   }),
 


### PR DESCRIPTION
This fixes #1577 as well as following issues that we've encountered before:
* failure of fetching metadata if there are special characters in the `cache_key`
* `unique constraint violation` due to the similar bug in the "asyncCacheKeyExists"

More importantly, it prevents metadata store from the potential SQL injection hazard.  