### PR TITLE
feat(experiments): Closes #1952 Use orig tiles algorithm for top sites

### DIFF
--- a/addon/Feeds/TopSitesFeed.js
+++ b/addon/Feeds/TopSitesFeed.js
@@ -2,11 +2,17 @@ const {PlacesProvider} = require("addon/PlacesProvider");
 const Feed = require("addon/lib/Feed");
 const {TOP_SITES_LENGTH} = require("common/constants");
 const am = require("common/action-manager");
+const simplePrefs = require("sdk/simple-prefs");
 const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
 
 module.exports = class TopSitesFeed extends Feed {
   // Used by this.refresh
   getData() {
+    if (simplePrefs.prefs["experiments.originalNewTabSites"]) {
+      return PlacesProvider.links.asyncGetTopNewTabSites()
+        .then(links => this.options.getCachedMetadata(links, "TOP_FRECENT_SITES_RESPONSE"))
+        .then(links => (am.actions.Response("TOP_FRECENT_SITES_RESPONSE", links)));
+    }
     return PlacesProvider.links.getTopFrecentSites()
       .then(links => this.options.getCachedMetadata(links, "TOP_FRECENT_SITES_RESPONSE"))
       .then(links => (am.actions.Response("TOP_FRECENT_SITES_RESPONSE", links)));

--- a/content-test/addon/Feeds/TopSitesFeed.test.js
+++ b/content-test/addon/Feeds/TopSitesFeed.test.js
@@ -1,8 +1,14 @@
 const testLinks = ["foo.com", "bar.com"];
 const getCachedMetadata = sites => sites.map(site => site.toUpperCase());
-const PlacesProvider = {links: {getTopFrecentSites: sinon.spy(() => Promise.resolve(testLinks))}};
+const PlacesProvider = {
+  links: {
+    asyncGetTopNewTabSites: sinon.spy(() => Promise.resolve(testLinks)),
+    getTopFrecentSites: sinon.spy(() => Promise.resolve(testLinks))
+  }
+};
 const moment = require("moment");
 const TopSitesFeed = require("inject!addon/Feeds/TopSitesFeed")({"addon/PlacesProvider": {PlacesProvider}});
+const simplePrefs = require("sdk/simple-prefs");
 
 const {TOP_SITES_LENGTH} = require("common/constants");
 
@@ -10,6 +16,7 @@ describe("TopSitesFeed", () => {
   let instance;
   beforeEach(() => {
     PlacesProvider.links.getTopFrecentSites.reset();
+    PlacesProvider.links.asyncGetTopNewTabSites.reset();
     instance = new TopSitesFeed({getCachedMetadata});
     sinon.spy(instance.options, "getCachedMetadata");
   });
@@ -35,6 +42,15 @@ describe("TopSitesFeed", () => {
       assert.equal(action.type, "TOP_FRECENT_SITES_RESPONSE", "type");
       assert.deepEqual(action.data, getCachedMetadata(testLinks));
     }));
+    it("should use the original tiles when in the experiment", () => {
+      simplePrefs.prefs["experiments.originalNewTabSites"] = true;
+      return instance.getData().then(() => {
+        assert.notCalled(PlacesProvider.links.getTopFrecentSites);
+        assert.calledOnce(PlacesProvider.links.asyncGetTopNewTabSites);
+        assert.calledWith(instance.options.getCachedMetadata, testLinks, "TOP_FRECENT_SITES_RESPONSE");
+        simplePrefs.prefs["experiments.originalNewTabSites"] = false;
+      });
+    });
   });
 
   describe("#onAction", () => {

--- a/experiments.json
+++ b/experiments.json
@@ -103,5 +103,20 @@
       "threshold": 0.1,
       "description": "Fetch page content locally"
     }
+  },
+  "originalNewTabSites": {
+    "name": "Original about:newtab top sites",
+    "active": true,
+    "description": "Use the sites from the original about:newtab",
+    "control": {
+      "value": false,
+      "description": "Use sites from tiles"
+    },
+    "variant": {
+      "id": "exp-008-original-newtab-sites",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Use sites from activity stream"
+    }
   }
 }


### PR DESCRIPTION
Use the newtab sites that are returned by ```NewtabUtils.jsm``` which are the same links that about:newtab shows on it's tiles

cc @emtwo 

dxr links: 
https://dxr.mozilla.org/mozilla-central/source/toolkit/modules/NewTabUtils.jsm#920
https://dxr.mozilla.org/mozilla-central/source/browser/base/content/newtab/grid.js#139

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1954)
<!-- Reviewable:end -->
