### PR TITLE
fix(places): Ignore expected control flow exception for bad URIs

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -142,19 +142,17 @@ let LinkChecker = {
   },
 
   _doCheckLoadURI: function LinkChecker_doCheckLoadURI(aURI) {
-    let result = false;
     // check for 'place:' protocol
     if (aURI.startsWith("place:")) {
       return false;
     }
     try {
       Services.scriptSecurityManager.checkLoadURIStrWithPrincipal(gPrincipal, aURI, this.flags);
-      result = true;
+      return true;
     } catch (e) {
       // We got a weird URI or one that would inherit the caller's principal.
-      Cu.reportError(e);
     }
-    return result;
+    return false;
   }
 };
 


### PR DESCRIPTION
Fix #1919. Just ignore the exception as it's expected for certain cases and is just control flow. r?@jaredkerim 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1943)
<!-- Reviewable:end -->
