### PR TITLE
Emit action when experiment prefs are changed

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -332,10 +332,6 @@ ActivityStreams.prototype = {
     }
   },
 
-  _respondToExperimentsRequest({worker}) {
-    this.send(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data), worker);
-  },
-
   /**
    * Handles changes to places
    */
@@ -384,8 +380,6 @@ ActivityStreams.prototype = {
         return this._onRouteChange(args);
       case am.type("NOTIFY_USER_EVENT"):
         return this._handleUserEvent(args);
-      case am.type("EXPERIMENTS_REQUEST"):
-        return this._respondToExperimentsRequest(args);
       case am.type("NOTIFY_TOGGLE_RECOMMENDATIONS"):
         return this._respondToRecommendationToggle();
     }

--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -363,6 +363,10 @@ ActivityStreams.prototype = {
     this._tabTracker.handleUserEvent(msg.data);
   },
 
+  _handleExperimentChange(prefName) {
+    this.broadcast(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data));
+  },
+
   _respondToRecommendationToggle() {
     simplePrefs.prefs.recommendations = !simplePrefs.prefs.recommendations;
   },
@@ -402,6 +406,9 @@ ActivityStreams.prototype = {
     this._handleCurrentEngineChanges = this._handleCurrentEngineChanges.bind(this);
     this._searchProvider.on("browser-search-engine-modified", this._handleCurrentEngineChanges);
 
+    this._handleExperimentChange = this._handleExperimentChange.bind(this);
+    this._experimentProvider.on("change", this._handleExperimentChange);
+
     // This is a collection of handlers that receive messages from content
     this._contentToAddonHandlers = (msgName, args) => {
       // Log requests first so that the requests are logged before responses
@@ -430,6 +437,7 @@ ActivityStreams.prototype = {
   _removeListeners() {
     PLACES_CHANGES_EVENTS.forEach(event => PlacesProvider.links.off(event, this._handlePlacesChanges));
     this._searchProvider.off("browser-search-engine-modified", this._handleCurrentEngineChanges);
+    this._experimentProvider.off("change", this._handleExperimentChange);
     this.off(CONTENT_TO_ADDON, this._contentToAddonHandlers);
   },
 

--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -53,7 +53,8 @@ const am = new ActionManager([
   "DISABLE_HINT",
   "APP_INIT",
   "PLACES_STATS_UPDATED",
-  "MERGE_STORE"
+  "MERGE_STORE",
+  "EXPERIMENT_OVERRIDE"
 ]);
 
 // This is a a set of actions that have sites in them,

--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -15,7 +15,6 @@ const am = new ActionManager([
   "RECENT_LINKS_RESPONSE",
   "HIGHLIGHTS_LINKS_REQUEST",
   "HIGHLIGHTS_LINKS_RESPONSE",
-  "EXPERIMENTS_REQUEST",
   "EXPERIMENTS_RESPONSE",
   "NOTIFY_BLOCK_URL",
   "NOTIFY_UNBLOCK_URL",
@@ -53,8 +52,7 @@ const am = new ActionManager([
   "DISABLE_HINT",
   "APP_INIT",
   "PLACES_STATS_UPDATED",
-  "MERGE_STORE",
-  "EXPERIMENT_OVERRIDE"
+  "MERGE_STORE"
 ]);
 
 // This is a a set of actions that have sites in them,
@@ -145,10 +143,6 @@ function NotifyManageEngines() {
 
 function NotifyUpdateSearchString(searchString) {
   return Notify("NOTIFY_UPDATE_SEARCH_STRING", {searchString}, {skipMasterStore: true});
-}
-
-function RequestExperiments() {
-  return RequestExpect("EXPERIMENTS_REQUEST", "EXPERIMENTS_RESPONSE");
 }
 
 function NotifyBookmarkAdd(url) {
@@ -261,7 +255,6 @@ am.defineActions({
   RequestHighlightsLinks,
   RequestInitialPrefs,
   RequestSearchSuggestions,
-  RequestExperiments,
   NotifyBlockURL,
   NotifyUnblockURL,
   NotifyBookmarkAdd,

--- a/content-test/addon/ExperimentProvider.test.js
+++ b/content-test/addon/ExperimentProvider.test.js
@@ -40,7 +40,17 @@ describe("ExperimentProvider", () => {
     experimentProvider.init();
   }
 
+  beforeEach(() => {
+    global.EventEmitter = {
+      decorate(ctx) {
+        ctx.emit = sinon.spy();
+        ctx.on = sinon.spy();
+      }
+    };
+  });
+
   afterEach(() => {
+    delete global.EventEmitter;
     experimentProvider.destroy();
     experimentProvider.clearPrefs();
     experimentProvider = null;
@@ -363,6 +373,14 @@ describe("ExperimentProvider", () => {
 
       assert.isTrue(experimentProvider.data.foo);
       assert.isTrue(ss.storage.overrideExperimentProvider);
+    });
+  });
+
+  describe("listeners", () => {
+    it("should emit a change event on a pref change", () => {
+      setup();
+      experimentProvider._onPrefChange("foo");
+      assert.calledWith(experimentProvider.emit, "change", "foo");
     });
   });
 });

--- a/shims/_utils/globals.js
+++ b/shims/_utils/globals.js
@@ -6,5 +6,6 @@ module.exports = {
 
   // These are Firefox globals that are often used
   Services: {obs: {notifyObservers: sinon.spy()}},
-  Task
+  Task,
+  XPCOMUtils: {defineLazyGetter() {}}
 };


### PR DESCRIPTION
To test this patch, open the debug page (look at the Experiments section) and edit an experiment pref in `about:config`.

On master, no change should show up immediately.
In this branch, you should immediately see the correct value.