### PR TITLE
fix(l10n): #2129 Fall back to en-US strings if some are missing

### DIFF
--- a/addon/Feeds/LocalizationFeed.js
+++ b/addon/Feeds/LocalizationFeed.js
@@ -2,10 +2,18 @@ const {PrefsTarget} = require("sdk/preferences/event-target");
 const {findClosestLocale, getPreferedLocales} = require("sdk/l10n/locale");
 const Feed = require("../lib/Feed");
 const am = require("../../common/action-manager");
-
+const DEFAULT_LOCALE = "en-US";
 const STRINGS = require("../../data/locales/locales.json");
 const AVAILABLE_LOCALES = Object.keys(STRINGS);
-const DEFAULT_LOCALE = "en-US";
+
+function getLocalizedStrings(locale, allStrings = STRINGS) {
+  if (locale === DEFAULT_LOCALE) {
+    return allStrings[DEFAULT_LOCALE];
+  }
+  const strings = allStrings[locale];
+  // This will include the English string for any missing ids
+  return Object.assign({}, allStrings[DEFAULT_LOCALE], strings || {});
+}
 
 // These all affect getPreferedLocales
 const LOCALE_PREFS = [
@@ -32,7 +40,7 @@ class LocalizationFeed extends Feed {
   }
   getData() {
     let locale = findClosestLocale(this.availableLocales, getPreferedLocales());
-    const strings = STRINGS[locale] || STRINGS[DEFAULT_LOCALE];
+    const strings = getLocalizedStrings(locale);
     return Promise.resolve(am.actions.Response("LOCALE_UPDATED", {locale, strings}));
   }
   onAction(state, action) {
@@ -47,7 +55,9 @@ class LocalizationFeed extends Feed {
   }
 }
 
+LocalizationFeed.DEFAULT_LOCALE = DEFAULT_LOCALE;
 LocalizationFeed.AVAILABLE_LOCALES = AVAILABLE_LOCALES;
 LocalizationFeed.LOCALE_PREFS = LOCALE_PREFS;
+LocalizationFeed.getLocalizedStrings = getLocalizedStrings;
 
 module.exports = LocalizationFeed;

--- a/content-test/addon/Feeds/LocalizationFeed.test.js
+++ b/content-test/addon/Feeds/LocalizationFeed.test.js
@@ -1,4 +1,5 @@
 const LocalizationFeed = require("addon/Feeds/LocalizationFeed");
+const {getLocalizedStrings, DEFAULT_LOCALE} = LocalizationFeed;
 const EventEmitter = require("shims/_utils/EventEmitter");
 
 describe("LocalizationFeed", () => {
@@ -63,6 +64,32 @@ describe("LocalizationFeed", () => {
       sinon.spy(instance, "removeListeners");
       instance.onAction({}, {type: "APP_UNLOAD"});
       assert.calledOnce(instance.removeListeners);
+    });
+  });
+  describe("getLocalizedStrings", () => {
+    it("should return default locale strings without merging if default locale is selected", () => {
+      const strings = {};
+      strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
+      const result = getLocalizedStrings(DEFAULT_LOCALE, strings);
+      assert.equal(result, strings[DEFAULT_LOCALE]);
+    });
+    it("should get strings for a given locale", () => {
+      const strings = {fr: {greeting: "bonjour"}};
+      strings[DEFAULT_LOCALE] = {greeting: "hello"};
+      const result = getLocalizedStrings("fr", strings);
+      assert.deepEqual(result, strings.fr);
+    });
+    it("should include strings from the default locale for any missing ids", () => {
+      const strings = {fr: {greeting: "bonjour"}};
+      strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
+      const result = getLocalizedStrings("fr", strings);
+      assert.deepEqual(result, {greeting: "bonjour", confirm: "yes"});
+    });
+    it("should just return default locale strings if a locale is missing", () => {
+      const strings = {};
+      strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
+      const result = getLocalizedStrings("fr", strings);
+      assert.deepEqual(result, strings[LocalizationFeed.DEFAULT_LOCALE]);
     });
   });
 });


### PR DESCRIPTION
This patch allows `en-US`strings to be fallbacks for the selected locale.

This is kind of hard to manually test right now – check out the unit tests for an example for how it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-stream/2139)
<!-- Reviewable:end -->
