### PR TITLE
Optimze webpack

### DIFF
--- a/addon/MetadataParser.js
+++ b/addon/MetadataParser.js
@@ -1,7 +1,7 @@
 /* globals require, exports */
 "use strict";
 
-const {getMetadata} = require("common/vendor")("PageMetadataParser");
+const {getMetadata} = require("common/vendor")("page-metadata-parser");
 const {Cc, Ci} = require("chrome");
 
 function MetadataParser() {

--- a/common/vendor-src.js
+++ b/common/vendor-src.js
@@ -1,3 +1,5 @@
+/* globals ADDON */
+
 // Note:
 // DO NOT import this file directly, as it needs to be processed by webpack.
 // Instead, import depdencies like this:
@@ -9,16 +11,23 @@ if (typeof platform_require !== "undefined") {
   global.clearTimeout = clearTimeout;
 }
 
+// Shared between both addon and content
 const vendorModules = {
   "redux": require("redux"),
   "redux-thunk": require("redux-thunk"),
   "reselect": require("reselect"),
-  "url-parse": require("url-parse"),
-  "PageMetadataParser": require("page-metadata-parser"),
-  "redux-watch": require("redux-watch"),
-  "lodash.debounce": require("lodash.debounce"),
-  "tippy-top-sites": require("tippy-top-sites")
+  "url-parse": require("url-parse")
 };
+
+// Addon-only modules. Also needed for tests
+if (ADDON || process.env.NODE_ENV === "test") {
+  Object.assign(vendorModules, {
+    "page-metadata-parser": require("page-metadata-parser"),
+    "redux-watch": require("redux-watch"),
+    "lodash.debounce": require("lodash.debounce"),
+    "tippy-top-sites": require("tippy-top-sites")
+  });
+}
 
 module.exports = function vendor(moduleName) {
   if (!vendorModules[moduleName]) {

--- a/content-src/lib/getRelativeTime.js
+++ b/content-src/lib/getRelativeTime.js
@@ -1,23 +1,24 @@
-const moment = require("moment");
+const TIME = {
+  s: 1000,
+  m: 1000 * 60,
+  h: 1000 * 60 * 60,
+  d: 1000 * 60 * 60 * 24
+};
 
-// Custom relative time
-// We can only have one instance of moment :(
-moment.updateLocale("en", {
-  relativeTime: {
-    future: "in %s",
-    past: "%s",
-    s: "<1m",
-    m: "%dm",
-    mm: "%dm",
-    h: "%dh",
-    hh: "%dh",
-    d: "%dd",
-    dd: "%dd",
-    M: "%dM",
-    MM: "%dM",
-    y: "%dy",
-    yy: "%dy"
+module.exports = function getRelativeTime(t) {
+  const now = new Date();
+  const diff = now - t;
+  const m = Math.floor((diff % TIME.h) / TIME.m);
+  const h = Math.floor((diff % TIME.d) / TIME.h);
+  const d = Math.floor(diff / TIME.d);
+  if (diff < TIME.m) {
+    return "<1m";
   }
-});
-
-module.exports = unixTimestamp => moment(unixTimestamp).fromNow();
+  else if (diff < TIME.h) {
+    return `${m}m`;
+  }
+  else if (diff < TIME.d) {
+    return `${h}h`;
+  }
+  return `${d}d`;
+};

--- a/content-src/main.js
+++ b/content-src/main.js
@@ -1,7 +1,6 @@
 const React = require("react");
 const ReactDOM = require("react-dom");
 const {Provider} = require("react-redux");
-
 const Base = require("components/Base/Base");
 const createStore = require("common/create-store");
 const {ADDON_TO_CONTENT, CONTENT_TO_ADDON} = require("common/event-constants");

--- a/content-test/lib/getRelativeTime.test.js
+++ b/content-test/lib/getRelativeTime.test.js
@@ -24,10 +24,4 @@ describe("getRelativeTime", () => {
     assert.equal(getRelativeTime(moment().subtract(1, "days").valueOf()), "1d");
     assert.equal(getRelativeTime(moment().subtract(5, "days").valueOf()), "5d");
   });
-
-  // eslint-disable-next-line no-template-curly-in-string
-  it("should show ${n}y for ~years", () => {
-    assert.equal(getRelativeTime(moment().subtract(1, "years").valueOf()), "1y");
-    assert.equal(getRelativeTime(moment().subtract(5, "years").valueOf()), "5y");
-  });
 });

--- a/webpack.addon.config.js
+++ b/webpack.addon.config.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   module: {loaders: [{test: /\.json$/, loader: "json"}]},
   plugins: [
+    new webpack.DefinePlugin({ADDON: true}),
     new webpack.BannerPlugin("let platform_require = require;\n", {raw: true})
   ]
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,6 +18,7 @@ let plugins = [
     reactEnv: true,
     log: false
   }),
+  new webpack.DefinePlugin({ADDON: false}),
   // Allows us to use requrie("common/vendor") as a way to import depdendencies in both addon/content code
   new webpack.NormalModuleReplacementPlugin(/common\/vendor/, absolute("./common/vendor-src.js"))
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
     vendor: [
       "react",
       "react-dom",
-      "moment"
+      "react-redux",
+      "redux"
     ]
   },
   output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,16 +21,14 @@ module.exports = {
     vendor: [
       "react",
       "react-dom",
-      "moment",
-      "wu",
-      "buffer",
-      "url"
+      "moment"
     ]
   },
   output: {
     path: outputDir,
     filename: outputFilename
   },
