### PR TITLE
fix(addon): #1877 Attach number of highlights in session ping

### DIFF
--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -167,6 +167,25 @@ TabTracker.prototype = {
     // in order to provide the more sepcific reasons other than "navigation"
     this._tabData.unload_reason = this._tabData.unload_reason || reason;
 
+    // Attach the number of highlights to the payload. Fetching the highlight count
+    // here other than doing so in onOpen to make it cover all the cases, such as
+    // new tab, refresh, back, and re-activate
+    //
+    // Note: the selector "selectAndDedup" on the content side might filter out some
+    // highlight links if they also belong to the Top Sites. The highlight count
+    // would be greater than the actual value in this case. This discrepancy will
+    // eventually go away as we are phasing out the filtering in the selectAndDedup
+    if (this._store) {
+      const currentState = this._store.getState();
+      if (currentState.Highlights.error || !currentState.Highlights.init) {
+        this._tabData.highlights_size = -1;
+      } else {
+        this._tabData.highlights_size = currentState.Highlights.rows.length;
+      }
+    } else {
+      this._tabData.highlights_size = -1;
+    }
+
     if (!this._tabData.tab_id) {
       // We're navigating away from an activity streams page that
       // didn't even load yet. Let's say it's been active for 0 seconds.

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -29,7 +29,8 @@ const EXPECTED_KEYS = [
   "total_bookmarks",
   "total_history_size",
   "unload_reason",
-  "url"
+  "url",
+  "highlights_size"
 ];
 
 let ACTIVITY_STREAMS_URL;


### PR DESCRIPTION
This closes #1877. 

The related change for the data pipeline is already deployed. We only track the total number of highlights as the first step instead of the breakdown as specified in #1877. The more detailed information could be implemented in the follow-up PRs or possibly by a new ping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1927)
<!-- Reviewable:end -->
