### PR TITLE
feat(Highlights): Closes #1767; show highlights after welcome popup w…

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -52,7 +52,8 @@ const am = new ActionManager([
   "ENABLE_ALL_HINTS",
   "DISABLE_HINT",
   "APP_INIT",
-  "PLACES_STATS_UPDATED"
+  "PLACES_STATS_UPDATED",
+  "MERGE_STORE"
 ]);
 
 // This is a a set of actions that have sites in them,

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -34,29 +34,10 @@ const NewTabPage = React.createClass({
     setFavicon("newtab-icon.svg");
 
     // Note that data may or may not be complete, depending on
-    // the state of the master store
+    // the state of the master store, as well as if all the selectors
+    // have finished (in which case the "Welcome" dialog maybe be being shown
+    // without any actual images).
     this.props.dispatch(actions.NotifyPerf("NEWTAB_RENDER"));
-
-    // Check for stabilization of state changes if things aren't ready
-    if (this.props.isReady === false) {
-      let lastSize = 0;
-      let lastUpdate = Date.now();
-      setInterval(() => {
-        // Reload the page if things appear to have stabilized
-        let now = Date.now();
-        let newSize = (localStorage.ACTIVITY_STREAM_STATE || "").length;
-        if (newSize === lastSize) {
-          if (now - lastUpdate > 3000) {
-            location.reload();
-          }
-        }
-        // Remember the time of the last state change
-        else {
-          lastSize = newSize;
-          lastUpdate = now;
-        }
-      }, 100);
-    }
   },
   render() {
     const props = this.props;


### PR DESCRIPTION
…/o reload.  

To test:

1. After building, do ```npm run firefox``` on a slow machine.  
2. Once the main window opens, quickly hit command-T to open a new tab.
3. Note the "Welcome..." Firefox dialog
4. After a few seconds, the dialog should go away and the rest of the page shoulder render without an actual reload happening

r=k88hudson?
