### PR TITLE
feat(a11y): Closes #1993 Bring '...' button to foreground

### DIFF
--- a/content-src/components/LinkMenuButton/LinkMenuButton.scss
+++ b/content-src/components/LinkMenuButton/LinkMenuButton.scss
@@ -18,4 +18,10 @@
   transition-property: transform, opacity;
   transition-duration: 200ms;
   z-index: 399;
+
+  &:focus,
+  &:active {
+    transform: scale(1);
+    opacity: 1;
+  }
 }

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -46,7 +46,7 @@ const SpotlightItem = React.createClass({
       }));
     }
     return (<li className={classNames("spotlight-item", {active: this.state.showContextMenu})}>
-      <a onClick={this.props.onClick} href={site.url} ref="link">
+      <a onClick={this.props.onClick} className="spotlight-inner" href={site.url} ref="link">
         <div className={classNames("spotlight-image", {portrait: isPortrait})} style={style} ref="image">
           <SiteIcon className="spotlight-icon" height={40} width={40} site={site} ref="icon" showBackground={true} border={false} faviconSize={32} />
         </div>

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -37,6 +37,12 @@
   margin-top: 12px;
   margin-bottom: 12px;
 
+  .spotlight-inner {
+    @include accessible-link-menu-button;
+    border-radius: $border-radius;
+    outline: 0;
+  }
+
   @media (min-width: $break-point) {
     flex-shrink: 0;
   }

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -52,8 +52,8 @@ const TopSitesItem = React.createClass({
 
     const {label} = selectSiteProperties(site);
 
-    return (<div className={classNames("tile-outer", {active: isActive})} key={site.guid || site.cache_key || index}>
-      <a onClick={() => this.props.onClick(index)} className="tile" href={site.url} ref="topSiteLink">
+    return (<div className="tile-outer" key={site.guid || site.cache_key || index}>
+      <a onClick={() => this.props.onClick(index)} className={classNames("tile", {active: isActive})} href={site.url} ref="topSiteLink">
         {screenshot && <div className="inner-border" />}
         {screenshot && <div ref="screenshot" className="screenshot" style={{backgroundImage: `url(${screenshot})`}} />}
         <SiteIcon

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -21,6 +21,56 @@
       margin-bottom: 0;
     }
 
+    &:hover {
+      .site-icon-title {
+        background-color: $tile-title-hover-color;
+      }
+    }
+
+    .tile {
+      @include accessible-link-menu-button;
+      border-radius: $border-radius;
+      outline: 0;
+      display: inline-flex;
+      flex-shrink: 0;
+      flex-direction: column;
+      font-size: $tile-font-size;
+      height: $tile-height;
+      position: relative;
+      text-decoration: none;
+      width: $tile-width;
+      color: inherit;
+
+      .site-title {
+        position: absolute;
+        top: 100%;
+        offset-inline-start: 0;
+        width: 100%;
+        padding-top: 6px;
+        font-size: 11px;
+        text-align: center;
+      }
+
+      .tile-img-container {
+        width: 100%;
+        overflow: hidden;
+        position: relative;
+        flex-grow: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &.top-corner {
+          position: absolute;
+          height: 40px;
+          width: 40px;
+          z-index: 1000;
+          top: -6px;
+          offset-inline-start: -6px;
+        }
+      }
+    }
+
     // Only display a placeholder version (ie just outlines/shapes), for use
     // before sufficient data is available to display.
     &.placeholder {
@@ -34,61 +84,15 @@
       }
     }
 
-    &:hover .site-icon-title {
-      background-color: $tile-title-hover-color;
-    }
-  }
-
-  .screenshot {
-    position: absolute;
-    top: 0;
-    offset-inline-start: 0;
-    height: 100%;
-    width: 100%;
-    background-size: 250%;
-    background-position: top center;
-    border-radius: 3px;
-  }
-
-  .tile {
-    display: inline-flex;
-    flex-shrink: 0;
-    flex-direction: column;
-    font-size: $tile-font-size;
-    height: $tile-height;
-    position: relative;
-    text-decoration: none;
-    width: $tile-width;
-    color: inherit;
-
-    .site-title {
+    .screenshot {
       position: absolute;
-      top: 100%;
+      top: 0;
       offset-inline-start: 0;
+      height: 100%;
       width: 100%;
-      padding-top: 6px;
-      font-size: 11px;
-      text-align: center;
-    }
-
-
-    .tile-img-container {
-      width: 100%;
-      overflow: hidden;
-      position: relative;
-      flex-grow: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      &.top-corner {
-        position: absolute;
-        height: 40px;
-        width: 40px;
-        z-index: 1000;
-        top: -6px;
-        offset-inline-start: -6px;
-      }
+      background-size: 250%;
+      background-position: top center;
+      border-radius: 3px;
     }
   }
 }
@@ -106,21 +110,21 @@
           height: $tile-width;
         }
       }