+  node: {Buffer: false, url: false},
   target: "web",
   module: webpack_common.module,
   devtool: env === "production" ? null : "eval", // This is for Firefox


### PR DESCRIPTION
This PR contains two bits of optimization:

1. 4b5595b changes the webpack config to exclude addon-only dependencies from `common/vendor`, as well as excluding un-needed node shims.
2. 1571bfe replaces `moment.js` in the build with a custom function. Note that moment.js is still used as a test utility.

In total, this results in a 46% reduction for the production build.

With patch (total 304k):
```
140K	./data/content/bundle.js
164K	./data/content/vendor.bundle.js
```
```
react: 617.99 KB (73.8%)
fbjs: 31.21 KB (3.73%)
redux: 22.36 KB (2.67%)
react-redux: 19.37 KB (2.31%)
url-parse: 11.23 KB (1.34%)
lodash: 5.77 KB (0.689%)
process: 5.17 KB (0.618%)
reselect: 3.74 KB (0.446%)
object-assign: 1.95 KB (0.233%)
invariant: 1.48 KB (0.177%)
object-sizeof: 1.47 KB (0.176%)
hoist-non-react-statics: 1.35 KB (0.162%)
querystringify: 1.27 KB (0.152%)
fancy-dedupe: 1.13 KB (0.135%)
symbol-observable: 1.12 KB (0.134%)
classnames: 1.08 KB (0.128%)
requires-port: 753 B (0.0878%)
redux-thunk: 529 B (0.0617%)
webpack: 241 B (0.0281%)
react-dom: 63 B (0.00735%)
<self>: 108.28 KB (12.9%)
```

Before (total 560k):
```
284K	./data/content/bundle.js
276K	./data/content/vendor.bundle.js
```
```
react: 617.99 KB (47.6%)
wu: 146.36 KB (11.3%)
moment: 137.5 KB (10.6%)
buffer: 47.47 KB (3.66%)
url: 36.04 KB (2.78%)
  punycode: 14.31 KB (39.7%)
  <self>: 21.74 KB (60.3%)
fbjs: 31.21 KB (2.40%)
tippy-top-sites: 31 KB (2.39%)
fathom-web: 30.47 KB (2.35%)
redux: 22.36 KB (1.72%)
react-redux: 19.37 KB (1.49%)
url-parse: 11.23 KB (0.865%)
lodash.debounce: 10.53 KB (0.811%)
object-path: 6.1 KB (0.470%)
lodash: 5.77 KB (0.445%)
process: 5.17 KB (0.399%)
page-metadata-parser: 4.58 KB (0.353%)
querystring: 4.51 KB (0.347%)
reselect: 3.74 KB (0.288%)
base64-js: 3.4 KB (0.262%)
ieee754: 2.01 KB (0.154%)
object-assign: 1.95 KB (0.150%)
invariant: 1.48 KB (0.114%)
object-sizeof: 1.47 KB (0.113%)
hoist-non-react-statics: 1.35 KB (0.104%)
querystringify: 1.27 KB (0.0979%)
fancy-dedupe: 1.13 KB (0.0869%)
symbol-observable: 1.12 KB (0.0866%)
classnames: 1.08 KB (0.0829%)
requires-port: 753 B (0.0566%)
hex-to-rgb: 568 B (0.0427%)
redux-watch: 557 B (0.0419%)
redux-thunk: 529 B (0.0398%)
webpack: 241 B (0.0181%)
isarray: 132 B (0.00993%)
react-dom: 63 B (0.00474%)
<self>: 108.03 KB (8.32%)
```