### PR TITLE
fix (debug): #1875 Fix debug page

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
     path: outputDir,
     filename: outputFilename
   },
-  node: {Buffer: false, url: false},
+  node: {Buffer: true, url: false},
   target: "web",
   module: webpack_common.module,
   devtool: env === "production" ? null : "eval", // This is for Firefox


### PR DESCRIPTION
Tweaked webpack config to include polyfill for Buffer because it is
required by object-sizeof.

This was broken in 1917fda4ed555cf28567bbcd85defe1f99168b1c

r? @jaredkerim

Fixes #1875