### PR TITLE
fix(metrics): #2244 - fix the missing session_id in the event pings

### DIFF
--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -106,6 +106,8 @@ TabTracker.prototype = {
     payload.addon_version = self.version;
     payload.locale = Locale.getLocale();
     payload.page = url.split("#/")[1] || eventConstants.defaultPage;
+    // Let's make sure we always have session id available.
+    this._tabData.session_id = this._tabData.session_id || String(uuid());
     payload.session_id = this._tabData.session_id;
     payload.user_prefs = this._getUserPreferences();
     if (this._experimentID) {
@@ -350,7 +352,7 @@ TabTracker.prototype = {
 
     // Some performance pings are sent before a tab is loaded. Let's make sure we have
     // session id available in advance for those pings.
-    this._tabData.session_id = String(uuid());
+    this._tabData.session_id = this._tabData.session_id || String(uuid());
   },
 
   _onPrefChange() {


### PR DESCRIPTION
This issue was also found in performance/masga pings.

The fix is a workaround that checks the `session_id` field before each assignment statement (i.e. `session_id` as a left value). 