### PR TITLE
fix(recommender): Remove recent filtering logic relying on faulty SCROLL_THRESHOLD usage

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -16,14 +16,6 @@ module.exports = {
     ageLimit: "-4 day"
   },
 
-  // This is how many pixels before the bottom that
-  // infinite scroll is triggered
-  INFINITE_SCROLL_THRESHOLD: 20,
-
-  // How many pixels offset for the infinite scroll top
-  // due to the header?
-  SCROLL_TOP_OFFSET: 50,
-
   // This is where we cache redux state so it can be shared between pages
   LOCAL_STORAGE_KEY: "ACTIVITY_STREAM_STATE"
 };

--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -2,7 +2,6 @@
 
 const URL = require("common/vendor")("url-parse");
 const getBestImage = require("../getBestImage");
-const {INFINITE_SCROLL_THRESHOLD} = require("../constants");
 
 /**
  * Score function for URLs.
@@ -166,8 +165,7 @@ class Baseline {
    * @returns {Array.<URLs>} sorted and with the associated score value.
    */
   score(entries) {
-    let results = this.filterOutRecentUrls(entries)
-                    .map(entry => this.extractFeatures(entry))
+    let results = entries.map(entry => this.extractFeatures(entry))
                     .map(entry => this.scoreEntry(entry))
                     .sort(this.sortDescByScore)
                     .filter(entry => entry.score > 0);
@@ -177,23 +175,7 @@ class Baseline {
     let dedupedEntries = this._dedupeSites(results);
 
     // Sort again after adjusting score.
-    return dedupedEntries.sort(this.sortDescByScore).slice(0, INFINITE_SCROLL_THRESHOLD);
-  }
-
-  /**
-   * It checks to see how many articles are older than 30 minutes.
-   * If we have more than 20 to show remove the recent ones.
-   * @param {Array} entries
-   * @returns {Array}
-   */
-  filterOutRecentUrls(entries) {
-    let olderEntries = entries.filter(entry => Date.now() - entry.lastVisitDate > 1e3 * 1800);
-
-    if (olderEntries.length > INFINITE_SCROLL_THRESHOLD) {
-      return olderEntries;
-    }
-
-    return entries;
+    return dedupedEntries.sort(this.sortDescByScore);
   }
 
   /**


### PR DESCRIPTION
Fix #1670 by not filtering out recently bookmarked/visited pages that relied on a pixel threshold. There isn't as much of a need to filter recent items now that we show 9 highlights.

r?@sarracini 