### PR TITLE
fix(bookmarks): Fixes #1957 Remove bookmark option unavailable

### DIFF
--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -220,6 +220,7 @@ PreviewProvider.prototype = {
       enhancedLink.cache_key = link.cache_key;
       enhancedLink.lastVisitDate = link.lastVisitDate;
       enhancedLink.bookmarkDateCreated = link.bookmarkDateCreated;
+      enhancedLink.bookmarkGuid = link.bookmarkGuid;
 
       // get favicon and background color from firefox
       const firefoxBackgroundColor = yield this._getFaviconColors(link);

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -491,6 +491,22 @@ exports.test_metadata_service_experiment = function(assert) {
   assert.equal(newPrefValue, gMetadataServiceSource, "properly set the actual pref itself");
 };
 
+exports.test_copy_over_correct_data_from_firefox = function*(assert) {
+  const expectedKeys = ["title", "type", "url", "cache_key", "lastVisitDate", "bookmarkGuid", "bookmarkDateCreated"];
+  const link = [{
+    title: "a firefox given title",
+    type: "bookmark",
+    url: "http://example.com",
+    cache_key: "example.com/",
+    lastVisitDate: 123456789,
+    bookmarkDateCreated: 123456789,
+    bookmarkGuid: 1234
+  }];
+
+  const cachedLink = yield gPreviewProvider.asyncGetEnhancedLinks(link);
+  expectedKeys.forEach(key => assert.equal(cachedLink[0][key], link[0][key], "even without metadata we kept all the firefox data for the link"));
+};
+
 before(exports, () => {
   simplePrefs.prefs.metadataSource = gEmbedlyServiceSource;
   simplePrefs.prefs["embedly.endpoint"] = `${gEndpointPrefix}${gEmbedlyEndpoint}`;


### PR DESCRIPTION
Add the ```bookmarkGuid``` to the link's properties so it can be checked against later when updating the context menu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1959)
<!-- Reviewable:end -->
