### PR TITLE
feat(prefs): Closes #2170 Global pref to turn experiments off

### DIFF
--- a/addon/ExperimentProvider.js
+++ b/addon/ExperimentProvider.js
@@ -53,6 +53,20 @@ exports.ExperimentProvider = class ExperimentProvider {
     this._experimentId = null;
   }
 
+  /**
+   * This is used to disable all experiments, i.e set all their
+   * values to their original control value.
+   */
+  disableAllExperiments() {
+    Object.keys(this._experiments).forEach(key => {
+      const experiment = this._experiments[key];
+      const {active, control} = experiment;
+      if (active) {
+        prefService.set(PREF_PREFIX + key, control.value);
+      }
+    });
+  }
+
   setValues() {
     if (ss.storage.overrideExperimentProvider) {
       console.log(`The following experiments were turned on via overrides:\n`); // eslint-disable-line no-console
@@ -64,6 +78,12 @@ exports.ExperimentProvider = class ExperimentProvider {
           prefService.set(PREF_PREFIX + experimentName, control.value);
         }
       });
+      return;
+    }
+
+    // if the global pref to disable experiments is on, disable experiments
+    if (!prefService.get(`extensions.${preferencesBranch}.activateExperiments`)) {
+      this.disableAllExperiments();
       return;
     }
 

--- a/content-test/addon/ExperimentProvider.test.js
+++ b/content-test/addon/ExperimentProvider.test.js
@@ -41,6 +41,7 @@ describe("ExperimentProvider", () => {
   }
 
   beforeEach(() => {
+    prefService.set(`extensions.${preferencesBranch}.activateExperiments`, true);
     global.EventEmitter = {
       decorate(ctx) {
         ctx.emit = sinon.spy();
@@ -373,6 +374,29 @@ describe("ExperimentProvider", () => {
 
       assert.isTrue(experimentProvider.data.foo);
       assert.isTrue(ss.storage.overrideExperimentProvider);
+    });
+    it("should disable all active experiments if pref says so", () => {
+      const data = {
+        clientID: "foo",
+        experiments: {
+          activeFoo: {
+            name: "Active Foo Test",
+            active: true,
+            control: {value: "control_val"},
+            variant: {id: "foo_01", value: "variant_val", threshold: 0.5}
+          },
+          notActiveFoo: {
+            name: "Not Active Foo Test",
+            active: false,
+            control: {value: false},
+            variant: {id: "foo_02", value: true, threshold: 0.5}
+          }
+        }
+      };
+      prefService.set(`extensions.${preferencesBranch}.activateExperiments`, false);
+      setup(data);
+      assert.equal(prefService.get(`${PREF_PREFIX}activeFoo`), data.experiments.activeFoo.control.value);
+      assert.equal(prefService.get(`${PREF_PREFIX}notActiveFoo`, undefined));
     });
   });
 

--- a/mozilla-central/prefs_general.diff
+++ b/mozilla-central/prefs_general.diff
@@ -1,10 +1,11 @@
 diff --git a/testing/profiles/prefs_general.js b/testing/profiles/prefs_general.js
 --- a/testing/profiles/prefs_general.js
 +++ b/testing/profiles/prefs_general.js
-@@ -268,2 +268,7 @@ user_pref('identity.fxaccounts.skipDeviceRegistration', true);
+@@ -268,2 +268,8 @@ user_pref('identity.fxaccounts.skipDeviceRegistration', true);
 
 +// Make sure that activity stream doesn't hit the network.
 +user_pref("extensions.@activity-streams.telemetry", false);
++user_pref("extensions.@activity-streams.activateExperiments", false);
 +user_pref("extensions.@activity-streams.telemetry.ping.endpoint", "https://localhost/v3/links/activity-stream");
 +user_pref("extensions.@activity-streams.metadata.endpoint", "https://localhost/v2/metadata");
 +

--- a/package.json
+++ b/package.json
@@ -150,6 +150,13 @@
       "type": "string",
       "value": "[-0.1, -0.1, -0.1, 0.4, 0.2]",
       "hidden": true
+    },
+    {
+      "name": "activateExperiments",
+      "title": "Activate Experiments",
+      "type": "bool",
+      "value": true,
+      "hidden": true
     }
   ],
   "repository": "mozilla/activity-stream",


### PR DESCRIPTION
* Creates a pref which, if set to false, will not initialize the experiment provider.
* Turns that pref to false in ```prefs_general.diff``` so we can turn them off during mochitests
* Adds a test 