### PR TITLE
Add screenshots

### DIFF
--- a/addon/lib/getScreenshots.js
+++ b/addon/lib/getScreenshots.js
@@ -1,0 +1,41 @@
+/* globals Task, XPCOMUtils, PreviewProvider */
+
+const {Cu} = require("chrome");
+
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Task.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "PreviewProvider",
+                                  "resource:///modules/PreviewProvider.jsm");
+
+/**
+ * getScreenshots: Given an array of sites with a url property, returns a Promise
+ *                 that resolves with new copy of the array of sites, each with a new .screenshot property
+ *
+ * @param  {array} sites                    An array of sites, where each site is an object with the property .url
+ * @param  {func} condition (optional)      A function that takes a single param "site", which fetches a screenshot if it
+ *                                          returns true, and skips it if it returns false
+ * @return {Promise}                              description
+ */
+module.exports = Task.async(function*getScreenshots(sites, condition) {
+  const result = {};
+  for (let site of sites) {
+    // Don't fetch screenshots if the site doesn't meet the conditions
+    if (condition && !condition(site)) {
+      break;
+    }
+
+    try {
+      const dataURI = yield PreviewProvider.getThumbnail(site.url);
+      result[site.url] = dataURI;
+    } catch (e) {
+      Cu.reportError(e);
+    }
+  }
+  return sites.map(site => {
+    if (!result[site.url]) {
+      return site;
+    }
+    return Object.assign({}, site, {screenshot: result[site.url]});
+  });
+});

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -7,6 +7,7 @@ const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
 const {PlaceholderSiteIcon, SiteIcon} = require("components/SiteIcon/SiteIcon");
 const Hint = require("components/Hint/Hint");
+const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 
 const DEFAULT_LENGTH = 6;
 const TOP_SITES_HINT_TEXT = "Get right to the sites you visit most: click on a tile to open or hover to share, bookmark or delete.";
@@ -25,10 +26,24 @@ const TopSitesItem = React.createClass({
     const site = this.props;
     const index = site.index;
     const isActive = this.state.showContextMenu && this.state.activeTile === index;
+    const screenshot = site.screenshot;
+
+    // The top-corner class puts the site icon in the top corner, overlayed over the screenshot.
+    const siteIconClasses = classNames("tile-img-container", {"top-corner": screenshot});
+
+    const {label} = selectSiteProperties(site);
+
     return (<div className={classNames("tile-outer", {active: isActive})} key={site.guid || site.cache_key || index}>
       <a onClick={() => this.props.onClick(index)} className="tile" href={site.url} ref="topSiteLink">
-        <SiteIcon ref="icon" className="tile-img-container" site={site} faviconSize={32} showTitle={true} />
         <div className="inner-border" />
+        {screenshot && <div ref="screenshot" className="screenshot" style={{backgroundImage: `url(${screenshot})`}} />}
+        <SiteIcon
+          ref="icon"
+          className={siteIconClasses}
+          site={site} faviconSize={32}
+          showTitle={!screenshot} />
+
+        {screenshot && <div ref="title" className="site-title">{label}</div>}
       </a>
       <LinkMenuButton onClick={() => this.setState({showContextMenu: true, activeTile: index})} />
       <LinkMenu

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -31,6 +31,16 @@
     }
   }
 
+  .screenshot {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background-size: 250%;
+    background-position: top left;
+  }
+
   .tile {
     @include item-shadow;
     display: inline-flex;
@@ -48,6 +58,16 @@
       margin-bottom: 0;
     }
 
+    .site-title {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      width: 100%;
+      padding-top: 6px;
+      font-size: 11px;
+      text-align: center;
+    }
+
 
     .tile-img-container {
       width: 100%;
@@ -57,6 +77,15 @@
       display: flex;
       align-items: center;
       justify-content: center;
+
+      &.top-corner {
+        position: absolute;
+        height: 40px;
+        width: 40px;
+        z-index: 1000;
+        top: -6px;
+        left: -6px;
+      }
     }
   }
 }

