### PR TITLE
Switch eslint from expecting ES5 to expecting ES8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true
-    }
+    },
+    "ecmaVersion": 8
   },
   "env": {
     "browser": true,


### PR DESCRIPTION
fix #2407. For performance reasons, [Firefox is switching away from Task.jsm to async/await](https://bugzilla.mozilla.org/show_bug.cgi?id=1353542).  Our infrastructure is almost set to do this, except that right now, we've got eslint using the default ES5 parser, rather than the ES8/ES2017 parser.  

I'm not so sure that we want to accept all the ES2017 features in our code base, but I don't see a way to turn async/await on selectively.  Additionally, the [Firefox codebase is already set to use ES8](https://dxr.mozilla.org/mozilla-central/source/.eslintrc.js#26).

An additional big bonus is that it makes it possible to [write more readable tests of Promise-based stuff, and ones that more robust against becoming "evergreen"](https://wietse.loves.engineering/testing-promises-with-mocha-90df8b7d2e35).