### PR TITLE
feat(system-addon): Closes #2312 Create search feed + base search UI

### DIFF
--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -12,7 +12,9 @@ const actionTypes = [
   "NEW_TAB_INITIAL_STATE",
   "NEW_TAB_LOAD",
   "NEW_TAB_UNLOAD",
+  "PERFORM_SEARCH",
   "SCREENSHOT_UPDATED",
+  "SEARCH_STATE_UPDATED",
   "TOP_SITES_UPDATED"
 // The line below creates an object like this:
 // {

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -33,6 +33,13 @@ const INITIAL_STATE = {
         "url": "https://twitter.com/"
       }
     ]
+  },
+  Search: {
+    currentEngine: {
+      name: "",
+      icon: ""
+    },
+    engines: []
   }
 };
 
@@ -60,7 +67,23 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
   }
 }
 
+function Search(prevState = INITIAL_STATE.Search, action) {
+  switch (action.type) {
+    case at.SEARCH_STATE_UPDATED: {
+      if (!action.data) {
+        return prevState;
+      }
+      let {currentEngine, engines} = action.data;
+      return Object.assign({}, prevState, {
+        currentEngine,
+        engines
+      });
+    }
+    default:
+      return prevState;
+  }
+}
 this.INITIAL_STATE = INITIAL_STATE;
-this.reducers = {TopSites};
+this.reducers = {TopSites, Search};
 
 this.EXPORTED_SYMBOLS = ["reducers", "INITIAL_STATE"];

