### PR TITLE
fix(store): Fixes #1766 Sync user actions to store update

### DIFF
--- a/addon/PageWorker.js
+++ b/addon/PageWorker.js
@@ -15,7 +15,7 @@ class PageWorker {
     this._onDispatch = this._onDispatch.bind(this);
     this._unsubscribe = null;
     this._store = store;
-    this._wait = wait || 1000;
+    this._wait = wait || 100;
   }
   _onDispatch() {
     this._page.port.emit(ADDON_TO_CONTENT, {
@@ -33,8 +33,15 @@ class PageWorker {
     // Note: watch only calls the callback (this._onDispatch) if something on
     // the state object actually changed
     const w = watch(this._store.getState);
-    // Note: According to the redux docs, calling .subscribe on a store
-    // returns a function which will unsubscribe
+
+    /* Notes:
+    1. According to the redux docs, calling .subscribe on a store
+    returns a function which will unsubscribe
+    2. We wait a certain amount of time (this._wait) before updating
+    local storage in order to not overload writing to the state. In order for
+    user actions to accurately represent the state of the app when we trigger a
+    refresh (or open a new tab) we must set the wait to be low i.e 100ms in this case */
+
     this._unsubscribe = this._store.subscribe(debounce(w(this._onDispatch), this._wait));
   }
   destroy() {

--- a/content-test/addon/PageWorker.test.js
+++ b/content-test/addon/PageWorker.test.js
@@ -28,7 +28,7 @@ describe("PageWorker", () => {
     assert.equal(pageWorker._store, store);
     assert.isNull(pageWorker._page);
     assert.isNull(pageWorker._unsubscribe);
-    assert.equal(pageWorker._wait, 1000);
+    assert.equal(pageWorker._wait, 100);
   });
   it("should allow overriding ._wait", () => {
     const pw = new PageWorker({store, wait: 300});


### PR DESCRIPTION
Lower the debounce time so we can sync up the store when someone opens a new tab immediately after doing a user action

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1958)
<!-- Reviewable:end -->
