### PR TITLE
fix(pagescraper): Fix #1859 PageScraper unhandled exception

### DIFF
--- a/addon/MetadataParser.js
+++ b/addon/MetadataParser.js
@@ -38,10 +38,8 @@ MetadataParser.prototype = {
    * Parse HTML, get the metadata from it, and format it
    */
   parseHTMLText(raw, url) {
-    return new Promise(resolve => {
-      const doc = this._getDocumentObject(raw);
-      resolve(this._formatData(getMetadata(doc, url), url));
-    });
+    const doc = this._getDocumentObject(raw);
+    return this._formatData(getMetadata(doc, url), url);
   }
 };
 

--- a/content-test/addon/MetadataParser.test.js
+++ b/content-test/addon/MetadataParser.test.js
@@ -69,14 +69,13 @@ describe("MetadataParser", () => {
       "favicon_url": TEST_ICON,
       "description": TEST_DESCRIPTION
     };
-    return metadataParser.parseHTMLText(TEST_HTML, url).then(result => {
-      assert.ok(result);
-      assert.equal(result.url, expectedResult.url);
-      assert.equal(result.provider_name, expectedResult.provider_name);
-      assert.equal(result.title, expectedResult.title);
-      assert.equal(result.description, expectedResult.description);
-      assert.deepEqual(result.images, expectedResult.images);
-      assert.equal(result.favicon_url, TEST_ICON);
-    });
+    let result = metadataParser.parseHTMLText(TEST_HTML, url);
+    assert.ok(result);
+    assert.equal(result.url, expectedResult.url);
+    assert.equal(result.provider_name, expectedResult.provider_name);
+    assert.equal(result.title, expectedResult.title);
+    assert.equal(result.description, expectedResult.description);
+    assert.deepEqual(result.images, expectedResult.images);
+    assert.equal(result.favicon_url, TEST_ICON);
   });
 });

--- a/data/page-scraper-content-script.js
+++ b/data/page-scraper-content-script.js
@@ -25,9 +25,11 @@ DOMFetcher.prototype = {
   },
 
   _sendContentMessage() {
-    const text = content.document.documentElement.outerHTML;
-    const url = content.document.documentURI;
-    sendAsyncMessage("page-scraper-message", {type: "PAGE_HTML", data: {text, url}});
+    if (content.document.documentElement) {
+      const text = content.document.documentElement.outerHTML;
+      const url = content.document.documentURI;
+      sendAsyncMessage("page-scraper-message", {type: "PAGE_HTML", data: {text, url}});
+    }
   }
 };
 

--- a/test/test-PageScraper.js
+++ b/test/test-PageScraper.js
@@ -79,18 +79,20 @@ exports.test_no_metadata_returned = function*(assert) {
   assert.equal(gMetadataStore[0].metadata, DUMMY_PARSED_METADATA.metadata, "we did insert a page with metadata");
 };
 
-exports.test_parse_html_rejects = function*(assert) {
+exports.test_parse_html_rejects = function(assert) {
   // force the metadata parser to throw an execption
   gPageScraper._metadataParser = {
     parseHTMLText() {
-      return Promise.reject();
+      throw new Error();
     }
   };
   // the DB should be empty to start
   assert.equal(gMetadataStore[0], undefined, "sanity check that our store is empty");
 
   // try to insert some empty metadata and make sure that it didn't get inserted
-  yield gPageScraper._asyncParseAndSave({});
+  gPageScraper._asyncParseAndSave({})
+    .then(() => assert.ok(false, "only called if the parse was successful"))
+    .catch(() => assert.ok(true, "the parsing exception was caught"));
   assert.equal(gMetadataStore[0], undefined, "we didn't insert the page with no metadata");
 };
 
@@ -133,7 +135,7 @@ before(exports, () => {
   gPageScraper._metadataParser = {
     parseHTMLText(raw, url) {
       parseCallCount++;
-      return Promise.resolve({images: [], title: raw.title, favicon_url: raw.favicon_url, url, metadata: raw.metadata, cache_key: url});
+      return {images: [], title: raw.title, favicon_url: raw.favicon_url, url, metadata: raw.metadata, cache_key: url};
     }
   };
 });


### PR DESCRIPTION
Makes ```parseHTMLText``` synchronous LIKE IT SHOULD BE
Properly catches errors in ```PageScraper```
Checks that the document actually exists before attempting to get it's outerHTML
Update tests