### PR TITLE
fix(content): Bumped tippy-top-sites for better icons

### DIFF
--- a/addon/TippyTopProvider.js
+++ b/addon/TippyTopProvider.js
@@ -2,10 +2,9 @@
 "use strict";
 
 const data = require("sdk/self").data;
-const getSiteData = require("common/vendor")("tippy-top-sites").getSiteData;
+const {IMAGE_SIZE, getSiteData} = require("common/vendor")("tippy-top-sites");
 
 const DEFAULT_OPTIONS = {sites: null};
-const FAVICON_DIMENSION = 64;
 
 function TippyTopProvider(options = {}) {
   this.options = Object.assign({}, DEFAULT_OPTIONS, options);
@@ -31,8 +30,8 @@ TippyTopProvider.prototype = {
     let usedTippyTopData = false;
     if ("image_url" in tippyTopSite) {
       enhancedSite.favicon_url = data.url(`content/favicons/images/${tippyTopSite.image_url}`);
-      enhancedSite.favicon_height = FAVICON_DIMENSION;
-      enhancedSite.favicon_width = FAVICON_DIMENSION;
+      enhancedSite.favicon_height = IMAGE_SIZE;
+      enhancedSite.favicon_width = IMAGE_SIZE;
       usedTippyTopData = true;
     }
     if ("background_color" in tippyTopSite) {

--- a/content-src/lib/first-run-data.js
+++ b/content-src/lib/first-run-data.js
@@ -1,6 +1,7 @@
 const FIRST_RUN_TYPE = "first-run";
 const FAVICON_PATH = "favicons/images/";
 
+// Note: this should probably be moved to the addon side and generated from tippy-top-sites instead
 module.exports = {
   FIRST_RUN_TYPE,
   TopSites: [
@@ -8,7 +9,7 @@ module.exports = {
       "title": "Facebook",
       "url": "https://www.facebook.com/",
       "favicon_url": "facebook-com.png",
-      "background_color": [237, 240, 245]
+      "background_color": [59, 89, 152]
     },
     {
       "title": "YouTube",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "redux-thunk": "2.1.0",
     "redux-watch": "1.1.1",
     "reselect": "2.5.4",
-    "tippy-top-sites": "1.0.1",
+    "tippy-top-sites": "1.1.1",
     "url-parse": "1.1.7"
   },
   "devDependencies": {

--- a/test/test-TippyTopProvider.js
+++ b/test/test-TippyTopProvider.js
@@ -2,6 +2,7 @@
 
 const {TippyTopProvider} = require("addon/TippyTopProvider");
 const urlParse = require("common/vendor")("url-parse");
+const {IMAGE_SIZE} = require("common/vendor")("tippy-top-sites");
 
 exports["test TippyTopProvider init"] = function(assert) {
   // Test the default init
@@ -66,8 +67,8 @@ exports["test TippyTopProvider processSite"] = function(assert) {
   assert.deepEqual({
     url: site.url,
     favicon_url: "resource://activity-streams/data/content/favicons/images/mozilla-org.png",
-    favicon_height: 64,
-    favicon_width: 64,
+    favicon_height: IMAGE_SIZE,
+    favicon_width: IMAGE_SIZE,
     background_color: "#fff",
     metadata_source: "TippyTopProvider"
   }, tippyTopProvider.processSite(site));
@@ -77,8 +78,8 @@ exports["test TippyTopProvider processSite"] = function(assert) {
   assert.deepEqual({
     url: site.url,
     favicon_url: "resource://activity-streams/data/content/favicons/images/github-com.png",
-    favicon_height: 64,
-    favicon_width: 64,
+    favicon_height: IMAGE_SIZE,
+    favicon_width: IMAGE_SIZE,
     background_color: "#eee",
     metadata_source: "TippyTopProvider"
   }, tippyTopProvider.processSite(site));
@@ -88,8 +89,8 @@ exports["test TippyTopProvider processSite"] = function(assert) {
   assert.deepEqual({
     url: site.url,
     favicon_url: "resource://activity-streams/data/content/favicons/images/github-com.png",
-    favicon_height: 64,
-    favicon_width: 64,
+    favicon_height: IMAGE_SIZE,
+    favicon_width: IMAGE_SIZE,
     background_color: "#eee",
     metadata_source: "TippyTopProvider"
   }, tippyTopProvider.processSite(site));
@@ -99,8 +100,8 @@ exports["test TippyTopProvider processSite"] = function(assert) {
   assert.deepEqual({
     url: site.url,
     favicon_url: "resource://activity-streams/data/content/favicons/images/example-com.png",
-    favicon_height: 64,
-    favicon_width: 64,
+    favicon_height: IMAGE_SIZE,
+    favicon_width: IMAGE_SIZE,
     background_color: "#ddd",
     metadata_source: "TippyTopProvider"
   }, tippyTopProvider.processSite(site));
@@ -110,8 +111,8 @@ exports["test TippyTopProvider processSite"] = function(assert) {
   assert.deepEqual({
     url: site.url,
     favicon_url: "resource://activity-streams/data/content/favicons/images/mozilla-org.png",
-    favicon_height: 64,
-    favicon_width: 64,
+    favicon_height: IMAGE_SIZE,
+    favicon_width: IMAGE_SIZE,
     background_color: "#fff",
     metadata_source: "TippyTopProvider"
   }, tippyTopProvider.processSite(site));
@@ -121,8 +122,8 @@ exports["test TippyTopProvider processSite"] = function(assert) {
   assert.deepEqual({
     url: site.url,
     favicon_url: "resource://activity-streams/data/content/favicons/images/mozilla-org.png",
-    favicon_height: 64,
-    favicon_width: 64,
+    favicon_height: IMAGE_SIZE,
+    favicon_width: IMAGE_SIZE,
     background_color: "#fff",
     metadata_source: "TippyTopProvider"
   }, tippyTopProvider.processSite(site));


### PR DESCRIPTION
This patch bumps `tippy-top-sites` to 1.1.1, which includes

- larger icons
- a constant for `IMAGE_SIZE`

I filed https://github.com/mozilla/activity-stream/issues/2069 as a follow-up to change the first-run sites to be generated from tippy-top sites instead of being hardcoded, since this requires somewhat of a larger change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2070)
<!-- Reviewable:end -->
