### PR TITLE
feat(content): Refresh pocket feed on pref change

### DIFF
--- a/addon/Feeds/PocketFeed.js
+++ b/addon/Feeds/PocketFeed.js
@@ -31,6 +31,12 @@ module.exports = class PocketFeed extends Feed {
         this.refresh();
         break;
 
+      case am.type("PREF_CHANGED_RESPONSE"):
+        if (action.data.name === "experiments.pocket") {
+          this.refresh();
+        }
+        break;
+
       case am.type("SYSTEM_TICK"):
         if (Date.now() - this.state.lastUpdated >= this.updateTime) {
           this.refresh();

--- a/content-test/addon/Feeds/PocketFeed.test.js
+++ b/content-test/addon/Feeds/PocketFeed.test.js
@@ -24,6 +24,14 @@ describe("PocketFeed", () => {
       instance.onAction(store.getState(), {type: "APP_INIT"});
       assert.calledOnce(instance.refresh);
     });
+    it("should call refresh on PREF_CHANGED_RESPONSE for pocket experiment", () => {
+      instance.onAction({}, {type: "PREF_CHANGED_RESPONSE", data: {name: "experiments.pocket"}});
+      assert.calledOnce(instance.refresh);
+    });
+    it("should not call refresh on unrelated PREF_CHANGED_RESPONSE", () => {
+      instance.onAction({}, {type: "PREF_CHANGED_RESPONSE", data: {}});
+      assert.notCalled(instance.refresh);
+    });
     it("should call refresh on SYSTEM_TICK", () => {
       instance.onAction({}, {type: "SYSTEM_TICK"});
       assert.calledOnce(instance.refresh);


### PR DESCRIPTION
Triggering a feed refresh on pref. change so that when experiment is turned on, firefox doesn't have to be restarted to see data.