### PR TITLE
feat(content): #1906 Add Snippet component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -10,6 +10,7 @@ function loadStories() {
   require("../content-test/components/ContextMenu.story");
   require("../content-test/components/Hint.story");
   require("../content-test/components/Loader.story");
+  require("../content-test/components/Snippet.story");
   // require as many stories as you need.
 }
 

--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -4,6 +4,7 @@ const {selectNewTabSites} = require("common/selectors/selectors");
 const {assignImageAndBackgroundColor} = require("common/selectors/colorSelectors");
 const {Spotlight, SpotlightItem} = require("components/Spotlight/Spotlight");
 const TopSites = require("components/TopSites/TopSites");
+const Snippet = require("components/Snippet/Snippet");
 const sizeof = require("object-sizeof");
 const {ShowAllHints} = require("common/action-manager").actions;
 const experimentDefinitions = require("../../../experiments.json");
@@ -44,7 +45,8 @@ const DebugPage = React.createClass({
     return {
       component: "TopSites",
       dataSource: "TopSites",
-      highlightData: createHighlightData()
+      highlightData: createHighlightData(),
+      showSnippet: true
     };
   },
   render() {
@@ -87,6 +89,12 @@ const DebugPage = React.createClass({
               })}
             </tbody>
           </table>
+        </section>
+
+        <section>
+          <h2>Example Snippet</h2>
+          <p hidden={!this.state.showSnippet}>Snippet should show up at the bottom of your screen.</p>
+          <p hidden={this.state.showSnippet}><button onClick={() => this.setState({showSnippet: true})}>Show Snippet</button></p>
         </section>
 
         <section>
@@ -139,6 +147,12 @@ const DebugPage = React.createClass({
           ))}
         </section>
       </div>
+      <Snippet
+        visible={this.state.showSnippet}
+        setVisibility={value => this.setState({showSnippet: value})}
+        image="https://support.cdn.mozilla.net/static/sumo/img/firefox-512.png?v=1"
+        description="Your snippet text goes here and should not be any longer than a Tweet, (140 characters). <a href='#'>Links should look like this.</a>"
+        title="Snippet Headline" />
     </main>);
   }
 });

--- a/content-src/components/HighlightContext/HighlightContext.js
+++ b/content-src/components/HighlightContext/HighlightContext.js
@@ -2,8 +2,10 @@ const React = require("react");
 const highlightTypes = require("./types");
 const Tooltip = require("components/Tooltip/Tooltip");
 const getRelativeTime = require("lib/getRelativeTime");
