### PR TITLE
chore (tippy-top): update tippy-top-sites to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "redux-thunk": "2.1.0",
     "redux-watch": "1.1.1",
     "reselect": "2.5.4",
-    "tippy-top-sites": "1.2.0"
+    "tippy-top-sites": "1.2.1"
   },
   "devDependencies": {
     "@kadira/storybook": "2.29.5",


### PR DESCRIPTION
just a tiny update for the Ycombinator icon.

before:
<img width="183" alt="screen shot 2017-03-09 at 5 14 10 pm" src="https://cloud.githubusercontent.com/assets/36629/23773228/4c75ed58-04ec-11e7-83d8-f84c690d5d00.png">

after:
<img width="192" alt="screen shot 2017-03-09 at 5 16 10 pm" src="https://cloud.githubusercontent.com/assets/36629/23773232/4f46bf58-04ec-11e7-8a33-ec4d80d48e4d.png">