--- a/system-addon/content-src/activity-stream.scss
+++ b/system-addon/content-src/activity-stream.scss
@@ -105,3 +105,4 @@ a {
 // Components
 @import './components/Base/Base';
 @import './components/TopSites/TopSites';
+@import './components/Search/Search';

--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -1,7 +1,9 @@
 const React = require("react");
 const TopSites = require("content-src/components/TopSites/TopSites");
+const Search = require("content-src/components/Search/Search");
 
 const Base = () => (<div className="outer-wrapper"><main>
+  <Search />
   <TopSites />
 </main></div>);
 

--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -1,0 +1,39 @@
+"use strict";
+const React = require("react");
+const {connect} = require("react-redux");
+const {actionTypes, actionCreators} = require("common/Actions.jsm");
+
+const Search = React.createClass({
+  getInitialState() {
+    return {searchString: ""};
+  },
+  performSearch(options) {
+    let searchData = {
+      engineName: options.engineName,
+      searchString: options.searchString,
+      searchPurpose: "newtab",
+      healthReportKey: "newtab"
+    };
+    this.props.dispatch(actionCreators.SendToMain({type: actionTypes.PERFORM_SEARCH, data: searchData}));
+  },
+  onClick(event) {
+    const {currentEngine} = this.props.Search;
+    event.preventDefault();
+    this.performSearch({engineName: currentEngine.name, searchString: this.state.searchString});
+  },
+  onChange(event) {
+    this.setState({searchString: event.target.value});
+  },
+  render() {
+    return (<form className="search-wrapper">
+      <span className="search-label" />
+      <input value={this.state.searchString} type="search"
+        onChange={this.onChange}
+        maxLength="256" title="Submit search"
+        placeholder="Search the Web" />
+        <button onClick={this.onClick} />
+        </form>);
+  }
+});
+
+module.exports = connect(state => ({Search: state.Search}))(Search);

--- a/system-addon/content-src/components/Search/Search.scss
+++ b/system-addon/content-src/components/Search/Search.scss
@@ -1,0 +1,242 @@
+.search-wrapper {
+  $search-bg-color: #FFF;
+  $search-border-radius: 4px;
+  $search-margin-top: 52px;
+  $search-margin-bottom: 48px;
+  $search-height: 36px;
+  $search-input-left-label-width: 35px;
+  $search-input-border-color: #BFBFBF;
+  $search-blue: #0996F8;
+  $search-hover-shadow: rgba(0.11, 0.34, 0.69, 0.5);
+  $search-focus-shadow: #0996F8;
+  $search-button-grey: #FBFBFB;
+  $search-button-border-color: #D4D4D4;
+  $search-button-width: 36px;
+  $search-glyph-image: url('#{$image-path}glyph-search-16.svg');
+  $search-glyph-size: 20px;
+  $search-text: #666;
+  $search-section-background: #F7F7F7;
+  $search-border-color: #EAEAEA;
+
+  @mixin list-items {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  @mixin list-link {
+    cursor: default;
+    color: $black;
+    display: block;
+
+    &:hover,
+    &.active {
+      background: $search-blue;
+      color: $white;
+    }
+  }
+
+  @mixin search-input {
+    border: 0;
+    box-shadow: 0 1px 0 0 $faintest-black;
+    flex-grow: 1;
+    margin: 0;
+    outline: none;
+    padding: 0 12px 0 $search-input-left-label-width;
+    height: 100%;
+
+    &:focus {
+      border-color: $search-blue;
+      box-shadow: 0 0 0 2px $search-focus-shadow;
+      transition: box-shadow 150ms;
+      z-index: 1;
+    }
+  }
+
+  cursor: default;
+  display: flex;
+  position: relative;
+  margin: 0 0 $search-margin-bottom;
+  width: 100%;
+  height: $search-height;
+
+  .search-container {
+    z-index: 1001;
+    background: $search-bg-color;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    margin-top: -2px;
+    border: 1px solid $search-input-border-color;
+    font-size: 12px;
+    box-shadow: 0 5px 10px $faintest-black;
+    overflow: hidden;
+
+    .search-title {
+      color: $search-text;
+      padding: 5px 10px;
+      background-color: $search-section-background;
+      display: flex;
+      align-items: center;
+      word-break: break-all;
+
+      p {
+        margin: 0;
+      }
+
+      #current-engine-icon {
+        margin-inline-end: 8px;
+      }
+    }
+
+    section {
+      border-bottom: 1px solid $search-border-color;
+      margin-bottom: 0;
+    }
+
+    .search-suggestions {
+      ul {
+        @include list-items;
+
+        li a {
+          @include list-link;
+          padding: 4px 36px;
+        }
+      }
+    }
+
+    .history-search-suggestions {
+      border-bottom: 0;
+
+      ul {
+        @include list-items;
+
+        li a {
+          @include list-link;
+          padding: 4px 10px;
+
+          &:hover > #historyIcon,
+          &.active > #historyIcon {
+            background-image: url('#{$image-path}glyph-search-history.svg#search-history-active');
+          }
+        }
+      }
+    }
+
+    .history-search-suggestions #historyIcon {
+      width: 16px;
+      height: 16px;
+      display: inline-block;
+      margin-inline-end: 10px;
+      margin-bottom: -3px;
+      background-image: url('#{$image-path}glyph-search-history.svg#search-history');
+    }
+
+    .search-partners {
+      ul {
+        @include list-items;
+
+        li {
+          display: inline-block;
+          padding: 5px 0;
+
+          a {
+            display: block;
+            padding: 3px 16px;
+            border-right: 1px solid $search-input-border-color;
+          }
+
+          &:hover,
+          &.active {
+            background: $search-blue;
+            color: $white;
+
+            a {
+              border-color: transparent;
+            }
+          }
+        }
+      }
+    }
+
+    .search-settings {
+      button {
+        color: $search-text;
+        margin: 0;
+        padding: 0;
+        height: 32px;
+        text-align: center;
+        width: 100%;
+        border-style: solid none none;
+        border-radius: 0;
+        background: $search-section-background;
+        border-top: 0;
+
+        &:hover,
+        &.active {
+          background: $very-light-grey;
+          box-shadow: none;
+        }
+      }
+    }
+  }
+
+  input {
+    @include search-input;
+    border-top-left-radius: $search-border-radius;
+    border-bottom-left-radius: $search-border-radius;
+    padding-inline-start: 35px;
+
+    &:focus + button {
+      z-index: 1;
+      transition: box-shadow 150ms;
+      box-shadow: 0 0 0 2px $search-focus-shadow;
+      background-color: $search-blue;
+      background-image: url('#{$image-path}glyph-forward-16-white.svg');
+      color: $white;
+    }
+  }
+
+  input:dir(rtl) {
+    border-radius: 0 $search-border-radius $search-border-radius 0;
+  }
+
+  .search-label {
+    background: $search-glyph-image no-repeat center center / $search-glyph-size;
+    position: absolute;
+    top: 0;
+    offset-inline-start: 0;
+    height: 100%;
+    width: $search-input-left-label-width;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2;
+  }
+
+  button {
+    border-radius: 0 $border-radius $border-radius 0;
+    margin-inline-start: -1px;
+    border: 0;
+    width: $search-button-width;
+    padding: 0;
+    transition: box-shadow 150ms;
+    box-shadow: 0 1px 0 0 $faintest-black;
+    background: $white url('#{$image-path}glyph-forward-16.svg') no-repeat center center;
+    background-size: 16px 16px;
+
+    &:hover {
+      z-index: 1;
+      transition: box-shadow 150ms;
+      box-shadow: 0 1px 0 0 $search-hover-shadow;
+      background-color: $search-blue;
+      background-image: url('#{$image-path}glyph-forward-16-white.svg');
+      color: $white;
+    }
+  }
+
+  button:dir(rtl) {
+    transform: scaleX(-1);
+  }
+}

