### PR TITLE
chore (tippy-top): update tippy-top-sites to v1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "redux-thunk": "2.1.0",
     "redux-watch": "1.1.1",
     "reselect": "2.5.4",
-    "tippy-top-sites": "1.2.1"
+    "tippy-top-sites": "1.2.2"
   },
   "devDependencies": {
     "@kadira/storybook": "2.29.5",


### PR DESCRIPTION
this fixes the icon for talking points memo.

before:
<img width="164" alt="screen shot 2017-03-13 at 11 54 21 am" src="https://cloud.githubusercontent.com/assets/36629/23862851/7e39424a-07e4-11e7-96f1-2916336429c1.png">

after:
<img width="157" alt="screen shot 2017-03-13 at 11 56 58 am" src="https://cloud.githubusercontent.com/assets/36629/23862854/81700250-07e4-11e7-9507-6e8e1fe901b7.png">
