### PR TITLE
feat(NewTab): (closes #1675) load placeholder content when "waiting"…

### DIFF
--- a/common/create-store.js
+++ b/common/create-store.js
@@ -41,7 +41,7 @@ function rehydrateFromLocalStorage() {
  *
  * @type {Number} milliseconds between polls
  */
-const _rehydrationInterval = 3 * 1000; // try every three seconds
+const _rehydrationInterval = 1 * 1000; // try every second
 let _rehydrationIntervalTimer = null;
 
 /**

--- a/content-src/components/HighlightContext/HighlightContext.js
+++ b/content-src/components/HighlightContext/HighlightContext.js
@@ -28,5 +28,31 @@ HighlightContext.propTypes = {
   date: React.PropTypes.number
 };
 
-module.exports = HighlightContext;
-module.exports.types = highlightTypes;
+/**
+ * Only display a placeholder version (ie just outlines/shapes), for use
+ * before sufficient data is available to display.
+ *
+ * This should be a stateless, functional component.  Unfortunately, testing
+ * these kinda sucks; see
+ * http://stackoverflow.com/questions/36682241/testing-functional-components-with-renderintodocument)
+ *
+ * The bottom line: we should start using Enzyme and switch this over.
+ */
+const PlaceholderHighlightContext = React.createClass({
+  render() {
+    return (
+      <div className="highlight-context placeholder">
+        <div className="hc-icon">
+          <div className="icon" />
+        </div>
+        <div className="hc-label" />
+      </div>
+    );
+  }
+});
+
+module.exports = {
+  HighlightContext,
+  PlaceholderHighlightContext,
+  types: highlightTypes
+};

--- a/content-src/components/HighlightContext/HighlightContext.scss
+++ b/content-src/components/HighlightContext/HighlightContext.scss
@@ -9,6 +9,25 @@
   display: flex;
   align-items: center;
 
+  // Only display a placeholder version (ie just outlines/shapes), for use
+  // before sufficient data is available to display.
+  &.placeholder {
+    .hc-icon {
+      background-color: $placeholder-grey;
+      opacity: 1;
+
+      .icon {
+        background-image: none;
+      }
+    }
+
+    .hc-label {
+      background-color: $placeholder-grey;
+      color: $placeholder-grey;
+      height: 16px;
+    }
+  }
+
   .hc-icon {
     opacity: 0.5;
     font-size: 13px;

--- a/content-src/components/Loader/Loader.scss
+++ b/content-src/components/Loader/Loader.scss
@@ -3,13 +3,11 @@
 // for both hints and the loader box.
 .loader {
   margin: auto;
-  left: 0;
-  right: 0;
 
   display: flex;
   flex-direction: column;
   padding: 20px;
-  color: $loader-popup-background-color;
+  background-color: $loader-popup-background-color;
 
   min-height: 200px; // don't crop the foxfinder graphic
   min-width: 420px;
@@ -21,7 +19,11 @@
   border-radius: $loader-border-radius;
   box-shadow: 0 5px 10px $faintest-black;
 
-  position: absolute;
+  // keep things centered on the viewport and in front of everything else
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: $loader-z-index;
 
   background-image: url('#{$image-path}foxfinder@2x.png');

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -7,7 +7,6 @@ const Search = require("components/Search/Search");
 const Loader = require("components/Loader/Loader");
 const {actions} = require("common/action-manager");
 const setFavicon = require("lib/set-favicon");
-const classNames = require("classnames");
 const PAGE_NAME = "NEW_TAB";
 const {HIGHLIGHTS_LENGTH} = require("common/constants");
 
@@ -58,14 +57,15 @@ const NewTabPage = React.createClass({
           title="Welcome to new tab"
           body="Firefox will use this space to show your most relevant bookmarks, articles, videos, and pages you've recently visited, so you can get back to them easily."
           label="Identifying your Highlights" />
-        <div className={classNames("show-on-init", {on: this.props.isReady})}>
+        <div className="show-on-init on">
           <section>
-            <TopSites page={PAGE_NAME} sites={props.TopSites.rows} showHint={props.TopSites.showHint} />
+            <TopSites placeholder={!this.props.isReady} page={PAGE_NAME}
+              sites={props.TopSites.rows} showHint={props.TopSites.showHint} />
           </section>
 
           <section>
-            <Spotlight page={PAGE_NAME} length={HIGHLIGHTS_LENGTH}
-              sites={props.Highlights.rows} />
+            <Spotlight placeholder={!this.props.isReady} page={PAGE_NAME}
+              length={HIGHLIGHTS_LENGTH} sites={props.Highlights.rows} />
           </section>
         </div>
       </div>

--- a/content-src/components/SiteIcon/SiteIcon.js
+++ b/content-src/components/SiteIcon/SiteIcon.js
@@ -67,4 +67,25 @@ SiteIcon.propTypes = {
   }).isRequired
 };
 
-module.exports = SiteIcon;
+/**
+ * A placeholder version (ie just outlines/shapes), for use before sufficient
+ * data is available to display.
+ *
+ * Unfortunately, this can't be a function component as long as we have the
+ * ref and it is used in testing.
+ */
+const PlaceholderSiteIcon = React.createClass({
+  render() {
+    return (
+      <div ref="icon" className="spotlight-icon">
+        <div className="site-icon-wrapper" />
+        <div className="site-icon-title" />
+      </div>
+    );
+  }
+});
+
+module.exports = {
+  PlaceholderSiteIcon,
+  SiteIcon
+};

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -4,10 +4,10 @@ const {justDispatch} = require("common/selectors/selectors");
 const getHighlightContextFromSite = require("common/selectors/getHighlightContextFromSite");
 const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 const {actions} = require("common/action-manager");
-const SiteIcon = require("components/SiteIcon/SiteIcon");
+const {SiteIcon, PlaceholderSiteIcon} = require("components/SiteIcon/SiteIcon");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
-const HighlightContext = require("components/HighlightContext/HighlightContext");
+const {HighlightContext, PlaceholderHighlightContext} = require("components/HighlightContext/HighlightContext");
 const Hint = require("components/Hint/Hint");
 const classNames = require("classnames");
 
@@ -88,6 +88,22 @@ const SpotlightItem = React.createClass({
   }
 });
 
+const PlaceholderSpotlightItem = React.createClass({
+  render() {
+    return (
+      <li className="spotlight-item placeholder">
+        <a>
+          <div className="spotlight-image portrait" ref="image">
+            <PlaceholderSiteIcon />
+          </div>
+          <div className="inner-border" />
+        </a>
+        <PlaceholderHighlightContext />
+      </li>
+    );
+  }
+});
+
 SpotlightItem.propTypes = {
   page: React.PropTypes.string,
   source: React.PropTypes.string,
@@ -105,7 +121,8 @@ const Spotlight = React.createClass({
   getDefaultProps() {
     return {
       length: 3,
-      page: "NEW_TAB"
+      page: "NEW_TAB",
+      placeholder: false
     };
   },
   onClickFactory(index, site) {
@@ -121,20 +138,38 @@ const Spotlight = React.createClass({
       this.props.dispatch(actions.NotifyEvent(payload));
     };
   },
-  render() {
+  // XXX factor out into a stateless component
+  renderSiteList() {
     const sites = this.props.sites.slice(0, this.props.length);
 
-    return (<section className="spotlight">
-      <h3 className="section-title">Highlights <Hint id="highlights_hint" title="Highlights" body={HIGHLIGHTS_HINT_TEXT} /></h3>
-      <ul className="spotlight-list">
-        {sites.map((site, i) => <SpotlightItem
+    return sites.map((site, i) =>
+        <SpotlightItem
           index={i}
           key={site.guid || site.cache_key || i}
           page={this.props.page}
           source="FEATURED"
           onClick={this.onClickFactory(i, site)}
           dispatch={this.props.dispatch}
-          {...site} />)}
+          {...site} />
+      );
+  },
+  // XXX factor out into a stateless component
+  renderPlaceholderSiteList() {
+    const PLACEHOLDER_SITE_LIST_LENGTH = 3;
+
+    let placeholders = [];
+    for (let i = 0; i < PLACEHOLDER_SITE_LIST_LENGTH; i++) {
+      placeholders.push(<PlaceholderSpotlightItem key={i} />);
+    }
+
+    return placeholders;
+  },
+  render() {
+    return (<section className="spotlight">
+      <h3 className="section-title">Highlights <Hint id="highlights_hint" title="Highlights" body={HIGHLIGHTS_HINT_TEXT} /></h3>
+      <ul className="spotlight-list">
+        {this.props.placeholder ? this.renderPlaceholderSiteList() :
+          this.renderSiteList()}
       </ul>
     </section>);
   }
@@ -149,3 +184,4 @@ Spotlight.propTypes = {
 module.exports = connect(justDispatch)(Spotlight);
 module.exports.Spotlight = Spotlight;
 module.exports.SpotlightItem = SpotlightItem;
+module.exports.PlaceholderSpotlightItem = PlaceholderSpotlightItem;

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -64,6 +64,20 @@
     }
   }
 
+  // Only display a placeholder version (ie just outlines/shapes), for use
+  // before sufficient data is available to display.
+  &.placeholder {
+    .spotlight-image {
+      background-color: $placeholder-grey;
+    }
+
+    .spotlight-icon {
+      width: 40px; // XXX should be derived or done from JS to match other code?
+      height: 40px;
+      background-color: $white;
+    }
+  }
+
   .spotlight-icon {
     border-radius: 3px;
     left: $spotlight-icon-gutter;

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -5,7 +5,7 @@ const {actions} = require("common/action-manager");
 const classNames = require("classnames");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
-const SiteIcon = require("components/SiteIcon/SiteIcon");
+const {PlaceholderSiteIcon, SiteIcon} = require("components/SiteIcon/SiteIcon");
 const Hint = require("components/Hint/Hint");
 
 const DEFAULT_LENGTH = 6;
@@ -27,7 +27,7 @@ const TopSitesItem = React.createClass({
     const isActive = this.state.showContextMenu && this.state.activeTile === index;
     return (<div className={classNames("tile-outer", {active: isActive})} key={site.guid || site.cache_key || index}>
       <a onClick={() => this.props.onClick(index)} className="tile" href={site.url} ref="topSiteLink">
-        <SiteIcon className="tile-img-container" site={site} faviconSize={32} showTitle={true} />
+        <SiteIcon ref="icon" className="tile-img-container" site={site} faviconSize={32} showTitle={true} />
         <div className="inner-border" />
       </a>
       <LinkMenuButton onClick={() => this.setState({showContextMenu: true, activeTile: index})} />
@@ -49,6 +49,19 @@ TopSitesItem.propTypes = {
   favicon_url: React.PropTypes.string,
   onClick: React.PropTypes.func
 };
+
+const PlaceholderTopSitesItem = React.createClass({
+  render() {
+    return (
+      <div className="tile-outer placeholder">
+        <a className="tile">
+          <PlaceholderSiteIcon />
+        </a>
+        <div className="inner-border" />
+      </div>
+    );
+  }
+});
 
 const TopSites = React.createClass({
   getDefaultProps() {
@@ -75,13 +88,22 @@ const TopSites = React.createClass({
     return (<section className="top-sites">
       <h3 className="section-title">Top Sites <Hint id="top_sites_hint" title="Top Sites" body={TOP_SITES_HINT_TEXT} /></h3>
       <div className="tiles-wrapper">
-        {sites.map((site, i) => <TopSitesItem
+        {sites.map((site, i) => {
+          // if this is a placeholder, we want all the widgets to render empty
+          if (this.props.placeholder) {
+            return (
+              <PlaceholderTopSitesItem key={site.guid || site.cache_key || i} />
+            );
+          }
+
+          return (<TopSitesItem
             index={i}
             key={site.guid || site.cache_key || i}
             page={this.props.page}
             onClick={this.onClickFactory(i, site)}
             {...site} />
-        )}
+          );
+        })}
       </div>
     </section>);
   }
@@ -98,9 +120,16 @@ TopSites.propTypes = {
       provider_name: React.PropTypes.string,
       parsedUrl: React.PropTypes.object
     })
-  ).isRequired
+  ).isRequired,
+
+  /**
+   * Only display a placeholder version (ie just outlines/shapes), for use
+   * before sufficient data is available to display.
+   */
+  placeholder: React.PropTypes.bool
 };
 
 module.exports = connect(justDispatch)(TopSites);
 module.exports.TopSites = TopSites;
 module.exports.TopSitesItem = TopSitesItem;
+module.exports.PlaceholderTopSitesItem = PlaceholderTopSitesItem;

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -16,6 +16,23 @@
     @media (min-width: $break-point) {
       display: flex;
     }
+
+    // Only display a placeholder version (ie just outlines/shapes), for use
+    // before sufficient data is available to display.
+    &.placeholder {
+      .site-icon-wrapper {
+        width: 32px;
+        height: 74px;
+      }
+
+      .site-icon-title {
+        border-top: 1px solid $faintest-black;
+      }
+
+      .tile {
+        box-shadow: none;
+      }
+    }
   }
 
   .tile {

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -2,6 +2,7 @@ $image-path: 'img/';
 
 $bg-color: #FFF;
 $bg-grey: #FBFBFB;
+$placeholder-grey: #F7F7F7;
 $very-light-grey: #EBEBEB;
 $light-grey: #A0A0A0;
 $mid-light-grey: #858585;
@@ -93,8 +94,9 @@ $search-border-color: #EAEAEA;
 $item-shadow: 0 1px 0 0 $faintest-black;
 $item-shadow-hover: 0 1px 0 0 $faintest-black, 0 0 0 5px $faintest-black;
 
+// override background transparency of image itself
+$loader-popup-background-color: $white;
 $loader-spinner-size: 16px;
-$loader-popup-background-color: #2B2B2B;
 $loader-border-color: #E0E0E0;
 $loader-border-radius: 4px;
 $loader-z-index: 10000;

--- a/content-test/components/HighlightContext.test.js
+++ b/content-test/components/HighlightContext.test.js
@@ -2,8 +2,7 @@ const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 
-const HighlightContext = require("components/HighlightContext/HighlightContext");
-const {types} = HighlightContext;
+const {types, PlaceholderHighlightContext, HighlightContext} = require("components/HighlightContext/HighlightContext");
 
 describe("HighlightContext", () => {
   let instance;
@@ -68,5 +67,20 @@ describe("HighlightContext", () => {
   it("should have a .tooltip-container class", () => {
     setup();
     assert.include(el.className, "tooltip-container");
+  });
+});
+
+describe("PlaceholderHighlightContext", () => {
+  let instance;
+  let el;
+
+  function setup() {
+    instance = TestUtils.renderIntoDocument(<PlaceholderHighlightContext />);
+    el = ReactDOM.findDOMNode(instance);
+  }
+
+  it("should have a .placeholder class", () => {
+    setup();
+    assert.include(el.className, "placeholder");
   });
 });

--- a/content-test/components/NewTabPage.story.js
+++ b/content-test/components/NewTabPage.story.js
@@ -34,8 +34,19 @@ const Container = props => (
 // itself.
 
 storiesOf("NewTabPage", module)
-  .add("Be on the lookout popup", () =>
-    <Container>
-      <NewTabPage {...mockData} page="SPOTLIGHT_STORYBOOK" dispatch={dispatch} />,
-    </Container>
+  .add("Data Available (this.props.isReady==true)", () => {
+    let dataAvail = Object.assign({}, mockData);
+    dataAvail.isReady = true;
+
+    return (
+      <Container>
+        <NewTabPage {...dataAvail} page="SPOTLIGHT_STORYBOOK"
+          dispatch={dispatch} />,
+      </Container>
+    );
+  })
+  .add("Data Unavailable (this.props.isReady==false)", () =>
+      <Container>
+        <NewTabPage {...mockData} page="SPOTLIGHT_STORYBOOK" dispatch={dispatch} />
+      </Container>
   );

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -5,6 +5,8 @@ const {NewTabPage} = ConnectedNewTabPage;
 const TopSites = require("components/TopSites/TopSites");
 const Spotlight = require("components/Spotlight/Spotlight");
 const {mockData, renderWithProvider} = require("test/test-utils");
+const {selectNewTabSites} = require("common/selectors/selectors");
+const {connect} = require("react-redux");
 
 const fakeProps = mockData;
 
@@ -15,7 +17,30 @@ describe("NewTabPage", () => {
     instance = renderWithProvider(<NewTabPage {...fakeProps} dispatch={() => {}} />);
   });
 
-  function setupConnected(dispatch = () => {}) {
+  /**
+   * A wrapper for selectNewTabSites that always forces isReady to true.
+   */
+  function forceIsReadySelectNewTabs(...args) {
+    let selected = selectNewTabSites(...args);
+    return Object.assign(selected, {isReady: true});
+  }
+
+  /**
+   * Overwrites the lexically scoped instance variable with a version
+   * that is connected to the mock store.
+   *
+   * @param {Function} dispatch   Dispatch function for the store; defaults
+   *                              to a NO-OP function
+   * @param {Function} mapStatesToProps  passed through to connect().
+   *                                     defaults to forceIsReadySelectNewTabs,
+   *                                     since we (almost?) always want to test
+   *                                     the regular display, not the placeholder
+   *                                     one.
+   */
+  function setupConnected(
+    dispatch = () => {}, mapStatesToProps = forceIsReadySelectNewTabs) {
+    let ConnectedNewTabPage = connect(mapStatesToProps)(NewTabPage);
+
     instance = TestUtils.findRenderedComponentWithType(
       renderWithProvider(<ConnectedNewTabPage />, {dispatch}),
       NewTabPage
@@ -44,6 +69,29 @@ describe("NewTabPage", () => {
     const container = renderWithProvider(<ConnectedNewTabPage />);
     const inner = TestUtils.findRenderedComponentWithType(container, NewTabPage);
     Object.keys(NewTabPage.propTypes).forEach(key => assert.property(inner.props, key));
+  });
+
+  it("should pass placeholder=true to Spotlight and TopSites when isReady is false", () => {
+    instance = renderWithProvider(
+      <NewTabPage {...fakeProps} dispatch={() => {}} />);
+
+    let spotlight = TestUtils.findRenderedComponentWithType(instance, Spotlight);
+    assert.equal(spotlight.props.placeholder, true);
+
+    let topSites = TestUtils.findRenderedComponentWithType(instance, TopSites);
+    assert.equal(topSites.props.placeholder, true);
+  });
+
+  it("should pass placeholder=false to Spotlight and TopSites when isReady is true", () => {
+    let propsWithIsReadyTrue = Object.assign({}, fakeProps, {isReady: true});
+    instance = renderWithProvider(
+      <NewTabPage {...propsWithIsReadyTrue} dispatch={() => {}} />);
+
+    let spotLight = TestUtils.findRenderedComponentWithType(instance, Spotlight);
+    assert.equal(spotLight.props.placeholder, false);
+
+    let topSites = TestUtils.findRenderedComponentWithType(instance, TopSites);
+    assert.equal(topSites.props.placeholder, false);
   });
 
   describe("delete events", () => {

--- a/content-test/components/SiteIcon.test.js
+++ b/content-test/components/SiteIcon.test.js
@@ -1,7 +1,7 @@
 const TestUtils = require("react-addons-test-utils");
 const React = require("react");
 const ReactDOM = require("react-dom");
-const SiteIcon = require("components/SiteIcon/SiteIcon");
+const {SiteIcon} = require("components/SiteIcon/SiteIcon");
 
 const fakeProps = {
   site: {

--- a/content-test/components/Spotlight.story.js
+++ b/content-test/components/Spotlight.story.js
@@ -57,6 +57,11 @@ storiesOf("Highlight List", module)
     <Container>
       <Spotlight length={HIGHLIGHTS_LENGTH} page="SPOTLIGHT_STORYBOOK" sites={fakeSpotlightItems.slice(1)} />
     </Container>
+  )
+  .add("Placeholder view (data still loading)", () =>
+    <Container>
+      <Spotlight placeholder={true} length={HIGHLIGHTS_LENGTH} page="SPOTLIGHT_STORYBOOK" sites={fakeSpotlightItems} />
+    </Container>
   );
 
 storiesOf("Highlight Item", module)

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -1,14 +1,14 @@
 const ConnectedSpotlight = require("components/Spotlight/Spotlight");
-const {Spotlight, SpotlightItem} = ConnectedSpotlight;
+const {PlaceholderSpotlightItem, Spotlight, SpotlightItem} = ConnectedSpotlight;
 const getHighlightContextFromSite = require("common/selectors/getHighlightContextFromSite");
 const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
-const HighlightContext = require("components/HighlightContext/HighlightContext");
+const {PlaceholderHighlightContext, HighlightContext} = require("components/HighlightContext/HighlightContext");
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
-const SiteIcon = require("components/SiteIcon/SiteIcon");
+const {PlaceholderSiteIcon, SiteIcon} = require("components/SiteIcon/SiteIcon");
 const {mockData, faker, renderWithProvider} = require("test/test-utils");
 const fakeSpotlightItems = mockData.Highlights.rows;
 const fakeSiteWithImage = faker.createSite();
@@ -18,12 +18,13 @@ fakeSiteWithImage.bestImage = fakeSiteWithImage.images[0];
 describe("Spotlight", () => {
   let instance;
   let el;
-  beforeEach(() => {
-    instance = renderWithProvider(<Spotlight sites={fakeSpotlightItems} />);
-    el = ReactDOM.findDOMNode(instance);
-  });
 
   describe("valid sites", () => {
+    beforeEach(() => {
+      instance = renderWithProvider(<Spotlight sites={fakeSpotlightItems} />);
+      el = ReactDOM.findDOMNode(instance);
+    });
+
     it("should create the element", () => {
       assert.ok(el);
     });
@@ -56,12 +57,13 @@ describe("SpotlightItem", () => {
   const fakeSite = fakeSiteWithImage;
   let instance;
   let el;
-  beforeEach(() => {
-    instance = renderWithProvider(<SpotlightItem {...fakeSite} />);
-    el = ReactDOM.findDOMNode(instance);
-  });
 
   describe("valid sites", () => {
+    beforeEach(() => {
+      instance = renderWithProvider(<SpotlightItem {...fakeSite} />);
+      el = ReactDOM.findDOMNode(instance);
+    });
+
     it("should create the element", () => {
       assert.ok(el);
     });
@@ -99,16 +101,27 @@ describe("SpotlightItem", () => {
       assert.equal(hc.props.type, "bookmark");
       assert.deepEqual(hc.props, props);
     });
-    it("should fire user event if there is no image", done => {
-      const fakeSiteWithoutImage = Object.assign({}, fakeSiteWithImage, {bestImage: {url: null}});
-      function dispatch(a) {
-        if (a.type === "NOTIFY_UNDESIRED_EVENT") {
-          assert.equal(a.data.event, "MISSING_IMAGE");
-          assert.equal(a.data.source, "HIGHLIGHTS");
-          done();
-        }
-      }
-      instance = renderWithProvider(<SpotlightItem {...fakeSiteWithoutImage} dispatch={dispatch} page={"NEW_TAB"} />);
-    });
+  });
+});
+
+describe("PlaceholderSpotlightItem", () => {
+  let instance;
+  let el;
+
+  beforeEach(() => {
+    instance = renderWithProvider(<PlaceholderSpotlightItem />);
+    el = ReactDOM.findDOMNode(instance);
+  });
+  it("should have a .placeholder class", () => {
+    assert(el.classList.contains("placeholder"));
+  });
+  it("should render a PlaceholderHighlightContext", () => {
+    const hc = TestUtils.findRenderedComponentWithType(instance, PlaceholderHighlightContext);
+
+    assert.instanceOf(hc, PlaceholderHighlightContext);
+  });
+  it("should render a PlaceholderSiteIcon", () => {
+    const icon = TestUtils.findRenderedComponentWithType(instance, PlaceholderSiteIcon);
+    assert.notEqual(null, icon);
   });
 });

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -1,12 +1,13 @@
 const TestUtils = require("react-addons-test-utils");
 const React = require("react");
 const ReactDOM = require("react-dom");
-const {overrideConsoleError, renderWithProvider} = require("test/test-utils");
+const {faker, overrideConsoleError, renderWithProvider} = require("test/test-utils");
 const ConnectedTopSites = require("components/TopSites/TopSites");
-const {TopSites, TopSitesItem} = ConnectedTopSites;
+const {PlaceholderTopSitesItem, TopSites, TopSitesItem} = ConnectedTopSites;
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
-const SiteIcon = require("components/SiteIcon/SiteIcon");
+const {PlaceholderSiteIcon, SiteIcon} = require("components/SiteIcon/SiteIcon");
+const fakeSiteWithImage = faker.createSite();
 
 const fakeProps = {
   sites: [
@@ -82,5 +83,40 @@ describe("TopSites", () => {
       topSites = renderWithProvider(<TopSites page={"NEW_TAB"} dispatch={dispatch} sites={fakeProps.sites} />);
       TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(topSites, TopSitesItem)[0].refs.topSiteLink);
     });
+  });
+});
+
+describe("TopSitesItem", () => {
+  const fakeSite = fakeSiteWithImage;
+  let instance;
+
+  describe("valid site", () => {
+    beforeEach(() => {
+      instance = renderWithProvider(<TopSitesItem {...fakeSite} />);
+    });
+
+    it("should render a SiteIcon with appropriate props", () => {
+      assert.instanceOf(instance.refs.icon, SiteIcon);
+      assert.include(instance.refs.icon.props.site, fakeSite);
+    });
+  });
+});
+
+describe("PlaceholderTopSitesItem", () => {
+  let instance;
+  let el;
+
+  beforeEach(() => {
+    instance = renderWithProvider(<PlaceholderTopSitesItem />);
+    el = ReactDOM.findDOMNode(instance);
+  });
+
+  it("should have a .placeholder class", () => {
+    assert(el.classList.contains("placeholder"));
+  });
+
+  it("should render a PlaceholderSiteIcon", () => {
+    let icon = TestUtils.findRenderedComponentWithType(instance, PlaceholderSiteIcon);
+    assert.notEqual(null, icon);
   });
 });


### PR DESCRIPTION
… dialog up

See #1675 for details of the intent here.

To test this out:

* view the storybook pages for the new and added files
* do "npm run start" in one shell; and then "npm run firefox -- -p some-profile-with-some-history" in another.  
  * Quickly click "Command-T" to open a new tab as soon as the browser comes up.  If you time it right, you'll see the skeleton page with the dialog, which will morph into a loaded page.


