### PR TITLE
feat(tests): Closes #2151 Migrate about:home test to mochitest

### DIFF
--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -62,7 +62,7 @@ That will build the debugger and copy over all the relevant files into `firefox`
 
 ## Adding New Tests
 
-If you add new tests, make sure to list them in the `browser.ini` file. You will see the other tests there. Add a new entry with the same format as the others. You can also add new JS or HTML files by listing in under `support-files`.
+If you add new tests, make sure to list them in the `browser.ini` file. You will see the other tests there. Add a new entry with the same format as the others. You can also add new JS or HTML files by listing in under `support-files`. Make sure to start your test name with "browser_", so that the test suite knows the pick it up. E.g: "browser_as_my_new_test.js".
 
 ## Writing Tests
 

--- a/test/functional/mochitest/.eslintrc
+++ b/test/functional/mochitest/.eslintrc
@@ -23,6 +23,7 @@
     "is": false,
     "isnot": false,
     "ok": false,
+    "OpenBrowserWindow": false,
     "Preferences": false,
     "registerCleanupFunction": false,
     "requestLongerTimeout": false,

--- a/test/functional/mochitest/browser.ini
+++ b/test/functional/mochitest/browser.ini
@@ -1,2 +1,3 @@
 [browser_as_load_location.js]
 [browser_as_private_browsing.js]
+[browser_as_about_home.js]

--- a/test/functional/mochitest/browser_as_about_home.js
+++ b/test/functional/mochitest/browser_as_about_home.js
@@ -1,0 +1,45 @@
+"use strict";
+
+let Cu = Components.utils;
+Cu.import("resource://gre/modules/Task.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+
+const ABOUT_HOME_PREF = "browser.startup.homepage";
+const STARTUP_PAGE_PREF = "browser.startup.page";
+const ACTIVITY_STREAM_HOME_URL = "resource://activity-streams/data/content/activity-streams.html#/HOME";
+const NOT_ACTIVITY_STREAM_URL = "https://example.com";
+
+/**
+ * Tests that opening a new window loads activity stream instead of about:home
+ */
+add_task(function*loads_about_home() {
+  // First, set the pref which allows to show the homepage during test runs. In
+  // other tests, this pref is set to 0 which makes the startup pages be about:blank. By
+  // setting it to 1 we let the startup page be decided by the pref 'browser.startup.homepage'
+  yield SpecialPowers.pushPrefEnv({set: [[STARTUP_PAGE_PREF, 1]]});
+
+  // open a new window and wait for it to be loaded
+  let win = OpenBrowserWindow();
+  yield BrowserTestUtils.waitForEvent(win, "load");
+  let browser = win.gBrowser.selectedBrowser;
+  yield BrowserTestUtils.browserLoaded(browser);
+
+  // check what the content task thinks has been loaded
+  yield ContentTask.spawn(browser, {url: ACTIVITY_STREAM_HOME_URL}, args => {
+    Assert.equal(content.location.href, args.url, "Correctly loaded activity-stream instead of about:home");
+  });
+
+  // close the window
+  yield BrowserTestUtils.closeWindow(win);
+});
+
+add_task(function*change_prefs() {
+  // By default, the home page should be set to ActivityStream.
+  let homeURL = Preferences.get(ABOUT_HOME_PREF);
+  Assert.equal(homeURL, ACTIVITY_STREAM_HOME_URL, "Correctly overriden homepage pref");
+
+  // If the pref is already overriden, ActivityStream shouldn't change it.
+  yield SpecialPowers.pushPrefEnv({set: [[ABOUT_HOME_PREF, NOT_ACTIVITY_STREAM_URL]]});
+  homeURL = Preferences.get(ABOUT_HOME_PREF);
+  Assert.equal(homeURL, NOT_ACTIVITY_STREAM_URL, "Do not change back to activity stream URL");
+});


### PR DESCRIPTION
Fix #2151. Creates a mochitest to ensure activity stream takes over about:home 