### PR TITLE
chore(telemetry): #2355 - track low-res favicons in topsites

### DIFF
--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -171,6 +171,7 @@ TabTracker.prototype = {
     this._tabData.topsites_size = payload.topsitesSize;
     this._tabData.topsites_tippytop = payload.topsitesTippytop;
     this._tabData.topsites_screenshot = payload.topsitesScreenshot;
+    this._tabData.topsites_lowresicon = payload.topsitesLowResIcon;
   },
 
   generateEvent(eventData) {
@@ -188,6 +189,7 @@ TabTracker.prototype = {
     this._tabData.topsites_size = 0;
     this._tabData.topsites_tippytop = 0;
     this._tabData.topsites_screenshot = 0;
+    this._tabData.topsites_lowresicon = 0;
   },
 
   navigateAwayFromPage(tab, reason) {

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -22,7 +22,8 @@ const NewTabPage = React.createClass({
       highlightsSize: 0,
       topsitesSize: 0,
       topsitesTippytop: 0,
-      topsitesScreenshot: 0
+      topsitesScreenshot: 0,
+      topsitesLowResIcon: 0
     };
     if (this.props.isReady) {
       const {showTopSites, showHighlights} = this.props.Prefs.prefs;
@@ -37,6 +38,8 @@ const NewTabPage = React.createClass({
             stats.topsitesScreenshot++;
           } else if (row && row.metadata_source === "TippyTopProvider") {
             stats.topsitesTippytop++;
+          } else if (row && !row.hasHighResIcon && !row.screenshot) {
+            stats.topsitesLowResIcon++;
           }
         });
       }

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -8,7 +8,7 @@ module.exports = {
     "error": false
   },
   "TopSites": {
-    "rows": faker.createRows({images: 3}),
+    "rows": faker.createRows({images: 3}).map(row => Object.assign({}, row, {hasHighResIcon: true})),
     "error": false
   },
   "Search": {

--- a/content-src/lib/first-run-data.js
+++ b/content-src/lib/first-run-data.js
@@ -13,7 +13,8 @@ module.exports = {
       "favicon_url": "facebook-com.png",
       "background_color": [59, 89, 152],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "YouTube",
@@ -23,7 +24,8 @@ module.exports = {
       "favicon_url": "youtube-com.png",
       "background_color": [219, 67, 56],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "Amazon",
@@ -33,7 +35,8 @@ module.exports = {
       "favicon_url": "amazon-com.png",
       "background_color": [255, 255, 255],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "Yahoo",
@@ -43,7 +46,8 @@ module.exports = {
       "favicon_url": "yahoo-com.png",
       "background_color": [80, 9, 167],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "eBay",
@@ -53,7 +57,8 @@ module.exports = {
       "favicon_url": "ebay-com.png",
       "background_color": [237, 237, 237],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     },
     {
       "title": "Twitter",
@@ -63,7 +68,8 @@ module.exports = {
       "favicon_url": "twitter-com.png",
       "background_color": [4, 159, 245],
       "favicon_height": 80,
-      "favicon_width": 80
+      "favicon_width": 80,
+      "hasHighResIcon": true
     }
   ].map(item => {
     item.type = FIRST_RUN_TYPE;

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -147,6 +147,7 @@ describe("NewTabPage", () => {
           assert.equal(a.data.topsitesSize, mockData.TopSites.rows.length);
           assert.equal(a.data.topsitesTippytop, 0);
           assert.equal(a.data.topsitesScreenshot, 0);
+          assert.equal(a.data.topsitesLowResIcon, 0);
           done();
         }
       }} />);

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -46,6 +46,7 @@ const EXPECTED_KEYS = [
   "topsites_size",
   "topsites_screenshot",
   "topsites_tippytop",
+  "topsites_lowresicon",
   "user_prefs"
 ];
 


### PR DESCRIPTION
This closes #2355.

Note that we only collect the # of low-res favicons as the high-res one could be easily inferred by using `highres = total - lowres - screenshots`