### PR TITLE
fix(search): Fixes #1900 Search suggestions not being displayed

### DIFF
--- a/addon/SearchProvider.js
+++ b/addon/SearchProvider.js
@@ -174,7 +174,6 @@ SearchProvider.prototype = {
     let ok = SearchSuggestionController.engineOffersSuggestions(engine);
     controller.maxLocalResults = ok ? MAX_LOCAL_SUGGESTIONS : MAX_SUGGESTIONS;
     controller.maxRemoteResults = ok ? MAX_SUGGESTIONS : 0;
-    controller.remoteTimeout = data.remoteTimeout || undefined;
     let isPrivate = PrivateBrowsingUtils.isBrowserPrivate(browser);
 
     let suggestions;


### PR DESCRIPTION
remoteTimeout was throwing the error - it seems as though it's been deprecated from ContentSearch.jsm - which is where this code originally comes from. As seen here:
https://dxr.mozilla.org/mozilla-central/source/browser/modules/ContentSearch.jsm#270-271

If they don't need it then neither do we. And we're not using it anywhere in the repo either

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1936)
<!-- Reviewable:end -->
