### PR TITLE
fix(coloranalyzer): Fix #1842 Color Analyzer throwing

### DIFF
--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -173,8 +173,9 @@ PreviewProvider.prototype = {
     return new Promise(resolve => {
       if (!link.favicon) {
         resolve(null);
+        return null;
       }
-      getColor(link.favicon, link.url)
+      return getColor(link.favicon, link.url)
         .then(color => resolve([...color, BACKGROUND_FADE]))
         .catch(err => {
           Cu.reportError(err);


### PR DESCRIPTION
Just resolving doesn't stop the code execution - so it went through to getColor with a null favicon and then ColorAnalyzer exploded. We have to bail out completely if we don't have a favicon