### PR TITLE
Fix(tests): fixes #2394 to make test-merges send mail on errors

### DIFF
--- a/bin/test-merges.js
+++ b/bin/test-merges.js
@@ -319,9 +319,13 @@ function main() {
       console.log("Processed all new merges.");
     }).catch(reason => {
       console.log("Something went wrong processing the merges:", reason);
+      process.exitCode = -1;
     });
   })
-  .catch(reason => console.error(reason));
+  .catch(reason => {
+    console.error(reason);
+    process.exitCode = -1;
+  });
 }
 
 main();


### PR DESCRIPTION
All this does is fix test-merges.js to exit with an actual error code, so that chronic/cron notice the error and handle message sending correctly.
