### PR TITLE
fix(topsites): Limit queried sites closer to visible count

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -29,7 +29,7 @@ XPCOMUtils.defineLazyGetter(this, "gPrincipal", () => {
   return Services.scriptSecurityManager.getNoAppCodebasePrincipal(uri);
 });
 
-const {LINKS_QUERY_LIMIT} = require("../common/constants");
+const {TOP_SITES_LENGTH, LINKS_QUERY_LIMIT} = require("../common/constants");
 
 const REV_HOST_BLACKLIST = [
   "moc.elgoog.www.",
@@ -333,8 +333,11 @@ Links.prototype = {
    */
   getTopFrecentSites: Task.async(function*(options = {}) {
     let {limit, ignoreBlocked} = options;
-    if (!limit || limit > LINKS_QUERY_LIMIT) {
-      limit = LINKS_QUERY_LIMIT;
+
+    // Use double the number to allow for immediate display when blocking sites
+    const QUERY_LIMIT = TOP_SITES_LENGTH * 2;
+    if (!limit || limit > QUERY_LIMIT) {
+      limit = QUERY_LIMIT;
     }
 
     // Either grab the plain frecency or combine them based on the experiment

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -7,6 +7,7 @@ const {PlacesProvider} = require("addon/PlacesProvider");
 const {PlacesTestUtils} = require("./lib/PlacesTestUtils");
 const {Ci, Cu} = require("chrome");
 const systemEvents = require("sdk/system/events");
+const {TOP_SITES_LENGTH} = require("common/constants");
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["btoa"]);
@@ -124,6 +125,21 @@ exports.test_Links_getTopFrecentSites_limit = function*(assert) {
 
   links = yield provider.getTopFrecentSites({limit: 0});
   assert.equal(links.length, 2, "invalid limit uses defaults");
+};
+
+exports.test_Links_getTopFrecentSites_maxLimit = function*(assert) {
+  let provider = PlacesProvider.links;
+
+  // add many visits
+  const MANY_LINKS = 20;
+  for (let i = 0; i < MANY_LINKS; i++) {
+    let testURI = NetUtil.newURI(`http://mozilla${i}.com`);
+    yield PlacesTestUtils.addVisits(testURI);
+  }
+
+  let links = yield provider.getTopFrecentSites();
+  assert.ok(links.length < MANY_LINKS, "query default limited to less than many");
+  assert.ok(links.length > TOP_SITES_LENGTH, "query default to more than visible count");
 };
 
 exports.test_Links_getTopFrecentSites_Order = function*(assert) {


### PR DESCRIPTION
Fix #1918. Use 2x the visible limit for now. r?@sarracini

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1941)
<!-- Reviewable:end -->
