### PR TITLE
fix(metadata): Fixes 1658 Consolidate favicon fields

### DIFF
--- a/addon/MetadataStore.js
+++ b/addon/MetadataStore.js
@@ -223,18 +223,6 @@ MetadataStore.prototype = {
     return rgb ? `#${((1 << 24) + (rgb[0] << 16) + (rgb[1] << 8) + rgb[2]).toString(16).slice(1).toUpperCase()}` : null;
   },
 
-  /**
-  * Convert a hex color string to the RGB form, e.g. #0A0102 => [10, 1, 2]
-  */
-  _hexToRgb(hex) {
-    let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result ? [
-      parseInt(result[1], 16),
-      parseInt(result[2], 16),
-      parseInt(result[3], 16)
-    ] : null;
-  },
-
   _asyncGetLastInsertRowID: Task.async(function*() {
     let result = yield this._conn.execute(SQL_LAST_INSERT_ROWID);
     return result[0].getResultByName("lastInsertRowID");
@@ -497,13 +485,13 @@ MetadataStore.prototype = {
           case IMAGE_TYPES.favicon_rich:
             metaObject.favicons.push({
               url: image.url,
-              color: this._hexToRgb(image.color)
+              color: image.color
             });
             break;
           case IMAGE_TYPES.preview:
             metaObject.images.push({
               url: image.url,
-              color: this._hexToRgb(image.color),
+              color: image.color,
               height: image.height,
               width: image.width
             });

--- a/addon/lib/utils.js
+++ b/addon/lib/utils.js
@@ -1,0 +1,49 @@
+/* globals module */
+"use strict";
+
+/**
+ * Convert a hex color string to the RGB form, e.g. #0A0102 => [10, 1, 2]
+ */
+function hexToRGB(hex) {
+  if (!hex) {
+    return hex;
+  }
+  let hexToConvert = hex;
+  // if the hex is in shorthand form, expand it first
+  if (/^#?([a-f\d])([a-f\d])([a-f\d])$/i.test(hexToConvert)) {
+    const expandedHex = [...hex].slice(1, 4).map(item => `${item}${item}`).join("");
+    hexToConvert = `#${expandedHex}`;
+  }
+  let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hexToConvert);
+  return result ? [
+    parseInt(result[1], 16),
+    parseInt(result[2], 16),
+    parseInt(result[3], 16)
+  ] : null;
+}
+
+/*
+ * Consolidate favicons from tippytop, firefox, and our own metadata. Tippytop
+ * is our number 1 choice, followed by the favicon returned by the metadata service,
+ * and finally firefox's data URI as a last resort
+ */
+function consolidateFavicons(tippyTopFavicon, metadataFavicons, firefoxFavicon) {
+  const metadataFavicon = metadataFavicons && metadataFavicons[0] && metadataFavicons[0].url;
+  return tippyTopFavicon || metadataFavicon || firefoxFavicon;
+}
+
+/*
+ * Consolidate the background colors from tippytop, firefox, and our own metadata.
+ * TippyTop background color and metadata background color both need to be converted
+ * from hex to an rgb array, whereas the firefox background color is already rgb
+ */
+function consolidateBackgroundColors(tippyTopBackgroundColor, metadataFavicons, firefoxBackgroundColor) {
+  const metadataBackgroundColor = metadataFavicons && metadataFavicons[0] && metadataFavicons[0].color;
+  return hexToRGB(tippyTopBackgroundColor) || hexToRGB(metadataBackgroundColor) || firefoxBackgroundColor;
+}
+
+module.exports = {
+  consolidateFavicons,
+  consolidateBackgroundColors,
+  hexToRGB
+};

--- a/common/constants.js
+++ b/common/constants.js
@@ -17,5 +17,8 @@ module.exports = {
   },
 
   // This is where we cache redux state so it can be shared between pages
-  LOCAL_STORAGE_KEY: "ACTIVITY_STREAM_STATE"
+  LOCAL_STORAGE_KEY: "ACTIVITY_STREAM_STATE",
+
+  // The opacity value of favicon background colors
+  BACKGROUND_FADE: 0.5
 };

--- a/common/selectors/siteMetadataSelectors.js
+++ b/common/selectors/siteMetadataSelectors.js
@@ -2,8 +2,7 @@ const urlParse = require("url-parse");
 const {prettyUrl} = require("lib/utils");
 
 function selectSiteProperties(site) {
-  const metadataFavicon = site.favicons && site.favicons[0] && site.favicons[0].url;
-  const favicon = site.favicon_url || metadataFavicon || site.favicon;
+  const favicon = site.favicon_url;
   const parsedUrl = site.parsedUrl || urlParse(site.url || "");
 
   // Remove the eTLD (e.g., com, net) and the preceding period from the hostname

--- a/content-src/components/SiteIcon/SiteIcon.js
+++ b/content-src/components/SiteIcon/SiteIcon.js
@@ -63,8 +63,7 @@ SiteIcon.propTypes = {
   site: React.PropTypes.shape({
     title: React.PropTypes.string,
     provider_name: React.PropTypes.string,
-    icons: React.PropTypes.array,
-    favicon_colors: React.PropTypes.array
+    icons: React.PropTypes.array
   }).isRequired
 };
 

--- a/content-src/lib/first-run-data.js
+++ b/content-src/lib/first-run-data.js
@@ -9,37 +9,37 @@ module.exports = {
       "title": "Facebook",
       "url": "https://www.facebook.com/",
       "favicon_url": "facebook-com.png",
-      "background_color": "#edf0f5"
+      "background_color": [237, 240, 245]
     },
     {
       "title": "YouTube",
       "url": "https://www.youtube.com/",
       "favicon_url": "youtube-com.png",
-      "background_color": "#db4338"
+      "background_color": [219, 67, 56]
     },
     {
       "title": "Amazon",
       "url": "http://www.amazon.com/",
       "favicon_url": "amazon-com.png",
-      "background_color": "#FFF"
+      "background_color": [255, 255, 255]
     },
     {
       "title": "Yahoo",
       "url": "https://www.yahoo.com/",
       "favicon_url": "yahoo-com.png",
-      "background_color": "#5009a7"
+      "background_color": [80, 9, 167]
     },
     {
       "title": "eBay",
       "url": "http://www.ebay.com",
       "favicon_url": "ebay-com.png",
-      "background_color": "#ededed"
+      "background_color": [237, 237, 237]
     },
     {
       "title": "Twitter",
       "url": "https://twitter.com/",
       "favicon_url": "twitter-com.png",
-      "background_color": "#049ff5"
+      "background_color": [4, 159, 245]
     }
   ].map(item => {
     item.type = FIRST_RUN_TYPE;
@@ -53,7 +53,7 @@ module.exports = {
       "url": "https://www.mozilla.org/firefox/sync/",
       "image_url": "firstrun-sync.png",
       "favicon_url": "firstrun-sync-icon.png",
-      "background_color": "#5AC6f8",
+      "background_color": [90, 198, 248],
       "context_message": "Save everywhere"
     },
     {
@@ -62,7 +62,7 @@ module.exports = {
       "url": "https://www.mozilla.org/firefox/desktop/customize/",
       "image_url": "firstrun-customize.png",
       "favicon_url": "firstrun-customize-icon.png",
-      "background_color": "#735C72",
+      "background_color": [115, 92, 114],
       "context_message": "Extend Firefox"
     },
     {
@@ -71,7 +71,7 @@ module.exports = {
       "url": "https://www.mozilla.org/firefox/android/",
       "image_url": "firstrun-mobile.png",
       "favicon_url": "firstrun-mobile-icon.png",
-      "background_color": "#0775A7",
+      "background_color": [7, 117, 167],
       "context_message": "Complete your install"
     }
   ].map(item => {

--- a/content-src/lib/utils.js
+++ b/content-src/lib/utils.js
@@ -14,7 +14,7 @@ const RANDOM_COLORS = [
 module.exports = {
   RANDOM_COLORS,
 
-  toRGBString(...color) {
+  toRGBString(color) {
     const name = color.length === 4 ? "rgba" : "rgb";
     return `${name}(${color.join(", ")})`;
   },

--- a/content-test/addon/PreviewProvider.test.js
+++ b/content-test/addon/PreviewProvider.test.js
@@ -1,0 +1,24 @@
+/* globals assert, require */
+"use strict";
+const createPreviewProvider = require("inject!addon/PreviewProvider");
+const {BACKGROUND_FADE} = require("../../common/constants");
+const BACKGROUND_COLOR = [255, 255, 255];
+const mockExperimentProvider = {data: {metadataService: false}};
+const getColor = function() {
+  return Promise.resolve(BACKGROUND_COLOR);
+};
+describe("PreviewProvider", () => {
+  const {PreviewProvider} = createPreviewProvider({"addon/ColorAnalyzerProvider": {getColor}});
+  const previewProvider = new PreviewProvider({}, {}, mockExperimentProvider);
+  let fakeSite = {"url": "https://getMyFaviconColor.com", "favicon": "favicon.ico"};
+
+  it("should be an get the correct color and set the background fade", () => {
+    const expectedColor = [...BACKGROUND_COLOR, BACKGROUND_FADE];
+    return previewProvider._getFaviconColors(fakeSite).then(color => assert.deepEqual(color, expectedColor));
+  });
+
+  it("should return null if there is no favicon provided", () => {
+    fakeSite.favicon = null;
+    return previewProvider._getFaviconColors(fakeSite).then(color => assert.equal(color, null));
+  });
+});

--- a/content-test/common/selectors/colorSelectors.test.js
+++ b/content-test/common/selectors/colorSelectors.test.js
@@ -1,11 +1,10 @@
 const {
   selectSiteIcon,
-  getBackgroundRGB,
+  getFallbackColor,
   assignImageAndBackgroundColor
 } = require("common/selectors/colorSelectors");
 
 const DEFAULT_FAVICON_BG_COLOR = [150, 150, 150];
-const BACKGROUND_FADE = 0.5;
 
 const validSpotlightSite = {
   "title": "man throws alligator in wendys wptv dnt cnn",
@@ -22,26 +21,14 @@ const validSpotlightSite = {
 };
 
 describe("colorSelectors", () => {
-  describe("getBackgroundRGB", () => {
-    it("should use favicon_colors if available", () => {
-      assert.deepEqual(
-        getBackgroundRGB({url: "http://foo.com", favicon_colors: [{color: [11, 11, 11]}]}),
-        [11, 11, 11]
-      );
-    });
-    it("should use favicons[0].color if available", () => {
-      assert.deepEqual(
-        getBackgroundRGB({url: "http://foo.com", favicons: [{color: [11, 11, 11]}]}),
-        [11, 11, 11]
-      );
-    });
+  describe("getFallbackColor", () => {
     it("should use a default bg if a favicon is supplied", () => {
-      const result = getBackgroundRGB({url: "http://foo.com", favicon_url: "adsd.ico"});
+      const result = getFallbackColor({url: "http://foo.com", favicon_url: "adsd.ico"});
       assert.ok(result);
       assert.deepEqual(result, DEFAULT_FAVICON_BG_COLOR);
     });
-    it("should use a random color if no favicon_colors or favicon or favicons[0].color", () => {
-      const result = getBackgroundRGB({url: "http://foo.com"});
+    it("should use a random color if no background_color", () => {
+      const result = getFallbackColor({url: "http://foo.com"});
       assert.ok(result);
       assert.notDeepEqual(result, DEFAULT_FAVICON_BG_COLOR);
     });
@@ -52,12 +39,7 @@ describe("colorSelectors", () => {
       eTLD: "com",
       url: "http://foo.com",
       favicon_url: "http://foo.com/favicon.ico",
-      favicon: "http://foo.com/favicon-16.ico",
-      favicons: [{
-        colors: [11, 11, 11],
-        url: "http://foo.com/metadatafavicon.ico"
-      }],
-      favicon_colors: [{color: [11, 11, 11]}]
+      background_color: [11, 11, 11]
     };
     let state;
     beforeEach(() => {
@@ -76,37 +58,30 @@ describe("colorSelectors", () => {
     it("should select favicon_url", () => {
       assert.equal(state.favicon, siteWithFavicon.favicon_url);
     });
-    it("should fall back to favicon", () => {
-      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_url: null, favicons: null}));
-      assert.equal(state.favicon, siteWithFavicon.favicon);
-    });
-    it("should use favicons[0].url if exists", () => {
-      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_url: null}));
-      assert.equal(state.favicon, siteWithFavicon.favicons[0].url);
-    });
     it("should select the first letter of the hostname", () => {
       state = selectSiteIcon(Object.assign({}, siteWithFavicon, {url: "http://kate.com"}));
       assert.equal(state.firstLetter, "k");
     });
     it("should use site.background_color if it exists", () => {
-      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {background_color: "#111111"}));
-      assert.equal(state.backgroundColor, "#111111");
+      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {background_color: [0, 0, 0]}));
+      assert.equal(state.backgroundColor, "rgb(0, 0, 0)");
     });
     it("should create a background color", () => {
-      assert.equal(state.backgroundColor, `rgba(11, 11, 11, ${BACKGROUND_FADE})`);
+      assert.equal(state.backgroundColor, "rgb(11, 11, 11)");
     });
     it("should create an opaque background color if there is no favicon", () => {
-      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_url: null, favicon: null, favicons: null}));
-      assert.equal(state.backgroundColor, "rgba(11, 11, 11, 1)");
+      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_url: null, background_color: null}));
+      const regex = /rgba\([1-9]+,\s{1}[1-9]+,\s{1}[1-9]+,\s{1}1\)/;
+      assert.ok(regex.test(state.backgroundColor));
     });
     it("should create a random background color if no favicon color exists", () => {
-      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_colors: null}));
+      state = selectSiteIcon(Object.assign({}, siteWithFavicon, {background_color: null}));
       assert.ok(state.backgroundColor);
     });
     it("should create a contrasting font color", () => {
-      const darkColor = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_colors: [{color: [1, 1, 1]}]}));
+      const darkColor = selectSiteIcon(Object.assign({}, siteWithFavicon, {background_color: [1, 1, 1]}));
       assert.equal(darkColor.fontColor, "white");
-      const lightColor = selectSiteIcon(Object.assign({}, siteWithFavicon, {favicon_colors: [{color: [200, 200, 200]}]}));
+      const lightColor = selectSiteIcon(Object.assign({}, siteWithFavicon, {background_color: [200, 200, 200]}));
       assert.equal(lightColor.fontColor, "black");
     });
     it("should add a label (hostname without eTLD)", () => {

--- a/content-test/common/selectors/selectors.test.js
+++ b/content-test/common/selectors/selectors.test.js
@@ -106,8 +106,8 @@ describe("selectors", () => {
         assert.equal(state.Highlights.rows[0].url, "https://bar.com");
       });
       it("should be processed by assignImageAndBackgroundColor", () => {
-        setup({Highlights: [{url: "http://asdad23asd.com", background_color: "#fff"}]});
-        assert.equal(state.Highlights.rows[0].backgroundColor, "#fff");
+        setup({Highlights: [{url: "http://asdad23asd.com", background_color: [0, 0, 0]}]});
+        assert.equal(state.Highlights.rows[0].backgroundColor, "rgb(0, 0, 0)");
       });
     });
 

--- a/content-test/components/SiteIcon.test.js
+++ b/content-test/components/SiteIcon.test.js
@@ -8,7 +8,7 @@ const fakeProps = {
     url: "https://foo.com",
     favicon_url: "http://www.google.com/favicon.ico",
     title: "Foo",
-    favicon_colors: [{color: [11, 11, 11]}]
+    background_color: [11, 11, 11]
   },
   className: "foo"
 };
