### PR TITLE
fix (addon): #1867 fix ExperimentProvider exception on unload.

### DIFF
--- a/content-test/addon/ExperimentProvider.test.js
+++ b/content-test/addon/ExperimentProvider.test.js
@@ -32,11 +32,8 @@ describe("ExperimentProvider", () => {
 
   function setup(options = {}) {
     const {experiments, n} = Object.assign({}, DEFAULT_OPTIONS, options);
-    const {ExperimentProvider} = createExperimentProvider({
-      "sdk/preferences/service": prefService,
-      "sdk/preferences/event-target": PrefsTarget
-    });
-    experimentProvider = new ExperimentProvider(experiments, n && (() => n));
+    const {ExperimentProvider} = createExperimentProvider({"sdk/preferences/event-target": PrefsTarget});
+    experimentProvider = new ExperimentProvider(experiments, n && (() => n), prefService);
     experimentProvider.init();
   }
 


### PR DESCRIPTION
Switched to using Provider.jsm instead of sdk/preferences/service.

That fixed the issue. You can repro/verify fix by disabling and enabling from about:addons looking at your browser console.

Maybe we should make this switch everywhere in the codebase?

r? @jaredkerim 

Fixes #1867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1924)
<!-- Reviewable:end -->
