### PR TITLE
fix(mc): #2423 Patch mozilla central to turn off top sites in tests

### DIFF
--- a/mozilla-central-patches/disable-as-top-sites-feed-tests.diff
+++ b/mozilla-central-patches/disable-as-top-sites-feed-tests.diff
@@ -1,0 +1,12 @@
+diff --git a/testing/profiles/prefs_general.js b/testing/profiles/prefs_general.js
+--- a/testing/profiles/prefs_general.js
++++ b/testing/profiles/prefs_general.js
+@@ -220,6 +220,9 @@ user_pref("browser.download.panel.shown"
+ // which test runs first and happens to open about:newtab
+ user_pref("browser.newtabpage.introShown", true);
+
++// Turn off Top Sites queries in activity-stream
++user_pref("browser.newtabpage.activity-stream.feeds.topsites", false);
++
+ // Enable webapps testing mode, which bypasses native installation.
+ user_pref("browser.webapps.testing", true);


### PR DESCRIPTION
This patch turns off top sites for tests.