### PR TITLE
feat(metrics): Closes #1961 Capture telemetry for clearing history

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -56,7 +56,8 @@ const PLACES_CHANGES_EVENTS = [
   "manyLinksChanged",
   "bookmarkAdded",
   "bookmarkRemoved",
-  "bookmarkChanged"
+  "bookmarkChanged",
+  "clearHistory"
 ];
 
 const HOME_PAGE_PREF = "browser.startup.homepage";
@@ -293,6 +294,9 @@ ActivityStreams.prototype = {
         break;
       case "manyLinksChanged":
         this.broadcast({type: "MANY_LINKS_CHANGED"});
+        break;
+      case "clearHistory":
+        this._tabTracker.handleUserEvent({event: "CLEAR_HISTORY"});
         break;
       default:
         this.broadcast(am.actions.Response("RECEIVE_PLACES_CHANGES", data));

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -767,6 +767,23 @@ exports.test_TabTracker_slow_addon_detected = function*(assert) {
   assert.deepEqual(pingData.action, "activity_stream_masga_event", "the ping has the correct action");
 };
 
+exports.test_TabTracker_clear_history_ping = function*(assert) {
+  let userEventPromise = new Promise(resolve => {
+    function observe(subject, topic, data) {
+      if (topic === "user-action-event") {
+        Services.obs.removeObserver(observe, "user-action-event");
+        resolve(JSON.parse(data));
+      }
+    }
+    Services.obs.addObserver(observe, "user-action-event", false);
+  });
+
+  // manually do a places change with clear history
+  app._handlePlacesChanges("clearHistory");
+  let pingData = yield userEventPromise;
+  assert.deepEqual("CLEAR_HISTORY", pingData.event, "the ping has the correct event");
+};
+
 before(exports, function*() {
   // we have to clear bookmarks and history before tests
   // to ensure that the app does not pick history or


### PR DESCRIPTION
Captures the event for when a user clears their history

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1963)
<!-- Reviewable:end -->
