### PR TITLE
 Fire event for experiment enrollment fixes #2477

### DIFF
--- a/addon/ExperimentProvider.js
+++ b/addon/ExperimentProvider.js
@@ -67,6 +67,12 @@ exports.ExperimentProvider = class ExperimentProvider {
     });
   }
 
+  enroll(experimentId, variant) {
+    this._experimentId = variant.id;
+    prefService.set(PREF_PREFIX + experimentId, variant.value);
+    this.emit("experimentEnrolled", {id: experimentId, variant});
+  }
+
   setValues() {
     if (simplePrefs.prefs.experimentsOverridden) {
       console.log(`The following experiments were turned on via overrides:\n`); // eslint-disable-line no-console
@@ -135,8 +141,7 @@ exports.ExperimentProvider = class ExperimentProvider {
       // randomly assign them to a variant (or control)
       inExperiment = randomNumber >= floor && randomNumber < ceiling;
       if (inExperiment) {
-        this._experimentId = variant.id;
-        prefService.set(PREF_PREFIX + key, variant.value);
+        this.enroll(key, variant);
       }
       floor = ceiling;
     });

--- a/content-test/addon/ExperimentProvider.test.js
+++ b/content-test/addon/ExperimentProvider.test.js
@@ -406,5 +406,12 @@ describe("ExperimentProvider", () => {
       experimentProvider._onPrefChange("foo");
       assert.calledWith(experimentProvider.emit, "change", "foo");
     });
+    it("should emit an event on experiment enrollment", () => {
+      setup();
+      const experimentId = "foo";
+      const variant = {description: "Twice the foo", id: "foo_01", threshold: 0.5, value: true};
+      experimentProvider.enroll(experimentId, variant);
+      assert.calledWith(experimentProvider.emit, "experimentEnrolled", {id: experimentId, variant});
+    });
   });
 });


### PR DESCRIPTION
Let's fire an event at experiment enrollment time to make it easy to detect when a user is first assigned to an experiment.