### PR TITLE
feat(l10n): Closes #2122 Add comments to strings.properties

### DIFF
--- a/content-src/components/HighlightContext/types.js
+++ b/content-src/components/HighlightContext/types.js
@@ -1,22 +1,22 @@
 module.exports = {
   history: {
-    intlID: "visited",
+    intlID: "type_label_visited",
     icon: "historyItem"
   },
   open: {
-    intlID: "open",
+    intlID: "type_label_open",
     icon: "tab"
   },
   synced: {
-    intlID: "synced",
+    intlID: "type_label_synced",
     icon: "sync"
   },
   bookmark: {
-    intlID: "bookmarked",
+    intlID: "type_label_bookmarked",
     icon: "bookmark"
   },
   topic: {
-    intlID: "topic",
+    intlID: "type_label_topic",
     icon: "topic"
   }
 };

--- a/content-src/components/LinkMenu/LinkMenu.js
+++ b/content-src/components/LinkMenu/LinkMenu.js
@@ -50,13 +50,13 @@ const LinkMenu = React.createClass({
     return [
       {
         ref: "copyAddress",
-        label: this.props.intl.formatMessage({id: "copy_address"}),
+        label: this.props.intl.formatMessage({id: "menu_action_copy_address"}),
         icon: "copy-address",
         onClick: () => dispatch(actions.NotifyCopyUrl(site.url))
       },
       {
         ref: "emailLink",
-        label: this.props.intl.formatMessage({id: "email_link"}),
+        label: this.props.intl.formatMessage({id: "menu_action_email_link"}),
         icon: "email-link",
         onClick: () => dispatch(actions.NotifyEmailUrl(site.url, site.title))
       }]
@@ -74,7 +74,7 @@ const LinkMenu = React.createClass({
       deleteOptions = [
         allowBlock && {
           ref: "dismiss",
-          label: this.props.intl.formatMessage({id: "dismiss"}),
+          label: this.props.intl.formatMessage({id: "menu_action_dismiss"}),
           icon: "dismiss",
           userEvent: "BLOCK",
           onClick: () => {
@@ -83,7 +83,7 @@ const LinkMenu = React.createClass({
         },
         {
           ref: "delete",
-          label: this.props.intl.formatMessage({id: "delete"}),
+          label: this.props.intl.formatMessage({id: "menu_action_delete"}),
           icon: "delete",
           userEvent: "DELETE",
           onClick: () => dispatch(actions.NotifyHistoryDelete(site.url))
@@ -100,13 +100,13 @@ const LinkMenu = React.createClass({
     return [
       (site.bookmarkGuid ? {
         ref: "removeBookmark",
-        label: this.props.intl.formatMessage({id: "remove_bookmark"}),
+        label: this.props.intl.formatMessage({id: "menu_action_remove_bookmark"}),
         icon: "bookmark-remove",
         userEvent: "BOOKMARK_DELETE",
         onClick: () => dispatch(actions.NotifyBookmarkDelete(site.bookmarkGuid))
       } : {
         ref: "addBookmark",
-        label: this.props.intl.formatMessage({id: "bookmark"}),
+        label: this.props.intl.formatMessage({id: "menu_action_bookmark"}),
         icon: "bookmark",
         userEvent: "BOOKMARK_ADD",
         onClick: () => dispatch(actions.NotifyBookmarkAdd(site.url))
@@ -114,21 +114,21 @@ const LinkMenu = React.createClass({
       {
         type: "submenu",
         ref: "share",
-        label: this.props.intl.formatMessage({id: "share"}),
+        label: this.props.intl.formatMessage({id: "menu_action_share"}),
         icon: "share",
         options: this.getShareOptions(site, ShareProviders ? ShareProviders.providers : [], dispatch)
       },
       {type: "separator"},
       {
         ref: "openWindow",
-        label: this.props.intl.formatMessage({id: "open_new_window"}),
+        label: this.props.intl.formatMessage({id: "menu_action_open_new_window"}),
         icon: "new-window",
         userEvent: "OPEN_NEW_WINDOW",
         onClick: () => dispatch(actions.NotifyOpenWindow({url: site.url}))
       },
       {
         ref: "openPrivate",
-        label: this.props.intl.formatMessage({id: "open_private_window"}),
+        label: this.props.intl.formatMessage({id: "menu_action_open_private_window"}),
         icon: "new-window-private",
         userEvent: "OPEN_PRIVATE_WINDOW",
         onClick: () => dispatch(actions.NotifyOpenWindow({url: site.url, isPrivate: true}))

--- a/content-src/components/Loader/Loader.js
+++ b/content-src/components/Loader/Loader.js
@@ -4,10 +4,7 @@ const {FormattedMessage} = require("react-intl");
 
 const Loader = React.createClass({
   getDefaultProps() {
-    return {
-      show: false,
-      label: "Loading..."
-    };
+    return {show: false};
   },
   render() {
     // refs are intended as testing hooks
@@ -17,7 +14,7 @@ const Loader = React.createClass({
         <p ref="body"><FormattedMessage id={this.props.body} defaultMessage={this.props.body} /></p>
         <div ref="statusBox" className="status-box">
           <div className="spinner" />
-          <FormattedMessage id={this.props.label} defaultMessage={this.props.label} />
+          <FormattedMessage id={this.props.label} defaultMessage={this.props.defaultLabel} />
         </div>
       </div>);
   }
@@ -27,6 +24,7 @@ Loader.propTypes = {
   body: React.PropTypes.string,
   show: React.PropTypes.bool,
   label: React.PropTypes.string,
+  defaultLabel: React.PropTypes.string,
   className: React.PropTypes.string,
   title: React.PropTypes.string
 };

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -17,7 +17,7 @@ const NewTabPage = React.createClass({
     return {showSettingsMenu: false};
   },
   componentDidMount() {
-    document.title = this.props.intl.formatMessage({id: "newtab"});
+    document.title = this.props.intl.formatMessage({id: "newtab_page_title"});
     setFavicon("newtab-icon.svg");
 
     // Note that data may or may not be complete, depending on
@@ -60,7 +60,8 @@ const NewTabPage = React.createClass({
           show={!this.props.isReady}
           title="welcome_title"
           body="welcome_body"
-          label="welcome_label" />
+          label="welcome_label"
+          defaultLabel="default_label_loading" />
         <div className="show-on-init on">
           <section>
             <TopSites placeholder={!this.props.isReady} page={PAGE_NAME}

--- a/content-src/components/Search/Search.js
+++ b/content-src/components/Search/Search.js
@@ -259,7 +259,7 @@ const Search = React.createClass({
         value={searchString} maxLength="256"
         aria-expanded={this.getDropdownVisible()}
         aria-activedescendant={this.getActiveDescendantId()} autoComplete="off"
-        placeholder={this.props.intl.formatMessage({id: "search_web"})}
+        placeholder={this.props.intl.formatMessage({id: "search_web_placeholder"})}
         onFocus={() => this.setState({focus: true})}
         onChange={e => this.setValueAndSuggestions(e.target.value)}
         onKeyDown={e => this.handleKeyPress(e)}
@@ -306,7 +306,7 @@ const Search = React.createClass({
         </ul>
       </section>
       <section className="search-title">
-        <p><FormattedMessage id="search_for" values={{search_term: <b>{searchString}</b>}} /></p>
+        <p><FormattedMessage id="search_for_something_with" values={{search_term: <b>{searchString}</b>}} /></p>
       </section>
       <section className="search-partners" role="group">
             <ul>

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -154,7 +154,7 @@ const Spotlight = React.createClass({
   },
   render() {
     return (<section className="spotlight">
-      <h3 className="section-title"><FormattedMessage id="highlights" /></h3>
+      <h3 className="section-title"><FormattedMessage id="header_highlights" /></h3>
       <ul className="spotlight-list">
         {this.props.placeholder ? this.renderPlaceholderSiteList() :
           this.renderSiteList()}

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -122,7 +122,7 @@ const TopSites = React.createClass({
   render() {
     const sites = this.props.sites.slice(0, this.props.length);
     return (<section className="top-sites">
-      <h3 className="section-title"><FormattedMessage id="top_sites" /></h3>
+      <h3 className="section-title"><FormattedMessage id="header_top_sites" /></h3>
       <div className="tiles-wrapper">
         {sites.map((site, i) => {
           // if this is a placeholder, we want all the widgets to render empty

--- a/content-src/lib/getRelativeTime.js
+++ b/content-src/lib/getRelativeTime.js
@@ -22,13 +22,13 @@ module.exports = function getRelativeTime(time) {
   const h = Math.floor((diff % TIME.d) / TIME.h);
   const d = Math.floor(diff / TIME.d);
   if (diff < TIME.m) {
-    return {timestampID: "less_than_minute_label"};
+    return {timestampID: "time_label_less_than_minute"};
   }
   else if (diff < TIME.h) {
-    return {timestampID: "minute_label", timestampNumber: m};
+    return {timestampID: "time_label_minute", timestampNumber: m};
   }
   else if (diff < TIME.d) {
-    return {timestampID: "hour_label", timestampNumber: h};
+    return {timestampID: "time_label_hour", timestampNumber: h};
   }
-  return {timestampID: "day_label", timestampNumber: d};
+  return {timestampID: "time_label_day", timestampNumber: d};
 };

--- a/content-test/components/HighlightContext.test.js
+++ b/content-test/components/HighlightContext.test.js
@@ -28,9 +28,7 @@ describe("HighlightContext", () => {
 
   it("should render the label defined by type if props.label is not specified", () => {
     setup({type: "bookmark"});
-    const label = types.bookmark.intlID;
-    const expectedString = `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
-    assert.equal(wrapper.find(".hc-label").text(), expectedString);
+    assert.equal(wrapper.find(".hc-label").text(), "Bookmarked");
   });
 
   it("should render props.date if specified", () => {

--- a/content-test/lib/getRelativeTime.test.js
+++ b/content-test/lib/getRelativeTime.test.js
@@ -3,27 +3,27 @@ const moment = require("moment");
 
 describe("getRelativeTime", () => {
   it("should show <1m for ~seconds", () => {
-    assert.equal(getRelativeTime(moment().valueOf()).timestampID, "less_than_minute_label");
-    assert.equal(getRelativeTime(moment().subtract(30, "seconds").valueOf()).timestampID, "less_than_minute_label");
+    assert.equal(getRelativeTime(moment().valueOf()).timestampID, "time_label_less_than_minute");
+    assert.equal(getRelativeTime(moment().subtract(30, "seconds").valueOf()).timestampID, "time_label_less_than_minute");
   });
 
   // eslint-disable-next-line no-template-curly-in-string
   it("should show ${n}m for ~minutes", () => {
-    assert.equal(getRelativeTime(moment().subtract(1, "minutes").valueOf()).timestampID, "minute_label");
+    assert.equal(getRelativeTime(moment().subtract(1, "minutes").valueOf()).timestampID, "time_label_minute");
     assert.equal(getRelativeTime(moment().subtract(1, "minutes").valueOf()).timestampNumber, "1");
     assert.equal(getRelativeTime(moment().subtract(5, "minutes").valueOf()).timestampNumber, "5");
   });
 
   // eslint-disable-next-line no-template-curly-in-string
   it("should show ${n}h for ~hours", () => {
-    assert.equal(getRelativeTime(moment().subtract(1, "hours").valueOf()).timestampID, "hour_label");
+    assert.equal(getRelativeTime(moment().subtract(1, "hours").valueOf()).timestampID, "time_label_hour");
     assert.equal(getRelativeTime(moment().subtract(1, "hours").valueOf()).timestampNumber, "1");
     assert.equal(getRelativeTime(moment().subtract(5, "hours").valueOf()).timestampNumber, "5");
   });
 
   // eslint-disable-next-line no-template-curly-in-string
   it("should show ${n}d for ~days", () => {
-    assert.equal(getRelativeTime(moment().subtract(1, "days").valueOf()).timestampID, "day_label");
+    assert.equal(getRelativeTime(moment().subtract(1, "days").valueOf()).timestampID, "time_label_day");
     assert.equal(getRelativeTime(moment().subtract(1, "days").valueOf()).timestampNumber, "1");
     assert.equal(getRelativeTime(moment().subtract(5, "days").valueOf()).timestampNumber, "5");
   });

--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -1,29 +1,57 @@
-top_sites=Top Sites
-highlights=Highlights
-visited=Visited
-bookmarked=Bookmarked
-synced=Synced from another device
-open=Open
-topic=Topic
-bookmark=Bookmark
-remove_bookmark=Remove Bookmark
-share=Share
-copy_address=Copy Address
-email_link=Email Link...
-open_new_window=Open in a New Window
-open_private_window=Open in a Private Window
-dismiss=Dismiss
-delete=Delete from History
-newtab=New Tab
-search_web=Search the Web
-search_for=Search for {search_term} with
-search_settings=Change Search Settings
+newtab_page_title=New Tab
+default_label_loading=Loading…
+
+header_top_sites=Top Sites
+header_highlights=Highlights
+
+# LOCALIZATION NOTE(type_label_*): These labels are shown with a page to give
+# context on how the page is related to the user
+# e.g. The type indicates that the page is bookmarked, or is currently open on
+# another device
+type_label_visited=Visited
+type_label_bookmarked=Bookmarked
+type_label_synced=Synced from another device
+type_label_open=Open
+type_label_topic=Topic
+
+# LOCALIZATION NOTE(menu_action_*): These shown in a context menu and are meant
+# as a call to action for a given page
+menu_action_bookmark=Bookmark
+menu_action_remove_bookmark=Remove Bookmark
+menu_action_share=Share
+menu_action_copy_address=Copy Address
+menu_action_email_link=Email Link…
+menu_action_open_new_window=Open in a New Window
+menu_action_open_private_window=Open in a Private Window
+menu_action_dismiss=Dismiss
+menu_action_delete=Delete from History
+
+# LOCALIZATION NOTE (search_for_something_with): {search_term} is a placeholder for
+# what the user has typed in the search input field.
+# e.g. 'Search for ' + search_term + 'with:' becomes 'Search for abc with:'
+# The search engine name is displayed as an icon and does not need a translation
+search_for_something_with=Search for {search_term} with:
+
+# LOCALIZATION NOTE (search_header): Displayed at the top of the panel
+# showing search suggestions. {search_term} is replaced with the name of the current
+# default search engine. e.g. 'Google Search'
 search_header={search_engine_name} Search
-loading=Loading...
+
+# LOCALIZATION NOTE (search_web_placeholder): This is shown in the searchbox when
+# the user hasn't typed anything yet.
+search_web_placeholder=Search the Web
+search_settings=Change Search Settings
+
+# LOCALIZATION NOTE (welcome_*): This is shown as a modal dialog typically on a
+# first-run experience when the data is not ready to show yet
 welcome_title=Welcome to new tab
-welcome_body=Firefox will use this space to show your most relevant bookmarks, articles, videos, and pages you've recently visited, so you can get back to them easily.
+welcome_body=Firefox will use this space to show your most relevant bookmarks, articles, videos, and pages you’ve recently visited, so you can get back to them easily.
 welcome_label=Identifying your Highlights
-less_than_minute_label=<1m
-minute_label={number}m
-hour_label={number}h
-day_label={number}d
+
+# LOCALIZATION NOTE (time_label_*): {number} is a placeholder for a number which reprents a
+# shortened timestamp format e.g. '10m' represents '10 minutes ago'. Do not translate 'm'
+# into 'minutes ago'
+time_label_less_than_minute=<1m
+time_label_minute={number}m
+time_label_hour={number}h
+time_label_day={number}d


### PR DESCRIPTION
Addresses the first few i18n comments mentioned here: https://github.com/mozilla/activity-stream/issues/2027#issuecomment-277087062
* Adds comments describing the strings for translators
* Uses unicode … rather than ```...```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2124)
<!-- Reviewable:end -->
