### PR TITLE
fix (styles): #2091 fix placeholder CSS when screenshot experiment enabled

### DIFF
--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -128,7 +128,10 @@
 // If/when we graduate the experiment, we'll just want to remove the HTML for
 // that completely.
 .top-sites-new-style {
-  .site-icon {
-    display: none;
+  .spotlight {
+    .site-icon,
+    .spotlight-icon {
+      display: none;
+    }
   }
 }

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -100,6 +100,12 @@
     .tile-outer {
       box-shadow: none;
       vertical-align: top;
+
+      &.placeholder {
+        .site-icon-wrapper {
+          height: 96px;
+        }
+      }
     }
 
     .tile {


### PR DESCRIPTION
The selector for hiding site icons in Highlights was a little too greedy. I also fixed the height of the placeholder icon when the experiment is on to make it square.

Fixes #2091

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2105)
<!-- Reviewable:end -->
