### PR TITLE
fix(highlights): Heavily boost recent bookmarks and not much from 3 days or older

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -2,6 +2,10 @@ module.exports = {
   // The opacity value of favicon background colors
   BACKGROUND_FADE: 0.5,
 
+  // Age of bookmarks in milliseconds that results in a 1.0 quotient, i.e., an
+  // age smaller/younger than this value results in a larger-than-1.0 fraction
+  BOOKMARK_AGE_DIVIDEND: 3 * 24 * 60 * 60 * 1000,
+
   // Number of large Highlight titles in the new Highlights world, including
   // all rows.
   HIGHLIGHTS_LENGTH: 9,

--- a/content-test/common/Baseline.test.js
+++ b/content-test/common/Baseline.test.js
@@ -392,7 +392,7 @@ describe("Baseline", () => {
       assert.throws(() => baseline.decay(10, {foo: 1, bar: undefined}, [2, 3]));
     });
     it("should call filter on the features", () => {
-      const result = baseline.decay(10, {foo: 1, isBookmarked: 2}, [1]);
+      const result = baseline.decay(10, {foo: 1, bookmarkAge: 2}, [1]);
 
       assert.isNumber(result);
     });
@@ -412,7 +412,7 @@ describe("Baseline", () => {
           queryLength: 0,
           imageCount: 1,
           pathLength: 1,
-          isBookmarked: 0,
+          bookmarkAge: 0,
           description: 10,
           image: 1
         }
@@ -469,13 +469,22 @@ describe("Baseline", () => {
     });
 
     it("should rank bookmarks higher", () => {
-      const features = Object.assign({}, entry.features, {isBookmarked: 1});
+      const features = Object.assign({}, entry.features, {bookmarkAge: 1});
       const bookmarkScore = baseline.adjustScore(10, features);
       const regularScore = baseline.adjustScore(10, entry.features);
 
       assert.isNumber(bookmarkScore);
       assert.isNumber(regularScore);
       assert.ok(bookmarkScore > regularScore);
+    });
+
+    it("should rank newer bookmarks higher", () => {
+      const oldFeatures = Object.assign({}, entry.features, {bookmarkAge: 100});
+      const oldScore = baseline.adjustScore(10, oldFeatures);
+      const newFeatures = Object.assign({}, entry.features, {bookmarkAge: 1});
+      const newScore = baseline.adjustScore(10, newFeatures);
+
+      assert.ok(newScore > oldScore);
     });
   });
 


### PR DESCRIPTION
Fix #1887. Instead of a fixed number, base the boost on the age of the bookmark. r?@ncloudioj 