### PR TITLE
feat (metrics): #1595 implement undesired event pings for loader and missing image

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -316,6 +316,10 @@ ActivityStreams.prototype = {
     this._tabTracker.handleUserEvent(msg.data);
   },
 
+  _handleUndesiredEvent({msg}) {
+    this._tabTracker.handleUndesiredEvent(msg.data);
+  },
+
   _handleExperimentChange(prefName) {
     this._tabTracker.experimentId = this._experimentProvider.exprimentID;
     this.broadcast(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data));
@@ -334,6 +338,8 @@ ActivityStreams.prototype = {
         return this._onRouteChange(args);
       case am.type("NOTIFY_USER_EVENT"):
         return this._handleUserEvent(args);
+      case am.type("NOTIFY_UNDESIRED_EVENT"):
+        return this._handleUndesiredEvent(args);
     }
     return undefined;
   },

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -18,6 +18,7 @@ const COMPLETE_NOTIF = "tab-session-complete";
 const ACTION_NOTIF = "user-action-event";
 const PERFORMANCE_NOTIF = "performance-event";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
+const UNDESIRED_NOTIF = "undesired-event";
 
 function TabTracker(options) {
   this._tabData = {};
@@ -110,6 +111,16 @@ TabTracker.prototype = {
     if (payload.event === "SEARCH" || payload.event === "CLICK") {
       this._tabData.unload_reason = payload.event.toLowerCase();
     }
+  },
+
+  handleUndesiredEvent(payload, experimentId) {
+    payload.action = "activity_stream_masga_event";
+    payload.tab_id = tabs.activeTab.id;
+    this._setCommonProperties(payload, tabs.activeTab.url);
+    if (!("value" in payload)) {
+      payload.value = 0;
+    }
+    Services.obs.notifyObservers(null, UNDESIRED_NOTIF, JSON.stringify(payload));
   },
 
   handlePerformanceEvent(eventData, eventName, value) {

--- a/addon/TelemetrySender.js
+++ b/addon/TelemetrySender.js
@@ -11,6 +11,7 @@ const TELEMETRY_PREF = "telemetry";
 const ACTION_NOTIF = "user-action-event";
 const PERFORMANCE_NOTIF = "performance-event";
 const COMPLETE_NOTIF = "tab-session-complete";
+const UNDESIRED_NOTIF = "undesired-event";
 const LOGGING_PREF = "performance.log";
 
 function TelemetrySender() {
@@ -25,6 +26,7 @@ function TelemetrySender() {
     Services.obs.addObserver(this, COMPLETE_NOTIF, true);
     Services.obs.addObserver(this, ACTION_NOTIF, true);
     Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
+    Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
   }
 }
 
@@ -35,7 +37,7 @@ TelemetrySender.prototype = {
   ]),
 
   observe(subject, topic, data) {
-    if (topic === COMPLETE_NOTIF || topic === ACTION_NOTIF || topic === PERFORMANCE_NOTIF) {
+    if (topic === COMPLETE_NOTIF || topic === ACTION_NOTIF || topic === PERFORMANCE_NOTIF || topic === UNDESIRED_NOTIF) {
       this._sendPing(data);
     }
   },
@@ -50,10 +52,12 @@ TelemetrySender.prototype = {
         Services.obs.removeObserver(this, COMPLETE_NOTIF);
         Services.obs.removeObserver(this, ACTION_NOTIF);
         Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
+        Services.obs.removeObserver(this, UNDESIRED_NOTIF);
       } else if (!this.enabled && newValue) {
         Services.obs.addObserver(this, COMPLETE_NOTIF, true);
         Services.obs.addObserver(this, ACTION_NOTIF, true);
         Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
+        Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
       }
 
       this.enabled = newValue;
@@ -84,6 +88,7 @@ TelemetrySender.prototype = {
         Services.obs.removeObserver(this, COMPLETE_NOTIF);
         Services.obs.removeObserver(this, ACTION_NOTIF);
         Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
+        Services.obs.removeObserver(this, UNDESIRED_NOTIF);
       }
       simplePrefs.removeListener(TELEMETRY_PREF, this._onPrefChange);
       simplePrefs.removeListener(ENDPOINT_PREF, this._onPrefChange);

--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -29,6 +29,7 @@ const am = new ActionManager([
   "NOTIFY_ROUTE_CHANGE",
   "NOTIFY_SHARE_URL",
   "NOTIFY_UNBLOCK_URL",
+  "NOTIFY_UNDESIRED_EVENT",
   "NOTIFY_UPDATE_PREF",
   "NOTIFY_UPDATE_SEARCH_STRING",
   "NOTIFY_USER_EVENT",
@@ -193,6 +194,16 @@ function NotifyEvent(data) {
   return Notify("NOTIFY_USER_EVENT", data);
 }
 
+function NotifyUndesiredEvent(data) {
+  if (!eventConstants.defaultPage === data.page) {
+    throw new Error(`${data.page} is not a valid page`);
+  }
+  if (!eventConstants.undesiredEvents.has(data.event)) {
+    throw new Error(`${data.event} is not a valid event type`);
+  }
+  return Notify("NOTIFY_UNDESIRED_EVENT", data);
+}
+
 function NotifyFilterQuery(data) {
   return Notify("NOTIFY_FILTER_QUERY", data);
 }
@@ -260,6 +271,7 @@ am.defineActions({
   NotifyRouteChange,
   NotifyShareUrl,
   NotifyUnblockURL,
+  NotifyUndesiredEvent,
   NotifyUpdatePref,
   NotifyUpdateSearchString,
   PlacesStatsUpdate,

--- a/common/event-constants.js
+++ b/common/event-constants.js
@@ -16,8 +16,13 @@ const constants = {
     "OPEN_PRIVATE_WINDOW",
     "SEARCH",
     "SHARE",
-    "UNBLOCK",
-    "SHARE_TOOLBAR"
+    "SHARE_TOOLBAR",
+    "UNBLOCK"
+  ]),
+  undesiredEvents: new Set([
+    "HIDE_LOADER",
+    "MISSING_IMAGE",
+    "SHOW_LOADER"
   ]),
   sources: new Set([
     "TOP_SITES",

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -24,6 +24,25 @@ const NewTabPage = React.createClass({
     // have finished (in which case the "Welcome" dialog maybe be being shown
     // without any actual images).
     this.props.dispatch(actions.NotifyPerf("NEWTAB_RENDER"));
+
+    if (!this.props.isReady) {
+      this.loaderShownAt = Date.now();
+      this.props.dispatch(actions.NotifyUndesiredEvent({
+        event: "SHOW_LOADER",
+        source: PAGE_NAME,
+        value: this.loaderShownAt
+      }));
+    }
+  },
+  componentDidUpdate(prevProps) {
+    if (this.props.isReady && this.loaderShownAt) {
+      this.props.dispatch(actions.NotifyUndesiredEvent({
+        event: "HIDE_LOADER",
+        source: PAGE_NAME,
+        value: Date.now() - this.loaderShownAt
+      }));
+      delete this.loaderShownAt;
+    }
   },
   render() {
     const props = this.props;

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -52,6 +52,10 @@ const SpotlightItem = React.createClass({
       style.backgroundImage = `url(${imageUrl})`;
     } else {
       style.backgroundColor = site.backgroundColor;
+      this.props.dispatch(actions.NotifyUndesiredEvent({
+        event: "MISSING_IMAGE",
+        source: "HIGHLIGHTS"
+      }));
     }
     return (<li className={classNames("spotlight-item", {active: this.state.showContextMenu})}>
       <a onClick={this.props.onClick} href={site.url} ref="link">
@@ -93,7 +97,8 @@ SpotlightItem.propTypes = {
   favicon_url: React.PropTypes.string,
   title: React.PropTypes.string.isRequired,
   description: React.PropTypes.string,
-  onClick: React.PropTypes.func
+  onClick: React.PropTypes.func,
+  dispatch: React.PropTypes.func.isRequired
 };
 
 const Spotlight = React.createClass({
@@ -128,6 +133,7 @@ const Spotlight = React.createClass({
           page={this.props.page}
           source="FEATURED"
           onClick={this.onClickFactory(i, site)}
+          dispatch={this.props.dispatch}
           {...site} />)}
       </ul>
     </section>);

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -76,4 +76,16 @@ describe("NewTabPage", () => {
       TestUtils.Simulate.click(deleteLink);
     });
   });
+
+  describe("loader events", () => {
+    it("should fire an event if data isn't ready and we show the loader", done => {
+      renderWithProvider(<NewTabPage {...fakeProps} isReady={false} dispatch={a => {
+        if (a.type === "NOTIFY_UNDESIRED_EVENT") {
+          assert.equal(a.data.event, "SHOW_LOADER");
+          assert.equal(a.data.source, "NEW_TAB");
+          done();
+        }
+      }} />);
+    });
+  });
 });

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -99,5 +99,16 @@ describe("SpotlightItem", () => {
       assert.equal(hc.props.type, "bookmark");
       assert.deepEqual(hc.props, props);
     });
+    it("should fire user event if there is no image", done => {
+      const fakeSiteWithoutImage = Object.assign({}, fakeSiteWithImage, {bestImage: {url: null}});
+      function dispatch(a) {
+        if (a.type === "NOTIFY_UNDESIRED_EVENT") {
+          assert.equal(a.data.event, "MISSING_IMAGE");
+          assert.equal(a.data.source, "HIGHLIGHTS");
+          done();
+        }
+      }
+      instance = renderWithProvider(<SpotlightItem {...fakeSiteWithoutImage} dispatch={dispatch} page={"NEW_TAB"} />);
+    });
   });
 });

--- a/data_dictionary.md
+++ b/data_dictionary.md
@@ -73,6 +73,22 @@ The Activity Stream addon sends various types of pings to the backend (HTTPS POS
 }
 ```
 
+# Example Activity Stream `undesired event` Log
+
+```json
+{
+  "action": "activity_stream_masga_event",
+  "addon_version": "1.0.12",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "event": "MISSING_IMAGE",
+  "locale": "en-US",
+  "page": "NEW_TAB",
+  "source": "HIGHLIGHTS",
+  "tab_id": "-5-2",
+  "value": 0
+}
+```
+
 | KEY | DESCRIPTION | &nbsp; |
 |-----|-------------|:-----:|
 | `action_position` | [Optional] The index of the element in the `source` that was clicked. | :one:

--- a/data_events.md
+++ b/data_events.md
@@ -199,3 +199,55 @@ Here are different scenarios that cause a session end event to be sent and the c
 4. Closing the browser: `"close"`
 5. Refreshing: `"refresh"`
 6. Navigating to a new URL via the url bar: `"navigation"`
+
+## Bad app state pings
+
+In some undesired app states, the app will send a ping about it to our metrics server.
+
+### Types of bad states
+
+#### Highlight without an image
+
+```js
+{
+  "event": "MISSING_IMAGE",
+  "source": "HIGHLIGHTS",
+  "page": "NEW_TAB",
+  "action": "activity_stream_masga_event",
+  "tab_id": "-5-2",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Show loader
+
+```js
+{
+  "event": "SHOW_LOADER",
+  "source": "NEW_TAB",
+  "page": "NEW_TAB",
+  "action": "activity_stream_masga_event",
+  "tab_id": "-5-2",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Hide loader
+
+```js
+{
+  "event": "HIDE_LOADER",
+  "source": "NEW_TAB",
+  "page": "NEW_TAB",
+  "value": 485, // amount of time shown in milliseconds
+  "action": "activity_stream_masga_event",
+  "tab_id": "-5-2",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```


### PR DESCRIPTION
This needs to wait for @ncloudioj to be back to r? the new pings and create the new table. Not sure if @sarracini or @k88hudson is around to r? the addon and frontend code changes?

Fixes #1595 