### PR TITLE
fix (style): tweak for top sites hover state

### DIFF
--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -107,7 +107,9 @@
 
     .tile-outer {
       box-shadow: none;
+      height: $tile-width;
       vertical-align: top;
+      width: $tile-width;
 
       &:hover {
         box-shadow: 0 0 0 5px $faintest-black;


### PR DESCRIPTION
this fixes a little issue @bryanbell noticed where there is some extra space between the bottom of the screenshot and the hover border (the container was a little too tall).

before:
<img width="133" alt="screen shot 2017-03-17 at 1 31 05 pm" src="https://cloud.githubusercontent.com/assets/36629/24055359/0ed8a8d4-0b16-11e7-8275-fc8e52237687.png">

after:
<img width="136" alt="screen shot 2017-03-17 at 1 29 02 pm" src="https://cloud.githubusercontent.com/assets/36629/24055363/12857d4a-0b16-11e7-8224-77e4da05736c.png">
