### PR TITLE
Workaround some enzyme/webpack weirdness for storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,7 +10,13 @@ module.exports = storybookBaseConfig => {
     module: Object.assign({}, webpack_common.module),
     resolve: webpack_common.resolve,
     devtool: "eval-sourcemap",
-    plugins: storybookBaseConfig.plugins.concat(webpack_common.plugins)
+    plugins: storybookBaseConfig.plugins.concat(webpack_common.plugins),
+    externals: {
+      // enzyme needs these for some reason
+      "react/addons": true,
+      "react/lib/ReactContext": true,
+      "react/lib/ExecutionEnvironment": true
+    }
   });
 
   // As of this writing CSS is not handled by webpack, so to get CSS changes to


### PR DESCRIPTION
I broke this when I landed the enzyme changes.  Fixed, in about the same way this is already fixed for Karma.

To test:

```
npm run start
npm run storybook   # in a separate shell
```

then navigate to localhost:9001.  It should work rather than spewing a bunch of errors.
r=@rlr?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2067)
<!-- Reviewable:end -->
