### PR TITLE
fix(coloranalyzer): Fixes #1920 Resolve on null color for ColorAnalyzer

### DIFF
--- a/addon/ColorAnalyzerProvider.js
+++ b/addon/ColorAnalyzerProvider.js
@@ -10,7 +10,7 @@ exports.getColor = function getColor(dataURI, label) {
           const rgb = [(number >> 16) & 0xFF, (number >> 8) & 0xFF, number & 0xFF];
           resolve(rgb);
         } else {
-          reject(new Error(`There was an error processing ${label}`));
+          resolve(null);
         }
       });
     } catch (e) {

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -176,7 +176,13 @@ PreviewProvider.prototype = {
         return null;
       }
       return getColor(link.favicon, link.url)
-        .then(color => resolve([...color, BACKGROUND_FADE]))
+        .then(color => {
+          if (!color) {
+            resolve(null);
+          } else {
+            resolve([...color, BACKGROUND_FADE]);
+          }
+        })
         .catch(err => {
           Cu.reportError(err);
           resolve(null);


### PR DESCRIPTION
Shuts ColorAnalyzer up because it's crying all the time for no reason

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1922)
<!-- Reviewable:end -->
