### PR TITLE
Create Screenshots Long Metadata Cache Experiment #2263

### DIFF
--- a/addon/Feeds/TopSitesFeed.js
+++ b/addon/Feeds/TopSitesFeed.js
@@ -37,7 +37,7 @@ module.exports = class TopSitesFeed extends Feed {
       this.missingData = false;
 
       // Get screenshots if the favicons are too small
-      if (experiments.screenshotsAsync) {
+      if (experiments.screenshotsLongCache) {
         for (let link of links) {
           if (this.shouldGetScreenshot(link)) {
             const screenshot = this.getScreenshot(link.url, this.store);

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -79,7 +79,7 @@ const NewTabPage = React.createClass({
     const props = this.props;
     const {showSearch, showTopSites, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
-    const topSitesExperimentIsOn = props.Experiments.values.screenshotsAsync;
+    const topSitesExperimentIsOn = props.Experiments.values.screenshotsLongCache;
     const newTabPrefsExperimentIsOn = props.Experiments.values.newTabPrefs;
 
     return (<main className={classNames("new-tab", {"top-sites-new-style": topSitesExperimentIsOn})}>

--- a/content-test/addon/Feeds/TopSitesFeed.test.js
+++ b/content-test/addon/Feeds/TopSitesFeed.test.js
@@ -79,7 +79,7 @@ describe("TopSitesFeed", () => {
       assert.deepEqual(action.data, getCachedMetadata(testLinks));
     }));
     it("should not add screenshots to sites that qualify for a screenshot if the experiment is disabled", () => {
-      reduxState.Experiments.values.screenshotsAsync = false;
+      reduxState.Experiments.values.screenshotsLongCache = false;
       instance.shouldGetScreenshot = site => true;
       return instance.getData().then(result => {
         assert.notCalled(instance.getScreenshot);
@@ -89,7 +89,7 @@ describe("TopSitesFeed", () => {
       });
     });
     it("should not add screenshots to sites that don't qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.shouldGetScreenshot = site => false;
       return instance.getData().then(result => {
         assert.notCalled(instance.getScreenshot);
@@ -99,7 +99,7 @@ describe("TopSitesFeed", () => {
       });
     });
     it("should add screenshots to sites that qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.shouldGetScreenshot = site => true;
       return instance.getData().then(result => {
         assert.calledTwice(instance.getScreenshot);
@@ -113,7 +113,7 @@ describe("TopSitesFeed", () => {
       instance.getData().then(result => assert.equal(instance.missingData, false))
     );
     it("should set missingData to true if screenshot experiment is enabled and a topsite is missing a required screenshot", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.shouldGetScreenshot = site => true;
       instance.getScreenshot = sinon.spy(site => null);
       return instance.getData().then(result => {
@@ -121,7 +121,7 @@ describe("TopSitesFeed", () => {
       });
     });
     it("should set missingData to true if screenshot experiment is enabled and a topsite is missing metadata", () => {
-      reduxState.Experiments.values.screenshotsAsync = true;
+      reduxState.Experiments.values.screenshotsLongCache = true;
       instance.options.getCachedMetadata = links => links.map(
         link => { link.hasMetadata = false; return link; }
       );

--- a/experiments.json
+++ b/experiments.json
@@ -166,7 +166,7 @@
   },
   "screenshotsAsync": {
     "name": "High Res Icons and Screenshots for Top Sites",
-    "active": true,
+    "active": false,
     "description": "Add high res icons or screenshots for some Top Sites",
     "control": {
       "value": false,
@@ -192,6 +192,21 @@
       "value": true,
       "threshold": 0.2,
       "description": "Show screenshots in Highlights"
+    }
+  },
+  "screenshotsLongCache": {
+    "name": "High Res Icons and Screenshots for Top Sites with a long metadata cache",
+    "active": true,
+    "description": "Add high res icons or screenshots for some Top Sites",
+    "control": {
+      "value": false,
+      "description": "Don't show screenshots"
+    },
+    "variant": {
+      "id": "exp-014-screenshotsasync",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Show screenshots"
     }
   }
 }

--- a/test/test-PreviewProvider-MetadataStore.js
+++ b/test/test-PreviewProvider-MetadataStore.js
@@ -175,7 +175,10 @@ before(exports, function*() {
   yield gMetadataStore.asyncConnect();
   let mockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
   gPreviewProvider = new PreviewProvider(mockTabTracker, gMetadataStore, {initFresh: true});
-  gPreviewProvider._store = {dispatch: () => {}};
+  gPreviewProvider._store = {
+    dispatch: () => {},
+    getState: () => ({Experiments: {values: {screenshotsLongCache: false}}})
+  };
   gPreviewProvider._getFaviconColors = function() {
     return Promise.resolve(null);
   };

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -63,6 +63,13 @@ const gMockMetadataStore = {
 };
 const gMockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
 
+function getMockStore() {
+  return {
+    dispatch: () => null,
+    getState: () => ({Experiments: {values: {screenshotsLongCache: false}}})
+  };
+}
+
 exports.test_only_request_links_once = function*(assert) {
   const msg1 = [{"url": "http://www.a.com"},
                 {"url": "http://www.b.com"},
@@ -200,7 +207,8 @@ exports.test_process_and_insert_links = function*(assert) {
   const fakeData = {"url": "http://example.com/1", "title": "Title for example.com/1"};
 
   const mockActions = [];
-  gPreviewProvider._store = {dispatch: action => mockActions.push(action)};
+  gPreviewProvider._store = getMockStore();
+  gPreviewProvider._store.dispatch = action => mockActions.push(action);
 
   // process and insert the links
   yield gPreviewProvider.processAndInsertMetadata(fakeData, "metadata_source");
@@ -443,7 +451,7 @@ exports.test_copy_over_correct_data_from_firefox = function*(assert) {
 exports.test_compute_image_sizes = function*(assert) {
   let mockExperimentProvider = {data: {metadataService: false}};
   gPreviewProvider = new PreviewProvider(gMockTabTracker, gMockMetadataStore, mockExperimentProvider, {initFresh: true});
-  gPreviewProvider._store = {dispatch: () => {}};
+  gPreviewProvider._store = getMockStore();
   let metadataObj = {
     url: "https://www.hasAnImage.com",
     images: [{url: "data:image;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAA"}] // a 1x1 pixel image
@@ -469,7 +477,7 @@ before(exports, () => {
   simplePrefs.prefs["metadata.endpoint"] = `${gEndpointPrefix}${gMetadataServiceEndpoint}`;
   simplePrefs.prefs["previews.enabled"] = true;
   gPreviewProvider = new PreviewProvider(gMockTabTracker, gMockMetadataStore, {initFresh: true});
-  gPreviewProvider._store = {dispatch: () => {}};
+  gPreviewProvider._store = getMockStore();
   gPreviewProvider._getFaviconColors = function() {
     return Promise.resolve(null);
   };


### PR DESCRIPTION
Create a new topsites screenshots experiment that includes a long metadata timeout so that high res icons don't disappear after 3 days.