### PR TITLE
feat(highlights): Always show recent bookmarks even without images

### DIFF
--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -42,7 +42,7 @@ class Baseline {
 
     const age = this.normalizeTimestamp(entry.lastVisitDate);
     const imageCount = entry.images ? entry.images.length : 0;
-    const isBookmarked = entry.bookmarkId || 0;
+    const isBookmarked = !!entry.bookmarkDateCreated;
     const description = this.extractDescriptionLength(entry);
     const pathLength = urlObj.pathname.split("/").filter(e => e.length).length;
     const image = this.extractImage(entry.images);
@@ -104,8 +104,9 @@ class Baseline {
       newScore *= 0.2;
     }
 
+    // Boost boomarks even if they have low score or no images
     if (features.isBookmarked) {
-      newScore *= 1.8;
+      newScore += 1.8;
     }
 
     return newScore;

--- a/content-test/common/Baseline.test.js
+++ b/content-test/common/Baseline.test.js
@@ -76,7 +76,7 @@ const fakeUrls = [
     host: "bar.com",
     visitCount: 1,
     title: "Activity Stream",
-    bookmarkId: 1,
+    bookmarkDateCreated: 1,
     description: "",
     images: [{"url": "bar.com", "width": 100, "height": 100}],
     imageCount: 1,
@@ -173,10 +173,10 @@ describe("Baseline", () => {
     assert.isOk(descending);
   });
 
-  it("should remove items with no images", () => {
+  it("should remove items with no images except bookmarks", () => {
     let fakeUrlsWithNoImages = fakeUrls.map(item => Object.assign({}, item, {images: []}));
     let items = baseline.score(fakeUrlsWithNoImages);
-    assert.equal(items.length, 0);
+    assert.equal(items.length, 1);
   });
 
   it("should decrease score for consecutive items from the same domain", () => {


### PR DESCRIPTION
Fix #1794. Turns out enhanced links don't get bookmarkId passed but bookmarkDateCreated does. Also, the boost for bookmarks doesn't work for image-less ones because that score drops to 0, so multiplying doesn't do anything.

r?@ncloudioj 