### PR TITLE
More getLocalizedStrings to reducers

### DIFF
--- a/addon/Feeds/LocalizationFeed.js
+++ b/addon/Feeds/LocalizationFeed.js
@@ -2,19 +2,8 @@ const {PrefsTarget} = require("sdk/preferences/event-target");
 const {findClosestLocale, getPreferedLocales} = require("sdk/l10n/locale");
 const Feed = require("../lib/Feed");
 const am = require("../../common/action-manager");
-const DEFAULT_LOCALE = "en-US";
-const STRINGS = require("../../data/locales/locales.json");
-const AVAILABLE_LOCALES = Object.keys(STRINGS);
+const AVAILABLE_LOCALES = Object.keys(require("../../data/locales/locales.json"));
 const RTL_LIST = ["ar", "he", "fa", "ur"];
-
-function getLocalizedStrings(locale, allStrings = STRINGS) {
-  if (locale === DEFAULT_LOCALE) {
-    return allStrings[DEFAULT_LOCALE];
-  }
-  const strings = allStrings[locale];
-  // This will include the English string for any missing ids
-  return Object.assign({}, allStrings[DEFAULT_LOCALE], strings || {});
-}
 
 function getDirection(locale) {
   return (RTL_LIST.indexOf(locale.split("-")[0]) >= 0) ? "rtl" : "ltr";
@@ -45,9 +34,8 @@ class LocalizationFeed extends Feed {
   }
   getData() {
     let locale = findClosestLocale(this.availableLocales, getPreferedLocales());
-    const strings = getLocalizedStrings(locale);
     const direction = getDirection(locale);
-    return Promise.resolve(am.actions.Response("LOCALE_UPDATED", {locale, strings, direction}));
+    return Promise.resolve(am.actions.Response("LOCALE_UPDATED", {locale, direction}));
   }
   onAction(state, action) {
     switch (action.type) {
@@ -61,10 +49,7 @@ class LocalizationFeed extends Feed {
   }
 }
 
-LocalizationFeed.DEFAULT_LOCALE = DEFAULT_LOCALE;
-LocalizationFeed.AVAILABLE_LOCALES = AVAILABLE_LOCALES;
 LocalizationFeed.LOCALE_PREFS = LOCALE_PREFS;
-LocalizationFeed.getLocalizedStrings = getLocalizedStrings;
 LocalizationFeed.getDirection = getDirection;
 
 module.exports = LocalizationFeed;

--- a/bin/strings-import.js
+++ b/bin/strings-import.js
@@ -3,7 +3,7 @@
 
 /* eslint-disable no-console */
 
-const DEFAULT_LOCALE = "en-US";
+const DEFAULT_LOCALE = require("../common/constants").DEFAULT_LOCALE;
 
 /* globals cd, cp, ls, mkdir, rm */
 require("shelljs/global");

--- a/common/constants.js
+++ b/common/constants.js
@@ -6,6 +6,9 @@ module.exports = {
   // age smaller/younger than this value results in a larger-than-1.0 fraction
   BOOKMARK_AGE_DIVIDEND: 3 * 24 * 60 * 60 * 1000,
 
+  // What is our default locale for the app?
+  DEFAULT_LOCALE: "en-US",
+
   // Number of large Highlight titles in the new Highlights world, including
   // all rows.
   HIGHLIGHTS_LENGTH: 9,

--- a/common/getLocalizedStrings.js
+++ b/common/getLocalizedStrings.js
@@ -1,4 +1,4 @@
-const DEFAULT_LOCALE = "en-US";
+const {DEFAULT_LOCALE} = require("../common/constants");
 const STRINGS = require("../data/locales/locales.json");
 
 module.exports = function getLocalizedStrings(locale, allStrings = STRINGS) {

--- a/common/getLocalizedStrings.js
+++ b/common/getLocalizedStrings.js
@@ -1,0 +1,11 @@
+const DEFAULT_LOCALE = "en-US";
+const STRINGS = require("../data/locales/locales.json");
+
+module.exports = function getLocalizedStrings(locale, allStrings = STRINGS) {
+  if (locale === DEFAULT_LOCALE) {
+    return allStrings[DEFAULT_LOCALE];
+  }
+  const strings = allStrings[locale];
+  // This will include the English string for any missing ids
+  return Object.assign({}, allStrings[DEFAULT_LOCALE], strings || {});
+};

--- a/common/reducers/Intl.js
+++ b/common/reducers/Intl.js
@@ -1,4 +1,5 @@
-const INITIAL_STATE = {locale: null, strings: {}, direction: null};
+const {DEFAULT_LOCALE} = require("common/constants");
+const INITIAL_STATE = {locale: DEFAULT_LOCALE, strings: {}, direction: "ltr"};
 const getLocalizedStrings = require("common/getLocalizedStrings");
 
 function Intl(prevState = INITIAL_STATE, action) {

--- a/common/reducers/Intl.js
+++ b/common/reducers/Intl.js
@@ -1,4 +1,5 @@
 const INITIAL_STATE = {locale: null, strings: {}, direction: null};
+const getLocalizedStrings = require("common/getLocalizedStrings");
 
 function Intl(prevState = INITIAL_STATE, action) {
   switch (action.type) {
@@ -8,7 +9,7 @@ function Intl(prevState = INITIAL_STATE, action) {
       }
       return Object.assign({}, prevState, {
         locale: action.data.locale,
-        strings: action.data.strings,
+        strings: getLocalizedStrings(action.data.locale),
         direction: action.data.direction
       });
     default:

--- a/content-test/addon/Feeds/LocalizationFeed.test.js
+++ b/content-test/addon/Feeds/LocalizationFeed.test.js
@@ -1,5 +1,6 @@
 const LocalizationFeed = require("addon/Feeds/LocalizationFeed");
-const {getLocalizedStrings, getDirection, DEFAULT_LOCALE} = LocalizationFeed;
+const {getDirection} = LocalizationFeed;
+const {DEFAULT_LOCALE} = require("common/constants");
 const EventEmitter = require("shims/_utils/EventEmitter");
 
 describe("LocalizationFeed", () => {
@@ -34,11 +35,10 @@ describe("LocalizationFeed", () => {
         assert.equal(action.type, "LOCALE_UPDATED");
       })
     ));
-    it("should resolve with a valid locale, strings and direction", () => (
+    it("should resolve with a valid locale and direction", () => (
       instance.getData().then(action => {
         assert.isObject(action.data);
-        assert.include(LocalizationFeed.AVAILABLE_LOCALES, action.data.locale);
-        assert.isObject(action.data.strings);
+        assert.include(instance.availableLocales, action.data.locale);
         assert.ok(action.data.direction);
       })
     ));
@@ -79,32 +79,6 @@ describe("LocalizationFeed", () => {
       sinon.spy(instance, "removeListeners");
       instance.onAction({}, {type: "APP_UNLOAD"});
       assert.calledOnce(instance.removeListeners);
-    });
-  });
-  describe("getLocalizedStrings", () => {
-    it("should return default locale strings without merging if default locale is selected", () => {
-      const strings = {};
-      strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
-      const result = getLocalizedStrings(DEFAULT_LOCALE, strings);
-      assert.equal(result, strings[DEFAULT_LOCALE]);
-    });
-    it("should get strings for a given locale", () => {
-      const strings = {fr: {greeting: "bonjour"}};
-      strings[DEFAULT_LOCALE] = {greeting: "hello"};
-      const result = getLocalizedStrings("fr", strings);
-      assert.deepEqual(result, strings.fr);
-    });
-    it("should include strings from the default locale for any missing ids", () => {
-      const strings = {fr: {greeting: "bonjour"}};
-      strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
-      const result = getLocalizedStrings("fr", strings);
-      assert.deepEqual(result, {greeting: "bonjour", confirm: "yes"});
-    });
-    it("should just return default locale strings if a locale is missing", () => {
-      const strings = {};
-      strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
-      const result = getLocalizedStrings("fr", strings);
-      assert.deepEqual(result, strings[LocalizationFeed.DEFAULT_LOCALE]);
     });
   });
 });

--- a/content-test/common/getLocalizedStrings.test.js
+++ b/content-test/common/getLocalizedStrings.test.js
@@ -1,0 +1,29 @@
+const {DEFAULT_LOCALE} = require("common/constants");
+const getLocalizedStrings = require("common/getLocalizedStrings");
+
+describe("getLocalizedStrings", () => {
+  it("should return default locale strings without merging if default locale is selected", () => {
+    const strings = {};
+    strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
+    const result = getLocalizedStrings(DEFAULT_LOCALE, strings);
+    assert.equal(result, strings[DEFAULT_LOCALE]);
+  });
+  it("should get strings for a given locale", () => {
+    const strings = {fr: {greeting: "bonjour"}};
+    strings[DEFAULT_LOCALE] = {greeting: "hello"};
+    const result = getLocalizedStrings("fr", strings);
+    assert.deepEqual(result, strings.fr);
+  });
+  it("should include strings from the default locale for any missing ids", () => {
+    const strings = {fr: {greeting: "bonjour"}};
+    strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
+    const result = getLocalizedStrings("fr", strings);
+    assert.deepEqual(result, {greeting: "bonjour", confirm: "yes"});
+  });
+  it("should just return default locale strings if a locale is missing", () => {
+    const strings = {};
+    strings[DEFAULT_LOCALE] = {greeting: "hello", confirm: "yes"};
+    const result = getLocalizedStrings("fr", strings);
+    assert.deepEqual(result, strings[DEFAULT_LOCALE]);
+  });
+});

--- a/content-test/common/reducers/Intl.test.js
+++ b/content-test/common/reducers/Intl.test.js
@@ -7,13 +7,18 @@ describe("Intl reducer", () => {
   });
   describe("LOCALE_UPDATED", () => {
     it("should not update if action.data is missing", () => {
-      const prevState = {locale: "en-US", strings: {}};
+      const prevState = {locale: "en-US", strings: {}, direction: "ltr"};
       const state = Intl(prevState, {type: "LOCALE_UPDATED"});
       assert.equal(state, prevState);
     });
     it("should update .locale, .strings and .direction", () => {
-      const state = Intl(undefined, {type: "LOCALE_UPDATED", data: {locale: "en-FOO", strings: {foo: "foo"}, direction: "ltr"}});
-      assert.deepEqual(state, Object.assign({}, Intl.INITIAL_STATE, {locale: "en-FOO", strings: {foo: "foo"}, direction: "ltr"}));
+      const state = Intl(undefined, {
+        type: "LOCALE_UPDATED",
+        data: {locale: "en-FOO", direction: "rtl"}
+      });
+      assert.equal(state.locale, "en-FOO", ".locale");
+      assert.isObject(state.strings, ".strings");
+      assert.equal(state.direction, "rtl");
     });
   });
 });

--- a/content-test/test-utils.js
+++ b/content-test/test-utils.js
@@ -27,7 +27,7 @@ function createMockProvider(custom) {
 }
 
 function createIntlProvider(component) {
-  const intlWrapper = (<IntlProvider locale="en" messages={messages}>{component}</IntlProvider>);
+  const intlWrapper = (<IntlProvider locale="en-US" messages={messages}>{component}</IntlProvider>);
   return intlWrapper;
 }
 


### PR DESCRIPTION
This patch fixes an issue where strings are not available during loading.

I also moved `DEFAULT_LOCALE` to our constants file.