### PR TITLE
String change to be consistent with desktop

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -22,7 +22,7 @@ menu_action_share=Share
 menu_action_copy_address=Copy Address
 menu_action_email_link=Email Link…
 menu_action_open_new_window=Open in a New Window
-menu_action_open_private_window=Open in a Private Window
+menu_action_open_private_window=Open in a New Private Window
 menu_action_dismiss=Dismiss
 menu_action_delete=Delete from History
 


### PR DESCRIPTION
Firefox desktop uses the strings `Open Link in a New Window` and `Open Link in a New Private Window`. Change to make string consistent with desktop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2135)
<!-- Reviewable:end -->
