### PR TITLE
fix(topsites): Restore eTLD truncating

### DIFF
--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -217,6 +217,7 @@ PreviewProvider.prototype = {
       enhancedLink.title = link.title;
       enhancedLink.type = link.type;
       enhancedLink.url = link.url;
+      enhancedLink.eTLD = link.eTLD;
       enhancedLink.cache_key = link.cache_key;
       enhancedLink.lastVisitDate = link.lastVisitDate;
       enhancedLink.bookmarkDateCreated = link.bookmarkDateCreated;

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -492,7 +492,7 @@ exports.test_metadata_service_experiment = function(assert) {
 };
 
 exports.test_copy_over_correct_data_from_firefox = function*(assert) {
-  const expectedKeys = ["title", "type", "url", "cache_key", "lastVisitDate", "bookmarkGuid", "bookmarkDateCreated"];
+  const expectedKeys = ["title", "type", "url", "eTLD", "cache_key", "lastVisitDate", "bookmarkGuid", "bookmarkDateCreated"];
   const link = [{
     title: "a firefox given title",
     type: "bookmark",


### PR DESCRIPTION
Fix #980. This got regressed with PreviewProvider change not extending the base link. r?@sarracini

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1983)
<!-- Reviewable:end -->