--- a/system-addon/content-src/styles/variables.scss
+++ b/system-addon/content-src/styles/variables.scss
@@ -35,3 +35,5 @@ $break-point-large: $wrapper-max-width-large + $base-gutter * 2;
 $section-title-font-size: 13px;
 $section-title-color: #6E707E;
 $section-title-bottom-margin: 18px;
+
+$image-path: 'assets/';

--- a/system-addon/data/content/assets/glyph-forward-16-white.svg
+++ b/system-addon/data/content/assets/glyph-forward-16-white.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <title>Forward - 16</title>
+  <g>
+    <polyline points="9 2 15 8 9 14" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <line x1="14" y1="8" x2="1" y2="8" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>

--- a/system-addon/data/content/assets/glyph-forward-16.svg
+++ b/system-addon/data/content/assets/glyph-forward-16.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <title>Forward - 16</title>
+  <g>
+    <polyline points="9 2 15 8 9 14" fill="none" stroke="#a0a0a0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <line x1="14" y1="8" x2="1" y2="8" fill="none" stroke="#a0a0a0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>

--- a/system-addon/data/content/assets/glyph-search-16.svg
+++ b/system-addon/data/content/assets/glyph-search-16.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #a0a0a0;
+        fill-rule: evenodd;
+      }
+    </style>
+  </defs>
+  <g id="glyph-search-16">
+    <path id="Icon_-_Search_-_16" data-name="Icon - Search - 16" class="cls-1" d="M226.989,348.571l-2.2,2.2-9.533-9.534a11.436,11.436,0,1,1,2.2-2.2ZM208.37,323.745a8.407,8.407,0,1,0,8.406,8.406A8.406,8.406,0,0,0,208.37,323.745Z" transform="translate(-196 -320)"/>
+  </g>
+</svg>

--- a/system-addon/data/content/assets/glyph-search-history.svg
+++ b/system-addon/data/content/assets/glyph-search-history.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+  <style>
+    use:not(:target) {
+      display: none;
+    }
+    use {
+      fill: graytext;
+    }
+    use[id$="-active"] {
+      fill: HighlightText;
+    }
+  </style>
+  <defs>
+    <path id="search-history-glyph" d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7c3.9,0,7-3.1,7-7 C15,4.1,11.9,1,8,1z M8,13.3c-2.9,0-5.3-2.4-5.3-5.3S5.1,2.7,8,2.7c2.9,0,5.3,2.4,5.3,5.3S10.9,13.3,8,13.3z M10.5,7H9V5 c0-0.6-0.4-1-1-1S7,4.4,7,5v3c0,0.6,0.4,1,1,1h2.5c0.6,0,1-0.4,1-1C11.5,7.4,11.1,7,10.5,7z"/>
+  </defs>
+  <use id="search-history" xlink:href="#search-history-glyph"/>
+  <use id="search-history-active" xlink:href="#search-history-glyph"/>
+</svg>

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-/* globals XPCOMUtils, NewTabInit, TopSitesFeed */
+/* globals XPCOMUtils, NewTabInit, TopSitesFeed, SearchFeed */
 
 "use strict";
 
@@ -15,6 +15,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "NewTabInit",
   "resource://activity-stream/lib/NewTabInit.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "TopSitesFeed",
   "resource://activity-stream/lib/TopSitesFeed.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "SearchFeed",
