### PR TITLE
Chore(testing) Fixes #2402, upgrades Sinon to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "sass-lint": "1.10.1",
     "shelljs": "0.7.6",
     "simple-git": "1.65.0",
-    "sinon": "1.17.6",
+    "sinon": "2.1.0",
     "style-loader": "0.13.1",
     "svgo": "0.7.1",
     "webpack": "2.2.1",


### PR DESCRIPTION
Here is the changelog. The primary motivator is that stubs now have .resolve and .reject methods for more readable tests: sinonjs/sinon#1211. There are some breaking changes in 2.x compared to 1.x; I've verified that we're not using any of the APIs that have changed.

As far as testing, if this passes Travis, we're good.  :-) fix #2402
