### PR TITLE
fix (content): #2071 fix site title overflow in top sites experiment

### DIFF
--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -105,6 +105,11 @@
         // graduates, we should change the HTML instead.
         overflow: visible;
       }
+
+      .site-title {
+        height: 22px;
+        overflow: hidden;
+      }
     }
 
     .site-icon {


### PR DESCRIPTION
r? @sarracini 

To repro: 

* start with a new profile
* enable the screenshots
* visit http://moz-activity-streams-prerelease.s3.amazonaws.com/
* open new tab page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2072)
<!-- Reviewable:end -->