+  "resource://activity-stream/lib/SearchFeed.jsm");
 
 const feeds = {
   // When you add a feed here:
@@ -25,7 +27,8 @@ const feeds = {
   // 3. You should use XPCOMUtils.defineLazyModuleGetter to import the Feed,
   //    so it isn't loaded until the feed is enabled.
   "feeds.newtabinit": () => new NewTabInit(),
-  "feeds.topsites": () => new TopSitesFeed()
+  "feeds.topsites": () => new TopSitesFeed(),
+  "feeds.search": () => new SearchFeed()
 };
 
 this.ActivityStream = class ActivityStream {

--- a/system-addon/lib/SearchFeed.jsm
+++ b/system-addon/lib/SearchFeed.jsm
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ /* globals ContentSearch, XPCOMUtils, Services */
+"use strict";
+
+const {utils: Cu} = Components;
+const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+const SEARCH_ENGINE_TOPIC = "browser-search-engine-modified";
+
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "ContentSearch",
+  "resource:///modules/ContentSearch.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "Services",
+  "resource://gre/modules/Services.jsm");
+
+this.SearchFeed = class SearchFeed {
+  addObservers() {
+    Services.obs.addObserver(this, SEARCH_ENGINE_TOPIC);
+  }
+  removeObservers() {
+    Services.obs.removeObserver(this, SEARCH_ENGINE_TOPIC);
+  }
+  observe(subject, topic, data) {
+    switch (topic) {
+      case SEARCH_ENGINE_TOPIC:
+        if (data !== "engine-default") {
+          this.getState();
+        }
+        break;
+    }
+  }
+  async getState() {
+    const state = await ContentSearch.currentStateObj(true);
+    const engines = state.engines.map(engine => ({
+      name: engine.name,
+      icon: engine.iconBuffer
+    }));
+    const currentEngine = {
+      name: state.currentEngine.name,
+      icon: state.currentEngine.iconBuffer
+    };
+    const action = {type: at.SEARCH_STATE_UPDATED, data: {engines, currentEngine}};
+    this.store.dispatch(ac.BroadcastToContent(action));
+  }
+  performSearch(browser, data) {
+    ContentSearch.performSearch({target: browser}, data);
+  }
+  onAction(action) {
+    switch (action.type) {
+      case at.INIT:
+        this.addObservers();
+        this.getState();
+        break;
+      case at.PERFORM_SEARCH:
+        this.performSearch(action._target.browser, action.data);
+        break;
+      case at.UNINIT:
+        this.removeObservers();
+        break;
+    }
+  }
+};
+this.EXPORTED_SYMBOLS = ["SearchFeed"];

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -1,5 +1,5 @@
 const {reducers, INITIAL_STATE} = require("common/Reducers.jsm");
-const {TopSites} = reducers;
+const {TopSites, Search} = reducers;
 const {actionTypes: at} = require("common/Actions.jsm");
 
 describe("Reducers", () => {
@@ -28,6 +28,24 @@ describe("Reducers", () => {
       const action = {type: at.SCREENSHOT_UPDATED, data: {url: "baz.com", screenshot: "data:123"}};
       const nextState = TopSites(oldState, action);
       assert.deepEqual(nextState, oldState);
+    });
+  });
+  describe("Search", () => {
+    it("should return the initial state", () => {
+      const nextState = Search(undefined, {type: "FOO"});
+      assert.equal(nextState, INITIAL_STATE.Search);
+    });
+    it("should not update state for empty action.data on Search", () => {
+      const nextState = Search(undefined, {type: at.SEARCH_STATE_UPDATED});
+      assert.equal(nextState, INITIAL_STATE.Search);
+    });
+    it("should update the current engine and the engines on SEARCH_STATE_UPDATED", () => {
+      const newEngine = {name: "Google", iconBuffer: "icon.ico"};
+      const nextState = Search(undefined, {type: at.SEARCH_STATE_UPDATED, data: {currentEngine: newEngine, engines: [newEngine]}});
+      assert.equal(nextState.currentEngine.name, newEngine.name);
+      assert.equal(nextState.currentEngine.icon, newEngine.icon);
+      assert.equal(nextState.engines[0].name, newEngine.name);
+      assert.equal(nextState.engines[0].icon, newEngine.icon);
     });
   });
 });

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -6,11 +6,13 @@ describe("ActivityStream", () => {
   let ActivityStream;
   function NewTabInit() {}
   function TopSitesFeed() {}
+  function SearchFeed() {}
   before(() => {
     sandbox = sinon.sandbox.create();
     ({ActivityStream} = injector({
       "lib/NewTabInit.jsm": {NewTabInit},
-      "lib/TopSitesFeed.jsm": {TopSitesFeed}
+      "lib/TopSitesFeed.jsm": {TopSitesFeed},
+      "lib/SearchFeed.jsm": {SearchFeed}
     }));
   });
 
@@ -59,6 +61,10 @@ describe("ActivityStream", () => {
     it("should create a TopSites feed", () => {
       const feed = as.feeds["feeds.topsites"]();
       assert.instanceOf(feed, TopSitesFeed);
+    });
+    it("should create a Search feed", () => {
+      const feed = as.feeds["feeds.search"]();
+      assert.instanceOf(feed, SearchFeed);
     });
   });
 });