--- a/content-test/addon/Feeds/TopSitesFeed.test.js
+++ b/content-test/addon/Feeds/TopSitesFeed.test.js
@@ -23,7 +23,7 @@ describe("TopSitesFeed", () => {
     PlacesProvider.links.asyncGetTopNewTabSites.reset();
     reduxState = {Experiments: {values: {}}};
     instance = new TopSitesFeed({getCachedMetadata});
-    instance.store = {getState() {return reduxState}};
+    instance.store = {getState() {return reduxState;}};
     sinon.spy(instance.options, "getCachedMetadata");
   });
   it("should create a TopSitesFeed", () => {
@@ -60,7 +60,7 @@ describe("TopSitesFeed", () => {
       reduxState.Experiments.values.screenshots = true;
       return instance.getData().then(result => {
         assert.calledOnce(getScreenshots);
-        // Note: our fake getScreenshots function resolves with ["foo"] 
+        // Note: our fake getScreenshots function resolves with ["foo"]
         assert.deepEqual(result.data, ["foo"]);
       });
     });

--- a/content-test/addon/lib/getScreenshots.test.js
+++ b/content-test/addon/lib/getScreenshots.test.js
@@ -1,0 +1,48 @@
+const getScreenshots = require("addon/lib/getScreenshots");
+const {overrideGlobals} = require("test/test-utils");
+
+// Fake stuff for testing
+const fakeThumbnail = url => `${url}/thumbnail.jpg`;
+const TEST_SITES = [{url: "foo.com"}, {url: "bar.com"}];
+
+// This is just a short form for calling getScreenshots with the default TEST_SITES data
+function runWithSites(callback) {
+  return getScreenshots(TEST_SITES).then(result => callback(result));
+}
+
+describe("getScreenshots", () => {
+  let restore;
+  beforeEach(() => {
+    restore = overrideGlobals(
+      {PreviewProvider: {getThumbnail: url => Promise.resolve(fakeThumbnail(url))}}
+    );
+  });
+  after(() => restore());
+
+  it("should return an array of sites", () => runWithSites(result => {
+    assert.equal(result.length, TEST_SITES.length);
+  }));
+
+  it("should return a new array without modifying the original", () => runWithSites(result => {
+    assert.notEqual(result, TEST_SITES);
+    assert.deepEqual(TEST_SITES, [{url: "foo.com"}, {url: "bar.com"}]);
+  }));
+
+  it("should add a screenshot property to each site", () => runWithSites(result => {
+    TEST_SITES.forEach((site, i) => {
+      assert.property(result[i], "screenshot");
+      assert.equal(result[i].screenshot, fakeThumbnail(result[i].url));
+    });
+  }));
+  it("should not get thumbnails if if condition returns false", () => (
+    getScreenshots(TEST_SITES, () => false).then(result => {
+      TEST_SITES.forEach((site, i) => assert.notProperty(result[i], "screenshot"));
+    })
+  ));
+  it("should get thumbnails if if condition returns true", () => (
+    getScreenshots(TEST_SITES, site => site.url === TEST_SITES[0].url).then(result => {
+      assert.property(result[0], "screenshot");
+      assert.notProperty(result[1], "screenshot");
+    })
+  ));
+});

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -7,6 +7,7 @@ const {PlaceholderTopSitesItem, TopSites, TopSitesItem} = ConnectedTopSites;
 const LinkMenu = require("components/LinkMenu/LinkMenu");
 const LinkMenuButton = require("components/LinkMenuButton/LinkMenuButton");
 const {PlaceholderSiteIcon, SiteIcon} = require("components/SiteIcon/SiteIcon");
+const {selectSiteProperties} = require("common/selectors/siteMetadataSelectors");
 const fakeSiteWithImage = faker.createSite();
 
 const fakeProps = {
@@ -98,6 +99,24 @@ describe("TopSitesItem", () => {
     it("should render a SiteIcon with appropriate props", () => {
       assert.instanceOf(instance.refs.icon, SiteIcon);
       assert.include(instance.refs.icon.props.site, fakeSite);
+    });
+  });
+
+  describe("screenshot", () => {
+    const siteWithScreenshot = Object.assign({}, fakeSiteWithImage, {screenshot: "cool.jpg"});
+    beforeEach(() => {
+      instance = renderWithProvider(<TopSitesItem {...siteWithScreenshot} />);
+    });
+    it("should render a title", () => {
+      assert.ok(instance.refs.title);
+      assert.equal(instance.refs.title.textContent, selectSiteProperties(siteWithScreenshot).label);
+    });
+    it("should render the screenshot element with the right background image", () => {
+      assert.ok(instance.refs.screenshot);
+      assert.equal(instance.refs.screenshot.style.backgroundImage, "url(\"cool.jpg\")");
+    });
+    it("should add the .top-corner class to SiteIcon", () => {
+      assert.include(instance.refs.icon.props.className, "top-corner");
     });
   });
 });

--- a/experiments.json
+++ b/experiments.json
@@ -118,5 +118,20 @@
       "threshold": 0.2,
       "description": "Use sites from activity stream"
     }
+  },
+  "screenshots": {
+    "name": "Screenshots for Top Sites",
+    "active": true,
+    "description": "Add screenshots for some Top Sites",
+    "control": {
+      "value": false,
+      "description": "Do'nt show screenshots"
+    },
+    "variant": {
+      "id": "exp-009-screenshots",
+      "value": true,
+      "threshold": 0,
+      "description": "Show screenshots"
+    }
   }
 }

--- a/shims/_utils/globals.js
+++ b/shims/_utils/globals.js
@@ -7,5 +7,5 @@ module.exports = {
   // These are Firefox globals that are often used
   Services: {obs: {notifyObservers: sinon.spy()}},
   Task,
-  XPCOMUtils: {defineLazyGetter() {}, defineLazyServiceGetter() {}}
+  XPCOMUtils: {defineLazyGetter() {}, defineLazyServiceGetter() {}, defineLazyModuleGetter() {}}
 };


### PR DESCRIPTION
This patch adds a `screenshots` experiment, in which screenshots are fetched for some Top Sites and UI is added to display them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2058)
<!-- Reviewable:end -->
