### PR TITLE
feat(feeds): #1750 PageModProvider, add broadcasting/send to feeds

### DIFF
--- a/addon/PageModProvider.js
+++ b/addon/PageModProvider.js
@@ -1,0 +1,120 @@
+const generateUUID = require("sdk/util/uuid");
+const privateBrowsing = require("sdk/private-browsing");
+const {Cu} = require("chrome");
+const {PageMod} = require("sdk/page-mod");
+const {data} = require("sdk/self");
+const {CONTENT_TO_ADDON} = require("common/event-constants");
+const {WORKER_ATTACHED_EVENT} = require("common/constants");
+
+module.exports = class PageModProvider {
+  constructor({pageURL, uuid, onAddWorker, onRemoveWorker} = {}) {
+    this.workers = new Map();
+    this.pageURL = pageURL;
+    this.uuid = uuid || (() => String(generateUUID.uuid()));
+    this.onAddWorker = onAddWorker;
+    this.onRemoveWorker = onRemoveWorker;
+    this._perfMeter = null;
+    this._pagemod = null;
+    this._logEvent = null;
+  }
+
+  /**
+   * Sets up communications with the pages and manages the lifecycle of workers
+   */
+  init({onAttach, onMessage, logEvent} = {}) {
+    this._logEvent = logEvent;
+    this._pagemod = new PageMod({
+      include: [`${this.pageURL}*`],
+      contentScriptFile: data.url("content-bridge.js"),
+      contentScriptWhen: "start",
+      attachTo: ["existing", "top"],
+      onAttach: worker => {
+        if (onAttach) {
+          onAttach();
+        }
+
+        // Don't attach when in private browsing. Send user to about:privatebrowsing
+        if (privateBrowsing.isPrivate(worker)) {
+          worker.tab.url = "about:privatebrowsing";
+          return;
+        }
+
+        // This detaches workers on reload or closing the tab
+        worker.on("detach", () => this.removeWorker(worker));
+
+        // add the worker to a set to enable broadcasting
+        const workerId = this.addWorker(worker);
+
+        worker.port.on(CONTENT_TO_ADDON, msg => {
+          if (!msg.type) {
+            Cu.reportError("ActivityStreams.dispatch error: unknown message type");
+            return;
+          }
+          // This detaches workers if a new url is launched
+          // it is important to remove the worker from the set, otherwise we will leak memory
+          if (msg.type === "pagehide") {
+            this.removeWorker(worker);
+          }
+          if (onMessage) {
+            const message = Object.assign({}, msg, {workerId});
+            onMessage({msg: message, worker});
+          }
+        });
+      },
+      onError: err => {
+        Cu.reportError(err);
+      }
+    });
+  }
+
+  /**
+   * getWorkerById - Returns a reference to a worker, given an id
+   *
+   * @param  {string} workerId unique identified of a worker
+   * @return {obj}             a worker
+   */
+  getWorkerById(workerId) {
+    let worker;
+    for (let [w, id] of this.workers) {
+      if (id === workerId) {
+        worker = w;
+      }
+    }
+    return worker;
+  }
+
+  /**
+   * Adds a worker and returns the new id
+   */
+  addWorker(worker) {
+    if (this.workers.has(worker)) {
+      return this.workers.get(worker);
+    }
+    const id = this.uuid();
+    this.workers.set(worker, id);
+    if (this._logEvent) {
+      this._logEvent(worker.tab, WORKER_ATTACHED_EVENT);
+    }
+    if (this.onAddWorker) {
+      this.onAddWorker();
+    }
+    return id;
+  }
+
+  /**
+   * Removes a worker
+   */
+  removeWorker(worker) {
+    this.workers.delete(worker);
+    if (this.onRemoveWorker) {
+      this.onRemoveWorker();
+    }
+  }
+
+  destroy() {
+    this.workers.clear();
+    if (this._pagemod) {
+      this._pagemod.destroy();
+    }
+  }
+};

--- a/addon/PerfMeter.js
+++ b/addon/PerfMeter.js
@@ -6,11 +6,12 @@ const tabs = require("sdk/tabs");
 const simplePrefs = require("sdk/simple-prefs");
 
 const {absPerf} = require("common/AbsPerf");
