### PR TITLE
fix(metrics): Remove no-longer-existant AddonWatcher usage

### DIFF
--- a/common/event-constants.js
+++ b/common/event-constants.js
@@ -26,8 +26,7 @@ const constants = {
   undesiredEvents: new Set([
     "HIDE_LOADER",
     "MISSING_IMAGE",
-    "SHOW_LOADER",
-    "SLOW_ADDON_DETECTED"
+    "SHOW_LOADER"
   ]),
   sources: new Set([
     "TOP_SITES",

--- a/docs/data_events.md
+++ b/docs/data_events.md
@@ -353,18 +353,3 @@ In some undesired app states, the app will send a ping about it to our metrics s
   "locale": "en-US"
 }
 ```
-
-#### Slow addon detected by Firefox
-
-```js
-{
-  "event": "SLOW_ADDON_DETECTED",
-  "source": "ADDON",
-  "page": "NEW_TAB",
-  "action": "activity_stream_masga_event",
-  "tab_id": "-5-2",
-  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
-  "addon_version": "1.0.12",
-  "locale": "en-US"
-}
-```

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -3,7 +3,6 @@
 "use strict";
 
 const {before, after} = require("sdk/test/utils");
-const self = require("sdk/self");
 const tabs = require("sdk/tabs");
 const {setTimeout} = require("sdk/timers");
 const {getTestActivityStream} = require("./lib/utils");
@@ -16,16 +15,6 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/ClientID.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Task",
                                   "resource://gre/modules/Task.jsm");
-
-let TOPIC_SLOW_ADDON_DETECTED;
-try {
-  // This import currently fails on travis which is running Firefox 46.
-  // This workaround is ugly but we are just being paranoid about future changes.
-  const {AddonWatcher} = Cu.import("resource://gre/modules/AddonWatcher.jsm", {});
-  TOPIC_SLOW_ADDON_DETECTED = AddonWatcher.TOPIC_SLOW_ADDON_DETECTED;
-} catch (e) {
-  TOPIC_SLOW_ADDON_DETECTED = "addon-watcher-detected-slow-addon";
-}
 
 const EXPECTED_KEYS = [
   "action",
@@ -768,27 +757,6 @@ exports.test_TabTracker_undesired_event_pings = function*(assert) {
   let pingData = yield undesiredEventPromise;
   assert.deepEqual(eventData.msg.data.event, pingData.event, "the ping has the correct event");
   assert.deepEqual(eventData.msg.data.action, "activity_stream_masga_event", "the ping has the correct action");
-};
-
-exports.test_TabTracker_slow_addon_detected = function*(assert) {
-  // Listen for undesired event pings
-  let undesiredEventPromise = new Promise(resolve => {
-    function observe(subject, topic, data) {
-      if (topic === "undesired-event") {
-        Services.obs.removeObserver(observe, "undesired-event");
-        resolve(JSON.parse(data));
-      }
-    }
-    Services.obs.addObserver(observe, "undesired-event", false);
-  });
-
-  // Trigger the slow addon detected notification
-  Services.obs.notifyObservers(null, TOPIC_SLOW_ADDON_DETECTED, self.id);
-
-  // Verify the ping data
-  let pingData = yield undesiredEventPromise;
-  assert.deepEqual(pingData.event, "SLOW_ADDON_DETECTED", "the ping has the correct event");
-  assert.deepEqual(pingData.action, "activity_stream_masga_event", "the ping has the correct action");
 };
 
 exports.test_TabTracker_clear_history_ping = function*(assert) {


### PR DESCRIPTION
Fix #2360 basically reverting #1782 2988d545 except the added `switch`/`case` structure. r?@rlr