### PR TITLE
fix (styles): #2125 fix site icon fallback style in screenshots experiment

### DIFF
--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -103,7 +103,7 @@
 
       &.placeholder {
         .site-icon-wrapper {
-          height: 96px;
+          height: $tile-width;
         }
       }
     }
@@ -142,6 +142,11 @@
           background: transparent;
         }
       }
+    }
+
+    .site-icon-fallback {
+      height: $tile-width;
+      line-height: $tile-width;
     }
   }
 }


### PR DESCRIPTION
r? @jaredkerim 

Quickest way to verify:
- start with a new profile (`npm run once` or whatever)
- visit https://moz-activity-streams-dev.s3.amazonaws.com/dist/latest.html
- verify top sites with `screenshots` experiment on and off

Fixes #2125 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2138)
<!-- Reviewable:end -->
