### PR TITLE
Preparing the release of Activity Stream 1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     skip_cleanup: true
     script: bin/continuous-integration.sh prerelease
     on:
-      branch: release-1.4.0
+      branch: release-1.9.0
 
 notifications:
   email: false

--- a/addon/Feeds/TopSitesFeed.js
+++ b/addon/Feeds/TopSitesFeed.js
@@ -5,7 +5,6 @@ const Feed = require("addon/lib/Feed");
 const {TOP_SITES_SHOWMORE_LENGTH} = require("common/constants");
 const am = require("common/action-manager");
 const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
-const MIN_ICON_SIZE = 64;
 const getScreenshot = require("addon/lib/getScreenshot");
 const {isRootDomain} = require("addon/lib/utils");
 
@@ -18,10 +17,7 @@ module.exports = class TopSitesFeed extends Feed {
     this.missingData = false;
   }
   shouldGetScreenshot(link) {
-    const isMissingIcon = !link.favicon_width && !link.favicon_height;
-    const hasSmallIcon = !isMissingIcon && ((link.favicon_width < MIN_ICON_SIZE) || (link.favicon_height < MIN_ICON_SIZE));
-    const badIcon = link.hasMetadata && (isMissingIcon || hasSmallIcon);
-    return !isRootDomain(link.url) || badIcon;
+    return !isRootDomain(link.url) || (link.hasMetadata && !link.hasHighResIcon);
   }
   getData() {
     return Task.spawn(function*() {
@@ -87,4 +83,3 @@ module.exports = class TopSitesFeed extends Feed {
 };
 
 module.exports.UPDATE_TIME = UPDATE_TIME;
-module.exports.MIN_ICON_SIZE = MIN_ICON_SIZE;

--- a/addon/Feeds/TopSitesFeed.js
+++ b/addon/Feeds/TopSitesFeed.js
@@ -25,31 +25,26 @@ module.exports = class TopSitesFeed extends Feed {
   }
   getData() {
     return Task.spawn(function*() {
-      const experiments = this.store.getState().Experiments.values;
-
       let links;
       // Get links from places
       links = yield PlacesProvider.links.getTopFrecentSites();
-
       // Get metadata from PreviewProvider
       links = yield this.options.getCachedMetadata(links, "TOP_FRECENT_SITES_RESPONSE");
 
       this.missingData = false;
 
       // Get screenshots if the favicons are too small
-      if (experiments.screenshotsLongCache) {
-        for (let link of links) {
-          if (this.shouldGetScreenshot(link)) {
-            const screenshot = this.getScreenshot(link.url, this.store);
-            if (screenshot) {
-              link.screenshot = screenshot;
-              link.metadata_source = `${link.metadata_source}+Screenshot`;
-            } else {
-              this.missingData = true;
-            }
-          } else if (!link.hasMetadata) {
+      for (let link of links) {
+        if (this.shouldGetScreenshot(link)) {
+          const screenshot = this.getScreenshot(link.url, this.store);
+          if (screenshot) {
+            link.screenshot = screenshot;
+            link.metadata_source = `${link.metadata_source}+Screenshot`;
+          } else {
             this.missingData = true;
           }
+        } else if (!link.hasMetadata) {
+          this.missingData = true;
         }
       }
 

--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -57,10 +57,7 @@ PreviewProvider.prototype = {
   _getMetadataTTL() {
     let timeout = 3 * 24 * 60 * 60 * 1000; // 3 days for the metadata to live
 
-    if (
-      this._store.getState().Experiments.values.screenshotsLongCache ||
-      this._store.getState().Experiments.values.metadataLongCache
-    ) {
+    if (this._store.getState().Experiments.values.metadataLongCache) {
       timeout = 90 * 24 * 60 * 60 * 1000; // 90 days for the metadata to live
     }
     return timeout;

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -171,6 +171,7 @@ TabTracker.prototype = {
     this._tabData.topsites_size = payload.topsitesSize;
     this._tabData.topsites_tippytop = payload.topsitesTippytop;
     this._tabData.topsites_screenshot = payload.topsitesScreenshot;
+    this._tabData.topsites_lowresicon = payload.topsitesLowResIcon;
   },
 
   generateEvent(eventData) {
@@ -188,6 +189,7 @@ TabTracker.prototype = {
     this._tabData.topsites_size = 0;
     this._tabData.topsites_tippytop = 0;
     this._tabData.topsites_screenshot = 0;
+    this._tabData.topsites_lowresicon = 0;
   },
 
   navigateAwayFromPage(tab, reason) {

--- a/common/constants.js
+++ b/common/constants.js
@@ -37,5 +37,8 @@ module.exports = {
     "showTopSites": 1 << 1,
     "showHighlights": 1 << 2,
     "showMoreTopSites": 1 << 3
-  }
+  },
+
+  // The minimum size to consider an icon high res
+  MIN_HIGHRES_ICON_SIZE: 64
 };

--- a/common/recommender/Baseline.js
+++ b/common/recommender/Baseline.js
@@ -109,12 +109,10 @@ class Baseline {
       newScore *= 0.2;
     }
 
-    if (this.options.experiments && this.options.experiments.bookmarkScreenshots) {
-      // Boost boomarks even if they have low score or no images giving a
-      // just-bookmarked page a near-infinite boost
-      if (features.bookmarkAge) {
-        newScore += BOOKMARK_AGE_DIVIDEND / features.bookmarkAge;
-      }
+    // Boost boomarks even if they have low score or no images giving a
+    // just-bookmarked page a near-infinite boost
+    if (features.bookmarkAge) {
+      newScore += BOOKMARK_AGE_DIVIDEND / features.bookmarkAge;
     }
 
     return newScore;

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -22,7 +22,8 @@ const NewTabPage = React.createClass({
       highlightsSize: 0,
       topsitesSize: 0,
       topsitesTippytop: 0,
-      topsitesScreenshot: 0
+      topsitesScreenshot: 0,
+      topsitesLowResIcon: 0
     };
     if (this.props.isReady) {
       const {showTopSites, showHighlights} = this.props.Prefs.prefs;
@@ -37,6 +38,8 @@ const NewTabPage = React.createClass({
             stats.topsitesScreenshot++;
           } else if (row.metadata_source === "TippyTopProvider") {
             stats.topsitesTippytop++;
+          } else if (row && !row.hasHighResIcon && !row.screenshot) {
+            stats.topsitesLowResIcon++;
           }
         });
       }

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -80,7 +80,7 @@ const NewTabPage = React.createClass({
     const {showSearch, showTopSites, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
     const topSitesExperimentIsOn = props.Experiments.values.screenshotsLongCache;
-    const newTabPrefsExperimentIsOn = props.Experiments.values.newTabPrefs;
+    const editTopSitesExperimentIsOn = props.Experiments.values.editTopSites;
 
     return (<main className={classNames("new-tab", {"top-sites-new-style": topSitesExperimentIsOn})}>
       <div className="new-tab-wrapper">
@@ -102,7 +102,7 @@ const NewTabPage = React.createClass({
               <TopSites placeholder={!this.props.isReady} page={PAGE_NAME}
                 sites={props.TopSites.rows} showNewStyle={topSitesExperimentIsOn}
                 length={showMoreTopSites ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH}
-                allowEdit={newTabPrefsExperimentIsOn} />
+                allowEdit={editTopSitesExperimentIsOn} />
             </section>
           }
           {showHighlights &&
@@ -113,9 +113,7 @@ const NewTabPage = React.createClass({
           }
         </div>
       </div>
-      {newTabPrefsExperimentIsOn &&
-        <PreferencesPane Prefs={props.Prefs} />
-      }
+      <PreferencesPane Prefs={props.Prefs} />
     </main>);
   }
 });

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -80,7 +80,6 @@ const NewTabPage = React.createClass({
     const {showSearch, showTopSites, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
     const topSitesExperimentIsOn = props.Experiments.values.screenshotsLongCache;
-    const editTopSitesExperimentIsOn = props.Experiments.values.editTopSites;
 
     return (<main className={classNames("new-tab", {"top-sites-new-style": topSitesExperimentIsOn})}>
       <div className="new-tab-wrapper">
@@ -102,7 +101,7 @@ const NewTabPage = React.createClass({
               <TopSites placeholder={!this.props.isReady} page={PAGE_NAME}
                 sites={props.TopSites.rows} showNewStyle={topSitesExperimentIsOn}
                 length={showMoreTopSites ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH}
-                allowEdit={editTopSitesExperimentIsOn} />
+                allowEdit={!!props.Experiments.values.editTopSites} />
             </section>
           }
           {showHighlights &&

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -82,9 +82,7 @@ const NewTabPage = React.createClass({
     const props = this.props;
     const {showSearch, showTopSites, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
-    const topSitesExperimentIsOn = props.Experiments.values.screenshotsLongCache;
-
-    return (<main className={classNames("new-tab", {"top-sites-new-style": topSitesExperimentIsOn})}>
+    return (<main className={classNames("new-tab", {"top-sites-new-style": true})}>
       <div className="new-tab-wrapper">
         {showSearch &&
           <section>
@@ -102,7 +100,7 @@ const NewTabPage = React.createClass({
           {showTopSites &&
             <section>
               <TopSites placeholder={!this.props.isReady} page={PAGE_NAME}
-                sites={props.TopSites.rows} showNewStyle={topSitesExperimentIsOn}
+                sites={props.TopSites.rows} showNewStyle={true}
                 length={showMoreTopSites ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH}
                 allowEdit={!!props.Experiments.values.editTopSites} />
             </section>

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -8,7 +8,7 @@ module.exports = {
     "error": false
   },
   "TopSites": {
-    "rows": faker.createRows({images: 3}),
+    "rows": faker.createRows({images: 3}).map(row => Object.assign({}, row, {hasHighResIcon: true})),
     "error": false
   },
   "Search": {

--- a/content-src/lib/first-run-data.js
+++ b/content-src/lib/first-run-data.js
@@ -13,7 +13,8 @@ module.exports = {
       "favicon_url": "facebook-com.png",
       "background_color": [59, 89, 152],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "YouTube",
@@ -23,7 +24,8 @@ module.exports = {
       "favicon_url": "youtube-com.png",
       "background_color": [219, 67, 56],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "Amazon",
@@ -33,7 +35,8 @@ module.exports = {
       "favicon_url": "amazon-com.png",
       "background_color": [255, 255, 255],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "Yahoo",
@@ -43,7 +46,8 @@ module.exports = {
       "favicon_url": "yahoo-com.png",
       "background_color": [80, 9, 167],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "eBay",
@@ -53,7 +57,8 @@ module.exports = {
       "favicon_url": "ebay-com.png",
       "background_color": [237, 237, 237],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "Twitter",
@@ -63,7 +68,8 @@ module.exports = {
       "favicon_url": "twitter-com.png",
       "background_color": [4, 159, 245],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     }
   ].map(item => {
     item.type = FIRST_RUN_TYPE;

--- a/content-test/addon/Feeds/HighlightsFeed.test.js
+++ b/content-test/addon/Feeds/HighlightsFeed.test.js
@@ -125,19 +125,7 @@ describe("HighlightsFeed", () => {
           assert.calledWithExactly(instance.baselineRecommender.scoreEntries, getCachedMetadata(testLinks))
         ));
     });
-    it("should not add screenshots to sites that qualify for a screenshot if the experiment is disabled", () => {
-      reduxState.Experiments.values.bookmarkScreenshots = false;
-      instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
-      instance.shouldGetScreenshot = () => true;
-      return instance.getData().then(result => {
-        assert.notCalled(instance.getScreenshot);
-        for (let link of result.data) {
-          assert.equal(link.screenshot, undefined);
-        }
-      });
-    });
-    it("should not add screenshots to sites that don't qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.bookmarkScreenshots = true;
+    it("should not add screenshots to sites that don't qualify for a screenshot", () => {
       instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
       instance.shouldGetScreenshot = () => false;
       return instance.getData().then(result => {
@@ -147,8 +135,7 @@ describe("HighlightsFeed", () => {
         }
       });
     });
-    it("should add screenshots to sites that qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.bookmarkScreenshots = true;
+    it("should add screenshots to sites that qualify for a screenshot", () => {
       instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
       instance.shouldGetScreenshot = () => true;
       return instance.getData().then(result => {
@@ -159,13 +146,7 @@ describe("HighlightsFeed", () => {
         }
       });
     });
-    it("should set missingData to false if experiment is disabled", () => {
-      reduxState.Experiments.values.bookmarkScreenshots = false;
-      instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
-      return instance.getData().then(result => assert.equal(instance.missingData, false));
-    });
-    it("should set missingData to true if experiment is enabled and a topsite is missing a required screenshot", () => {
-      reduxState.Experiments.values.bookmarkScreenshots = true;
+    it("should set missingData to true if a topsite is missing a required screenshot", () => {
       instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
       instance.shouldGetScreenshot = () => true;
       instance.getScreenshot = sinon.spy(site => null);
@@ -173,8 +154,7 @@ describe("HighlightsFeed", () => {
         assert.equal(instance.missingData, true);
       });
     });
-    it("should set missingData to true if experiment is enabled and a highlight is missing metadata", () => {
-      reduxState.Experiments.values.bookmarkScreenshots = true;
+    it("should set missingData to true if a highlight is missing metadata", () => {
       instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
       instance.options.getCachedMetadata = links => links.map(
         link => { link.hasMetadata = false; return link; }

--- a/content-test/addon/Feeds/TopSitesFeed.test.js
+++ b/content-test/addon/Feeds/TopSitesFeed.test.js
@@ -38,32 +38,23 @@ describe("TopSitesFeed", () => {
     beforeEach(() => {
       testSite = {
         hasMetadata: true,
-        url: "http://www.example.com/",
-        favicon_width: TopSitesFeed.MIN_ICON_SIZE,
-        favicon_height: TopSitesFeed.MIN_ICON_SIZE
+        hasHighResIcon: true,
+        url: "http://www.example.com/"
       };
-    });
-    it("should not get a screenshot for sites missing metadata", () => {
-      testSite.favicon_width = null;
-      testSite.favicon_height = null;
-      testSite.hasMetadata = false;
-      assert.equal(false, instance.shouldGetScreenshot(testSite));
     });
     it("should not get a screenshot for sites with metadata and large icons", () => {
       assert.equal(false, instance.shouldGetScreenshot(testSite));
     });
+    it("should not get a screenshot for sites missing metadata", () => {
+      testSite.hasMetadata = false;
+      assert.equal(false, instance.shouldGetScreenshot(testSite));
+    });
     it("should get a screenshot for sites with metadata and small icons", () => {
-      testSite.favicon_width = TopSitesFeed.MIN_ICON_SIZE - 1;
-      testSite.favicon_height = TopSitesFeed.MIN_ICON_SIZE - 1;
+      testSite.hasHighResIcon = false;
       assert.equal(true, instance.shouldGetScreenshot(testSite));
     });
     it("should get a screenshot for sites with metadata and large icons that are not root domains", () => {
       testSite.url = "http://www.example.com/non/root/";
-      assert.equal(true, instance.shouldGetScreenshot(testSite));
-    });
-    it("should get a screenshot for sites with metadata and missing icon size", () => {
-      testSite.favicon_width = null;
-      testSite.favicon_height = null;
       assert.equal(true, instance.shouldGetScreenshot(testSite));
     });
   });

--- a/content-test/addon/Feeds/TopSitesFeed.test.js
+++ b/content-test/addon/Feeds/TopSitesFeed.test.js
@@ -1,6 +1,10 @@
 const testLinks = [{url: "http://foo.com/"}, {url: "http://bar.com/"}];
 const getCachedMetadata = links => links.map(
-  link => { link.hasMetadata = true; return link; }
+  link => {
+    link.hasMetadata = true;
+    link.hasHighResIcon = true;
+    return link;
+  }
 );
 const PlacesProvider = {links: {getTopFrecentSites: sinon.spy(() => Promise.resolve(testLinks))}};
 const testScreenshot = "screenshot.jpg";
@@ -78,18 +82,7 @@ describe("TopSitesFeed", () => {
       assert.equal(action.type, "TOP_FRECENT_SITES_RESPONSE", "type");
       assert.deepEqual(action.data, getCachedMetadata(testLinks));
     }));
-    it("should not add screenshots to sites that qualify for a screenshot if the experiment is disabled", () => {
-      reduxState.Experiments.values.screenshotsLongCache = false;
-      instance.shouldGetScreenshot = site => true;
-      return instance.getData().then(result => {
-        assert.notCalled(instance.getScreenshot);
-        for (let link of result.data) {
-          assert.equal(link.screenshot, undefined);
-        }
-      });
-    });
-    it("should not add screenshots to sites that don't qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.screenshotsLongCache = true;
+    it("should not add screenshots to sites that don't qualify for a screenshot", () => {
       instance.shouldGetScreenshot = site => false;
       return instance.getData().then(result => {
         assert.notCalled(instance.getScreenshot);
@@ -98,8 +91,7 @@ describe("TopSitesFeed", () => {
         }
       });
     });
-    it("should add screenshots to sites that qualify for a screenshot if the experiment is enabled", () => {
-      reduxState.Experiments.values.screenshotsLongCache = true;
+    it("should add screenshots to sites that qualify for a screenshot", () => {
       instance.shouldGetScreenshot = site => true;
       return instance.getData().then(result => {
         assert.calledTwice(instance.getScreenshot);
@@ -109,19 +101,14 @@ describe("TopSitesFeed", () => {
         }
       });
     });
-    it("should set missingData to false if screenshot experiment is disabled", () =>
-      instance.getData().then(result => assert.equal(instance.missingData, false))
-    );
-    it("should set missingData to true if screenshot experiment is enabled and a topsite is missing a required screenshot", () => {
-      reduxState.Experiments.values.screenshotsLongCache = true;
+    it("should set missingData to true if a topsite is missing a required screenshot", () => {
       instance.shouldGetScreenshot = site => true;
       instance.getScreenshot = sinon.spy(site => null);
       return instance.getData().then(result => {
         assert.equal(instance.missingData, true);
       });
     });
-    it("should set missingData to true if screenshot experiment is enabled and a topsite is missing metadata", () => {
-      reduxState.Experiments.values.screenshotsLongCache = true;
+    it("should set missingData to true if and a topsite is missing metadata", () => {
       instance.options.getCachedMetadata = links => links.map(
         link => { link.hasMetadata = false; return link; }
       );

--- a/content-test/common/Baseline.test.js
+++ b/content-test/common/Baseline.test.js
@@ -112,10 +112,7 @@ describe("Baseline", () => {
     sandbox = sinon.sandbox.create();
     baseline = new Baseline(
       fakeHistory,
-      {
-        experiments: {bookmarkScreenshots: true},
-        highlightsCoefficients: [-0.1, -0.1, -0.1, 0.4, 0.2]
-      }
+      {highlightsCoefficients: [-0.1, -0.1, -0.1, 0.4, 0.2]}
     );
   });
 

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -147,6 +147,7 @@ describe("NewTabPage", () => {
           assert.equal(a.data.topsitesSize, mockData.TopSites.rows.length);
           assert.equal(a.data.topsitesTippytop, 0);
           assert.equal(a.data.topsitesScreenshot, 0);
+          assert.equal(a.data.topsitesLowResIcon, 0);
           done();
         }
       }} />);

--- a/experiments.json
+++ b/experiments.json
@@ -151,7 +151,7 @@
   },
   "newTabPrefs": {
     "name": "Preferences Pane",
-    "active": true,
+    "active": false,
     "description": "Enable the New Tab Prefs feature",
     "control": {
       "value": false,
@@ -222,6 +222,21 @@
       "value": true,
       "threshold": 0.2,
       "description": "Long metadata timeout"
+    }
+  },
+  "editTopSites": {
+    "name": "Edit Top Sites",
+    "active": true,
+    "description": "Enable the Edit Top Sites feature",
+    "control": {
+      "value": false,
+      "description": "Edit Top Sites is disabled"
+    },
+    "variant": {
+      "id": "exp-016-newtab-prefs",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Edit Top Sites is enabled"
     }
   }
 }

--- a/experiments.json
+++ b/experiments.json
@@ -196,7 +196,7 @@
   },
   "screenshotsLongCache": {
     "name": "High Res Icons and Screenshots for Top Sites with a long metadata cache",
-    "active": true,
+    "active": false,
     "description": "Add high res icons or screenshots for some Top Sites",
     "control": {
       "value": false,

--- a/experiments.json
+++ b/experiments.json
@@ -181,7 +181,7 @@
   },
   "bookmarkScreenshots": {
     "name": "Screenshots for Highlights",
-    "active": true,
+    "active": false,
     "description": "Show a screenshot for Highlights that otherwise don't have an image",
     "control": {
       "value": false,

--- a/experiments.json
+++ b/experiments.json
@@ -226,7 +226,7 @@
   },
   "editTopSites": {
     "name": "Edit Top Sites",
-    "active": true,
+    "active": false,
     "description": "Enable the Edit Top Sites feature",
     "control": {
       "value": false,

--- a/test/test-PlacesProvider-synced-tabs.js
+++ b/test/test-PlacesProvider-synced-tabs.js
@@ -29,6 +29,10 @@ MockTabsEngine.prototype = {
 
   getOpenURLs() {
     return new Set();
+  },
+
+  finalize() {
+    return Promise.resolve();
   }
 };
 

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -453,14 +453,13 @@ exports.test_Links_onLinkChanged = function*(assert) {
 
   let linkChangedPromise = new Promise(resolve => {
     let handler = (_, link) => {
-      // There are 3 linkChanged events:
+      // There are 2 linkChanged events:
       // 1. visit insertion (-1 frecency by default)
       // 2. frecency score update (after transition type calculation etc)
-      // 3. title change
       if (link.url === url) {
         assert.equal(link.url, url, "expected url on linkChanged event");
         linkChangedMsgCount += 1;
-        if (linkChangedMsgCount === 3) {
+        if (linkChangedMsgCount === 2) {
           assert.ok(true, "all linkChanged events captured");
           provider.off("linkChanged", this);
           resolve();

--- a/test/test-PreviewProvider-MetadataStore.js
+++ b/test/test-PreviewProvider-MetadataStore.js
@@ -177,7 +177,7 @@ before(exports, function*() {
   gPreviewProvider = new PreviewProvider(mockTabTracker, gMetadataStore, {initFresh: true});
   gPreviewProvider._store = {
     dispatch: () => {},
-    getState: () => ({Experiments: {values: {screenshotsLongCache: false}}})
+    getState: () => ({Experiments: {values: {}}})
   };
   gPreviewProvider._getFaviconColors = function() {
     return Promise.resolve(null);

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -66,7 +66,7 @@ const gMockTabTracker = {handlePerformanceEvent() {}, generateEvent() {}};
 function getMockStore() {
   return {
     dispatch: () => null,
-    getState: () => ({Experiments: {values: {screenshotsLongCache: false}}})
+    getState: () => ({Experiments: {values: {}}})
   };
 }
 

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -46,6 +46,7 @@ const EXPECTED_KEYS = [
   "topsites_size",
   "topsites_screenshot",
   "topsites_tippytop",
+  "topsites_lowresicon",
   "user_prefs"
 ];
 


### PR DESCRIPTION
Hi all,

We are now preparing the release of A-S 1.9.0. The add-on has been made available at [pre-release channel](https://moz-activity-streams-prerelease.s3.amazonaws.com/dist/latest.html). Please install it, test it, and leave the feedback, bug reports, and other inputs in this thread.

# Highlights
* [new] Newtab preference
* [new] Screenshots for top sites and Bookmarked highlights
* [telemetry] Tracking high-res/low-res favicons in top sites

# Release checklist
- QA
  - [x] @pdehaan 
  - [ ] @SoftVision
- Product
  - [x] @nchapman 
  - [x] @aaronrbenson 
- Engineering
  - [x] @tspurway 
  - [x] @jennchaulk 

Please use the `release/block` or `release/uplift` to label the bug reports as well as other release related issues. Once you finish the review, please check off the corresponding item in the above checklist.

*Note*: checking off the item may not work, you can either modify it in place (i.e modify `[ ]` to `[x]`), or just drop a good old `r+` comment below.  

Thanks