### PR TITLE
chore(package): update various dependencies to latest version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,9 +29,7 @@
     "eslint:recommended"
   ],
   "rules": {
-    "mozilla/components-imports": 1,
-    "mozilla/import-globals-from": 1,
-    "mozilla/this-top-level-scope": 1,
+    "mozilla/import-globals": 1,
 
     "promise/param-names": 2,
     "promise/catch-or-return": 2,

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "style-loader": "0.13.1",
     "svgo": "0.7.1",
     "tippy-top-sites": "0.2.0",
-    "webpack": "1.13.2",
+    "webpack": "1.13.3",
     "webpack-env-loader-plugin": "0.1.4",
     "webpack-notifier": "1.4.1",
     "yamscripts": "0.0.3"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cpx": "1.5.0",
     "eslint": "3.9.1",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-mozilla": "0.0.3",
+    "eslint-plugin-mozilla": "0.2.3",
     "eslint-plugin-promise": "3.3.0",
     "eslint-plugin-react": "6.5.0",
     "eslint-watch": "2.1.14",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-loader": "6.2.7",
     "babel-plugin-transform-es2015-destructuring": "6.18.0",
     "babel-plugin-transform-es2015-parameters": "6.18.0",
-    "babel-plugin-transform-strict-mode": "6.11.3",
+    "babel-plugin-transform-strict-mode": "6.18.0",
     "babel-preset-react": "6.16.0",
     "chai": "3.5.0",
     "co-task": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-json-inspector": "7.0.0",
     "react-redux": "4.4.5",
     "redux": "3.6.0",
-    "redux-logger": "2.7.0",
+    "redux-logger": "2.7.4",
     "redux-thunk": "2.1.0",
     "redux-watch": "1.1.1",
     "reselect": "2.5.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "redux-thunk": "2.1.0",
     "redux-watch": "1.1.1",
     "reselect": "2.5.4",
-    "url-parse": "1.1.6"
+    "url-parse": "1.1.7"
   },
   "devDependencies": {
     "@kadira/storybook": "2.29.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@kadira/storybook": "2.25.1",
     "babel": "6.5.2",
-    "babel-core": "6.17.0",
+    "babel-core": "6.18.2",
     "babel-loader": "6.2.5",
     "babel-plugin-transform-es2015-destructuring": "6.16.0",
     "babel-plugin-transform-es2015-parameters": "6.17.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url-parse": "1.1.6"
   },
   "devDependencies": {
-    "@kadira/storybook": "2.25.1",
+    "@kadira/storybook": "2.29.0",
     "babel": "6.5.2",
     "babel-core": "6.18.2",
     "babel-loader": "6.2.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@kadira/storybook": "2.29.0",
     "babel": "6.5.2",
     "babel-core": "6.18.2",
-    "babel-loader": "6.2.5",
+    "babel-loader": "6.2.7",
     "babel-plugin-transform-es2015-destructuring": "6.16.0",
     "babel-plugin-transform-es2015-parameters": "6.17.0",
     "babel-plugin-transform-strict-mode": "6.11.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-mozilla": "0.0.3",
     "eslint-plugin-promise": "3.3.0",
-    "eslint-plugin-react": "6.4.1",
+    "eslint-plugin-react": "6.5.0",
     "eslint-watch": "2.1.14",
     "eventemitter2": "2.1.3",
     "faker": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-core": "6.18.2",
     "babel-loader": "6.2.7",
     "babel-plugin-transform-es2015-destructuring": "6.16.0",
-    "babel-plugin-transform-es2015-parameters": "6.17.0",
+    "babel-plugin-transform-es2015-parameters": "6.18.0",
     "babel-plugin-transform-strict-mode": "6.11.3",
     "babel-preset-react": "6.16.0",
     "chai": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel": "6.5.2",
     "babel-core": "6.18.2",
     "babel-loader": "6.2.7",
-    "babel-plugin-transform-es2015-destructuring": "6.16.0",
+    "babel-plugin-transform-es2015-destructuring": "6.18.0",
     "babel-plugin-transform-es2015-parameters": "6.18.0",
     "babel-plugin-transform-strict-mode": "6.11.3",
     "babel-preset-react": "6.16.0",


### PR DESCRIPTION
Pretty much the same thing as #1684 with #1688 merged into the `eslint-plugin-mozilla` commit. Trying to track down why this is going red on master when it was green in #1684...