### PR TITLE
#2227 - New Tab Preferences Design Updates

### DIFF
--- a/content-src/components/NewTabPage/NewTabPage.scss
+++ b/content-src/components/NewTabPage/NewTabPage.scss
@@ -1,7 +1,8 @@
 .new-tab-wrapper {
   width: 100%;
   max-width: $wrapper-max-width;
-  margin: $search-margin-bottom auto 0;
+  margin: auto;
+  padding: $wrapper-vertical-padding 0;
 }
 
 @keyframes fadeIn {

--- a/content-src/components/PreferencesPane/PreferencesPane.js
+++ b/content-src/components/PreferencesPane/PreferencesPane.js
@@ -33,7 +33,7 @@ const PreferencesPane = React.createClass({
     }));
   },
   render() {
-    const {showSearch, showTopSites, showHighlights} = this.props.Prefs.prefs;
+    const {showSearch, showTopSites, showHighlights, showMoreTopSites} = this.props.Prefs.prefs;
 
     return (
       <div className="prefs-pane-wrapper" ref="wrapper">
@@ -57,12 +57,18 @@ const PreferencesPane = React.createClass({
                   </label>
                   <p><FormattedMessage id="settings_pane_search_body" /></p>
                 </section>
-                <section>
+                <section className={showTopSites ? "" : "disabled"}>
                   <input ref="showTopSitesCheckbox" type="checkbox" id="showTopSites" name="showTopSites" checked={showTopSites} onChange={this.handleChange} />
                   <label htmlFor="showTopSites">
                     <FormattedMessage id="settings_pane_topsites_header" />
                   </label>
                   <p><FormattedMessage id="settings_pane_topsites_body" /></p>
+                  <div className="options">
+                    <input ref="showMoreTopSites" type="checkbox" id="showMoreTopSites" name="showMoreTopSites" checked={showMoreTopSites} onChange={this.handleChange} disabled={!showTopSites} />
+                    <label htmlFor="showMoreTopSites">
+                      <FormattedMessage id="settings_pane_topsites_options_showmore" />
+                    </label>
+                  </div>
                 </section>
                 <section>
                   <input ref="showHighlightsCheckbox" type="checkbox" id="showHighlights" name="showHighlights" checked={showHighlights} onChange={this.handleChange} />

--- a/content-src/components/PreferencesPane/PreferencesPane.js
+++ b/content-src/components/PreferencesPane/PreferencesPane.js
@@ -7,6 +7,18 @@ const {injectIntl, FormattedMessage} = require("react-intl");
 const PreferencesPane = React.createClass({
   getDefaultProps() {return {dispatch: () => {}};},
   getInitialState() {return {showPane: false};},
+  componentDidMount() {
+    document.addEventListener("click", this.handleClickOutside);
+  },
+  componentWillUnmount() {
+    document.removeEventListener("click", this.handleClickOutside);
+  },
+  handleClickOutside(event) {
+    // if we are showing the sidebar and there is a click outside, close it.
+    if (this.refs.sidebar && !this.refs.wrapper.contains(event.target)) {
+      this.togglePane();
+    }
+  },
   handleChange(event) {
     const target = event.target;
     this.props.dispatch(actions.NotifyPrefChange(target.name, target.checked));
@@ -24,7 +36,7 @@ const PreferencesPane = React.createClass({
     const {showSearch, showTopSites, showHighlights} = this.props.Prefs.prefs;
 
     return (
-      <div className="prefs-pane-wrapper">
+      <div className="prefs-pane-wrapper" ref="wrapper">
         <div className="prefs-pane-button">
           <button
             ref="prefs-button"
@@ -34,8 +46,7 @@ const PreferencesPane = React.createClass({
         </div>
         {this.state.showPane &&
           <div className="prefs-pane">
-            <div className="modal-overlay" />
-            <div className="modal" ref="modal">
+            <div className="sidebar" ref="sidebar">
               <div className="prefs-modal-inner-wrapper">
                 <h1><FormattedMessage id="settings_pane_header" /></h1>
                 <p><FormattedMessage id="settings_pane_body" /></p>

--- a/content-src/components/PreferencesPane/PreferencesPane.scss
+++ b/content-src/components/PreferencesPane/PreferencesPane.scss
@@ -1,28 +1,27 @@
 .prefs-pane {
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: 11000;
+  font-size: 13px;
 
-  .modal {
-    margin: 70px auto 0;
-    max-width: $wrapper-max-width;
-    position: relative;
-    width: 90%;
+  .sidebar {
+    background: $white;
+    border-left: solid 1px $faintest-black;
+    box-shadow: $sidebar-shadow;
+    min-height: 100%;
+    padding: 40px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 400px;
+    z-index: 11000;
 
     h1 {
       border-bottom: solid 1px $faintest-black;
-      font-size: 27px;
+      font-size: 24px;
       margin: 0;
       padding: 20px 0;
     }
   }
 
   .prefs-modal-inner-wrapper {
-    padding: 20px 125px;
-
     section {
       margin: 20px 0;
 
@@ -31,7 +30,7 @@
       }
 
       label {
-        font-size: 17px;
+        font-size: 16px;
         font-weight: bold;
         position: relative;
 
@@ -42,6 +41,10 @@
         }
       }
     }
+  }
+
+  .actions {
+    padding: 15px 0;
   }
 
   // CSS styled checkbox
@@ -110,11 +113,12 @@
     background-color: transparent;
     border: 0;
     cursor: pointer;
+    opacity: 0.7;
     padding: 15px;
     position: absolute;
-    right: 5px;
-    top: 5px;
-    z-index: 11002;
+    right: 15px;
+    top: 15px;
+    z-index: 11001;
 
     &:hover {
       background-color: $very-light-grey;

--- a/content-src/components/PreferencesPane/PreferencesPane.scss
+++ b/content-src/components/PreferencesPane/PreferencesPane.scss
@@ -30,14 +30,38 @@
       }
 
       label {
-        font-size: 16px;
-        font-weight: bold;
         position: relative;
 
         input {
           left: -30px;
           position: absolute;
           top: 0;
+        }
+      }
+
+      > label {
+        font-size: 16px;
+        font-weight: bold;
+      }
+
+      .options {
+        background: $bg-grey;
+        border: solid 1px $faintest-black;
+        border-radius: $border-radius;
+        margin: 15px 0 15px 30px;
+        padding: 10px;
+
+        label {
+          display: inline-block;
+          font-weight: normal;
+          height: 21px;
+          line-height: 21px;
+        }
+      }
+
+      &.disabled {
+        .options {
+          opacity: 0.5;
         }
       }
     }

--- a/content-src/main.scss
+++ b/content-src/main.scss
@@ -89,37 +89,38 @@ a {
   border-radius: $border-radius;
   font-size: 14px;
   z-index: 11002;
+}
 
-  .actions {
-    border-top: solid 1px $faintest-black;
-    display: flex;
-    flex-direction: row;
-    margin: 0;
-    padding: 15px 25px;
-    justify-content: flex-start;
+.actions {
+  border-top: solid 1px $faintest-black;
+  display: flex;
+  flex-direction: row;
+  margin: 0;
+  padding: 15px 25px;
+  justify-content: flex-start;
 
-    button {
-      background: $default-button-bg;
-      border: solid 1px $default-button-border;
-      border-radius: 5px;
-      color: $mid-light-grey;
-      cursor: pointer;
-      padding: 10px 30px;
+  button {
+    background: $default-button-bg;
+    border: solid 1px $default-button-border;
+    border-radius: 5px;
+    color: $mid-light-grey;
+    cursor: pointer;
+    padding: 10px 30px;
 
-      &:hover {
-        box-shadow: 0 0 0 5px $faintest-black;
-        transition: box-shadow 150ms;
-      }
+    &:hover {
+      box-shadow: 0 0 0 5px $faintest-black;
+      transition: box-shadow 150ms;
+    }
 
-      &.done {
-        background: $blue-button-bg;
-        border: solid 1px $blue-button-border;
-        color: $white;
-        margin-inline-start: auto;
-      }
+    &.done {
+      background: $blue-button-bg;
+      border: solid 1px $blue-button-border;
+      color: $white;
+      margin-inline-start: auto;
     }
   }
 }
+
 
 @import './styles/icons';
 

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -29,6 +29,7 @@ $checkbox-border: #C1C1C1;
 $checkbox-blue: #1691D2;
 
 $wrapper-max-width: 736px;
+$wrapper-vertical-padding: 62px;
 $break-point: $wrapper-max-width + 40px;
 
 $base-gutter: 32px;
@@ -134,6 +135,8 @@ $tooltip-anchor-margin: -42px 0 0 -24px;
 $code-font: Menlo, Monaco, Consolas, monospace;
 $code-background: #FCF2F4;
 $code-color: #E8005C;
+
+$sidebar-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08);
 
 @mixin item-shadow {
   box-shadow: $item-shadow;

--- a/content-test/components/PreferencesPane.test.js
+++ b/content-test/components/PreferencesPane.test.js
@@ -4,6 +4,7 @@ const {mountWithIntl} = require("test/test-utils");
 const DEFAULT_PREFS = {
   "showSearch": true,
   "showTopSites": true,
+  "showMoreTopSites": false,
   "showHighlights": true
 };
 
@@ -21,12 +22,12 @@ describe("PreferencesPane", () => {
   });
 
   it("the modal should be hidden by default", () => {
-    assert.equal(0, wrapper.ref("modal").length);
+    assert.equal(0, wrapper.ref("sidebar").length);
   });
 
   it("the modal should be shown when settings button is clicked", () => {
     wrapper.ref("prefs-button").simulate("click");
-    assert.equal(1, wrapper.ref("modal").length);
+    assert.equal(1, wrapper.ref("sidebar").length);
   });
 
   it("the search checkbox should be checked by default", () => {
@@ -37,6 +38,11 @@ describe("PreferencesPane", () => {
   it("the top sites checkbox should be checked by default", () => {
     wrapper.ref("prefs-button").simulate("click");
     assert.isTrue(wrapper.ref("showTopSitesCheckbox").prop("checked"));
+  });
+
+  it("the show two rows of top sites checkbox should be unchecked by default", () => {
+    wrapper.ref("prefs-button").simulate("click");
+    assert.isFalse(wrapper.ref("showMoreTopSites").prop("checked"));
   });
 
   it("the highlights checkbox should be checked by default", () => {
@@ -56,6 +62,12 @@ describe("PreferencesPane", () => {
     assert.isFalse(wrapper.ref("showTopSitesCheckbox").prop("checked"));
   });
 
+  it("the show two rows of top sites checkbox should be unchecked if pref is off", () => {
+    setup({showMoreTopSites: true});
+    wrapper.ref("prefs-button").simulate("click");
+    assert.isTrue(wrapper.ref("showMoreTopSites").prop("checked"));
+  });
+
   it("the highlights checkbox should be unchecked if pref is off", () => {
     setup({showHighlights: false});
     wrapper.ref("prefs-button").simulate("click");
@@ -64,8 +76,8 @@ describe("PreferencesPane", () => {
 
   it("the modal should be closed when done button is clicked", () => {
     wrapper.ref("prefs-button").simulate("click");
-    assert.equal(1, wrapper.ref("modal").length);
+    assert.equal(1, wrapper.ref("sidebar").length);
     wrapper.ref("done-button").simulate("click");
-    assert.equal(0, wrapper.ref("modal").length);
+    assert.equal(0, wrapper.ref("sidebar").length);
   });
 });

--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -60,17 +60,17 @@ time_label_minute={number}m
 time_label_hour={number}h
 time_label_day={number}d
 
-# LOCALIZATION NOTE (settings_pane_*): This is shown in the Settings Pane modal
-# dialog.
+# LOCALIZATION NOTE (settings_pane_*): This is shown in the Settings Pane sidebar.
 settings_pane_button_label=Customize your New Tab page
 settings_pane_header=New Tab Preferences
-settings_pane_body=Show these items on my new tab page.
+settings_pane_body=Choose what you see when you open a new tab.
 settings_pane_search_header=Search
-settings_pane_search_body=Search the web from your new tab.
+settings_pane_search_body=Search the Web from your new tab.
 settings_pane_topsites_header=Top Sites
-settings_pane_topsites_body=Your most frequently visited websites.
+settings_pane_topsites_body=Access the websites you visit most.
+settings_pane_topsites_options_showmore=Show two rows
 settings_pane_highlights_header=Highlights
-settings_pane_highlights_body=Your most interesting recent activity, and newly created bookmarks, in one handy location.
+settings_pane_highlights_body=Look back at your recent browsing history and newly created bookmarks.
 settings_pane_done_button=Done
 
 # LOCALIZATION NOTE (edit_topsites_*): This is shown in the Edit Top Sites modal


### PR DESCRIPTION
This changes the prefs modal to a sidebar among other tweaks listed out in the issue.

before:
<img width="906" alt="screen shot 2017-03-21 at 4 23 20 pm" src="https://cloud.githubusercontent.com/assets/36629/24169006/9e4a7c1a-0e52-11e7-852e-220c264df166.png">

after:
<img width="927" alt="screen shot 2017-03-21 at 4 21 51 pm" src="https://cloud.githubusercontent.com/assets/36629/24169010/a11741d0-0e52-11e7-964d-39aaabb43801.png">

Fixes #2227