--- a/system-addon/test/unit/lib/SearchFeed.test.js
+++ b/system-addon/test/unit/lib/SearchFeed.test.js
@@ -1,0 +1,77 @@
+"use strict";
+const {SearchFeed} = require("lib/SearchFeed.jsm");
+const {GlobalOverrider} = require("test/unit/utils");
+const {actionTypes: at} = require("common/Actions.jsm");
+const fakeEngines = [{name: "Google", iconBuffer: "icon.ico"}];
+describe("Search Feed", () => {
+  let feed;
+  let globals;
+  before(() => {
+    globals = new GlobalOverrider();
+    globals.set("ContentSearch", {
+      currentStateObj: globals.sandbox.spy(() => Promise.resolve({engines: fakeEngines, currentEngine: {}})),
+      performSearch: globals.sandbox.spy((browser, searchData) => Promise.resolve({browser, searchData}))
+    });
+  });
+  beforeEach(() => {
+    feed = new SearchFeed();
+    feed.store = {dispatch: sinon.spy()};
+  });
+  afterEach(() => globals.reset());
+  after(() => globals.restore());
+
+  it("should call get state (with true) from the content search provider on INIT", () => {
+    feed.onAction({type: at.INIT});
+    // calling currentStateObj with 'true' allows us to return a data uri for the
+    // icon, instead of an array buffer
+    assert.calledWith(global.ContentSearch.currentStateObj, true);
+  });
+  it("should get the the state on INIT", () => {
+    sinon.stub(feed, "getState");
+    feed.onAction({type: at.INIT});
+    assert.calledOnce(feed.getState);
+  });
+  it("should add observers on INIT", () => {
+    sinon.stub(feed, "addObservers");
+    feed.onAction({type: at.INIT});
+    assert.calledOnce(feed.addObservers);
+  });
+  it("should remove observers on UNINIT", () => {
+    sinon.stub(feed, "removeObservers");
+    feed.onAction({type: at.UNINIT});
+    assert.calledOnce(feed.removeObservers);
+  });
+  it("should call services.obs.addObserver on INIT", () => {
+    feed.onAction({type: at.INIT});
+    assert.calledOnce(global.Services.obs.addObserver);
+  });
+  it("should call services.obs.removeObserver on UNINIT", () => {
+    feed.onAction({type: at.UNINIT});
+    assert.calledOnce(global.Services.obs.removeObserver);
+  });
+  it("should dispatch one event with the state", () => (
+    feed.getState().then(() => {
+      assert.calledOnce(feed.store.dispatch);
+    })
+  ));
+  it("should perform a search on PERFORM_SEARCH", () => {
+    sinon.stub(feed, "performSearch");
+    feed.onAction({_target: {browser: {}}, type: at.PERFORM_SEARCH});
+    assert.calledOnce(feed.performSearch);
+  });
+  it("should call performSearch with an action", () => {
+    const action = {_target: {browser: "browser"}, data: {searchString: "hello"}};
+    feed.performSearch(action._target.browser, action.data);
+    assert.calledWith(global.ContentSearch.performSearch, {target: action._target.browser}, action.data);
+  });
+  it("should get the state if we change the search engines", () => {
+    sinon.stub(feed, "getState");
+    feed.observe(null, "browser-search-engine-modified", "engine-current");
+    assert.calledOnce(feed.getState);
+  });
+  it("shouldn't get the state if it's not the right notification", () => {
+    sinon.stub(feed, "getState");
+    feed.observe(null, "some-other-notification", "engine-current");
+    assert.notCalled(feed.getState);
+  });
+});

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -1,5 +1,4 @@
 const {GlobalOverrider} = require("test/unit/utils");
-const Task = require("co-task");
 
 const req = require.context(".", true, /\.test\.js$/);
 const files = req.keys();
@@ -29,8 +28,7 @@ overrider.set({
       addObserver: overrider.sandbox.spy(),
       removeObserver: overrider.sandbox.spy()
     }
-  },
-  Task
+  }
 });
 
 describe("activity-stream", () => {


### PR DESCRIPTION
Closes #2312 Adds some base functionality for the Search component:
- Search react component (just the search bar + button)
- CSS for the Search component 
- Functionality to perform a search
- Functionality to get the default engine so the search properly works
- Brand new assets for the new search spec: https://mozilla.invisionapp.com/share/GMBA4GJRA#/screens
- Tests for the reducer, and the feed

Notes: the actual search component isn't tested - though it's simple

To try it out: ```npm run buildmc``` in activity stream -> ```./mach build faster && ./mach run``` in mozilla-central. and voila! we are able to do some searches! (without suggestions for now)