### PR TITLE
feat(experiments): #1721 Add display for experiments to debug

### DIFF
--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -6,6 +6,7 @@ const TopSites = require("components/TopSites/TopSites");
 const faker = require("test/faker");
 const sizeof = require("object-sizeof");
 const {ShowAllHints} = require("common/action-manager").actions;
+const experimentDefinitions = require("../../../experiments.json");
 
 // Only include this in DEVELOPMENT builds
 let JSONTree;
@@ -45,6 +46,33 @@ const DebugPage = React.createClass({
 
     return (<main className="debug-page">
       <div className="new-tab-wrapper">
+
+        <section className="experiments">
+          <h2>Experiments</h2>
+          <p>
+            To override these experiments, check <code>about:config</code> for <code>extensions.@activity-streams.experiments.prefName</code>, where <code>prefName</code> is the name of the pref in this table.
+          </p>
+          <table className="experiment-table">
+            <tr>
+              <th>Experiment</th>
+              <th>Pref name</th>
+              <th>Description</th>
+              <th>Value</th>
+            </tr>
+            {Object.keys(experimentDefinitions)
+              .filter(id => experimentDefinitions[id].active)
+              .map(id => {
+                const valueAsString = JSON.stringify(this.props.raw.Experiments.values[id]);
+                return (<tr key={id}>
+                  <td>{experimentDefinitions[id].name}</td>
+                  <td><code>{id}</code></td>
+                  <td>{experimentDefinitions[id].description}</td>
+                  <td>{valueAsString}</td>
+                </tr>);
+              })}
+          </table>
+        </section>
+
         <section>
           <h2>State as plain text</h2>
           <p>Apx. current size: {Math.round(sizeof(this.props.raw) / 1024)}kb</p>

--- a/content-src/components/DebugPage/DebugPage.scss
+++ b/content-src/components/DebugPage/DebugPage.scss
@@ -57,6 +57,29 @@
   }
 }
 
+.experiments {
+  .experiment-table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th,
+    td {
+      padding: 8px;
+      text-align: left;
+      border: 1px solid $very-light-grey;
+    }
+  }
+
+  code {
+    font-family: $code-font;
+    background: $code-background;
+    color: $code-color;
+    padding: 3px 7px;
+    border-radius: 3px;
+    font-size: 0.8em;
+  }
+}
+
 .json-inspector,
 .json-inspector__selection {
   font: 14px/1.4 Consolas, monospace;

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -143,6 +143,10 @@ $hint-button-color: #2083F2;
 $hint-button-padding: 8px;
 $hint-button-font-size: 15px;
 
+$code-font: Menlo, Monaco, Consolas, monospace;
+$code-background: #FCF2F4;
+$code-color: #E8005C;
+
 @mixin item-shadow {
   box-shadow: $item-shadow;
 


### PR DESCRIPTION
Fix #1721 . This patch adds a display for experiments in the debug page; no editing for now, but it does include a description of how to find the relevant prefs.