### PR TITLE
Create Local Metadata Long Cache Experiment fixes #2356

### DIFF
--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -57,7 +57,10 @@ PreviewProvider.prototype = {
   _getMetadataTTL() {
     let timeout = 3 * 24 * 60 * 60 * 1000; // 3 days for the metadata to live
 
-    if (this._store.getState().Experiments.values.screenshotsLongCache) {
+    if (
+      this._store.getState().Experiments.values.screenshotsLongCache ||
+      this._store.getState().Experiments.values.metadataLongCache
+    ) {
       timeout = 90 * 24 * 60 * 60 * 1000; // 90 days for the metadata to live
     }
     return timeout;

--- a/experiments.json
+++ b/experiments.json
@@ -208,5 +208,20 @@
       "threshold": 0.2,
       "description": "Show screenshots"
     }
+  },
+  "metadataLongCache": {
+    "name": "Metadata with Long Cache",
+    "active": true,
+    "description": "Change the timeout for metadata to a long time",
+    "control": {
+      "value": false,
+      "description": "Short metadata timeout"
+    },
+    "variant": {
+      "id": "exp-015-metadatalongcache",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Long metadata timeout"
+    }
   }
 }


### PR DESCRIPTION
Create an experiment that increases the metadata cache timeout to a long time to see how it affects engagement