### PR TITLE
fix(l10n): Work around SDK locale selection bug by lower-casing

### DIFF
--- a/addon/Feeds/LocalizationFeed.js
+++ b/addon/Feeds/LocalizationFeed.js
@@ -28,7 +28,9 @@ class LocalizationFeed extends Feed {
     LOCALE_PREFS.forEach(pref => this.prefsTarget.removeListener(pref, this.onPrefChange));
   }
   getData() {
-    let locale = findClosestLocale(this.availableLocales, getPreferedLocales());
+    // NB: Work around a SDK bug of partially case sensitive matching locales
+    let lowerPrefered = getPreferedLocales().map(l => l.toLowerCase());
+    let locale = findClosestLocale(this.availableLocales, lowerPrefered);
     return Promise.resolve(am.actions.Response("LOCALE_UPDATED", locale));
   }
   onAction(state, action) {


### PR DESCRIPTION
Fix #2452. r?@sarracini There's a bug in `findClosestLocale` where the preferred locale is kept as "zh-TW" but the array of locales is checked as lower case, so it doesn't detect an "exact match" and falls back to partial matching of "zh-CN".

https://dxr.mozilla.org/mozilla-central/source/addon-sdk/source/lib/sdk/l10n/locale.js#45-48

Fixing this so localizers can test their strings even though we won't be using the SDK for system-addon.