### PR TITLE
fix(mc): #2430 Upgrade jsm parser, lazily import feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel": "6.5.2",
     "babel-core": "6.18.2",
     "babel-loader": "6.2.7",
-    "babel-plugin-jsm-to-commonjs": "0.1.1",
+    "babel-plugin-jsm-to-commonjs": "0.2.0",
     "babel-plugin-transform-async-to-module-method": "^6.24.1",
     "babel-plugin-transform-es2015-destructuring": "6.18.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -1,15 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* globals XPCOMUtils, NewTabInit, TopSitesFeed */
+
 "use strict";
 
 const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 const {Store} = Cu.import("resource://activity-stream/lib/Store.jsm", {});
 const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
 // Feeds
-const {NewTabInit} = Cu.import("resource://activity-stream/lib/NewTabInit.jsm", {});
-const {TopSitesFeed} = Cu.import("resource://activity-stream/lib/TopSitesFeed.jsm", {});
+XPCOMUtils.defineLazyModuleGetter(this, "NewTabInit",
+  "resource://activity-stream/lib/NewTabInit.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "TopSitesFeed",
+  "resource://activity-stream/lib/TopSitesFeed.jsm");
 
 this.ActivityStream = class ActivityStream {
 


### PR DESCRIPTION
Changes for `babel-plugin-jsm-to-commonjs` here: https://github.com/k88hudson/babel-plugin-jsm-to-commonjs/commit/1f14d9e7872873a399a3785af04e3dc61898f266