### PR TITLE
fix(topsites): Guess that .com is a TLD if none is provided

### DIFF
--- a/common/selectors/siteMetadataSelectors.js
+++ b/common/selectors/siteMetadataSelectors.js
@@ -4,11 +4,12 @@ const {prettyUrl} = require("lib/utils");
 function selectSiteProperties(site) {
   const favicon = site.favicon_url;
   const parsedUrl = site.parsedUrl || urlParse(site.url || "");
+  const {hostname} = parsedUrl;
 
   // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
-  const eTLDLength = (site.eTLD || "").length;
+  const eTLDLength = (site.eTLD || "").length || (hostname.match(/\.com$/) && 3);
   const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
-  const label = prettyUrl(parsedUrl.hostname).slice(0, eTLDExtra);
+  const label = prettyUrl(hostname).slice(0, eTLDExtra);
 
   return {favicon, parsedUrl, label};
 }

--- a/content-test/common/selectors/siteMetadataSelectors.test.js
+++ b/content-test/common/selectors/siteMetadataSelectors.test.js
@@ -28,10 +28,15 @@ describe("siteMetadataSelectors", () => {
 
       assert.ok(result.parsedUrl);
     });
-    it("should set label prop without eTLD set", () => {
+    it("should set label prop without eTLD set for .com", () => {
       let result = selectSiteProperties(validSpotlightSite);
 
-      assert.equal(result.label, "cnn.com");
+      assert.equal(result.label, "cnn");
+    });
+    it("should set label prop without eTLD set for not .com", () => {
+      let result = selectSiteProperties(Object.assign({}, validSpotlightSite, {url: "https://www.mozilla.org/"}));
+
+      assert.equal(result.label, "mozilla.org");
     });
     it("should set label prop with eTLD set", () => {
       let result = selectSiteProperties(Object.assign({}, validSpotlightSite, {eTLD: "com"}));


### PR DESCRIPTION
Followup from #1983. r?@rlr 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/1992)
<!-- Reviewable:end -->
