### PR TITLE
Add commit hash in the version string

### DIFF
--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -49,6 +49,11 @@ const DebugPage = React.createClass({
     return (<main className="debug-page">
       <div className="new-tab-wrapper">
 
+        <section>
+          <h2>Version</h2>
+          <p>{this.props.raw.Prefs.prefs["sdk.version"]}</p>
+        </section>
+
         <section className="experiments">
           <h2>Experiments</h2>
           <p>


### PR DESCRIPTION
This closes #1799 and closes #1203 

For the dev and pre-release channel, it'll attach the commit hash to the version string. Also, it'll show the version in the DebugPage.