### PR TITLE
fix (addon): #1867 fix ExperimentProvider exception on unload

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -494,9 +494,9 @@ ActivityStreams.prototype = {
       case "disable":
       case "uninstall":
         this._tabTracker.handleUserEvent({event: reason});
-        this._experimentProvider.clearPrefs();
         this._unsetHomePage();
         defaultUnload();
+        this._experimentProvider.clearPrefs();
         break;
       default:
         defaultUnload();


### PR DESCRIPTION
We were clearing the prefs before unhooking the pref change listeners. Clearing the prefs at the end of unload fixes the issue.

You can repro/verify fix by disabling and enabling from about:addons looking at your browser console.

r? @jaredkerim

Fixes #1867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1925)
<!-- Reviewable:end -->
