### PR TITLE
fix(addon): Differentiate homepage-loaded activity stream for pings

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -546,12 +546,12 @@ ActivityStreams.prototype = {
     if (!ss.storage.homepageOverriden &&
         (!prefService.isSet(HOME_PAGE_PREF) ||
          ["about:home", "about:blank"].includes(prefService.get(HOME_PAGE_PREF)))) {
-      prefService.set(HOME_PAGE_PREF, this._newTabURL);
+      prefService.set(HOME_PAGE_PREF, `${this._newTabURL}HOME`);
     }
   },
 
   _unsetHomePage() {
-    if (prefService.get(HOME_PAGE_PREF) === this._newTabURL) {
+    if (prefService.get(HOME_PAGE_PREF) === `${this._newTabURL}HOME`) {
       // Reset home page back if user didn't change it.
       prefService.reset(HOME_PAGE_PREF);
     } else {
@@ -569,7 +569,8 @@ ActivityStreams.prototype = {
       let baseUrl = this.options.pageURL;
       this._appURLs = [
         baseUrl,
-        `${baseUrl}#/`
+        `${baseUrl}#/`,
+        `${baseUrl}#/HOME`
       ];
     }
     return this._appURLs;

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -79,7 +79,7 @@ TabTracker.prototype = {
     payload.client_id = this._clientID;
     payload.addon_version = self.version;
     payload.locale = Locale.getLocale();
-    payload.page = eventConstants.defaultPage;
+    payload.page = url.split("#/")[1] || eventConstants.defaultPage;
     payload.session_id = this._tabData.session_id;
     if (this._experimentID) {
       payload.experiment_id = this._experimentID;

--- a/data_dictionary.md
+++ b/data_dictionary.md
@@ -19,7 +19,7 @@ The Activity Stream addon sends various types of pings to the backend (HTTPS POS
   "load_reason": "restore",
   "locale": "en-US",
   "max_scroll_depth": 145,
-  "page": "NEW_TAB",
+  "page": "NEW_TAB or HOME",
   "receive_at": 1457396660000,
   "session_duration": 1635,
   "tab_id": "1-3",
@@ -42,7 +42,7 @@ The Activity Stream addon sends various types of pings to the backend (HTTPS POS
   "event": "click or scroll or search or delete",
   "ip": "10.192.171.13",
   "locale": "en-US",
-  "page": "NEW_TAB",
+  "page": "NEW_TAB or HOME",
   "receive_at": 1457396660000,
   "source": "top sites, or bookmarks, or...",
   "tab_id": "1-3",
@@ -89,7 +89,7 @@ The Activity Stream addon sends various types of pings to the backend (HTTPS POS
 | `locale` | [Auto populated by Onyx] The browser chrome's language (eg. en-US). | :two:
 | `max_scroll_depth` | [Optional] The maximum number of pixels the scroll bar was dragged in this session. | :one:
 | `metadata_source` | [Optional] The source of which we computed metadata. Either (`Embedly` or `MetadataService` or `Local` or `TippyTopProvider`). | :one:
-| `page` | [Required] "NEW_TAB". | :one:
+| `page` | [Required] Either ["NEW_TAB", "HOME"]. | :one:
 | `provider` | [Optional] The name of share provider. | :one:
 | `recommender_type` | [Optional] The type of recommendation that is being shown, if any. | :one:
 | `session_duration` | [Required] Defined to be the time in milliseconds between the newtab gaining and losing focus. | :one:

--- a/data_events.md
+++ b/data_events.md
@@ -16,7 +16,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "[CLICK | DELETE | BLOCK | SHARE | LOAD_MORE | SEARCH | SHARE_TOOLBAR]",
 
   // This is where the interaction occurred
-  "page": "NEW_TAB",
+  "page": ["NEW_TAB" | "HOME"],
 
   // Optional field indicating the UI component type
   "source": ["TOP_SITES" | "FEATURED" | "ACTIVITY_FEED"],
@@ -43,7 +43,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   "event": "SEARCH",
-  "page": "NEW_TAB",
+  "page": ["NEW_TAB" | "HOME"],
   "action": "activity_stream_event",
   "tab_id": "-5-2",
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
@@ -57,7 +57,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   "event": "CLICK",
-  "page": "NEW_TAB",
+  "page": ["NEW_TAB" | "HOME"],
   "source": ["TOP_SITES" | "FEATURED" | "ACTIVITY_FEED"],
   "action_position": 2,
   "action": "activity_stream_event",
@@ -78,7 +78,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
   {
     "event": "DELETE",
-    "page": "NEW_TAB",
+    "page": ["NEW_TAB" | "HOME"],
     "source": ["TOP_SITES" | "FEATURED" | "ACTIVITY_FEED"],
     "action_position": 0,
     "action": "activity_stream_event",
@@ -95,7 +95,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   "event": "BLOCK",
-  "page": "NEW_TAB",
+  "page": ["NEW_TAB" | "HOME"],
   "source": ["TOP_SITES" | "FEATURED" | "ACTIVITY_FEED"],
   "action_position": 4,
   "action": "activity_stream_event",
@@ -116,7 +116,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   "event": "SHARE",
-  "page": "NEW_TAB"
+  "page": ["NEW_TAB" | "HOME"],
   "source": "ACTIVITY_FEED",
   "provider": "https://facebook.com",
   "action_position": 0,
@@ -136,7 +136,7 @@ It doesn't capture success or failure to share after.
 ```js
 {
   "event": "SHARE_TOOLBAR",
-  "page": "NEW_TAB",
+  "page": ["NEW_TAB" | "HOME"],
   "provider": "https://facebook.com",
   "action": "activity_stream_event",
   "tab_id": "-3-16",
@@ -157,7 +157,7 @@ All `"activity_stream_session"` pings have the following basic shape. Some field
 ```js
 {
   // These are all variable. See below for what causes different unload_reasons
-  "url": "resource://activity-streams/data/content/activity-streams.html",
+  "url": "resource://activity-streams/data/content/activity-streams.html#/[|HOME]",
   "load_reason": "[newtab | focus]",
   "unload_reason": "[navigation | unfocus | refresh]",
 
@@ -168,7 +168,7 @@ All `"activity_stream_session"` pings have the following basic shape. Some field
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "addon_version": "1.0.12",
   "locale": "en-US",
-  "page": "NEW_TAB",
+  "page": ["NEW_TAB" | "HOME"],
   "action": "activity_stream_session",
   "session_duration": 4199
 }

--- a/test/test-ActivityStreams-home-page.js
+++ b/test/test-ActivityStreams-home-page.js
@@ -11,11 +11,11 @@ exports["test activity stream loads on home page when appropriate"] = function(a
   let app = getTestActivityStream({pageURL: url});
 
   // By default, the home page should be set to ActivityStream.
-  assert.equal(`${url}#/`, prefService.get("browser.startup.homepage"));
+  assert.equal(`${url}#/HOME`, prefService.get("browser.startup.homepage"));
 
   // Unload ActivityStream and the home page should still be ours.
   app.unload();
-  assert.equal(`${url}#/`, prefService.get("browser.startup.homepage"));
+  assert.equal(`${url}#/HOME`, prefService.get("browser.startup.homepage"));
 
   // Unload ActivityStream with reason="disable" and it should be unset.
   app = getTestActivityStream({pageURL: url});

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -591,6 +591,9 @@ exports.test_TabTracker_pageType = function*(assert) {
   assert.deepEqual(app.tabData, {}, "tabData starts out empty");
   let pingData = yield openTestTab(ACTIVITY_STREAMS_URL);
   assert.equal(pingData.page, "NEW_TAB", "page type is newtab");
+
+  pingData = yield openTestTab(`${ACTIVITY_STREAMS_URL}HOME`);
+  assert.equal(pingData.page, "HOME", "page type is home");
 };
 
 const openTestTabExample = Task.async(function*(openUrl) {


### PR DESCRIPTION
Fix #1606 by setting the home page to a special #/HOME hash that gets reported as the page in payloads.

r?@rlr 