### PR TITLE
feat(metadata): Closes #1685 Fetch page content locally

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -95,7 +95,8 @@ function ActivityStreams(metadataStore, tabTracker, telemetrySender, options = {
     fetchNewMetadata: (links, type) => {
       const event = this._tabTracker.generateEvent({source: type});
       return this._previewProvider.asyncSaveLinks(links, event);
-    }
+    },
+    fetchNewMetadataLocally: (links, type) => this._pageScraper.asyncFetchLinks(links, type)
   });
   this._store = createStore({middleware: this._feeds.reduxMiddleware});
   this._feeds.connectStore(this._store);

--- a/addon/Feeds/MetadataFeed.js
+++ b/addon/Feeds/MetadataFeed.js
@@ -1,6 +1,7 @@
 /* globals module, require */
 "use strict";
 const {PlacesProvider} = require("addon/PlacesProvider");
+const simplePrefs = require("sdk/simple-prefs");
 const Feed = require("addon/lib/Feed");
 const am = require("common/action-manager");
 const MAX_NUM_LINKS = 5;
@@ -29,6 +30,11 @@ module.exports = class MetadataFeed extends Feed {
   getData() {
     let links = Array.from(this.linksToFetch.keys(), item => Object.assign({"url": item}));
     this.linksToFetch.clear();
+
+    // if we are in the experiment, make a network request through PageScraper
+    if (simplePrefs.prefs["experiments.locallyFetchMetadata"]) {
+      return this.options.fetchNewMetadataLocally(links, "METADATA_FEED_REQUEST").then(() => (am.actions.Response("METADATA_FEED_UPDATED")));
+    }
     return this.options.fetchNewMetadata(links, "METADATA_FEED_REQUEST").then(() => (am.actions.Response("METADATA_FEED_UPDATED")));
   }
   onAction(state, action) {

--- a/addon/PageScraper.js
+++ b/addon/PageScraper.js
@@ -9,10 +9,21 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.importGlobalProperties(["URL"]);
+Cu.importGlobalProperties(["fetch"]);
 
 const DEFAULT_OPTIONS = {
   framescriptPath: new URL("data/page-scraper-content-script.js", options.prefixURI),
   blacklist: ["about:", "localhost:", "resource://"]
+};
+const PERFORMANCE_EVENT_NAMES = {
+  framescript_event: "framescriptMessageReceived",
+  local_fetch_event: "localFetchStarted",
+  metadata_raw_html: "metadataReceivedRawHTML",
+  metadata_exists: "metadataExists",
+  metadata_invalid: "metadataInvalidReceived",
+  metadata_sucess: "metadataParseSuccess",
+  metadata_fail: "metadataParseFail",
+  network_fail: "networkRequestFailed"
 };
 
 function PageScraper(previewProvider, tabTracker, options = {}) {
@@ -30,30 +41,71 @@ function PageScraper(previewProvider, tabTracker, options = {}) {
 
 PageScraper.prototype = {
   /**
-   * Check if the link is already in the metadata database. If not, parse the
-   * HTML and insert it in the metadata database
+   * Parse the HTML and attempt to insert it in the metadata database
    */
-  _asyncParseAndSave: Task.async(function*(rawHTML, url, event) {
-    let startTime = Date.now();
-    this._tabTracker.handlePerformanceEvent(event, "metadataReceivedRawHTML", startTime);
-
-    let link = yield this._previewProvider.asyncLinkExist(url);
-    if (!link) {
-      const metadata = this._metadataParser.parseHTMLText(rawHTML, url);
-      if (this._shouldSaveMetadata(metadata)) {
-        try {
-          metadata.images = yield this._computeImageSize(metadata);
-        } catch (e) {
-          Cu.reportError(`PageScraper failed to compute image size for ${url}`);
-        }
-        this._insertMetadata(metadata);
-        this._tabTracker.handlePerformanceEvent(event, "metadataParseSuccess", Date.now() - startTime);
-      } else {
-        this._tabTracker.handlePerformanceEvent(event, "metadataInvalidReceived", Date.now() - startTime);
-      }
-    } else {
-      this._tabTracker.handlePerformanceEvent(event, "metadataExists", Date.now() - startTime);
+  _parseAndSave(rawHTML, url, event) {
+    this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.metadata_raw_html, Date.now());
+    let metadata;
+    try {
+      metadata = this._metadataParser.parseHTMLText(rawHTML, url);
+    } catch (err) {
+      Cu.reportError(`MetadataParser failed to parse ${url}. ${err}`);
+      this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.metadata_fail, Date.now());
+      return;
     }
+    this._asyncSaveMetadata(metadata, event);
+  },
+
+  /**
+   * Save the metadata in the MetadataStore DB
+   */
+  _asyncSaveMetadata: Task.async(function*(metadata, event) {
+    const startTime = Date.now();
+    const shouldSaveMetadata = yield this._shouldSaveMetadata(metadata);
+    if (!shouldSaveMetadata) {
+      return;
+    }
+    try {
+      metadata.images = yield this._computeImageSize(metadata);
+    } catch (e) {
+      Cu.reportError(`PageScraper failed to compute image size for ${metadata.url}`);
+    }
+    this._previewProvider.processAndInsertMetadata(metadata, "Local");
+    this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.metadata_sucess, Date.now() - startTime);
+  }),
+
+  /**
+   * Make a network request for links that the MetadataFeed has requested metadata for.
+   * Attempt to parse the html from that page and insert into the DB
+   */
+  asyncFetchLinks: Task.async(function*(links, eventType) {
+    for (let link of links) {
+      const event = this._tabTracker.generateEvent({source: eventType});
+      this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.local_fetch_event, Date.now());
+      let linkExists = yield this._previewProvider.asyncLinkExist(link.url);
+      if (linkExists) {
+        this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.metadata_exists, Date.now());
+        return;
+      }
+      let rawHTML;
+      try {
+        rawHTML = yield this._fetchContent(link.url);
+      } catch (err) {
+        Cu.reportError(`PageScraper failed to get page content for ${link.url}. ${err}`);
+        this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.network_fail, Date.now());
+        return;
+      }
+      this._parseAndSave(rawHTML, link.url, event);
+    }
+  }),
+
+  /**
+   * Wrapper for requesting the URL and returning it's DOM
+   */
+  _fetchContent: Task.async(function*(url) {
+    const response = yield fetch(url);
+    const rawHTML = yield response.text();
+    return rawHTML;
   }),
 
   /**
@@ -80,19 +132,21 @@ PageScraper.prototype = {
   },
 
   /**
-   * Insert the metadata in the metadata database, along with it's source.
-   */
-  _insertMetadata(metadata) {
-    this._previewProvider.processAndInsertMetadata(metadata, "Local");
-  },
-
-  /**
    * If metadata has neither a title, nor a favicon_url we do not want to insert
-   * it into the metadata DB
+   * it into the metadata DB. If the link already exists we do not want to insert
+   * it into the metadata DB. Capture both events
    */
-  _shouldSaveMetadata(metadata) {
-    return (metadata && !!metadata.title && !!metadata.favicon_url);
-  },
+  _shouldSaveMetadata: Task.async(function*(metadata, event) {
+    const linkExists = yield this._previewProvider.asyncLinkExist(metadata.url);
+    if (linkExists) {
+      this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.metadata_exists, Date.now());
+    }
+    const hasMetadata = metadata && !!metadata.title && !!metadata.favicon_url;
+    if (!hasMetadata) {
+      this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.metadata_invalid, Date.now());
+    }
+    return (hasMetadata && !linkExists);
+  }),
 
   /**
    * Ensure that the page doesn't belong to a blacklist by checking that the
@@ -104,27 +158,30 @@ PageScraper.prototype = {
   },
 
   /**
+   * Message handler for the incoming framescript messages
+   */
+  _messageHandler(message) {
+    let {text, url} = message.data.data;
+    if (message.data.type === "PAGE_HTML" && this._blacklistFilter(url)) {
+      const event = this._tabTracker.generateEvent({source: "PAGE_SCRAPER"});
+      this._tabTracker.handlePerformanceEvent(event, PERFORMANCE_EVENT_NAMES.framescript_event, Date.now());
+      this._parseAndSave(text, url, event);
+    }
+  },
+
+  /**
    * Initialize the Page Scraper
    */
   init() {
     Services.mm.loadFrameScript(this.options.framescriptPath, true);
-    Services.mm.addMessageListener("page-scraper-message", message => {
-      let {text, url} = message.data.data;
-      if (message.data.type === "PAGE_HTML" && this._blacklistFilter(url)) {
-        const event = this._tabTracker.generateEvent({source: "PAGE_SCRAPER"});
-        this._asyncParseAndSave(text, url, event).catch(err => {
-          Cu.reportError(`MetadataParser failed to parse ${url}. ${err}`);
-          this._tabTracker.handlePerformanceEvent(event, "metadataParseFail", Date.now());
-        });
-      }
-    });
+    Services.mm.addMessageListener("page-scraper-message", this._messageHandler.bind(this));
   },
 
   /**
    * Uninitialize the Page Scraper
    */
   uninit() {
-    Services.mm.removeMessageListener("page-scraper-message", this);
+    Services.mm.removeMessageListener("page-scraper-message", this._messageHandler);
     Services.mm.removeDelayedFrameScript(this.options.framescriptPath);
   }
 };

--- a/experiments.json
+++ b/experiments.json
@@ -88,5 +88,20 @@
       "threshold": 0.5,
       "description": "Use combined frecency"
     }
+  },
+  "locallyFetchMetadata": {
+    "name": "Fetch Page Content Locally",
+    "active": true,
+    "description": "Make a network request for content of a URL",
+    "control": {
+      "value": false,
+      "description": "Use remote service for metadata"
+    },
+    "variant": {
+      "id": "exp-007-locally-fetch-metadata",
+      "value": true,
+      "threshold": 0.1,
+      "description": "Fetch page content locally"
+    }
   }
 }

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -103,7 +103,8 @@ function getTestActivityStream(options = {}) {
     options: {framescriptPath: ""},
     init() {},
     uninit() {},
-    _asyncParseAndSave() {}
+    _parseAndSave() {},
+    asyncFetchLinks() {}
   };
 
   const mockPageWorker = {


### PR DESCRIPTION
* Creates an experiment to fetch page content locally
* If the experiment is on - call a new function in PageScraper
* Split some logic in PageScraper for less code duplication with new function
* Create a separate function for framescript listener (having it in the init is yucky)
* Update existing tests
* Write new tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1894)
<!-- Reviewable:end -->
