### PR TITLE
feature(telemetry): fixes #2284, port TelemetrySender to system addon

### DIFF
--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /* globals Preferences, Services, XPCOMUtils */
 
 const {interfaces: Ci, utils: Cu} = Components;

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -9,6 +9,7 @@ Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.importGlobalProperties(["fetch"]);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
 
 const ENDPOINT_PREF = "telemetry.ping.endpoint";
 const TELEMETRY_PREF = "telemetry";
@@ -110,7 +111,7 @@ TelemetrySender.prototype = {
     if (this.logging) {
       // performance related pings cause a lot of logging, so we mute them
       if (JSON.parse(data).action !== "activity_stream_performance") {
-        Cu.reportError(`TELEMETRY PING: ${data}`);
+        console.log(`TELEMETRY PING: ${data}`); // eslint-disable-line no-console
       }
     }
 

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -24,6 +24,16 @@ const UNDESIRED_NOTIF = "undesired-event";
 // installed.  Though maybe we should just forcibly disable the old add-on?
 const PREF_BRANCH = "browser.newtabpage.activity-stream";
 
+/**
+ * Observe various notifications and send them to a telemetry endpoint.
+ *
+ * @param {Object} args - optional arguments
+ * @param {Function} args.prefInitHook - if present, will be called back
+ *                   inside the Prefs constructor. Typically used from tests
+ *                   to save off a pointer to a fake Prefs instance so that
+ *                   stubs and spies can be inspected by the test code.
+ *
+ */
 function TelemetrySender(args) {
   let prefArgs = {branch: PREF_BRANCH};
   if (args) {

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -1,0 +1,126 @@
+/* globals Preferences, Services, XPCOMUtils */
+
+const {interfaces: Ci, utils: Cu} = Components;
+
+Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.importGlobalProperties(["fetch"]);
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+
+const ENDPOINT_PREF = "telemetry.ping.endpoint";
+const TELEMETRY_PREF = "telemetry";
+const LOGGING_PREF = "performance.log";
+
+const ACTION_NOTIF = "user-action-event";
+const PERFORMANCE_NOTIF = "performance-event";
+const COMPLETE_NOTIF = "tab-session-complete";
+const UNDESIRED_NOTIF = "undesired-event";
+
+// This is intentionally a different pref-branch than the SDK-based add-on
+// used, to avoid extra weirdness for people who happen to have the SDK-based
+// installed.  Though maybe we should just forcibly disable the old add-on?
+const PREF_BRANCH = "browser.newtabpage.activity-stream";
+
+function TelemetrySender(args) {
+  let prefArgs = {branch: PREF_BRANCH};
+  if (args) {
+    if ("prefInitHook" in args) {
+      prefArgs.initHook = args.prefInitHook;
+    }
+  }
+
+  this._prefs = new Preferences(prefArgs);
+
+  this.enabled = this._prefs.get(TELEMETRY_PREF);
+  this._onTelemetryPrefChange = this._onTelemetryPrefChange.bind(this);
+  this._prefs.observe(TELEMETRY_PREF, this._onTelemetryPrefChange);
+
+  this.logging = this._prefs.get(LOGGING_PREF);
+  this._onLoggingPrefChange = this._onLoggingPrefChange.bind(this);
+  this._prefs.observe(LOGGING_PREF, this._onLoggingPrefChange);
+
+  this._pingEndpoint = this._prefs.get(ENDPOINT_PREF);
+  this._onEndpointPrefChange = this._onEndpointPrefChange.bind(this);
+  this._prefs.observe(ENDPOINT_PREF, this._onEndpointPrefChange);
+
+  if (this.enabled) {
+    Services.obs.addObserver(this, COMPLETE_NOTIF, true);
+    Services.obs.addObserver(this, ACTION_NOTIF, true);
+    Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
+    Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
+  }
+}
+
+TelemetrySender.prototype = {
+  /* We need this to be multi-process safe while using the observer service
+   * (though it's not obvious to me how the weak reference helps that). */
+  QueryInterface: XPCOMUtils.generateQI([
+    Ci.nsIObserver,
+    Ci.nsISupportsWeakReference
+  ]),
+
+  observe(subject, topic, data) {
+    if (topic === COMPLETE_NOTIF || topic === ACTION_NOTIF || topic === PERFORMANCE_NOTIF || topic === UNDESIRED_NOTIF) {
+      this._sendPing(data);
+    }
+  },
+
+  _onEndpointPrefChange(prefVal) {
+    this._pingEndpoint = prefVal;
+  },
+
+  _onLoggingPrefChange(prefVal) {
+    this.logging = prefVal;
+  },
+
+  _onTelemetryPrefChange(prefVal) {
+    if (this.enabled && !prefVal) {
+      Services.obs.removeObserver(this, COMPLETE_NOTIF);
+      Services.obs.removeObserver(this, ACTION_NOTIF);
+      Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
+      Services.obs.removeObserver(this, UNDESIRED_NOTIF);
+    } else if (!this.enabled && prefVal) {
+      Services.obs.addObserver(this, COMPLETE_NOTIF, true);
+      Services.obs.addObserver(this, ACTION_NOTIF, true);
+      Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
+      Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
+    }
+
+    this.enabled = prefVal;
+  },
+
+  async _sendPing(data) {
+    if (this.logging) {
+      // performance related pings cause a lot of logging, so we mute them
+      if (JSON.parse(data).action !== "activity_stream_performance") {
+        Cu.reportError(`TELEMETRY PING: ${data}`);
+      }
+    }
+
+    return fetch(this._pingEndpoint, {method: "POST", body: data}).then(response => {
+      if (!response.ok) {
+        Cu.reportError(`Ping failure with HTTP response code: ${response.status}`);
+      }
+    }).catch(e => {
+      Cu.reportError(`Ping failure with error: ${e}`);
+    });
+  },
+
+  uninit() {
+    try {
+      if (this.enabled) {
+        Services.obs.removeObserver(this, COMPLETE_NOTIF);
+        Services.obs.removeObserver(this, ACTION_NOTIF);
+        Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
+        Services.obs.removeObserver(this, UNDESIRED_NOTIF);
+      }
+      this._prefs.ignore(TELEMETRY_PREF, this._onTelemetryPrefChange);
+      this._prefs.ignore(ENDPOINT_PREF, this._onEndpointPrefChange);
+    } catch (e) {
+      Cu.reportError(e);
+    }
+  }
+};
+
+this.TelemetrySender = TelemetrySender;
+this.EXPORTED_SYMBOLS = ["TelemetrySender"];

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -53,8 +53,6 @@ function TelemetrySender(args) {
   this._prefs.observe(LOGGING_PREF, this._onLoggingPrefChange);
 
   this._pingEndpoint = this._prefs.get(ENDPOINT_PREF);
-  this._onEndpointPrefChange = this._onEndpointPrefChange.bind(this);
-  this._prefs.observe(ENDPOINT_PREF, this._onEndpointPrefChange);
 
   if (this.enabled) {
     Services.obs.addObserver(this, COMPLETE_NOTIF, true);
@@ -76,10 +74,6 @@ TelemetrySender.prototype = {
     if (topic === COMPLETE_NOTIF || topic === ACTION_NOTIF || topic === PERFORMANCE_NOTIF || topic === UNDESIRED_NOTIF) {
       this._sendPing(data);
     }
-  },
-
-  _onEndpointPrefChange(prefVal) {
-    this._pingEndpoint = prefVal;
   },
 
   _onLoggingPrefChange(prefVal) {
@@ -128,7 +122,6 @@ TelemetrySender.prototype = {
         Services.obs.removeObserver(this, UNDESIRED_NOTIF);
       }
       this._prefs.ignore(TELEMETRY_PREF, this._onTelemetryPrefChange);
-      this._prefs.ignore(ENDPOINT_PREF, this._onEndpointPrefChange);
     } catch (e) {
       Cu.reportError(e);
     }

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -55,10 +55,7 @@ function TelemetrySender(args) {
   this._pingEndpoint = this._prefs.get(ENDPOINT_PREF);
 
   if (this.enabled) {
-    Services.obs.addObserver(this, COMPLETE_NOTIF, true);
-    Services.obs.addObserver(this, ACTION_NOTIF, true);
-    Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
-    Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
+    this._addObservers();
   }
 }
 
@@ -87,18 +84,26 @@ TelemetrySender.prototype = {
 
   _onTelemetryPrefChange(prefVal) {
     if (this.enabled && !prefVal) {
-      Services.obs.removeObserver(this, COMPLETE_NOTIF);
-      Services.obs.removeObserver(this, ACTION_NOTIF);
-      Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
-      Services.obs.removeObserver(this, UNDESIRED_NOTIF);
+      this._removeObservers();
     } else if (!this.enabled && prefVal) {
-      Services.obs.addObserver(this, COMPLETE_NOTIF, true);
-      Services.obs.addObserver(this, ACTION_NOTIF, true);
-      Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
-      Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
+      this._addObservers();
     }
 
     this.enabled = prefVal;
+  },
+
+  _addObservers() {
+    Services.obs.addObserver(this, COMPLETE_NOTIF, true);
+    Services.obs.addObserver(this, ACTION_NOTIF, true);
+    Services.obs.addObserver(this, PERFORMANCE_NOTIF, true);
+    Services.obs.addObserver(this, UNDESIRED_NOTIF, true);
+  },
+
+  _removeObservers() {
+    Services.obs.removeObserver(this, COMPLETE_NOTIF);
+    Services.obs.removeObserver(this, ACTION_NOTIF);
+    Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
+    Services.obs.removeObserver(this, UNDESIRED_NOTIF);
   },
 
   async _sendPing(data) {
@@ -121,10 +126,7 @@ TelemetrySender.prototype = {
   uninit() {
     try {
       if (this.enabled) {
-        Services.obs.removeObserver(this, COMPLETE_NOTIF);
-        Services.obs.removeObserver(this, ACTION_NOTIF);
-        Services.obs.removeObserver(this, PERFORMANCE_NOTIF);
-        Services.obs.removeObserver(this, UNDESIRED_NOTIF);
+        this._removeObservers();
       }
       this._prefs.ignore(TELEMETRY_PREF, this._onTelemetryPrefChange);
     } catch (e) {

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -71,8 +71,13 @@ TelemetrySender.prototype = {
   ]),
 
   observe(subject, topic, data) {
-    if (topic === COMPLETE_NOTIF || topic === ACTION_NOTIF || topic === PERFORMANCE_NOTIF || topic === UNDESIRED_NOTIF) {
-      this._sendPing(data);
+    switch (topic) {
+      case COMPLETE_NOTIF:
+      case ACTION_NOTIF:
+      case PERFORMANCE_NOTIF:
+      case UNDESIRED_NOTIF:
+        this._sendPing(data);
+        break;
     }
   },
 

--- a/system-addon/test/unit/lib/TelemetrySender.test.js
+++ b/system-addon/test/unit/lib/TelemetrySender.test.js
@@ -145,7 +145,7 @@ describe("TelemetrySender", () => {
 
       await tSender._sendPing(fakePingJSON);
 
-      assert.called(global.Components.utils.reportError);
+      assert.called(console.log); // eslint-disable-line no-console
     });
   });
 

--- a/system-addon/test/unit/lib/TelemetrySender.test.js
+++ b/system-addon/test/unit/lib/TelemetrySender.test.js
@@ -144,22 +144,6 @@ describe("TelemetrySender", () => {
 
       assert.called(global.Components.utils.reportError);
     });
-
-    it("should POST to a changed value of telemetry.ping.endpoint", async () => {
-      FakePrefs.prototype.prefs = {
-        "telemetry": true,
-        "telemetry.ping.endpoint": fakeEndpointUrl
-      };
-      tSender = new TelemetrySender(tsArgs);
-      fetchStub.resolves(fakeFetchSuccessResponse);
-
-      fakePrefs.set("telemetry.ping.endpoint", "http://127.0.0.1/fake");
-      await tSender._sendPing(fakePingJSON);
-
-      assert.calledOnce(fetchStub);
-      assert.calledWithExactly(fetchStub, "http://127.0.0.1/fake",
-        {method: "POST", body: fakePingJSON});
-    });
   });
 
   describe("#observe()", () => {
@@ -191,15 +175,6 @@ describe("TelemetrySender", () => {
   });
 
   describe("#uninit()", () => {
-    it("should remove the telemetry.ping.endpoint pref listener", () => {
-      tSender = new TelemetrySender(tsArgs);
-      assert.property(fakePrefs.observers, "telemetry.ping.endpoint");
-
-      tSender.uninit();
-
-      assert.notProperty(fakePrefs.observers, "telemetry.ping.endpoint");
-    });
-
     it("should remove the telemetry pref listener", () => {
       tSender = new TelemetrySender(tsArgs);
       assert.property(fakePrefs.observers, "telemetry");
@@ -212,7 +187,6 @@ describe("TelemetrySender", () => {
     it("should remove all notification observers if telemetry pref is true", () => {
       FakePrefs.prototype.prefs = {telemetry: true};
       tSender = new TelemetrySender(tsArgs);
-      assert.property(fakePrefs.observers, "telemetry.ping.endpoint");
 
       tSender.uninit();
 
@@ -222,7 +196,6 @@ describe("TelemetrySender", () => {
     it("should not remove notification observers if telemetry pref is false", () => {
       FakePrefs.prototype.prefs = {telemetry: false};
       tSender = new TelemetrySender(tsArgs);
-      assert.property(fakePrefs.observers, "telemetry.ping.endpoint");
 
       tSender.uninit();
 

--- a/system-addon/test/unit/lib/TelemetrySender.test.js
+++ b/system-addon/test/unit/lib/TelemetrySender.test.js
@@ -1,0 +1,295 @@
+const {GlobalOverrider, FakePrefs} = require("test/unit/utils");
+const {TelemetrySender} = require("lib/TelemetrySender.jsm");
+
+/**
+ * A reference to the fake preferences object created by the TelemetrySender
+ * constructor so that we can use the API.
+ */
+let fakePrefs;
+const prefInitHook = function() {
+  fakePrefs = this; // eslint-disable-line consistent-this
+};
+const tsArgs = {prefInitHook};
+
+describe("TelemetrySender", () => {
+  let globals;
+  let tSender;
+  let fetchStub;
+  const observerTopics = ["user-action-event", "performance-event",
+    "tab-session-complete", "undesired-event"];
+  const fakeEndpointUrl = "http://127.0.0.1/stuff";
+  const fakePingJSON = JSON.stringify({action: "fake_action", monkey: 1});
+  const fakeFetchHttpErrorResponse = {ok: false, status: 400};
+  const fakeFetchSuccessResponse = {ok: true, status: 200};
+
+  function assertNotificationObserversAdded() {
+    observerTopics.forEach(topic => {
+      assert.calledWithExactly(
+        global.Services.obs.addObserver, tSender, topic, true);
+    });
+  }
+
+  function assertNotificationObserversRemoved() {
+    observerTopics.forEach(topic => {
+      assert.calledWithExactly(
+        global.Services.obs.removeObserver, tSender, topic);
+    });
+  }
+
+  before(() => {
+    globals = new GlobalOverrider();
+
+    fetchStub = globals.sandbox.stub();
+
+    globals.set("Preferences", FakePrefs);
+    globals.set("fetch", fetchStub);
+  });
+
+  beforeEach(() => {
+  });
+
+  afterEach(() => {
+    globals.reset();
+    FakePrefs.prototype.prefs = {};
+  });
+
+  after(() => globals.restore());
+
+  it("should construct the Prefs object with the right branch", () => {
+    globals.sandbox.spy(global, "Preferences");
+
+    tSender = new TelemetrySender(tsArgs);
+
+    assert.calledOnce(global.Preferences);
+    assert.calledWith(global.Preferences,
+      sinon.match.has("branch", "browser.newtabpage.activity-stream"));
+  });
+
+  it("should set the enabled prop to false if the pref is false", () => {
+    FakePrefs.prototype.prefs = {telemetry: false};
+
+    tSender = new TelemetrySender(tsArgs);
+
+    assert.isFalse(tSender.enabled);
+  });
+
+  it("should not add notification observers if the enabled pref is false", () => {
+    FakePrefs.prototype.prefs = {telemetry: false};
+
+    tSender = new TelemetrySender(tsArgs);
+
+    assert.notCalled(global.Services.obs.addObserver);
+  });
+
+  it("should set the enabled prop to true if the pref is true", () => {
+    FakePrefs.prototype.prefs = {telemetry: true};
+
+    tSender = new TelemetrySender(tsArgs);
+
+    assert.isTrue(tSender.enabled);
+  });
+
+  it("should add all notification observers if the enabled pref is true", () => {
+    FakePrefs.prototype.prefs = {telemetry: true};
+
+    tSender = new TelemetrySender(tsArgs);
+
+    assertNotificationObserversAdded();
+  });
+
+  describe("#_sendPing()", () => {
+    beforeEach(() => {
+      FakePrefs.prototype.prefs = {
+        "telemetry": true,
+        "telemetry.ping.endpoint": fakeEndpointUrl
+      };
+      tSender = new TelemetrySender(tsArgs);
+    });
+
+    it("should POST given ping data to telemetry.ping.endpoint pref w/fetch",
+    async () => {
+      fetchStub.resolves(fakeFetchSuccessResponse);
+      await tSender._sendPing(fakePingJSON);
+
+      assert.calledOnce(fetchStub);
+      assert.calledWithExactly(fetchStub, fakeEndpointUrl,
+        {method: "POST", body: fakePingJSON});
+    });
+
+    it("should log HTTP failures using Cu.reportError", async () => {
+      fetchStub.resolves(fakeFetchHttpErrorResponse);
+
+      await tSender._sendPing(fakePingJSON);
+
+      assert.called(Components.utils.reportError);
+    });
+
+    it("should log an error using Cu.reportError if fetch rejects", async () => {
+      fetchStub.rejects("Oh noes!");
+
+      await tSender._sendPing(fakePingJSON);
+
+      assert.called(Components.utils.reportError);
+    });
+
+    it("should log if logging is on && if action is not activity_stream_performance", async () => {
+      FakePrefs.prototype.prefs = {
+        "telemetry": true,
+        "performance.log": true
+      };
+      fetchStub.resolves(fakeFetchSuccessResponse);
+      tSender = new TelemetrySender(tsArgs);
+
+      await tSender._sendPing(fakePingJSON);
+
+      assert.called(global.Components.utils.reportError);
+    });
+
+    it("should POST to a changed value of telemetry.ping.endpoint", async () => {
+      FakePrefs.prototype.prefs = {
+        "telemetry": true,
+        "telemetry.ping.endpoint": fakeEndpointUrl
+      };
+      tSender = new TelemetrySender(tsArgs);
+      fetchStub.resolves(fakeFetchSuccessResponse);
+
+      fakePrefs.set("telemetry.ping.endpoint", "http://127.0.0.1/fake");
+      await tSender._sendPing(fakePingJSON);
+
+      assert.calledOnce(fetchStub);
+      assert.calledWithExactly(fetchStub, "http://127.0.0.1/fake",
+        {method: "POST", body: fakePingJSON});
+    });
+  });
+
+  describe("#observe()", () => {
+    before(() => {
+      globals.sandbox.stub(TelemetrySender.prototype, "_sendPing");
+    });
+
+    observerTopics.forEach(topic => {
+      it(`should call this._sendPing with data for ${topic}`, () => {
+        const fakeSubject = "fakeSubject";
+        tSender = new TelemetrySender(tsArgs);
+
+        tSender.observe(fakeSubject, topic, fakePingJSON);
+
+        assert.calledOnce(TelemetrySender.prototype._sendPing);
+        assert.calledWithExactly(TelemetrySender.prototype._sendPing,
+          fakePingJSON);
+      });
+    });
+
+    it("should not call this._sendPing for 'nonexistent-topic'", () => {
+      const fakeSubject = "fakeSubject";
+      tSender = new TelemetrySender(tsArgs);
+
+      tSender.observe(fakeSubject, "nonexistent-topic", fakePingJSON);
+
+      assert.notCalled(TelemetrySender.prototype._sendPing);
+    });
+  });
+
+  describe("#uninit()", () => {
+    it("should remove the telemetry.ping.endpoint pref listener", () => {
+      tSender = new TelemetrySender(tsArgs);
+      assert.property(fakePrefs.observers, "telemetry.ping.endpoint");
+
+      tSender.uninit();
+
+      assert.notProperty(fakePrefs.observers, "telemetry.ping.endpoint");
+    });
+
+    it("should remove the telemetry pref listener", () => {
+      tSender = new TelemetrySender(tsArgs);
+      assert.property(fakePrefs.observers, "telemetry");
+
+      tSender.uninit();
+
+      assert.notProperty(fakePrefs.observers, "telemetry");
+    });
+
+    it("should remove all notification observers if telemetry pref is true", () => {
+      FakePrefs.prototype.prefs = {telemetry: true};
+      tSender = new TelemetrySender(tsArgs);
+      assert.property(fakePrefs.observers, "telemetry.ping.endpoint");
+
+      tSender.uninit();
+
+      assertNotificationObserversRemoved();
+    });
+
+    it("should not remove notification observers if telemetry pref is false", () => {
+      FakePrefs.prototype.prefs = {telemetry: false};
+      tSender = new TelemetrySender(tsArgs);
+      assert.property(fakePrefs.observers, "telemetry.ping.endpoint");
+
+      tSender.uninit();
+
+      assert.notCalled(global.Services.obs.removeObserver);
+    });
+
+    it("should call Cu.reportError if this._prefs.ignore throws", () => {
+      globals.sandbox.stub(FakePrefs.prototype, "ignore").throws("Some Error");
+      tSender = new TelemetrySender(tsArgs);
+
+      tSender.uninit();
+
+      assert.called(global.Components.utils.reportError);
+    });
+  });
+
+  describe("Misc pref changes", () => {
+    describe("telemetry changes from true to false", () => {
+      beforeEach(() => {
+        FakePrefs.prototype.prefs = {"telemetry": true};
+        tSender = new TelemetrySender(tsArgs);
+        assert.propertyVal(tSender, "enabled", true);
+      });
+
+      it("should set the enabled property to false", () => {
+        fakePrefs.set("telemetry", false);
+
+        assert.propertyVal(tSender, "enabled", false);
+      });
+
+      it("should remove all notification observers", () => {
+        fakePrefs.set("telemetry", false);
+
+        assertNotificationObserversRemoved();
+      });
+    });
+
+    describe("telemetry changes from false to true", () => {
+      beforeEach(() => {
+        FakePrefs.prototype.prefs = {"telemetry": false};
+        tSender = new TelemetrySender(tsArgs);
+        assert.propertyVal(tSender, "enabled", false);
+      });
+
+      it("should set the enabled property to true", () => {
+        fakePrefs.set("telemetry", true);
+
+        assert.propertyVal(tSender, "enabled", true);
+      });
+
+      it("should add all topic observers", () => {
+        fakePrefs.set("telemetry", true);
+
+        assertNotificationObserversAdded();
+      });
+    });
+
+    describe("performance.log changes from false to true", () => {
+      it("should change this.logging from false to true", () => {
+        FakePrefs.prototype.prefs = {"performance.log": false};
+        tSender = new TelemetrySender(tsArgs);
+        assert.propertyVal(tSender, "logging", false);
+
+        fakePrefs.set("performance.log", true);
+
+        assert.propertyVal(tSender, "logging", true);
+      });
+    });
+  });
+});

--- a/system-addon/test/unit/lib/TelemetrySender.test.js
+++ b/system-addon/test/unit/lib/TelemetrySender.test.js
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 const {GlobalOverrider, FakePrefs} = require("test/unit/utils");
 const {TelemetrySender} = require("lib/TelemetrySender.jsm");
 

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -22,6 +22,7 @@ overrider.set({
     defineLazyServiceGetter: overrider.sandbox.spy(),
     generateQI: overrider.sandbox.stub().returns(() => {})
   },
+  console: {log: overrider.sandbox.spy()},
   dump: overrider.sandbox.spy(),
   Services: {
     obs: {

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -20,7 +20,7 @@ overrider.set({
   XPCOMUtils: {
     defineLazyModuleGetter: overrider.sandbox.spy(),
     defineLazyServiceGetter: overrider.sandbox.spy(),
-    generateQI: overrider.sandbox.spy()
+    generateQI: overrider.sandbox.stub().returns(() => {})
   },
   dump: overrider.sandbox.spy(),
   Services: {

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -10,16 +10,25 @@ sinon.assert.expose(assert, {prefix: ""});
 let overrider = new GlobalOverrider();
 overrider.set({
   Components: {
+    interfaces: {},
     utils: {
       import: overrider.sandbox.spy(),
+      importGlobalProperties: overrider.sandbox.spy(),
       reportError: overrider.sandbox.spy()
     }
   },
   XPCOMUtils: {
     defineLazyModuleGetter: overrider.sandbox.spy(),
-    defineLazyServiceGetter: overrider.sandbox.spy()
+    defineLazyServiceGetter: overrider.sandbox.spy(),
+    generateQI: overrider.sandbox.spy()
   },
   dump: overrider.sandbox.spy(),
+  Services: {
+    obs: {
+      addObserver: overrider.sandbox.spy(),
+      removeObserver: overrider.sandbox.spy()
+    }
+  },
   Task
 });
 

--- a/system-addon/test/unit/utils.js
+++ b/system-addon/test/unit/utils.js
@@ -70,6 +70,41 @@ class GlobalOverrider {
 }
 
 /**
+ * Very simple fake for the most basic semantics of Preferences.jsm. Lots of
+ * things aren't yet supported.  Feel free to add them in.
+ *
+ * @param {[type]} args [description]
+ */
+function FakePrefs(args) {
+  if (args) {
+    if ("initHook" in args) {
+      args.initHook.call(this);
+    }
+  }
+}
+FakePrefs.prototype = {
+  observers: {},
+  observe(prefName, callback) {
+    this.observers[prefName] = callback;
+  },
+  ignore(prefName, callback) {
+    if (prefName in this.observers) {
+      delete this.observers[prefName];
+    }
+  },
+
+  prefs: {},
+  get(prefName) { return this.prefs[prefName]; },
+  set(prefName, value) {
+    this.prefs[prefName] = value;
+
+    if (prefName in this.observers) {
+      this.observers[prefName](value);
+    }
+  }
+};
+
+/**
  * addNumberReducer - a simple dummy reducer for testing that adds a number
  */
 function addNumberReducer(prevState = 0, action) {
@@ -77,6 +112,7 @@ function addNumberReducer(prevState = 0, action) {
 }
 
 module.exports = {
+  FakePrefs,
   GlobalOverrider,
   addNumberReducer
 };

--- a/system-addon/test/unit/utils.js
+++ b/system-addon/test/unit/utils.js
@@ -73,7 +73,11 @@ class GlobalOverrider {
  * Very simple fake for the most basic semantics of Preferences.jsm. Lots of
  * things aren't yet supported.  Feel free to add them in.
  *
- * @param {[type]} args [description]
+ * @param {Object} args - optional arguments
+ * @param {Function} args.initHook - if present, will be called back
+ *                   inside the constructor. Typically used from tests
+ *                   to save off a pointer to the created instance so that
+ *                   stubs and spies can be inspected by the test code.
  */
 function FakePrefs(args) {
   if (args) {


### PR DESCRIPTION
Port of TelemetrySender file, with fresh unit tests.  It's not actually hooked up to anything yet, so the only thing to do to test is it to run the unit tests.

r=@sarracini?