### PR TITLE
chore(feeds): #1829 Refactor respondToSearchRequests into SearchFeed

### DIFF
--- a/addon/Feeds/SearchFeed.js
+++ b/addon/Feeds/SearchFeed.js
@@ -1,5 +1,7 @@
 const Feed = require("addon/lib/Feed");
 const am = require("common/action-manager");
+const getCurrentBrowser = require("addon/lib/getCurrentBrowser");
+const {Cu} = require("chrome");
 
 module.exports = class SearchFeed extends Feed {
 
@@ -23,6 +25,38 @@ module.exports = class SearchFeed extends Feed {
     this.store.dispatch({type: "SEARCH_STATE_UPDATED", data: state});
   }
 
+  /**
+   * getSuggestions - Retrieves search suggestions for a search string (action.data)
+   *                  Dispatches an array of suggestions.
+   */
+  getSuggestions(action) {
+    const browser = getCurrentBrowser();
+    return this.options.searchProvider.asyncGetSuggestions(browser, action.data)
+      .then(suggestions => this.options.send(am.actions.Response("SEARCH_SUGGESTIONS_RESPONSE", suggestions), action.workerId, true))
+      .catch(e => Cu.reportError(e));
+  }
+
+  cycleCurrentEngine(action) {
+    this.options.searchProvider.cycleCurrentEngine(action.data);
+    const engine = this.options.searchProvider.currentEngine;
+    this.options.send(am.actions.Response("SEARCH_CYCLE_CURRENT_ENGINE_RESPONSE", {currentEngine: engine}), action.workerId);
+  }
+
+  /**
+   * doSearch - Triggers a search in the current new tab, given a search string.
+   */
+  doSearch(action) {
+    this.options.searchProvider.asyncPerformSearch(getCurrentBrowser(), action.data);
+  }
+
+  removeFormHistoryEntry(action) {
+    this.options.searchProvider.removeFormHistoryEntry(getCurrentBrowser(), action.data);
+  }
+
+  manageEngines() {
+    this.options.searchProvider.manageEngines(getCurrentBrowser());
+  }
+
   onAction(state, action) {
     switch (action.type) {
       case am.type("APP_INIT"):
@@ -33,6 +67,22 @@ module.exports = class SearchFeed extends Feed {
       case am.type("SEARCH_ENGINES_CHANGED"):
         this.getEngines();
         break;
+      case am.type("SEARCH_SUGGESTIONS_REQUEST"):
+        this.getSuggestions(action);
+        break;
+      case am.type("NOTIFY_PERFORM_SEARCH"):
+        this.doSearch(action);
+        break;
+      case am.type("NOTIFY_REMOVE_FORM_HISTORY_ENTRY"):
+        this.removeFormHistoryEntry(action);
+        break;
+      case am.type("NOTIFY_MANAGE_ENGINES"):
+        this.manageEngines();
+        break;
+      case am.type("SEARCH_CYCLE_CURRENT_ENGINE_REQUEST"): {
+        this.cycleCurrentEngine(action);
+        break;
+      }
     }
   }
 };

--- a/addon/lib/getCurrentBrowser.js
+++ b/addon/lib/getCurrentBrowser.js
@@ -1,0 +1,14 @@
+/* globals XPCOMUtils, windowMediator */
+const {Cu} = require("chrome");
+
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyServiceGetter(this, "windowMediator",
+                                   "@mozilla.org/appshell/window-mediator;1",
+                                   "nsIWindowMediator");
+
+module.exports = function getCurrentBrowser() {
+  const win = windowMediator.getMostRecentWindow("navigator:browser");
+  const gBrowser = win.getBrowser();
+  return gBrowser.selectedBrowser;
+};

--- a/content-test/addon/Feeds/SearchFeed.test.js
+++ b/content-test/addon/Feeds/SearchFeed.test.js
@@ -1,4 +1,6 @@
-const SearchFeed = require("addon/Feeds/SearchFeed");
+const am = require("common/action-manager");
+const FAKE_BROWSER = {};
+const SearchFeed = require("inject!addon/Feeds/SearchFeed")({"addon/lib/getCurrentBrowser": () => FAKE_BROWSER});
 
 describe("SearchFeed", () => {
   let instance;
@@ -7,10 +9,15 @@ describe("SearchFeed", () => {
   beforeEach(() => {
     store = {dispatch: sinon.spy()};
     searchProvider = {
+      currentEngine: {},
       currentState: {engines: [{name: "foo"}, {name: "bar"}], currentEngine: {name: "foo"}},
-      searchSuggestionUIStrings: {searchString: "Search"}
+      searchSuggestionUIStrings: {searchString: "Search"},
+      cycleCurrentEngine: sinon.spy(),
+      asyncPerformSearch: sinon.spy(),
+      removeFormHistoryEntry: sinon.spy(),
+      manageEngines: sinon.spy()
     };
-    instance = new SearchFeed({searchProvider});
+    instance = new SearchFeed({searchProvider, send: sinon.spy()});
     instance.connectStore(store);
   });
   it("should create a SearchFeed", () => {
@@ -42,19 +49,92 @@ describe("SearchFeed", () => {
     });
   });
 
+  describe("#getSuggestions", () => {
+    it("should call options.searchProvider.asyncGetSuggestions", () => {
+      const action = {data: "a"};
+      searchProvider.asyncGetSuggestions = sinon.spy(() => Promise.resolve([]));
+      instance.getSuggestions(action);
+      assert.calledWith(searchProvider.asyncGetSuggestions, FAKE_BROWSER);
+    });
+    it("should call options.send with the right data", () => {
+      const action = {data: "a", workerId: "abc23jaskj2"};
+      const suggestions = ["ab", "abc"];
+      searchProvider.asyncGetSuggestions = () => Promise.resolve(suggestions);
+      return instance.getSuggestions(action).then(() => {
+        assert.calledOnce(instance.options.send);
+        assert.calledWith(instance.options.send, am.actions.Response("SEARCH_SUGGESTIONS_RESPONSE", suggestions), action.workerId, true);
+      });
+    });
+  });
+
+  describe("#cycleCurrentEngine", () => {
+    it("should call searchProvider.cycleCurrentEngine", () => {
+      const action = {data: {}};
+      instance.cycleCurrentEngine(action);
+      assert.calledWith(searchProvider.cycleCurrentEngine, action.data);
+    });
+    it("should call options.send with the right data", () => {
+      const action = {data: {}, workerId: "Adsj2kk"};
+      instance.cycleCurrentEngine(action);
+      assert.calledWith(
+        instance.options.send,
+        am.actions.Response("SEARCH_CYCLE_CURRENT_ENGINE_RESPONSE", {currentEngine: searchProvider.currentEngine}),
+        action.workerId
+      );
+    });
+  });
+
+  describe("#doSearch", () => {
+    it("should call searchProvider.asyncPerformSearch", () => {
+      instance.doSearch({data: "foo"});
+      assert.calledWith(searchProvider.asyncPerformSearch, FAKE_BROWSER, "foo");
+    });
+  });
+
+  describe("#removeFormHistoryEntry", () => {
+    it("should call searchProvider.removeFormHistoryEntry", () => {
+      instance.removeFormHistoryEntry({data: "foo"});
+      assert.calledWith(searchProvider.removeFormHistoryEntry, FAKE_BROWSER, "foo");
+    });
+  });
+
+  describe("#manageEngines", () => {
+    it("should call searchProvider.manageEngines", () => {
+      instance.manageEngines();
+      assert.calledWith(searchProvider.manageEngines, FAKE_BROWSER);
+    });
+  });
+
   describe("#onAction", () => {
-    beforeEach(() => {
+    it("should call getEngines + getUIStrings on APP_INIT", () => {
       instance.getEngines = sinon.spy();
       instance.getUIStrings = sinon.spy();
-    });
-    it("should call getEngines + getUIStrings on APP_INIT", () => {
       instance.onAction({}, {type: "APP_INIT"});
       assert.calledOnce(instance.getEngines);
       assert.calledOnce(instance.getUIStrings);
     });
     it("should call getEngines on SEARCH_ENGINES_CHANGED", () => {
+      instance.getEngines = sinon.spy();
       instance.onAction({}, {type: "SEARCH_ENGINES_CHANGED"});
       assert.calledOnce(instance.getEngines);
+    });
+    it("should call doSearch on NOTIFY_PERFORM_SEARCH", () => {
+      instance.doSearch = sinon.spy();
+      const action = {type: "NOTIFY_PERFORM_SEARCH"};
+      instance.onAction({}, action);
+      assert.calledWith(instance.doSearch, action);
+    });
+    it("should call doSearch on NOTIFY_MANAGE_ENGINES", () => {
+      instance.manageEngines = sinon.spy();
+      const action = {type: "NOTIFY_MANAGE_ENGINES"};
+      instance.onAction({}, action);
+      assert.calledOnce(instance.manageEngines);
+    });
+    it("should call cycleCurrentEngines on SEARCH_CYCLE_CURRENT_ENGINE_REQUEST", () => {
+      instance.cycleCurrentEngine = sinon.spy();
+      const action = {type: "SEARCH_CYCLE_CURRENT_ENGINE_REQUEST"};
+      instance.onAction({}, action);
+      assert.calledWith(instance.cycleCurrentEngine, action);
     });
   });
 });


### PR DESCRIPTION
This patch removes the rest of the search-related items from `ActivityStreams.js` and adds them to `SearchFeed.js`, and adds unit tests for each thing.