### PR TITLE
experiments(topsites): Compare uncombined/combined frecency scores of deduped top sites

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -337,6 +337,12 @@ Links.prototype = {
       limit = LINKS_QUERY_LIMIT;
     }
 
+    // Either grab the plain frecency or combine them based on the experiment
+    let frecencyScore = "";
+    if (simplePrefs.prefs["experiments.dedupedCombinedFrecency"]) {
+      frecencyScore = "SUM(frecency)";
+    }
+
     let blockedURLs = ignoreBlocked ? [] : this.blockedURLs.items().map(item => `"${item}"`);
 
     // this query does "GROUP BY rev_nowww" (rev_host without www) to remove urls from same domain.
@@ -345,7 +351,7 @@ Links.prototype = {
     // In general the groupby behavior in the absence of aggregates is not
     // defined in SQL, hence we are relying on sqlite implementation that may
     // change in the future.
-    let sqlQuery = `SELECT url, title, SUM(frecency) frecency, guid, bookmarkGuid,
+    let sqlQuery = `SELECT url, title, ${frecencyScore} frecency, guid, bookmarkGuid,
                           last_visit_date / 1000 as lastVisitDate, favicon, mimeType,
                           "history" as type
                     FROM

--- a/experiments.json
+++ b/experiments.json
@@ -73,5 +73,20 @@
       "threshold": 0.2,
       "description": "Use MetadataService"
     }
+  },
+  "dedupedCombinedFrecency": {
+    "name": "Combine score of deduped sites",
+    "active": true,
+    "description": "Add frecencies of deduped top sites for ranking",
+    "control": {
+      "value": false,
+      "description": "Use last frecency"
+    },
+    "variant": {
+      "id": "exp-006-deduped-combined-frecency",
+      "value": true,
+      "threshold": 0.5,
+      "description": "Use combined frecency"
+    }
   }
 }

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -2,6 +2,7 @@
 "use strict";
 
 const {before} = require("sdk/test/utils");
+const simplePrefs = require("sdk/simple-prefs");
 const {PlacesProvider} = require("addon/PlacesProvider");
 const {PlacesTestUtils} = require("./lib/PlacesTestUtils");
 const {Ci, Cu} = require("chrome");
@@ -81,6 +82,14 @@ exports.test_Links_getTopFrecentSites_dedupeWWW = function*(assert) {
   testURI = NetUtil.newURI("http://www.mozilla.com");
   yield PlacesTestUtils.addVisits(testURI);
 
+  // Test with uncombined score control
+  simplePrefs.prefs["experiments.dedupedCombinedFrecency"] = false;
+  links = yield provider.getTopFrecentSites();
+  assert.equal(links.length, 1, "adding both www. and no-www. yields one link");
+  assert.equal(links[0].frecency, 100, "frecency scores are not combined");
+
+  // Test with combined score experiment
+  simplePrefs.prefs["experiments.dedupedCombinedFrecency"] = true;
   links = yield provider.getTopFrecentSites();
   assert.equal(links.length, 1, "adding both www. and no-www. yields one link");
   assert.equal(links[0].frecency, 200, "frecency scores are combined");


### PR DESCRIPTION
Fix #1896. Support both original plain frecency and combined frecency as control and experiment variant. r?@sarracini 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1928)
<!-- Reviewable:end -->
