### PR TITLE
fix(l10n): #2158 use componentWillMount to load locale data

### DIFF
--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -9,7 +9,7 @@ const {IntlProvider, addLocaleData} = require("react-intl");
 
 const Base = React.createClass({
   getInitialState() {return {showDebugPage: false};},
-  componentDidMount() {
+  componentWillMount() {
     // Add the locale data for pluralization and relative-time formatting
     addLocaleData([{locale: this.props.Intl.locale, parentLocale: "en"}]);
     document.documentElement.lang = this.props.Intl.locale;


### PR DESCRIPTION
Here is the fix – we were trying to look for locale data AFTER the strings were already being rendered, this adds locale data before. We missed this because we were testing languages that were variants of `en`. Oops!

We will add a test for non-`en` locales as a follow-up, but putting this up on its own since it's fairly urgent.