### PR TITLE
fix(pageScraper): Fixes #1947 Handle image load failures

### DIFF
--- a/addon/PageScraper.js
+++ b/addon/PageScraper.js
@@ -60,7 +60,7 @@ PageScraper.prototype = {
    * Locally compute the size of the preview image
    */
   _computeImageSize(metadata) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       if (metadata.images.length) {
         const metadataImage = metadata.images[0];
         let image = new Services.appShell.hiddenDOMWindow.Image();
@@ -73,6 +73,7 @@ PageScraper.prototype = {
           };
           resolve([imageWithSize]);
         });
+        image.addEventListener("error", () => reject());
       } else {
         resolve([]);
       }

--- a/test/test-PageScraper.js
+++ b/test/test-PageScraper.js
@@ -122,6 +122,16 @@ exports.test_compute_image_sizes = function*(assert) {
   assert.equal(newImage[0].width, 1, "computed the correct image width");
   assert.equal(newImage[0].height, 1, "computed the correct image height");
 
+  // force the image to reject by giving it a null src
+  metadataObj.images[0].url = null;
+  let error = false;
+  try {
+    newImage = yield gPageScraper._computeImageSize(metadataObj);
+  } catch (e) {
+    error = true;
+  }
+  assert.deepEqual(error, true, "we rejected the when the image fails to load");
+
   // when the metadata has no images, don't compute any sizes for it
   metadataObj.images = [];
   newImage = yield gPageScraper._computeImageSize(metadataObj);


### PR DESCRIPTION
Handle the case that the image fails to load

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1948)
<!-- Reviewable:end -->
