### PR TITLE
fix(content): #2079 Remove vertical padding on search input

### DIFF
--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -174,7 +174,8 @@ $code-color: #E8005C;
   flex-grow: 1;
   margin: 0;
   outline: none;
-  padding: 6px 12px 8px $search-input-left-label-width;
+  padding: 0 12px 0 $search-input-left-label-width;
+  height: 100%;
 
   &:focus {
     border-color: $search-blue;


### PR DESCRIPTION
Fixes an issue where letters are cut off in certain fonts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2086)
<!-- Reviewable:end -->
