### PR TITLE
chore(lint): Switch to new import-globals rule to fix warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,9 +28,7 @@
     "eslint:recommended"
   ],
   "rules": {
-    "mozilla/components-imports": 1,
-    "mozilla/import-globals-from": 1,
-    "mozilla/this-top-level-scope": 1,
+    "mozilla/import-globals": 1,
 
     "react/jsx-boolean-value": [2, "always"],
     "react/jsx-closing-bracket-location": [2, "after-props"],


### PR DESCRIPTION
Fix #1687. r?@pdehaan 