### PR TITLE
fix(topsites): Combine frecency of deduped pages

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -348,7 +348,7 @@ Links.prototype = {
     // In general the groupby behavior in the absence of aggregates is not
     // defined in SQL, hence we are relying on sqlite implementation that may
     // change in the future.
-    let sqlQuery = `SELECT url, title, frecency, guid, bookmarkGuid,
+    let sqlQuery = `SELECT url, title, SUM(frecency) frecency, guid, bookmarkGuid,
                           last_visit_date / 1000 as lastVisitDate, favicon, mimeType,
                           "history" as type
                     FROM

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -84,6 +84,7 @@ exports.test_Links_getTopFrecentSites_dedupeWWW = function*(assert) {
 
   links = yield provider.getTopFrecentSites();
   assert.equal(links.length, 1, "adding both www. and no-www. yields one link");
+  assert.equal(links[0].frecency, 200, "frecency scores are combined");
 };
 
 exports.test_Links_getTopFrecentSites_Order = function*(assert) {


### PR DESCRIPTION
Fix #1874. r?@sarracini Some pages were picking the lower scored page instead of the higher scored page. We can use both scores by combining them.

