### PR TITLE
Increase localFetch experiment population to 20% fixes #2144

### DIFF
--- a/addon/Feeds/MetadataFeed.js
+++ b/addon/Feeds/MetadataFeed.js
@@ -32,7 +32,7 @@ module.exports = class MetadataFeed extends Feed {
     this.linksToFetch.clear();
 
     // if we are in the experiment, make a network request through PageScraper
-    if (simplePrefs.prefs["experiments.locallyFetchMetadata"]) {
+    if (simplePrefs.prefs["experiments.locallyFetchMetadata20"]) {
       return this.options.fetchNewMetadataLocally(links, "METADATA_FEED_REQUEST").then(() => (am.actions.Response("METADATA_FEED_UPDATED")));
     }
     return this.options.fetchNewMetadata(links, "METADATA_FEED_REQUEST").then(() => (am.actions.Response("METADATA_FEED_UPDATED")));

--- a/content-test/addon/Feeds/MetadataFeed.test.js
+++ b/content-test/addon/Feeds/MetadataFeed.test.js
@@ -33,11 +33,11 @@ describe("MetadataFeed", () => {
         assert.calledOnce(instance.options.fetchNewMetadata)))
     );
     it("should run sites through fetchNewMetadataLocally if experiment pref is on", () => {
-      simplePrefs.prefs["experiments.locallyFetchMetadata"] = true;
+      simplePrefs.prefs["experiments.locallyFetchMetadata20"] = true;
       return instance.getData().then(() => {
         assert.notCalled(instance.options.fetchNewMetadata);
         assert.calledOnce(instance.options.fetchNewMetadataLocally);
-        simplePrefs.prefs["experiments.locallyFetchMetadata"] = false;
+        simplePrefs.prefs["experiments.locallyFetchMetadata20"] = false;
       });
     });
     it("should resolve with an action, but no data", () => (

--- a/experiments.json
+++ b/experiments.json
@@ -91,7 +91,7 @@
   },
   "locallyFetchMetadata": {
     "name": "Fetch Page Content Locally",
-    "active": true,
+    "active": false,
     "description": "Make a network request for content of a URL",
     "control": {
       "value": false,
@@ -132,6 +132,21 @@
       "value": true,
       "threshold": 0.2,
       "description": "Show screenshots"
+    }
+  },
+  "locallyFetchMetadata20": {
+    "name": "Fetch Page Content Locally",
+    "active": true,
+    "description": "Make a network request for content of a URL",
+    "control": {
+      "value": false,
+      "description": "Use remote service for metadata"
+    },
+    "variant": {
+      "id": "exp-010-locally-fetch-metadata",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Fetch page content locally"
     }
   }
 }


### PR DESCRIPTION
Close the old experiment, create a new experiment, switch all references to the new experiment.