### PR TITLE
fix(topsites): Fixes #1154 TopSites tile loses highlight on hover

### DIFF
--- a/content-src/components/SiteIcon/SiteIcon.scss
+++ b/content-src/components/SiteIcon/SiteIcon.scss
@@ -49,8 +49,4 @@
     overflow: hidden;
     z-index: 1;
   }
-
-  &:hover .site-icon-title {
-    background-color: $tile-title-hover-color;
-  }
 }

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -9,7 +9,9 @@
 
   // This is a container for the delete menu
   .tile-outer {
+    @include item-shadow;
     @include link-menu-button;
+    border-radius: $border-radius;
     position: relative;
     display: inline-block;
     margin: 0 $tile-gutter 0 0;
@@ -29,6 +31,10 @@
         box-shadow: none;
       }
     }
+
+    &:hover .site-icon-title {
+      background-color: $tile-title-hover-color;
+    }
   }
 
   .screenshot {
@@ -43,10 +49,8 @@
   }
 
   .tile {
-    @include item-shadow;
     display: inline-flex;
     flex-shrink: 0;
-    border-radius: $border-radius;
     flex-direction: column;
     font-size: $tile-font-size;
     height: $tile-height;
@@ -96,7 +100,6 @@
   .top-sites {
 
     .tile {
-      @include item-shadow;
       box-shadow: none;
 
       .tile-img-container {


### PR DESCRIPTION
Keeps the focus on top sites when you hover over link menu button. Works on both original tiles UI and new tiles UI
Uplift to 1.3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2096)
<!-- Reviewable:end -->