-    }
 
-    .tile {
-      box-shadow: none;
+      .tile {
+        box-shadow: none;
 
-      .tile-img-container {
-        // This is a hack so the title is visible since we are positioning
-        // it outside of the container for the experiment. If/when the experiment
-        // graduates, we should change the HTML instead.
-        overflow: visible;
-      }
+        .tile-img-container {
+          // This is a hack so the title is visible since we are positioning
+          // it outside of the container for the experiment. If/when the experiment
+          // graduates, we should change the HTML instead.
+          overflow: visible;
+        }
 
-      .site-title {
-        height: 22px;
-        overflow: hidden;
+        .site-title {
+          height: 22px;
+          overflow: hidden;
+        }
       }
     }
 

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -132,19 +132,34 @@ $code-color: #E8005C;
 @mixin item-shadow {
   box-shadow: $item-shadow;
 
-  &:hover,
-  &.active {
+  &:hover {
     box-shadow: $item-shadow-hover;
     transition: box-shadow 150ms;
   }
 }
 
 @mixin link-menu-button {
-  &:hover,
-  &.active {
+  &:hover {
     .link-menu-button {
       transform: scale(1);
       opacity: 1;
+    }
+  }
+}
+
+@mixin accessible-link-menu-button {
+  &:active,
+  &:focus {
+    box-shadow: $item-shadow-hover;
+    transition: box-shadow 150ms;
+
+    + .link-menu-button {
+      transform: scale(1);
+      opacity: 1;
+    }
+
+    .site-icon-title {
+      background-color: $tile-title-hover-color;
     }
   }
 }

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -66,7 +66,7 @@ describe("TopSites", () => {
     it("should make the tile active when link menu button is clicked", () => {
       const button = ReactDOM.findDOMNode(TestUtils.scryRenderedComponentsWithType(topSites, LinkMenuButton)[0]);
       TestUtils.Simulate.click(button);
-      const tileOuter = el.querySelector(".tile-outer");
+      const tileOuter = el.querySelector(".tile");
       assert.include(tileOuter.className, "active");
     });
   });


### PR DESCRIPTION
This diff is really hard to read but basically what I did was:
1. Move ```.tile``` so that it's nested in ```.tile-outer```. This allowed for some of the focus stuff to work properly
2. Add a new mixin for these "inner" elements, ```.tile``` and ```.spotlight-inner``` which keeps the border and shows the link menu button when you tab through it

The best way to test this is to just run this and start tabbing through the top sites and highlights. What happens is when you tab through it, it'll show focus in 3 ways: 1. the border shows up 2. background colour of ```.site-icon-title``` turns white and 3. the menu link button shows up. Another tab brings the menu link button into focus and if you press enter it'll open the context menu. This works for both top sites and highlights.

Note: In the original ticket #1993 it was mentioned that if you press "ESC" then the context menu doesn't close. That behaviour is still happening here, I figured we could fix that when we make the context menu accessible in general