### PR TITLE
fix(tests) disable tightly coupled search tests on pine; closes #2339

### DIFF
--- a/bin/prepare-mochitests-dev
+++ b/bin/prepare-mochitests-dev
@@ -62,6 +62,15 @@ if [ $ENABLE_MC_AS ]; then
   if [ $exit_code -ne 0 ]; then
     exit $exit_code
   fi
+
+  patch --directory="$FIREFOX_PATH" -p1 --force --no-backup-if-mismatch \
+    --input=$AS_GIT_BIN_REPO/mozilla-central-patches/disable-search-tests.diff
+
+  # If someting goes sideways, don't keep going
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    exit $exit_code
+  fi
 fi
 
 

--- a/mozilla-central-patches/disable-search-tests.diff
+++ b/mozilla-central-patches/disable-search-tests.diff
@@ -1,0 +1,49 @@
+diff --git a/browser/components/search/test/browser.ini b/browser/components/search/test/browser.ini
+--- a/browser/components/search/test/browser.ini
++++ b/browser/components/search/test/browser.ini
+@@ -14,40 +14,44 @@ support-files =
+   tooManyEnginesOffered.html
+   webapi.html
+ 
+ [browser_426329.js]
+ [browser_483086.js]
+ [browser_addEngine.js]
+ [browser_amazon.js]
+ [browser_amazon_behavior.js]
++skip-if = true # mozilla/activity-stream#2339
+ [browser_bing.js]
+ [browser_bing_behavior.js]
++skip-if = true # mozilla/activity-stream#2339
+ [browser_contextmenu.js]
+ [browser_contextSearchTabPosition.js]
+ skip-if = os == "mac" # bug 967013
+ [browser_ddg.js]
+ [browser_ddg_behavior.js]
++skip-if = true # mozilla/activity-stream#2339
+ [browser_google.js]
+ skip-if = artifact # bug 1315953
+ [browser_google_codes.js]
+ skip-if = artifact # bug 1315953
+ [browser_google_nocodes.js]
+ skip-if = artifact # bug 1315953
+ [browser_google_behavior.js]
+-skip-if = artifact # bug 1315953
++skip-if = true # mozilla/activity-stream#2339
+ [browser_healthreport.js]
+ [browser_hiddenOneOffs_cleanup.js]
+ [browser_hiddenOneOffs_diacritics.js]
+ [browser_oneOffContextMenu.js]
+ [browser_oneOffContextMenu_setDefault.js]
+ [browser_oneOffHeader.js]
+ [browser_private_search_perwindowpb.js]
+ [browser_yahoo.js]
+ [browser_yahoo_behavior.js]
++skip-if = true # mozilla/activity-stream#2339
+ [browser_abouthome_behavior.js]
+ skip-if = true # Bug ??????, Bug 1100301 - leaks windows until shutdown when --run-by-dir
+ [browser_aboutSearchReset.js]
+ [browser_searchbar_openpopup.js]
+ skip-if = os == "linux" # Linux has different focus behaviours.
+ [browser_searchbar_keyboard_navigation.js]
+ [browser_searchbar_smallpanel_keyboard_navigation.js]
+ [browser_webapi.js]

--- a/mozilla-central-patches/disable-search-tests.diff
+++ b/mozilla-central-patches/disable-search-tests.diff
@@ -1,49 +1,23 @@
 diff --git a/browser/components/search/test/browser.ini b/browser/components/search/test/browser.ini
 --- a/browser/components/search/test/browser.ini
 +++ b/browser/components/search/test/browser.ini
-@@ -14,40 +14,44 @@ support-files =
-   tooManyEnginesOffered.html
-   webapi.html
- 
- [browser_426329.js]
- [browser_483086.js]
- [browser_addEngine.js]
- [browser_amazon.js]
+@@ -21,4 +21,6 @@ support-files =
  [browser_amazon_behavior.js]
 +skip-if = true # mozilla/activity-stream#2339
  [browser_bing.js]
  [browser_bing_behavior.js]
 +skip-if = true # mozilla/activity-stream#2339
  [browser_contextmenu.js]
- [browser_contextSearchTabPosition.js]
- skip-if = os == "mac" # bug 967013
- [browser_ddg.js]
+@@ -28,2 +30,3 @@ skip-if = os == "mac" # bug 967013
  [browser_ddg_behavior.js]
 +skip-if = true # mozilla/activity-stream#2339
  [browser_google.js]
- skip-if = artifact # bug 1315953
- [browser_google_codes.js]
- skip-if = artifact # bug 1315953
- [browser_google_nocodes.js]
- skip-if = artifact # bug 1315953
+@@ -35,3 +38,3 @@ skip-if = artifact # bug 1315953
  [browser_google_behavior.js]
 -skip-if = artifact # bug 1315953
 +skip-if = true # mozilla/activity-stream#2339
  [browser_healthreport.js]
- [browser_hiddenOneOffs_cleanup.js]
- [browser_hiddenOneOffs_diacritics.js]
- [browser_oneOffContextMenu.js]
- [browser_oneOffContextMenu_setDefault.js]
- [browser_oneOffHeader.js]
- [browser_private_search_perwindowpb.js]
- [browser_yahoo.js]
+@@ -45,2 +48,3 @@ skip-if = artifact # bug 1315953
  [browser_yahoo_behavior.js]
 +skip-if = true # mozilla/activity-stream#2339
  [browser_abouthome_behavior.js]
- skip-if = true # Bug ??????, Bug 1100301 - leaks windows until shutdown when --run-by-dir
- [browser_aboutSearchReset.js]
- [browser_searchbar_openpopup.js]
- skip-if = os == "linux" # Linux has different focus behaviours.
- [browser_searchbar_keyboard_navigation.js]
- [browser_searchbar_smallpanel_keyboard_navigation.js]
- [browser_webapi.js]


### PR DESCRIPTION
This just adds a patch disabling some tests that are a bit too tightly coupled to help green up pine.  To test:

```
./bin/prepare-mochitest-dev
cd ../mozilla-central
./mach mochitest -f browser browser/components/search/test
```

Should no longer have 15 errors.
