### PR TITLE
fix(tests): temporarily disable coupled telemetry tests on pine, clos…

### DIFF
--- a/bin/prepare-mochitests-dev
+++ b/bin/prepare-mochitests-dev
@@ -47,14 +47,12 @@ npm run buildmc
 # Patch mozilla-central (on top of the export) so that AS is preffed on, and
 # the mochitests are turned on.
 if [ $ENABLE_MC_AS ]; then
-  patch --directory="$FIREFOX_PATH" -p1 --force --no-backup-if-mismatch \
-    --input=$AS_GIT_BIN_REPO/mozilla-central-patches/enable-mc-as.diff
-
-  patch --directory="$FIREFOX_PATH" -p1 --force --no-backup-if-mismatch \
-    --input=$AS_GIT_BIN_REPO/mozilla-central-patches/disable-search-tests.diff
-
-  patch --directory="$FIREFOX_PATH" -p1 --force --no-backup-if-mismatch \
-    --input=$AS_GIT_BIN_REPO/mozilla-central-patches/disable-tiles-tests.diff
+  PATCHES=$AS_GIT_BIN_REPO/mozilla-central-patches/*.diff
+  for p in $PATCHES
+  do
+    patch --directory="$FIREFOX_PATH" -p1 --force --no-backup-if-mismatch \
+    --input=$p
+  done
 fi
 
 # Be sure that we've built, and that the test glop in the objdir has been

--- a/mozilla-central-patches/disable-usage-telemetry-tests.diff
+++ b/mozilla-central-patches/disable-usage-telemetry-tests.diff
@@ -1,0 +1,7 @@
+diff --git a/browser/modules/test/browser/browser.ini b/browser/modules/test/browser/browser.ini
+--- a/browser/modules/test/browser/browser.ini
++++ b/browser/modules/test/browser/browser.ini
+@@ -44,2 +44,3 @@ support-files =
+ [browser_UsageTelemetry_content.js]
++skip-if = true # disabled on pine until we have newtab search implemented
+ [browser_UsageTelemetry_content_aboutHome.js]


### PR DESCRIPTION
fixes #2345

With this applied, running the relevant mochitests

```
./mach mochitest browser/modules/test/browser
```

should show no failing tests.