### PR TITLE
fix (metadata): #2432 fetch metadata for pinned sites first

### DIFF
--- a/addon/Feeds/MetadataFeed.js
+++ b/addon/Feeds/MetadataFeed.js
@@ -22,26 +22,26 @@ module.exports = class MetadataFeed extends Feed {
    * the state
    */
   getInitialMetadata(reason) {
-    // Get initial topsites metadata
+    // First, get the metadata for pinned sites
+    let pinned = this.pinnedLinks.links;
+    pinned.forEach(item => {
+      // Skip any empty slots
+      if (item && item.url) {
+        this.linksToFetch.set(item.url, Date.now());
+      }
+    });
+    this.refresh(reason);
+
+    // Then, get initial topsites metadata
     return PlacesProvider.links.getTopFrecentSites().then(links => {
       links.forEach(item => this.linksToFetch.set(item.url, Date.now()));
       this.refresh(reason);
     })
-    // Get initial highlights metadata
+    // Finally, get initial highlights metadata. This should be done last because
+    // it takes the longest, processing 100+ urls.
     .then(() => PlacesProvider.links.getRecentlyVisited())
     .then(links => {
       links.forEach(item => this.linksToFetch.set(item.url, Date.now()));
-      this.refresh(reason);
-    })
-    // Get the metadata for pinned sites
-    .then(() => {
-      let pinned = this.pinnedLinks.links;
-      pinned.forEach(item => {
-        // Skip any empty slots
-        if (item && item.url) {
-          this.linksToFetch.set(item.url, Date.now());
-        }
-      });
       this.refresh(reason);
     });
   }

--- a/content-test/addon/Feeds/MetadataFeed.test.js
+++ b/content-test/addon/Feeds/MetadataFeed.test.js
@@ -44,14 +44,20 @@ describe("MetadataFeed", () => {
       instance.refresh = sinon.spy();
     });
 
-    it("should get TopFrecentSites metadata then RecentlyVisited metadata", () =>
-      instance.getInitialMetadata().then(() => {
+    it("should get TopFrecentSites metadata then RecentlyVisited metadata", () => {
+      instance.pinnedLinks.links = [
+        null,
+        {url: "https://github.com/mozilla/activity-stream"},
+        null,
+        null,
+        {url: "https://mozilla.org"}];
+      return instance.getInitialMetadata().then(() => {
         assert.called(PlacesProvider.links.getTopFrecentSites);
         assert.called(PlacesProvider.links.getRecentlyVisited);
         assert.calledThrice(instance.refresh);
-        assert.equal(instance.linksToFetch.size, 4);
-      })
-    );
+        assert.equal(instance.linksToFetch.size, 6);
+      });
+    });
   });
   describe("#getData", () => {
     it("should run sites through fetchNewMetadata", () => instance.getData().then(() => (


### PR DESCRIPTION
The TopSitesFeed seems to have everything required already: https://github.com/mozilla/activity-stream/blob/04789d1c3c1b28afea575378a0f0d84d858e938d/addon/Feeds/TopSitesFeed.js#L75-L87

r? @jaredkerim 

Fixes #2432