### PR TITLE
fix(newtab): Show a border between top site icon/title and highlight picture/details

### DIFF
--- a/content-src/components/SiteIcon/SiteIcon.js
+++ b/content-src/components/SiteIcon/SiteIcon.js
@@ -77,7 +77,7 @@ SiteIcon.propTypes = {
 const PlaceholderSiteIcon = React.createClass({
   render() {
     return (
-      <div ref="icon" className="spotlight-icon">
+      <div ref="icon" className="site-icon">
         <div className="site-icon-wrapper" />
         <div className="site-icon-title" />
       </div>

--- a/content-src/components/SiteIcon/SiteIcon.scss
+++ b/content-src/components/SiteIcon/SiteIcon.scss
@@ -37,6 +37,9 @@
     width: 100%;
     font-size: $tile-title-font-size;
     border-radius: 0 0 $border-radius $border-radius;
+    border-top-color: $faintest-black;
+    border-top-style: solid;
+    border-top-width: 1px;
     background-color: $tile-title-bg-color;
     height: $tile-title-height;
     line-height: $tile-title-height;

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -4,7 +4,7 @@ const {justDispatch} = require("common/selectors/selectors");
 const getHighlightContextFromSite = require("common/selectors/getHighlightContextFromSite");
 const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 const {actions} = require("common/action-manager");
-const {SiteIcon, PlaceholderSiteIcon} = require("components/SiteIcon/SiteIcon");
+const {SiteIcon} = require("components/SiteIcon/SiteIcon");
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
 const {HighlightContext, PlaceholderHighlightContext} = require("components/HighlightContext/HighlightContext");
@@ -94,7 +94,7 @@ const PlaceholderSpotlightItem = React.createClass({
       <li className="spotlight-item placeholder">
         <a>
           <div className="spotlight-image portrait" ref="image">
-            <PlaceholderSiteIcon />
+            <div className="spotlight-icon" ref="icon" />
           </div>
           <div className="inner-border" />
         </a>

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -57,6 +57,9 @@
     background-position: center;
     background-repeat: no-repeat;
     height: $spotlight-img-height;
+    border-bottom-color: $faintest-black;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
     border-radius: $border-radius $border-radius 0 0;
 
     &.portrait {

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -25,10 +25,6 @@
         height: 74px;
       }
 
-      .site-icon-title {
-        border-top: 1px solid $faintest-black;
-      }
-
       .tile {
         box-shadow: none;
       }

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -8,7 +8,7 @@ const {PlaceholderHighlightContext, HighlightContext} = require("components/High
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
-const {PlaceholderSiteIcon, SiteIcon} = require("components/SiteIcon/SiteIcon");
+const {SiteIcon} = require("components/SiteIcon/SiteIcon");
 const {mockData, faker, renderWithProvider} = require("test/test-utils");
 const fakeSpotlightItems = mockData.Highlights.rows;
 const fakeSiteWithImage = faker.createSite();
@@ -120,8 +120,8 @@ describe("PlaceholderSpotlightItem", () => {
 
     assert.instanceOf(hc, PlaceholderHighlightContext);
   });
-  it("should render a PlaceholderSiteIcon", () => {
-    const icon = TestUtils.findRenderedComponentWithType(instance, PlaceholderSiteIcon);
+  it("should render an icon", () => {
+    const icon = instance.refs.icon;
     assert.notEqual(null, icon);
   });
 });


### PR DESCRIPTION
Fix #1892. r?@dmose There was a reference to "spotlight-icon" from `PlaceholderSiteIcon` that was being used for `PlaceholderSpotlightItem`, so I switched it to "site-icon" and updated both places.

After/before pictures here: https://github.com/mozilla/activity-stream/issues/1892#issuecomment-268619007