### PR TITLE
fix(mc): #2369 Only include .js and .jsm files from vendor dir

### DIFF
--- a/system-addon/jar.mn
+++ b/system-addon/jar.mn
@@ -6,5 +6,6 @@
 % resource activity-stream %content/
   content/lib/ (./lib/*)
   content/common/ (./common/*)
-  content/vendor/ (./vendor/*)
+  content/vendor/ (./vendor/*.js)
+  content/vendor/ (./vendor/*.jsm)
   content/data/ (./data/*)


### PR DESCRIPTION
I'm not sure if there's a better way to do this, but this should fix it