### PR TITLE
fix(highlights): Fixes #1932 Cap the retry logic for HIGHLIGHTS_AWAITING_METADATA

### DIFF
--- a/addon/Feeds/HighlightsFeed.js
+++ b/addon/Feeds/HighlightsFeed.js
@@ -12,6 +12,7 @@ module.exports = class HighlightsFeed extends Feed {
   constructor(options) {
     super(options);
     this.baselineRecommender = null; // Added in initializeRecommender, if the experiment is turned on
+    this.retryHighlightsCount = 0;
   }
 
   /**
@@ -61,7 +62,8 @@ module.exports = class HighlightsFeed extends Feed {
       .then(links => this.options.getCachedMetadata(links, "HIGHLIGHTS_RESPONSE"))
       .then(links => ({metadataLinks: links, weightedLinks: this.baselineRecommender.scoreEntries(links)}))
       .then(({metadataLinks, weightedLinks}) => {
-        if (metadataLinks.length && !weightedLinks.length) {
+        if (metadataLinks.length && !weightedLinks.length && this.retryHighlightsCount <= 5) {
+          this.retryHighlightsCount++;
           return am.actions.Response("HIGHLIGHTS_AWAITING_METADATA");
         }
         return am.actions.Response("HIGHLIGHTS_RESPONSE", weightedLinks);

--- a/content-test/addon/Feeds/HighlightsFeed.test.js
+++ b/content-test/addon/Feeds/HighlightsFeed.test.js
@@ -107,6 +107,22 @@ describe("HighlightsFeed", () => {
           assert.equal(action.type, "HIGHLIGHTS_AWAITING_METADATA");
         });
     });
+    it("should resolve with a HIGHLIGHTS_RESPONSE action if we've tried more than 5 times", () => {
+      instance.retryHighlightsCount = 5;
+      instance.baselineRecommender = {scoreEntries: () => []};
+      return instance.getData()
+        .then(action => {
+          assert.isObject(action);
+          assert.equal(action.type, "HIGHLIGHTS_AWAITING_METADATA");
+          assert.equal(instance.retryHighlightsCount, 6);
+          return instance.getData();
+        })
+        .then(action => {
+          assert.isObject(action);
+          assert.equal(action.type, "HIGHLIGHTS_RESPONSE");
+          assert.equal(instance.retryHighlightsCount, 6);
+        });
+    });
     it("should run sites through getCachedMetadata", () => {
       instance.baselineRecommender = {scoreEntries: links => links};
       return instance.getData()


### PR DESCRIPTION
Cap the number of times we retry to get metadata after a re-install to > 5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1935)
<!-- Reviewable:end -->
