### PR TITLE
Prepareing the release of Activity Stream 1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     skip_cleanup: true
     script: bin/continuous-integration.sh prerelease
     on:
-      branch: release-1.4.0
+      branch: release-1.8.0
 
 notifications:
   email: false

--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -298,6 +298,10 @@ ActivityStreams.prototype = {
     this._tabTracker.handleUndesiredEvent(msg.data);
   },
 
+  _handleNewTabStats({msg}) {
+    this._tabTracker.handleNewTabStats(msg.data);
+  },
+
   _handleExperimentChange(prefName) {
     this._tabTracker.experimentId = this._experimentProvider.exprimentID;
     this.broadcast(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data));
@@ -310,6 +314,8 @@ ActivityStreams.prototype = {
         return this._handleUserEvent(args);
       case am.type("NOTIFY_UNDESIRED_EVENT"):
         return this._handleUndesiredEvent(args);
+      case am.type("NOTIFY_NEWTAB_STATS"):
+        return this._handleNewTabStats(args);
     }
     return undefined;
   },

--- a/addon/Feeds/TopSitesFeed.js
+++ b/addon/Feeds/TopSitesFeed.js
@@ -37,7 +37,7 @@ module.exports = class TopSitesFeed extends Feed {
       this.missingData = false;
 
       // Get screenshots if the favicons are too small
-      if (experiments.screenshotsAsync) {
+      if (experiments.screenshotsLongCache) {
         for (let link of links) {
           if (this.shouldGetScreenshot(link)) {
             const screenshot = this.getScreenshot(link.url, this.store);

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -31,7 +31,7 @@ Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
 const DEFAULT_OPTIONS = {
-  metadataTTL: 3 * 24 * 60 * 60 * 1000, // 3 days for the metadata to live
+  metadataTTL: 30 * 24 * 60 * 60 * 1000, // 30 days for the metadata to live
   proxyMaxLinks: 25, // number of links proxy accepts per request
   initFresh: false
 };

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -57,7 +57,10 @@ PreviewProvider.prototype = {
   _getMetadataTTL() {
     let timeout = 3 * 24 * 60 * 60 * 1000; // 3 days for the metadata to live
 
-    if (this._store.getState().Experiments.values.screenshotsLongCache) {
+    if (
+      this._store.getState().Experiments.values.screenshotsLongCache ||
+      this._store.getState().Experiments.values.metadataLongCache
+    ) {
       timeout = 90 * 24 * 60 * 60 * 1000; // 90 days for the metadata to live
     }
     return timeout;

--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -24,6 +24,7 @@ const am = new ActionManager([
   "NOTIFY_HISTORY_DELETE",
   "NOTIFY_HISTORY_DELETE_CANCELLED",
   "NOTIFY_MANAGE_ENGINES",
+  "NOTIFY_NEWTAB_STATS",
   "NOTIFY_OPEN_WINDOW",
   "NOTIFY_PERFORMANCE",
   "NOTIFY_PERFORM_SEARCH",
@@ -185,6 +186,13 @@ function NotifyUndesiredEvent(data) {
   return Notify("NOTIFY_UNDESIRED_EVENT", data);
 }
 
+function NotifyNewTabStats(data) {
+  if (!eventConstants.defaultPage === data.page) {
+    throw new Error(`${data.page} is not a valid page`);
+  }
+  return Notify("NOTIFY_NEWTAB_STATS", data);
+}
+
 function NotifyFilterQuery(data) {
   return Notify("NOTIFY_FILTER_QUERY", data);
 }
@@ -228,6 +236,7 @@ am.defineActions({
   NotifyFilterQuery,
   NotifyHistoryDelete,
   NotifyManageEngines,
+  NotifyNewTabStats,
   NotifyOpenWindow,
   NotifyPerf,
   NotifyPerformSearch,

--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -109,10 +109,12 @@ class Baseline {
       newScore *= 0.2;
     }
 
-    // Boost boomarks even if they have low score or no images giving a
-    // just-bookmarked page a near-infinite boost
-    if (features.bookmarkAge) {
-      newScore += BOOKMARK_AGE_DIVIDEND / features.bookmarkAge;
+    if (this.options.experiments && this.options.experiments.bookmarkScreenshots) {
+      // Boost boomarks even if they have low score or no images giving a
+      // just-bookmarked page a near-infinite boost
+      if (features.bookmarkAge) {
+        newScore += BOOKMARK_AGE_DIVIDEND / features.bookmarkAge;
+      }
     }
 
     return newScore;

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -79,7 +79,7 @@ const NewTabPage = React.createClass({
     const props = this.props;
     const {showSearch, showTopSites, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
-    const topSitesExperimentIsOn = props.Experiments.values.screenshotsAsync;
+    const topSitesExperimentIsOn = props.Experiments.values.screenshotsLongCache;
     const newTabPrefsExperimentIsOn = props.Experiments.values.newTabPrefs;
 
     return (<main className={classNames("new-tab", {"top-sites-new-style": topSitesExperimentIsOn})}>

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -72,7 +72,8 @@ const NewTabPage = React.createClass({
             <section>
               <TopSites placeholder={!this.props.isReady} page={PAGE_NAME}
                 sites={props.TopSites.rows} showNewStyle={topSitesExperimentIsOn}
-                length={showMoreTopSites ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH} />
+                length={showMoreTopSites ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH}
+                allowEdit={newTabPrefsExperimentIsOn} />
             </section>
           }
           {showHighlights &&

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -17,6 +17,32 @@ const NewTabPage = React.createClass({
   getInitialState() {
     return {showSettingsMenu: false};
   },
+  _getNewTabStats() {
+    let stats = {
+      highlightsSize: 0,
+      topsitesSize: 0,
+      topsitesTippytop: 0,
+      topsitesScreenshot: 0
+    };
+    if (this.props.isReady) {
+      const {showTopSites, showHighlights} = this.props.Prefs.prefs;
+      if (showHighlights) {
+        stats.highlightsSize = this.props.Highlights.rows.length;
+      }
+      if (showTopSites) {
+        const topSites = this.props.TopSites.rows;
+        stats.topsitesSize = topSites.length;
+        topSites.forEach(row => {
+          if (row.screenshot) {
+            stats.topsitesScreenshot++;
+          } else if (row.metadata_source === "TippyTopProvider") {
+            stats.topsitesTippytop++;
+          }
+        });
+      }
+    }
+    return stats;
+  },
   componentDidMount() {
     document.title = this.props.intl.formatMessage({id: "newtab_page_title"});
     setFavicon("newtab-icon.svg");
@@ -34,10 +60,13 @@ const NewTabPage = React.createClass({
         source: PAGE_NAME,
         value: this.loaderShownAt
       }));
+    } else {
+      this.props.dispatch(actions.NotifyNewTabStats(this._getNewTabStats()));
     }
   },
   componentDidUpdate(prevProps) {
     if (this.props.isReady && this.loaderShownAt) {
+      this.props.dispatch(actions.NotifyNewTabStats(this._getNewTabStats()));
       this.props.dispatch(actions.NotifyUndesiredEvent({
         event: "HIDE_LOADER",
         source: PAGE_NAME,

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -38,6 +38,8 @@ const SpotlightItem = React.createClass({
 
     if (imageUrl) {
       style.backgroundImage = `url(${imageUrl})`;
+    } else if (site.screenshot) {
+      style.backgroundImage = `url(${site.screenshot})`;
     } else {
       style.backgroundColor = site.backgroundColor;
       this.props.dispatch(actions.NotifyUndesiredEvent({
@@ -45,7 +47,7 @@ const SpotlightItem = React.createClass({
         source: "HIGHLIGHTS"
       }));
     }
-    return (<li className={classNames("spotlight-item", {active: this.state.showContextMenu})}>
+    return (<li className={classNames("spotlight-item", {active: this.state.showContextMenu, screenshot: site.screenshot})}>
       <a onClick={this.props.onClick} className="spotlight-inner" href={site.url} ref="link">
         <div className={classNames("spotlight-image", {portrait: isPortrait})} style={style} ref="image">
           <SiteIcon className="spotlight-icon" height={40} width={40} site={site} ref="icon" showBackground={true} border={false} faviconSize={32} />

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -127,6 +127,12 @@
     font-size: $spotlight-font-size;
     margin: 0;
   }
+
+  &.screenshot {
+    .spotlight-image {
+      background-position: top;
+    }
+  }
 }
 
 // Overrides for Top Sites styling experiment.

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -119,7 +119,8 @@ const TopSites = React.createClass({
     return {
       length: TOP_SITES_DEFAULT_LENGTH,
       // This is for event reporting
-      page: "NEW_TAB"
+      page: "NEW_TAB",
+      allowEdit: true
     };
   },
   onClickFactory(index, site) {
@@ -157,7 +158,7 @@ const TopSites = React.createClass({
           );
         })}
       </div>
-      {!this.props.placeholder &&
+      {!this.props.placeholder && this.props.allowEdit &&
         <EditTopSitesIntl {...this.props} />
       }
     </section>);
@@ -181,7 +182,8 @@ TopSites.propTypes = {
    */
   placeholder: React.PropTypes.bool,
 
-  showNewStyle: React.PropTypes.bool
+  showNewStyle: React.PropTypes.bool,
+  allowEdit: React.PropTypes.bool
 };
 
 const EditTopSites = React.createClass({

--- a/content-test/addon/Feeds/HighlightsFeed.test.js
+++ b/content-test/addon/Feeds/HighlightsFeed.test.js
@@ -6,7 +6,7 @@ const simplePrefs = new SimplePrefs();
 const testLinks = [{url: "foo.com"}, {url: "bar.com"}];
 const oldTestLinks = [{url: "boo.com"}, {url: "far.com"}];
 const getCachedMetadata = links => links.map(
-  link => { link.hasMetadata = true; return link; }
+  link => {link.hasMetadata = true; return link;}
 );
 const PlacesProvider = {
   links: {
@@ -44,7 +44,7 @@ describe("HighlightsFeed", () => {
     instance = new HighlightsFeed({getCachedMetadata});
     instance.refresh = sinon.spy();
     reduxState = {Experiments: {values: {}}};
-    instance.store = {getState() { return reduxState; }};
+    instance.store = {getState() {return reduxState;}};
     sinon.spy(instance.options, "getCachedMetadata");
   });
   it("should create a HighlightsFeed", () => {
@@ -177,7 +177,7 @@ describe("HighlightsFeed", () => {
       reduxState.Experiments.values.bookmarkScreenshots = true;
       instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
       instance.options.getCachedMetadata = links => links.map(
-        link => { link.hasMetadata = false; return link; }
+        link => {link.hasMetadata = false; return link;}
       );
       return instance.getData().then(result => {
         assert.equal(instance.missingData, true);

--- a/content-test/addon/Feeds/TopSitesFeed.test.js
+++ b/content-test/addon/Feeds/TopSitesFeed.test.js
@@ -79,7 +79,7 @@ describe("TopSitesFeed", () => {
       assert.deepEqual(action.data, getCachedMetadata(testLinks));
     }));
     it("should not add screenshots to sites that qualify for a screenshot if the experiment is disabled", () => {
-      reduxState.Experiments.values.screenshotsAsync = false;
+      reduxState.Experiments.values.screenshotsLongCache = false;
       instance.shouldGetScreenshot = site => true;
       return instance.getData().then(result => {
         assert.notCalled(instance.getScreenshot);
@@ -89,7 +89,7 @@ describe("TopSitesFeed", () => {
       });
     });
     it("should not add screenshots to sites that don't qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.shouldGetScreenshot = site => false;
       return instance.getData().then(result => {
         assert.notCalled(instance.getScreenshot);
@@ -99,7 +99,7 @@ describe("TopSitesFeed", () => {
       });
     });
     it("should add screenshots to sites that qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.shouldGetScreenshot = site => true;
       return instance.getData().then(result => {
         assert.calledTwice(instance.getScreenshot);
@@ -113,7 +113,7 @@ describe("TopSitesFeed", () => {
       instance.getData().then(result => assert.equal(instance.missingData, false))
     );
     it("should set missingData to true if screenshot experiment is enabled and a topsite is missing a required screenshot", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.shouldGetScreenshot = site => true;
       instance.getScreenshot = sinon.spy(site => null);
       return instance.getData().then(result => {
@@ -121,7 +121,7 @@ describe("TopSitesFeed", () => {
       });
     });
     it("should set missingData to true if screenshot experiment is enabled and a topsite is missing metadata", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.options.getCachedMetadata = links => links.map(
         link => {link.hasMetadata = false; return link;}
       );

--- a/content-test/common/Baseline.test.js
+++ b/content-test/common/Baseline.test.js
@@ -110,8 +110,13 @@ describe("Baseline", () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    baseline = new Baseline(fakeHistory,
-                            {highlightsCoefficients: [-0.1, -0.1, -0.1, 0.4, 0.2]});
+    baseline = new Baseline(
+      fakeHistory,
+      {
+        experiments: {bookmarkScreenshots: true},
+        highlightsCoefficients: [-0.1, -0.1, -0.1, 0.4, 0.2]
+      }
+    );
   });
 
   afterEach(() => {

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -138,4 +138,18 @@ describe("NewTabPage", () => {
       }} />);
     });
   });
+
+  describe("NewTab stats event", () => {
+    it("should fire an event if data is ready", done => {
+      renderWithProvider(<NewTabPage {...fakeProps} isReady={true} dispatch={a => {
+        if (a.type === "NOTIFY_NEWTAB_STATS") {
+          assert.equal(a.data.highlightsSize, mockData.Highlights.rows.length);
+          assert.equal(a.data.topsitesSize, mockData.TopSites.rows.length);
+          assert.equal(a.data.topsitesTippytop, 0);
+          assert.equal(a.data.topsitesScreenshot, 0);
+          done();
+        }
+      }} />);
+    });
+  });
 });

--- a/experiments.json
+++ b/experiments.json
@@ -178,5 +178,20 @@
       "threshold": 0.3,
       "description": "Show screenshots"
     }
+  },
+  "bookmarkScreenshots": {
+    "name": "Screenshots for Highlights",
+    "active": true,
+    "description": "Show a screenshot for Highlights that otherwise don't have an image",
+    "control": {
+      "value": false,
+      "description": "Don't show screenshots in Highlights"
+    },
+    "variant": {
+      "id": "exp-013-bookmark-screenshots",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Show screenshots in Highlights"
+    }
   }
 }

--- a/experiments.json
+++ b/experiments.json
@@ -151,7 +151,7 @@
   },
   "newTabPrefs": {
     "name": "Preferences Pane",
-    "active": true,
+    "active": false,
     "description": "Enable the New Tab Prefs feature",
     "control": {
       "value": false,

--- a/experiments.json
+++ b/experiments.json
@@ -208,5 +208,20 @@
       "threshold": 0.2,
       "description": "Show screenshots"
     }
+  },
+  "metadataLongCache": {
+    "name": "Metadata with Long Cache",
+    "active": true,
+    "description": "Change the timeout for metadata to a long time",
+    "control": {
+      "value": false,
+      "description": "Short metadata timeout"
+    },
+    "variant": {
+      "id": "exp-015-metadatalongcache",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Long metadata timeout"
+    }
   }
 }

--- a/experiments.json
+++ b/experiments.json
@@ -166,7 +166,7 @@
   },
   "screenshotsAsync": {
     "name": "High Res Icons and Screenshots for Top Sites",
-    "active": true,
+    "active": false,
     "description": "Add high res icons or screenshots for some Top Sites",
     "control": {
       "value": false,
@@ -192,6 +192,21 @@
       "value": true,
       "threshold": 0.2,
       "description": "Show screenshots in Highlights"
+    }
+  },
+  "screenshotsLongCache": {
+    "name": "High Res Icons and Screenshots for Top Sites with a long metadata cache",
+    "active": true,
+    "description": "Add high res icons or screenshots for some Top Sites",
+    "control": {
+      "value": false,
+      "description": "Don't show screenshots"
+    },
+    "variant": {
+      "id": "exp-014-screenshotsasync",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Show screenshots"
     }
   }
 }

--- a/test/test-PreviewProvider-MetadataStore.js
+++ b/test/test-PreviewProvider-MetadataStore.js
@@ -175,7 +175,10 @@ before(exports, function*() {
   yield gMetadataStore.asyncConnect();
   let mockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
   gPreviewProvider = new PreviewProvider(mockTabTracker, gMetadataStore, {initFresh: true});
-  gPreviewProvider._store = {dispatch: () => {}};
+  gPreviewProvider._store = {
+    dispatch: () => {},
+    getState: () => ({Experiments: {values: {screenshotsLongCache: false}}})
+  };
   gPreviewProvider._getFaviconColors = function() {
     return Promise.resolve(null);
   };

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -63,6 +63,13 @@ const gMockMetadataStore = {
 };
 const gMockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
 
+function getMockStore() {
+  return {
+    dispatch: () => null,
+    getState: () => ({Experiments: {values: {screenshotsLongCache: false}}})
+  };
+}
+
 exports.test_only_request_links_once = function*(assert) {
   const msg1 = [{"url": "http://www.a.com"},
                 {"url": "http://www.b.com"},
@@ -200,7 +207,8 @@ exports.test_process_and_insert_links = function*(assert) {
   const fakeData = {"url": "http://example.com/1", "title": "Title for example.com/1"};
 
   const mockActions = [];
-  gPreviewProvider._store = {dispatch: action => mockActions.push(action)};
+  gPreviewProvider._store = getMockStore();
+  gPreviewProvider._store.dispatch = action => mockActions.push(action);
 
   // process and insert the links
   yield gPreviewProvider.processAndInsertMetadata(fakeData, "metadata_source");
@@ -443,7 +451,7 @@ exports.test_copy_over_correct_data_from_firefox = function*(assert) {
 exports.test_compute_image_sizes = function*(assert) {
   let mockExperimentProvider = {data: {metadataService: false}};
   gPreviewProvider = new PreviewProvider(gMockTabTracker, gMockMetadataStore, mockExperimentProvider, {initFresh: true});
-  gPreviewProvider._store = {dispatch: () => {}};
+  gPreviewProvider._store = getMockStore();
   let metadataObj = {
     url: "https://www.hasAnImage.com",
     images: [{url: "data:image;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAA"}] // a 1x1 pixel image
@@ -469,7 +477,7 @@ before(exports, () => {
   simplePrefs.prefs["metadata.endpoint"] = `${gEndpointPrefix}${gMetadataServiceEndpoint}`;
   simplePrefs.prefs["previews.enabled"] = true;
   gPreviewProvider = new PreviewProvider(gMockTabTracker, gMockMetadataStore, {initFresh: true});
-  gPreviewProvider._store = {dispatch: () => {}};
+  gPreviewProvider._store = getMockStore();
   gPreviewProvider._getFaviconColors = function() {
     return Promise.resolve(null);
   };


### PR DESCRIPTION
Hi all,

We are now preparing the release of A-S 1.8.0. The add-on has been made available at [pre-release channel](https://moz-activity-streams-prerelease.s3.amazonaws.com/dist/latest.html). Please install it, test it, and leave the feedback, bug reports, and other inputs in this thread.

# Release checklist
- QA
  - [x] @pdehaan 
  - [x] @SoftVision
- Product
  - [x] @nchapman 
  - [x] @aaronrbenson 
- Engineering
  - [x] @tspurway 
  - [x] @jennchaulk 

Please use the `release/block` or `release/uplift` to label the bug reports as well as other release related issues. Once you finish the review, please check off the corresponding item in the above checklist.

*Note*: checking off the item may not work, you can either modify it in place (i.e modify `[ ]` to `[x]`), or just drop a good old `r+` comment below.

Highlights:
* [new] New experiment for newtab customization
* [new] "show more/less" in Topsites
* [telemetry] Tracking user's preferences
* [deprecated] Remove legacy routes   

Thanks