### PR TITLE
fix (addon): add eTLD property after all places queries

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -436,14 +436,7 @@ Links.prototype = {
     });
 
     links = this._faviconBytesToDataURI(links);
-    links = links.map(link => {
-      try {
-        link.eTLD = Services.eTLD.getPublicSuffix(Services.io.newURI(link.url, null, null));
-      } catch (e) {
-        link.eTLD = "";
-      }
-      return link;
-    });
+    links = this._addETLD(links);
     return links.filter(link => LinkChecker.checkLoadURI(link.url));
   }),
 
@@ -493,6 +486,7 @@ Links.prototype = {
     });
 
     links = this._faviconBytesToDataURI(links);
+    links = this._addETLD(links);
     links.filter(link => LinkChecker.checkLoadURI(link.url));
     if (links.length) {
       return links[0];
@@ -558,6 +552,7 @@ Links.prototype = {
 
     let links = yield this.executePlacesQuery(sqlQuery, {columns, params: {limit}});
     links = this._faviconBytesToDataURI(links);
+    links = this._addETLD(links);
     return links.filter(link => LinkChecker.checkLoadURI(link.url));
   }),
 
@@ -641,6 +636,7 @@ Links.prototype = {
     });
 
     links = this._faviconBytesToDataURI(links);
+    links = this._addETLD(links);
     links = links.filter(link => LinkChecker.checkLoadURI(link.url));
 
     // Add the sync data to each link.
@@ -664,6 +660,25 @@ Links.prototype = {
         link.favicon = `data:${link.mimeType};base64,${encodedData}`;
       }
       delete link.mimeType;
+      return link;
+    });
+  },
+
+  /**
+   * Add the eTLD to each link in the array of links.
+   *
+   * @param {Array} links
+   *            an array containing objects with urls
+   *
+   * @returns {Array} an array of links with eTLDs added
+   */
+  _addETLD(links) {
+    return links.map(link => {
+      try {
+        link.eTLD = Services.eTLD.getPublicSuffix(Services.io.newURI(link.url, null, null));
+      } catch (e) {
+        link.eTLD = "";
+      }
       return link;
     });
   },

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -104,6 +104,10 @@ describe("SpotlightItem", () => {
       assert.equal(hc.props().type, "bookmark");
       assert.deepEqual(hc.props(), props);
     });
+    it("should render the label without the eTLD if eTLD is specified", () => {
+      let site = Object.assign({}, fakeSite, {"url": "https://google.ca", "eTLD": "ca"});
+      assert.equal(renderWithProvider(<SpotlightItem {...site} />).refs.label.textContent, "google");
+    });
   });
 });
 

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -247,6 +247,7 @@ exports.test_Links_getRecentlyVisited = function*(assert) {
   let links = yield provider.getRecentlyVisited({limit});
   assert.equal(links.length > 0, true, "it should retrieve some links");
   assert.equal(links.length, limit, "query should not retrieve more than the limit even with recent");
+  assert.equal(links[0].eTLD, "com", "set 'com' as the eTLD");
 };
 
 exports.test_Links_getRecentlyVisited_old_links = function*(assert) {


### PR DESCRIPTION
@Mardak I see you did the original eTLD stuff. Now we (@bryanbell) want it for everywhere else (highlights). r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2055)
<!-- Reviewable:end -->
