### PR TITLE
fix(topsites): Fixes #2073 TopSites icon displayed over search suggestions

### DIFF
--- a/content-src/components/Search/Search.scss
+++ b/content-src/components/Search/Search.scss
@@ -7,7 +7,7 @@
   height: $search-height;
 
   .search-container {
-    z-index: 999;
+    z-index: 1001;
     background: $bg-color;
     position: absolute;
     left: 0;


### PR DESCRIPTION
Make the search suggestions the biggest z-index (the top sites icon is at 1000)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2074)
<!-- Reviewable:end -->
