### PR TITLE
Chore(testing): make prepare-mochitest-dev run standalone again, fixe…

### DIFF
--- a/bin/prepare-mochitests-dev
+++ b/bin/prepare-mochitests-dev
@@ -10,7 +10,7 @@
 #  we're running from.
 if [ -z ${AS_GIT_BIN_REPO+x} ]; then
   ROOT=`dirname $0`
-  AS_GIT_BIN_REPO="../../../../activity-stream"
+  AS_GIT_BIN_REPO="../activity-stream" # as seen from mozilla-central
 else
   ROOT=${AS_GIT_BIN_REPO}/bin
 fi


### PR DESCRIPTION
fix #2334.  

See mochitests.MD for details.  Running prepare-mochitest-dev should work with this fix, rather than exploding when attempting to patch mozilla-central.