### PR TITLE
content(metadata): #1706 Upgrade tippy-top-sites to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "sinon": "1.17.6",
     "style-loader": "0.13.1",
     "svgo": "0.7.1",
-    "tippy-top-sites": "0.2.0",
+    "tippy-top-sites": "0.3.0",
     "webpack": "1.13.3",
     "webpack-env-loader-plugin": "0.1.4",
     "webpack-notifier": "1.4.1",


### PR DESCRIPTION
This upgrade adds a bunch of new sites and updated images.
Fixes #1706