### PR TITLE
fix(events): #2113 do not fire bookmark events if no data in event

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -260,9 +260,17 @@ ActivityStreams.prototype = {
   _handlePlacesChanges(eventName, data) {
     switch (eventName) {
       case "bookmarkAdded":
+        // Note: Firefox sometimes fires bookmarkAdded and bookmarkRemoved events
+        // that have no data associated with them
+        if (!data) {
+          return;
+        }
         this.broadcast(am.actions.Response("RECEIVE_BOOKMARK_ADDED", data));
         break;
       case "bookmarkRemoved":
+        if (!data) {
+          return;
+        }
         this.broadcast(am.actions.Response("RECEIVE_BOOKMARK_REMOVED", data));
         break;
       case "manyLinksChanged":


### PR DESCRIPTION
This fixes an issue where if bookmark-related event is fired with no data (from a test, for example) it will not propagate through our system.

It was causing `data.action is undefined` errors