### PR TITLE
fix(tests): Fixes #2366 browser_google_codes.js failure on pine

### DIFF
--- a/mozilla-central-patches/disable-search-tests.diff
+++ b/mozilla-central-patches/disable-search-tests.diff
@@ -12,6 +12,11 @@ diff --git a/browser/components/search/test/browser.ini b/browser/components/sea
  [browser_ddg_behavior.js]
 +skip-if = true # mozilla/activity-stream#2339
  [browser_google.js]
+@@ -31,3 +34,3 @@ skip-if = artifact # bug 1315953
+ [browser_google_codes.js]
+-skip-if = artifact # bug 1315953
++skip-if = true # bug 1315953 / mozilla/activity-stream#2366
+ [browser_google_nocodes.js]
 @@ -35,3 +38,3 @@ skip-if = artifact # bug 1315953
  [browser_google_behavior.js]
 -skip-if = artifact # bug 1315953


### PR DESCRIPTION
This just completely disables a test that was already disabled on artifact builds.  Once this is pushed to pine, the browser_google_codes.js failure should go away. fix #2366

r=Mardak?