### PR TITLE
fix(tests): #2362 disable m-c undo notification tests

### DIFF
--- a/mozilla-central-patches/disable-undo-notification-tests.diff
+++ b/mozilla-central-patches/disable-undo-notification-tests.diff
@@ -1,0 +1,9 @@
+diff --git a/browser/components/migration/tests/browser/browser.ini b/browser/components/migration/tests/browser/browser.ini
+--- a/browser/components/migration/tests/browser/browser.ini
++++ b/browser/components/migration/tests/browser/browser.ini
+@@ -1,3 +1,5 @@
+ [browser_undo_notification.js]
++skip-if = true # disable until activity-stream handles the appropriate messages
+ [browser_undo_notification_wording.js]
++skip-if = true # disable until activity-stream handles the appropriate messages
+ [browser_undo_notification_multiple_dismissal.js]


### PR DESCRIPTION
This disables a couple of tests which expect about:home and about:newtab to handle various migration undo related messages.  These will need to be implemented before we can pref on A-S in mozilla-central.