+const PureRenderMixin = require("react-addons-pure-render-mixin");
 
 const HighlightContext = React.createClass({
+  mixins: [PureRenderMixin],
   render() {
     let timestamp;
     const type = this.props.type;
@@ -39,6 +41,7 @@ HighlightContext.propTypes = {
  * The bottom line: we should start using Enzyme and switch this over.
  */
 const PlaceholderHighlightContext = React.createClass({
+  mixins: [PureRenderMixin],
   render() {
     return (
       <div className="highlight-context placeholder">

--- a/content-src/components/Snippet/Snippet.js
+++ b/content-src/components/Snippet/Snippet.js
@@ -1,0 +1,55 @@
+const React = require("react");
+const classNames = require("classnames");
+
+const Snippet = React.createClass({
+  onClose(e) {
+    e.preventDefault();
+    this.props.setVisibility(false);
+  },
+  render() {
+    const {visible, description, title, image} = this.props;
+    const imageAttributes = {
+      className: classNames("snippet-image", {"placeholder": !image}),
+      style: {backgroundImage: image ? `url(${image})` : "none"}
+    };
+    return (<div className={classNames("snippet", {"hide-with-fade-out": !visible})}>
+      <div className="snippet-container">
+        <div ref="image" {...imageAttributes} />
+        <div className="snippet-text">
+          {title && <h3 ref="title" className="snippet-title">{title}</h3>}
+          {/*
+            NOTE: This could potentially be dangerous if we end up changing
+            the data source to something other than commited strings to the repo.
+            We should consider sanitization/reevaluating this strategy when we
+            change the data source for snippets.
+          */}
+          <p
+            dangerouslySetInnerHTML={{__html: description}} // eslint-disable-line react/no-danger
+            className="snippet-description"
+            ref="description" />
+        </div>
+      </div>
+      <button ref="closeButton" className="snippet-close-button" onClick={this.onClose}>
+        <span className="icon icon-dismiss" />
+        <span className="sr-only">Close snippet</span>
+      </button>
+    </div>);
+  }
+});
+
+/**
+ * Snippet - A component for the New Tab page snippet
+ *
+ * @prop  {bool} visible        Determines whether the snippet is currently visible or not
+ * @prop  {string} description  ~140 character text in the snippet
+ * @prop  {string} title        Bold text at the top of the snippet
+ * @prop  {func} setVisibility  Called with false when the user clicks on the 'close' button
+ */
+Snippet.propTypes = {
+  visible: React.PropTypes.bool,
+  description: React.PropTypes.string.isRequired,
+  title: React.PropTypes.string,
+  setVisibility: React.PropTypes.func.isRequired
+};
+
+module.exports = Snippet;

--- a/content-src/components/Snippet/Snippet.js
+++ b/content-src/components/Snippet/Snippet.js
@@ -1,7 +1,15 @@
 const React = require("react");
 const classNames = require("classnames");
 
+/**
+ * This should be a stateless, functional component.  Unfortunately, testing these kinda sucks; see
+ * http://stackoverflow.com/questions/36682241/testing-functional-components-with-renderintodocument)
+ * So for now, we are using PureRenderMixin.
+ */
+const PureRenderMixin = require("react-addons-pure-render-mixin");
+
 const Snippet = React.createClass({
+  mixins: [PureRenderMixin],
   onClose(e) {
     e.preventDefault();
     this.props.setVisibility(false);

--- a/content-src/components/Snippet/Snippet.scss
+++ b/content-src/components/Snippet/Snippet.scss
@@ -1,0 +1,78 @@
+.snippet {
+  $snippet-padding: 26px;
+  $snippet-bg-color: rgba($white, 0.95);
+  $snippet-divider-color: rgba($black, 0.1);
+  $snippet-width: 500px;
+  $snippet-base-font-size: 12px;
+  $snippet-title-size: 14px;
+  $snippet-image-size: 64px;
+  $snippet-image-margin: 15px;
+  $snippet-link-color: $link-blue;
+
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: $snippet-bg-color;
+  padding: $snippet-padding;
+  border-top: 1px solid $snippet-divider-color;
+  z-index: 1000;
+  align-items: center;
+
+  &.hide-with-fade-out {
+    transition: opacity 250ms ease-out, transform 250ms ease-out;
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  .snippet-container {
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    max-width: $snippet-width;
+    font-size: $snippet-base-font-size;
+  }
+
+  .snippet-image {
+    width: $snippet-image-size;
+    height: $snippet-image-size;
+    background-size: cover;
+    margin-right: $snippet-image-margin;
+    flex-shrink: 0;
+
+    &.placeholder {
+      border-radius: 8px;
+      border: 1px dashed $faintest-black;
+      background-color: $bg-grey;
+    }
+  }
+
+  .snippet-text {
+    a {
+      color: $snippet-link-color;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    .snippet-title {
+      font-size: $snippet-title-size;
+      // This is in ems since it should be relative to the title size
+      margin: 0 0 0.2em;
+    }
+
+    .snippet-description {
+      margin: 0;
+    }
+  }
+
+  .snippet-close-button {
+    background: none;
+    border: 0;
+    padding: 8px;
+    cursor: pointer;
+  }
+}

--- a/content-src/main.scss
+++ b/content-src/main.scss
@@ -89,3 +89,4 @@ a {
 @import './components/HighlightContext/HighlightContext';
 @import './components/Tooltip/Tooltip';
 @import './components/Hint/Hint';
+@import './components/Snippet/Snippet';

--- a/content-test/components/Snippet.story.js
+++ b/content-test/components/Snippet.story.js
@@ -1,0 +1,16 @@
+const React = require("react");
+const {storiesOf} = require("@kadira/storybook");
+const Snippet = require("components/Snippet/Snippet");
+
+const sampleProps = {
+  visible: true,
+  title: "Snippet Headline",
+  image: "https://support.cdn.mozilla.net/static/sumo/img/firefox-512.png?v=1",
+  description: "Your snippet text goes here and should not be any longer than a Tweet, (140 characters). <a href='#'>Links should look like this.</a>",
+  setVisibility: () => {}
+};
+
+storiesOf("Snippet", module)
+  .add("Basic example", () => <Snippet {...sampleProps} />)
+  .add("No title", () => <Snippet {...sampleProps} title={null} />)
+  .add("No image", () => <Snippet {...sampleProps} image={null} />);

--- a/content-test/components/Snippet.test.js
+++ b/content-test/components/Snippet.test.js
@@ -1,0 +1,65 @@
+const React = require("react");
+const Snippet = require("components/Snippet/Snippet");
+const TestUtils = require("react-addons-test-utils");
+const ReactDOM = require("react-dom");
+
+const validProps = {
+  visible: true,
+  title: "Snippet Headline",
+  image: "https://support.cdn.mozilla.net/static/sumo/img/firefox-512.png?v=1",
+  description: "Your snippet text goes here and should not be any longer than a Tweet, (140 characters). <a href='#'>Links should look like this.</a>",
+  setVisibility: () => {}
+};
+
+function createInstance(custom = {}) {
+  return TestUtils.renderIntoDocument(<Snippet {...Object.assign({}, validProps, custom)} />);
+}
+
+describe("Snippet", () => {
+  it("should render a snippet", () => {
+    assert.ok(createInstance());
+  });
+  describe(".visible", () => {
+    it("should not be hidden be default", () => {
+      assert.notInclude(ReactDOM.findDOMNode(createInstance()).className, "hide-with-fade-out");
+    });
+    it("should hide the snippet if props.visible is false", () => {
+      const instance = createInstance({visible: false});
+      assert.include(ReactDOM.findDOMNode(instance).className, "hide-with-fade-out");
+    });
+  });
+  describe(".setVisibility", () => {
+    it("should call props.setVisibility with false when the close button is clicked", () => {
+      const setVisibility = sinon.spy();
+      const instance = createInstance({setVisibility});
+      TestUtils.Simulate.click(instance.refs.closeButton);
+      assert.calledWith(setVisibility, false);
+    });
+  });
+  describe(".title", () => {
+    it("should show the title prop", () => {
+      const instance = createInstance({title: "Foo bar"});
+      assert.equal(instance.refs.title.textContent, "Foo bar");
+    });
+    it("should hide the title element if no title is given", () => {
+      const instance = createInstance({title: null});
+      assert.isUndefined(instance.refs.title);
+    });
+  });
+  describe(".description", () => {
+    it("should show the description prop", () => {
+      const instance = createInstance({description: "Foo bar"});
+      assert.equal(instance.refs.description.textContent, "Foo bar");
+    });
+  });
+  describe(".image", () => {
+    it("should show the image prop", () => {
+      const instance = createInstance();
+      assert.equal(instance.refs.image.style.backgroundImage, `url("${validProps.image}")`);
+    });
+    it("should add the .placeholder class if no image is supplied", () => {
+      const instance = createInstance({image: null});
+      assert.include(instance.refs.image.className, "placeholder");
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "object-sizeof": "1.1.1",
     "page-metadata-parser": "0.5.2",
     "react": "15.3.2",
+    "react-addons-pure-render-mixin": "15.3.2",
     "react-dom": "15.3.2",
     "react-json-inspector": "7.0.0",
     "react-redux": "4.4.5",


### PR DESCRIPTION
This patch adds a `Snippet` component, as well as an example in the `Debug` page, a storybook, and tests. Refer to the trello card for more information: https://trello.com/c/LmsamLox/39-as-mozilla-we-want-to-inform-our-users-about-interesting-things-marketing-initiatives-friendly-tips-other

To try it:
- Open the debug page, you should see it in the bottom
- Run `npm run storybooks`

Notes:
- I had to use `dangerouslySetInnerHTML` for the snippet description, since it sometimes contains links/other HTML. However, because this text is controlled internally, this should be OK. We should keep this in mind whenever we decide how to store/ship snippet content.
- There is no implementation of the snippet yet on the New Tab page, I will do that once we confirm the variants for the experiment in #1904

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1907)
<!-- Reviewable:end -->
