### PR TITLE
fix(content) #1816 Use label instead of provider_name for spotlight

### DIFF
--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -2,6 +2,7 @@ const React = require("react");
 const {connect} = require("react-redux");
 const {justDispatch} = require("common/selectors/selectors");
 const getHighlightContextFromSite = require("common/selectors/getHighlightContextFromSite");
+const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 const {actions} = require("common/action-manager");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
@@ -44,7 +45,7 @@ const SpotlightItem = React.createClass({
 
     // We may want to reconsider this as part of
     // https://github.com/mozilla/activity-stream/issues/1473
-    const providerName = site.provider_name ? site.provider_name.toLowerCase() : "";
+    const {label} = selectSiteProperties(site);
     const style = {};
 
     if (imageUrl) {
@@ -60,8 +61,8 @@ const SpotlightItem = React.createClass({
         <div className="spotlight-details">
           <div className="spotlight-info">
             <div className="spotlight-text">
-              <div className="spotlight-provider-name">
-                {providerName}
+              <div ref="label" className="spotlight-label">
+                {label}
               </div>
               <h4 ref="title" className="spotlight-title">{site.title}</h4>
               <p className="spotlight-description" ref="description">{description}</p>

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -72,7 +72,7 @@
     top: $spotlight-icon-gutter;
   }
 
-  .spotlight-provider-name {
+  .spotlight-label {
     color: $mid-light-grey;
     font-size: 10px;
   }

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -1,6 +1,7 @@
 const ConnectedSpotlight = require("components/Spotlight/Spotlight");
 const {Spotlight, SpotlightItem} = ConnectedSpotlight;
 const getHighlightContextFromSite = require("common/selectors/getHighlightContextFromSite");
+const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
 const HighlightContext = require("components/HighlightContext/HighlightContext");
@@ -99,6 +100,9 @@ describe("SpotlightItem", () => {
     });
     it("should render the title", () => {
       assert.equal(instance.refs.title.textContent, fakeSite.title);
+    });
+    it("should render the label (e.g. foo.com)", () => {
+      assert.equal(instance.refs.label.textContent, selectSiteProperties(fakeSite).label);
     });
     it("should render the description", () => {
       assert.include(instance.refs.description.textContent, fakeSite.description);


### PR DESCRIPTION
This patch changes the `Spotlight` component to show the hostname (e.g. `foo.com`) instead of the provider name.