+const {WORKER_ATTACHED_EVENT} = require("common/constants");
 
 const VALID_TELEMETRY_TAGS = new Set([
   "TAB_READY",
-  "WORKER_ATTACHED",
-  "NOTIFY_PERFORMANCE"
+  "NOTIFY_PERFORMANCE",
+  WORKER_ATTACHED_EVENT
 ]);
 
 function PerfMeter(trackableURLs) {
@@ -140,7 +141,7 @@ PerfMeter.prototype = {
 
       // when tab is reloaded, the worker will be re-attached to the tab and another
       // WORKER_ATTACHED event will be sent. In which case we re-initialize tabData
-      if (tag === "WORKER_ATTACHED") {
+      if (tag === WORKER_ATTACHED_EVENT) {
         if (tabData.workerWasAttached) {
           // tab is reloaded - re-initialize it. Since reload does not generate TAB_OPEN
           // and TAB_READY events, we introduce articficial ones starting at 0

--- a/common/constants.js
+++ b/common/constants.js
@@ -20,5 +20,8 @@ module.exports = {
   LOCAL_STORAGE_KEY: "ACTIVITY_STREAM_STATE",
 
   // The opacity value of favicon background colors
-  BACKGROUND_FADE: 0.5
+  BACKGROUND_FADE: 0.5,
+
+  // This is a perf event
+  WORKER_ATTACHED_EVENT: "WORKER_ATTACHED"
 };

--- a/content-test/addon/PageModProvider.test.js
+++ b/content-test/addon/PageModProvider.test.js
@@ -1,0 +1,178 @@
+const PageModProvider = require("inject!addon/PageModProvider")({"addon/lib/uuid": () => String(Math.random())});
+const {PageMod, Worker} = require("sdk/page-mod");
+const TEST_URL = "foo.html";
+const {CONTENT_TO_ADDON} = require("common/event-constants");
+const {WORKER_ATTACHED_EVENT} = require("common/constants");
+
+describe("#PageModProvider", () => {
+  let instance;
+  beforeEach(() => {
+    instance = new PageModProvider({pageURL: TEST_URL});
+  });
+  describe("#init", () => {
+    it("should add ._logEvent if logEvent is defined", () => {
+      const logEvent = () => {};
+      instance.init({logEvent});
+      assert.equal(instance._logEvent, logEvent);
+    });
+    it("should add ._pagemod", () => {
+      instance.init();
+      assert.instanceOf(instance._pagemod, PageMod);
+    });
+  });
+  describe("._pagemod", () => {
+    it("should have the set .include according to the pageURL", () => {
+      instance = new PageModProvider({pageURL: "hello.html"});
+      instance.init();
+      assert.deepEqual(instance._pagemod.options.include, ["hello.html*"]);
+    });
+    describe("#onAttach", () => {
+      let worker;
+      function setup(custom = {}) {
+        worker = new Worker(custom.url || TEST_URL);
+        instance.init(custom.options);
+        instance._pagemod.options.onAttach(worker);
+      }
+      it("should call onAttach passed to init(), if defined", () => {
+        const onAttach = sinon.spy();
+        setup({options: {onAttach}});
+        assert.calledOnce(onAttach);
+      });
+      it("should add the worker to .workers", () => {
+        setup();
+        assert.equal(instance.workers.size, 1);
+        assert.ok(instance.workers.get(worker));
+      });
+      it("should listen to detach, and remove worker when it is detached", () => {
+        setup();
+        assert.ok(instance.workers.get(worker));
+        const [eventName, callback] = worker.on.firstCall.args;
+        assert.equal(eventName, "detach", "added callback to 'detach'");
+        callback();
+        assert.isUndefined(instance.workers.get(worker), "callback removes worker");
+      });
+      it("should listen to CONTENT_TO_ADDON event from worker port", () => {
+        setup();
+        assert.calledWith(worker.port.on, CONTENT_TO_ADDON);
+        assert.isFunction(worker.port.on.firstCall.args[1]);
+      });
+      describe("worker.on(CONTENT_TO_ADDON)", () => {
+        let onMessage;
+        function setupWithOnMessage() {
+          onMessage = sinon.spy();
+          setup({options: {onMessage}});
+          // This is the callback for a CONTENT_TO_ADDON message
+          return worker.port.on.firstCall.args[1];
+        }
+        it("should remove the worker if the event type is 'pagehide'", () => {
+          const callback = setupWithOnMessage();
+          assert.ok(instance.workers.get(worker));
+          callback({type: "pagehide"});
+          assert.isUndefined(instance.workers.get(worker), "pagehide event removes worker");
+        });
+        it("should call onMessage if defined", () => {
+          const callback = setupWithOnMessage();
+          callback({type: "FOO"});
+          assert.calledOnce(onMessage);
+        });
+        it("should call onMessage with the right message", () => {
+          const callback = setupWithOnMessage();
+          callback({type: "FOO", data: "bar"});
+          const result = onMessage.firstCall.args[0];
+          assert.deepEqual(result.msg, {
+            type: "FOO",
+            data: "bar",
+            workerId: instance.workers.get(worker)
+          });
+        });
+        it("should call onMessage with the right worker", () => {
+          const callback = setupWithOnMessage();
+          callback({type: "FOO"});
+          const result = onMessage.firstCall.args[0];
+          assert.equal(result.worker, worker);
+        });
+      });
+    });
+  });
+  describe("#getWorkerById", () => {
+    it("should get a worker by id", () => {
+      const id = "foo";
+      const worker = new Worker("index.html");
+      instance.workers.set(worker, id);
+      instance.workers.set(new Worker("bar.html"), "bar");
+      instance.workers.set(new Worker("baz.html"), "baz");
+      assert.equal(instance.getWorkerById(id), worker);
+    });
+    it("should return undefined if the worker is not found", () => {
+      instance.workers.set(new Worker("bar.html"), "bar");
+      assert.isUndefined(instance.getWorkerById("foo"));
+    });
+  });
+  describe("#addWorker", () => {
+    it("should add a new worker", () => {
+      const worker = new Worker();
+      assert.equal(instance.workers.size, 0);
+      instance.addWorker(worker);
+      assert.equal(instance.workers.size, 1);
+    });
+    it("should generate an uuid for that worker and return it", () => {
+      const worker = new Worker();
+      instance = new PageModProvider({uuid: () => "foo"});
+      instance.addWorker(worker);
+      assert.equal(instance.workers.get(worker), "foo", "adds the worker id to the map");
+      assert.equal(instance.addWorker(worker), "foo", "returns the id");
+    });
+    it("should just return the worker if it is already in the map", () => {
+      const worker = new Worker();
+      instance.addWorker(worker);
+      instance.addWorker(worker);
+      assert.equal(instance.addWorker(worker), instance.workers.get(worker), "returns the worker");
+      assert.equal(instance.workers.size, 1, "does not add multiple copies of the worker");
+    });
+    it("should call options.onAddWorker if it is defined", () => {
+      const onAddWorker = sinon.spy();
+      instance = new PageModProvider({onAddWorker});
+      instance.addWorker(new Worker());
+      assert.calledOnce(onAddWorker);
+    });
+    it("should call logEvent if it was passed to the init function", () => {
+      const logEvent = sinon.spy();
+      const worker = new Worker();
+      instance.init({logEvent});
+      instance.addWorker(worker);
+      assert.calledWith(logEvent, worker.tab, WORKER_ATTACHED_EVENT);
+    });
+  });
+  describe("#removeWorker", () => {
+    it("should remove a worker", () => {
+      const worker = new Worker();
+      instance.addWorker(worker);
+      instance.removeWorker(worker);
+      assert.equal(instance.workers.size, 0);
+    });
+    it("should call options.onRemoveWorker if it is defined", () => {
+      const onRemoveWorker = sinon.spy();
+      instance = new PageModProvider({onRemoveWorker});
+      instance.removeWorker(new Worker());
+      assert.calledOnce(onRemoveWorker);
+    });
+  });
+  describe("#destroy", () => {
+    it("should should not throw if .init was never called", () => {
+      assert.doesNotThrow(() => instance.destroy());
+    });
+    it("should clear .workers", () => {
+      instance.addWorker(new Worker());
+      instance.addWorker(new Worker());
+      instance.addWorker(new Worker());
+      assert.equal(instance.workers.size, 3);
+      instance.destroy();
+      assert.equal(instance.workers.size, 0);
+    });
+    it("should destroy the sdk/page-mod if it was initialized", () => {
+      instance.init();
+      instance.destroy();
+      assert.calledOnce(instance._pagemod.destroy);
+    });
+  });
+});

--- a/content-test/addon/PerfMeter.test.js
+++ b/content-test/addon/PerfMeter.test.js
@@ -1,6 +1,7 @@
 const injector = require("inject!addon/PerfMeter");
 const {SimplePrefs} = require("shims/sdk/simple-prefs");
 const {Tabs, Tab} = require("shims/sdk/tabs");
+const {WORKER_ATTACHED_EVENT} = require("common/constants");
 
 // This is the event that indicates a tab has completely loaded
 // it should actually be store as a constant somwhere else...
@@ -244,7 +245,7 @@ describe("PerfMeter", () => {
     });
     it("should set .workerWasAttached if tag is WORKER_ATTACHED", () => {
       const tab = new Tab({url: TEST_URL});
-      perfMeter.log(tab, "WORKER_ATTACHED");
+      perfMeter.log(tab, WORKER_ATTACHED_EVENT);
       assert.isTrue(perfMeter._tabs[tab.id].workerWasAttached);
     });
     it("should replace tabData if tag is WORKER_ATTACHED and workerWasAttached is true", () => {
@@ -253,7 +254,7 @@ describe("PerfMeter", () => {
       const tabData = perfMeter._tabs[tab.id];
       const {openAt} = tabData;
       tabData.workerWasAttached = true;
-      perfMeter.log(tab, "WORKER_ATTACHED");
+      perfMeter.log(tab, WORKER_ATTACHED_EVENT);
 
       assert.include(tabData.events.map(e => e.tag), "TAB_RELOAD");
       assert.include(tabData.events.map(e => e.tag), "TAB_READY");

--- a/shims/_utils/globals.js
+++ b/shims/_utils/globals.js
@@ -7,5 +7,5 @@ module.exports = {
   // These are Firefox globals that are often used
   Services: {obs: {notifyObservers: sinon.spy()}},
   Task,
-  XPCOMUtils: {defineLazyGetter() {}}
+  XPCOMUtils: {defineLazyGetter() {}, defineLazyServiceGetter() {}}
 };

--- a/shims/sdk/page-mod.js
+++ b/shims/sdk/page-mod.js
@@ -1,0 +1,18 @@
+const EventEmitter = require("shims/_utils/EventEmitter");
+const {Tab} = require("shims/sdk/tabs");
+module.exports.PageMod = class PageMod {
+  constructor(options) {
+    this.options = options;
+    this.destroy = sinon.spy();
+  }
+};
+
+// Utility for mocking workers
+module.exports.Worker = class Worker extends EventEmitter {
+  constructor(url = "foo.html") {
+    super();
+    this.tab = new Tab({url});
+    this.port = new EventEmitter();
+    this.url = url;
+  }
+};

--- a/shims/sdk/private-browsing.js
+++ b/shims/sdk/private-browsing.js
@@ -1,0 +1,1 @@
+module.exports = {isPrivate: sinon.spy(() => false)};

--- a/shims/sdk/util/uuid.js
+++ b/shims/sdk/util/uuid.js
@@ -1,0 +1,1 @@
+module.exports.uuid = () => Math.random();

--- a/test/test-ActivityStreams-workers.js
+++ b/test/test-ActivityStreams-workers.js
@@ -19,11 +19,11 @@ exports["test load worker"] = function(assert, done) {
   app = getTestActivityStream({pageURL: url});
   function onReady(tab) {
     if (tab.url === url) {
-      assert.equal(app.workers.size, 1, "Worker is loaded");
+      assert.equal(app._pagemod.workers.size, 1, "Worker is loaded");
     }
     done();
   }
-  assert.equal(app.workers.size, 0, "app.workers start at 0");
+  assert.equal(app._pagemod.workers.size, 0, "app.workers start at 0");
   tabs.once("ready", onReady);
   tabs.open({url});
 };
@@ -32,17 +32,17 @@ exports["test removing worker on url change"] = function(assert, done) {
   app = getTestActivityStream({
     pageURL: url,
     onRemoveWorker() {
-      assert.equal(app.workers.size, 0, "app.worker should be removed on a url change");
+      assert.equal(app._pagemod.workers.size, 0, "app.worker should be removed on a url change");
       done();
     }
   });
   function onReady(tab) {
-    assert.equal(app.workers.size, 1, "app.worker should be added");
+    assert.equal(app._pagemod.workers.size, 1, "app.worker should be added");
     tab.url = otherUrl;
   }
   tabs.once("ready", onReady);
 
-  assert.equal(app.workers.size, 0, "app.workers start at 0");
+  assert.equal(app._pagemod.workers.size, 0, "app.workers start at 0");
   tabs.open({url});
 };
 
@@ -52,15 +52,15 @@ exports["test workers for page reload"] = function(assert, done) {
     pageURL: url,
     onAddWorker() {
       if (isFirstLoad) {
-        assert.equal(app.workers.size, 1, "start with one worker");
+        assert.equal(app._pagemod.workers.size, 1, "start with one worker");
       } else {
-        assert.equal(app.workers.size, 1, "new worker should be attached after a reload");
+        assert.equal(app._pagemod.workers.size, 1, "new worker should be attached after a reload");
         done();
       }
     },
     onRemoveWorker() {
       if (isFirstLoad) {
-        assert.equal(app.workers.size, 0, "first worker should get removed on reload");
+        assert.equal(app._pagemod.workers.size, 0, "first worker should get removed on reload");
         isFirstLoad = false;
       }
     }
@@ -70,7 +70,7 @@ exports["test workers for page reload"] = function(assert, done) {
     tab.reload();
   }
 
-  assert.equal(app.workers.size, 0, "app.workers start at 0");
+  assert.equal(app._pagemod.workers.size, 0, "app.workers start at 0");
   tabs.once("ready", onReady);
   tabs.open({url});
 };


### PR DESCRIPTION
This patch refactors the worker management to use a `Map` with unique identifiers, so actions from each worker are tagged with a `workerId`. 

Actually using send/broadcast in feeds will be implemented in https://github.com/mozilla/activity-stream/issues/1829