### PR TITLE
fix(style): #2076 force alignment of top sites titles

### DIFF
--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -122,6 +122,7 @@
         border: 0;
         position: absolute;
         top: 100%;
+        offset-inline-start: 0;
       }
 
       &:hover {


### PR DESCRIPTION
I couldn't reproduce this, but this will fix it; 

Note that `offset-inline-start` is an RTL-compatible version of `left`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2090)
<!-- Reviewable:end -->
