### PR TITLE
Fix(addon): #1620 - Update experimentId for TabTracker upon changes

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -360,6 +360,7 @@ ActivityStreams.prototype = {
   },
 
   _handleExperimentChange(prefName) {
+    this._tabTracker.experimentId = this._experimentProvider.exprimentID;
     this.broadcast(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data));
   },
 

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -94,6 +94,10 @@ TabTracker.prototype = {
     }
   },
 
+  set experimentId(experimentId) {
+    this._experimentID = experimentId || null;
+  },
+
   isActivityStreamsURL(URL) {
     return this._trackableURLs.indexOf(URL) !== -1;
   },


### PR DESCRIPTION
This closes #1620 