### PR TITLE
fix (experiments): #2246 hide New Tab Prefs behind an experiment

### DIFF
--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -51,6 +51,7 @@ const NewTabPage = React.createClass({
     const {showSearch, showTopSites, showHighlights} = props.Prefs.prefs;
 
     const topSitesExperimentIsOn = props.Experiments.values.screenshots;
+    const newTabPrefsExperimentIsOn = props.Experiments.values.newTabPrefs;
 
     return (<main className={classNames("new-tab", {"top-sites-new-style": topSitesExperimentIsOn})}>
       <div className="new-tab-wrapper">
@@ -81,7 +82,9 @@ const NewTabPage = React.createClass({
           }
         </div>
       </div>
-      <PreferencesPane Prefs={props.Prefs} />
+      {newTabPrefsExperimentIsOn &&
+        <PreferencesPane Prefs={props.Prefs} />
+      }
     </main>);
   }
 });

--- a/experiments.json
+++ b/experiments.json
@@ -148,5 +148,20 @@
       "threshold": 0.2,
       "description": "Fetch page content locally"
     }
+  },
+  "newTabPrefs": {
+    "name": "Preferences Pane",
+    "active": true,
+    "description": "Enable the New Tab Prefs feature",
+    "control": {
+      "value": false,
+      "description": "New Tab Prefs is disabled"
+    },
+    "variant": {
+      "id": "exp-011-newtab-prefs",
+      "value": true,
+      "threshold": 0.2,
+      "description": "New Tab Prefs is enabled"
+    }
   }
 }


### PR DESCRIPTION
This one needs to be uplifted to release with an additional commit to deactivate it for now.

r? @ncloudioj 

Fixes #2246