@@ -83,11 +83,6 @@ describe("SiteIcon", () => {
       assert.equal(instance.refs.favicon.src, fakeProps.site.favicon_url);
     });
 
-    it("should use favicon as a fallback to favicon_url", () => {
-      setup({}, {favicon_url: null, favicon: "https://www.wikipedia.org/static/favicon/wikipedia.ico"});
-      assert.equal(instance.refs.favicon.src, "https://www.wikipedia.org/static/favicon/wikipedia.ico");
-    });
-
     it("should use favicon for 16x16 favicon", done => {
       setup({}, {favicon_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAAAAAA6mKC9AAAAD0lEQVQYV2P4jwYYRrYAAID5%2FwHnXPpAAAAAAElFTkSuQmCC"});
       instance.refs.favicon.addEventListener("load", () => {
@@ -101,8 +96,7 @@ describe("SiteIcon", () => {
     beforeEach(() => {
       setup({}, {
         favicon_url: null,
-        favicon: null,
-        favicon_colors: [{color: [0, 0, 0]}],
+        background_color: [0, 0, 0],
         url: "http://foo.com"
       });
     });

--- a/content-test/components/Spotlight.story.js
+++ b/content-test/components/Spotlight.story.js
@@ -92,9 +92,7 @@ storiesOf("Highlight Item", module)
     const site = createSite({images: 1});
     site.bestImage = site.images[0];
     site.favicon_url = null;
-    site.favicon = null;
-    site.favicon_color = null;
-    site.favicon_colors = null;
+    site.background_color = null;
     return (<Container><SpotlightItem {...site} /></Container>);
   })
   .add("Missing a description", () => {

--- a/content-test/faker.js
+++ b/content-test/faker.js
@@ -68,7 +68,6 @@ function createSite(optional = {}) {
     // This is stuff from Firefox
     "bookmarkDateCreated": null,
     "bookmarkGuid": null,
-    "favicon": "data:image/png;base64,iVBORw0KGgoAA",
     "title": tiptopSite.title || `${name} - ${faker.company.catchPhrase()}`,
     "url": tiptopSite.url || faker.internet.url(),
     "lastVisitDate": date.valueOf(),
@@ -98,12 +97,12 @@ function createSite(optional = {}) {
     site.images = arrayOf(createImage, options.images);
   }
 
-  // Only create favicon_colors if there is a favicon_url
+  // Only create background_color if there is a favicon_url
   if (site.favicon_url && tiptopSite.background_color_rgb) {
-    site.favicon_colors = [createColor(tiptopSite.background_color_rgb)];
+    site.background_color = [createColor(tiptopSite.background_color_rgb)];
   }
-  if (site.favicon_url && options.favicon_colors) {
-    site.favicon_colors = arrayOf(createColor, options.favicon_colors);
+  if (site.favicon_url && options.background_color) {
+    site.background_color = arrayOf(createColor, options.background_color);
   }
 
   if (options.hasBookmark || site.type === "bookmark") {

--- a/content-test/faker.test.js
+++ b/content-test/faker.test.js
@@ -22,16 +22,10 @@ describe("createSite", () => {
     assert.isNull(result.title);
     assert.isNull(result.images);
   });
-  it("should add n favicon_colors", () => {
-    const result = createSite({favicon_colors: 5});
+  it("should omit background_color if favicon_url is falsey", () => {
+    const result = createSite({background_color: 5, override: {favicon_url: null}});
     assert.isObject(result);
-    assert.isArray(result.favicon_colors);
-    assert.lengthOf(result.favicon_colors, 5);
-  });
-  it("should omit favicon_colors if favicon_url is falsey", () => {
-    const result = createSite({favicon_colors: 5, override: {favicon_url: null}});
-    assert.isObject(result);
-    assert.notProperty(result, "favicon_colors");
+    assert.notProperty(result, "background_color");
   });
 });
 

--- a/content-test/lib/utils.test.js
+++ b/content-test/lib/utils.test.js
@@ -2,10 +2,10 @@ const utils = require("lib/utils");
 
 describe("toRGBString", () => {
   it("should convert R, G, B values to a css string", () => {
-    assert.equal(utils.toRGBString(12, 20, 30), "rgb(12, 20, 30)");
+    assert.equal(utils.toRGBString([12, 20, 30]), "rgb(12, 20, 30)");
   });
   it("should convert R, G, B, A values to a css string", () => {
-    assert.equal(utils.toRGBString(12, 20, 30, 0.2), "rgba(12, 20, 30, 0.2)");
+    assert.equal(utils.toRGBString([12, 20, 30, 0.2]), "rgba(12, 20, 30, 0.2)");
   });
 });
 

--- a/test/test-MetadataStore.js
+++ b/test/test-MetadataStore.js
@@ -295,17 +295,14 @@ exports.test_on_an_invalid_connection = function*(assert) {
 };
 
 exports.test_color_conversions = function(assert) {
-  const white = [0, 0, 0];
-  const black = [255, 255, 255];
+  const black = [0, 0, 0];
+  const white = [255, 255, 255];
   const randomColor = [111, 122, 133];
 
-  assert.deepEqual(white,
-    gMetadataStore._hexToRgb(gMetadataStore._rgbToHex(white)));
-  assert.deepEqual(black,
-    gMetadataStore._hexToRgb(gMetadataStore._rgbToHex(black)));
-  assert.deepEqual(randomColor,
-    gMetadataStore._hexToRgb(gMetadataStore._rgbToHex(randomColor)));
-  assert.equal(gMetadataStore._hexToRgb(gMetadataStore._rgbToHex(null)), null);
+  assert.deepEqual("#FFFFFF", gMetadataStore._rgbToHex(white));
+  assert.deepEqual("#000000", gMetadataStore._rgbToHex(black));
+  assert.deepEqual("#6F7A85", gMetadataStore._rgbToHex(randomColor));
+  assert.equal(gMetadataStore._rgbToHex(null), null);
 };
 
 exports.test_data_expiry = function*(assert) {

--- a/test/test-PreviewProvider-MetadataStore.js
+++ b/test/test-PreviewProvider-MetadataStore.js
@@ -74,13 +74,13 @@ exports.test_get_links_from_metadatastore = function*(assert) {
   const links = [
     {cache_key: "https://www.mozilla.org/", places_url: "https://www.mozilla.org/"},
     {cache_key: "https://www.mozilla.org/en-US/firefox/new/", places_url: "https://www.mozilla.org/en-US/firefox/new"},
-    {cache_key: "https://www.notinDB.com/", places_url: "https://www.notinDB.com/"}];
+    {cache_key: "https://www.notinDB.com/", places_url: "https://www.notinDB.com/", favicon_url: "https://www.someImage.com/image.jpg"}];
 
   // get enhanced links - the third link should be returned as is since it
   // is not yet in the database
   let cachedLinks = yield gPreviewProvider._asyncGetEnhancedLinks(links);
   assert.equal(cachedLinks.length, 3, "returned all 3 links");
-  assert.deepEqual(cachedLinks[2], links[2], "the third link's cache_key was untouched");
+  assert.deepEqual(cachedLinks[2].cache_key, links[2].cache_key, "the third link's cache_key was untouched");
 
   // get enhanced links after third link has been inserted in db - the third
   // link should now have more properties i.e title, description etc...
@@ -88,9 +88,9 @@ exports.test_get_links_from_metadatastore = function*(assert) {
   cachedLinks = yield gPreviewProvider._asyncGetEnhancedLinks(links);
   assert.equal(cachedLinks.length, 3, "returned all 3 links");
   assert.equal(cachedLinks[2].title, null, "the third link has a title field");
-  assert.equal(cachedLinks[2].description, null, "the third links has a description field");
-  assert.deepEqual(cachedLinks[2].images, [], "the third links has images field");
-  assert.deepEqual(cachedLinks[2].favicons, [], "the third links has favicons field");
+  assert.equal(cachedLinks[2].description, null, "the third link has a description field");
+  assert.deepEqual(cachedLinks[2].images, [], "the third link has images field");
+  assert.equal(cachedLinks[2].favicon_url, links[2].favicon_url, "the third link has favicon_url field");
 };
 
 function waitForAsyncReset() {
@@ -126,6 +126,9 @@ before(exports, function*() {
   yield gMetadataStore.asyncConnect();
   let mockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
   gPreviewProvider = new PreviewProvider(mockTabTracker, gMetadataStore, {data: {metadataService: false}}, {initFresh: true});
+  gPreviewProvider._getFaviconColors = function() {
+    return Promise.resolve(null);
+  };
 });
 
 after(exports, function*() {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,64 @@
+/* globals require, exports */
+
+"use strict";
+
+const {hexToRGB, consolidateFavicons, consolidateBackgroundColors} = require("addon/lib/utils");
+
+exports.test_favicon_consolidation = function(assert) {
+  // create some fake icon urls
+  let fakeFirefoxFavicon = "firefoxFavicon.ico";
+  let fakeTippyTopFavicon = "tippyTopFavicon.ico";
+  let fakeMetadataFavicon = [{"url": "metadataFavicon.ico", "color": [255, 255, 255]}];
+
+  // choose the best one - it's tippytop
+  let chosenFavicon = consolidateFavicons(fakeTippyTopFavicon, fakeMetadataFavicon, fakeFirefoxFavicon);
+  assert.equal(chosenFavicon, fakeTippyTopFavicon, "chose the tippytop favicon first");
+
+  // without tippytop the next best one should be from metadata service
+  fakeTippyTopFavicon = null;
+  chosenFavicon = consolidateFavicons(fakeTippyTopFavicon, fakeMetadataFavicon, fakeFirefoxFavicon);
+  assert.equal(chosenFavicon, fakeMetadataFavicon[0].url, "chose the metadata favicon second");
+
+  // without metadata service our last resort is the firefox favicon
+  fakeMetadataFavicon = null;
+  chosenFavicon = consolidateFavicons(fakeTippyTopFavicon, fakeMetadataFavicon, fakeFirefoxFavicon);
+  assert.equal(chosenFavicon, fakeFirefoxFavicon, "and finally falls back to the firefox favicon");
+};
+
+exports.test_background_color_consolidation = function(assert) {
+  // create some fake background colors
+  let fakeFirefoxBackgroundColor = [150, 150, 150];
+  let fakeTippyTopBackgroundColor = "#FFFFFF";
+  let fakeMetadataBackgroundColor = [{"url": "metadataFavicon.ico", "color": "#000000"}];
+
+  // choose the best one - it's tippytop but it should be converted from hex to rgb
+  let chosenBackgroundColor = consolidateBackgroundColors(fakeTippyTopBackgroundColor, fakeMetadataBackgroundColor, fakeFirefoxBackgroundColor);
+  assert.deepEqual(chosenBackgroundColor, hexToRGB(fakeTippyTopBackgroundColor), "chose the tippytop background color first");
+
+  // without tippytop the next best one is from metadata, which should get converted from hex to rgb
+  fakeTippyTopBackgroundColor = null;
+  chosenBackgroundColor = consolidateBackgroundColors(fakeTippyTopBackgroundColor, fakeMetadataBackgroundColor, fakeFirefoxBackgroundColor);
+  assert.deepEqual(chosenBackgroundColor, hexToRGB(fakeMetadataBackgroundColor[0].color), "chose the firefox background color second");
+
+  // without metadata our last resort is firefox color, already in rgb
+  fakeMetadataBackgroundColor = null;
+  chosenBackgroundColor = consolidateBackgroundColors(fakeTippyTopBackgroundColor, fakeMetadataBackgroundColor, fakeFirefoxBackgroundColor);
+  assert.equal(chosenBackgroundColor, fakeFirefoxBackgroundColor, "and finally falls back to metadata background colors");
+};
+
+exports.test_rgbToHex = function(assert) {
+  const correctRGB = [0, 51, 255];
+  let hex = "#0033FF";
+  const longHex = hexToRGB(hex);
+  assert.deepEqual(longHex, correctRGB, "successfully converted a long hex to rgb");
+
+  hex = "#03F";
+  const shortHex = hexToRGB(hex);
+  assert.deepEqual(shortHex, correctRGB, "successfully converted a short hex to rgb");
+
+  hex = null;
+  const noHex = hexToRGB(hex);
+  assert.equal(noHex, null, "return null if there is no hex to convert");
+};
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
Consolidates favicon, favicons, and favicon_url into favicon_url
Consolidates background_color, favicons.color, favicon_colors, favicon_color into background_color
Does that on addon side so we only store the ones we need - and removes it from selectors side
Updates Tests

Don't review - needs addon tests for consolidation
