### PR TITLE
Add importmc task

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "prebuildmc": "npm run export:clean && npm run  export:patch",
     "buildmc:copy": "cpx \"system-addon/**/*\" ../mozilla-central/browser/extensions/activity-stream",
     "startmc": "npm run prebuildmc && npm run buildmc:copy -- -w",
+    "importmc": "cpx \"../mozilla-central/browser/extensions/activity-stream/**/*\" system-addon/",
     "start": "npm-run-all --parallel start:*",
     "prestart": "npm run clean && npm run copyTestImages",
     "start:static": "npm run bundle:static -- -w",

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /* globals Components, XPCOMUtils, Preferences, ActivityStream */
 "use strict";
 
@@ -51,7 +54,7 @@ function uninit(reason) {
 /**
  * onPrefChanged - handler for changes to ACTIVITY_STREAM_ENABLED_PREF
  *
- * @param  {bool} isEnabled Determines whether
+ * @param  {bool} isEnabled Determines whether Activity Stream is enabled
  */
 function onPrefChanged(isEnabled) {
   if (isEnabled) {

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -1,5 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
-
 
 class ActivityStream {
 

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -58,6 +58,9 @@ scripts:
 # startmc: Start developing the bootstrapped add-on
   startmc: =>prebuildmc && =>buildmc:copy -- -w
 
+  # importmc: Import changes from mc to github repo
+  importmc: cpx "../mozilla-central/browser/extensions/activity-stream/**/*" system-addon/
+
 # start: Start watching/compiling assets,
   start:
     _parallel: true


### PR DESCRIPTION
This patch adds a task which simply copies changes from `mozilla-central` back to this repository.

It's needed because there were a couple of (small) review changes as per https://bugzilla.mozilla.org/show_bug.cgi?id=1344319

What do you think? Not exactly a sophisticated approach, but works for now maybe?