### PR TITLE
 Remove metadata cache expiry fixes #2352

### DIFF
--- a/addon/PreviewProvider.js
+++ b/addon/PreviewProvider.js
@@ -54,15 +54,6 @@ function createCacheKey(spec) {
 
 PreviewProvider.prototype = {
 
-  _getMetadataTTL() {
-    let timeout = 3 * 24 * 60 * 60 * 1000; // 3 days for the metadata to live
-
-    if (this._store.getState().Experiments.values.metadataLongCache) {
-      timeout = 90 * 24 * 60 * 60 * 1000; // 90 days for the metadata to live
-    }
-    return timeout;
-  },
-
   _onPrefChange(prefName) {
     if (ALLOWED_PREFS.has(prefName)) {
       switch (prefName) {
@@ -387,10 +378,7 @@ PreviewProvider.prototype = {
    * DB and adding them to the metadata cache
    */
   insertMetadata(links, metadataSource) {
-    const linksToInsert = links.map(link => Object.assign({}, link, {
-      expired_at: (this._getMetadataTTL()) + Date.now(),
-      metadata_source: metadataSource
-    }));
+    const linksToInsert = links.map(link => Object.assign({}, link, {metadata_source: metadataSource}));
     return this._metadataStore.asyncInsert(linksToInsert, true).then(() => {
       this._store.dispatch({type: "METADATA_UPDATED"});
     }).catch(err => {

--- a/experiments.json
+++ b/experiments.json
@@ -211,7 +211,7 @@
   },
   "metadataLongCache": {
     "name": "Metadata with Long Cache",
-    "active": true,
+    "active": false,
     "description": "Change the timeout for metadata to a long time",
     "control": {
       "value": false,

--- a/test/test-MetadataStore.js
+++ b/test/test-MetadataStore.js
@@ -351,35 +351,6 @@ exports.test_color_conversions = function(assert) {
   assert.equal(gMetadataStore._rgbToHex(null), null);
 };
 
-exports.test_data_expiry = function*(assert) {
-  let item = Object.assign({}, metadataFixture[0]);
-  let expected = 2;
-  let isDeleted = false;
-  let ticked = 0;
-
-  gMetadataStore.enableDataExpiryJob(100);
-  item.expired_at = Date.now();
-  yield gMetadataStore.asyncInsert([].concat(item, metadataFixture.slice(1, 3)));
-  // It waits until the expired item gets deleted or the waitUntil hits the timeout
-  // Note that waitUntil only takes a function, and won't work for generators as
-  // the predicate function
-  yield waitUntil(() => {
-    if (isDeleted || ticked++ > 10) {
-      return true;
-    }
-    gMetadataStore.asyncExecuteQuery("SELECT * FROM page_metadata")
-    .then(items => {
-      if (items.length === expected) {
-        isDeleted = true;
-      }
-    }).catch(err => { throw new Error(err); });
-    return false;
-  }, 500);
-
-  assert.ok(isDeleted, "It should have deleted the expired page");
-  gMetadataStore.disableDataExpiryJob();
-};
-
 exports.test_delete = function*(assert) {
   yield gMetadataStore.asyncInsert(metadataFixture);
   yield gMetadataStore.asyncTearDown();

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -335,7 +335,6 @@ exports.test_mock_metadata_request = function*(assert) {
 
   // we should have saved the fake site into the database
   assert.deepEqual(gMetadataStore[0][0].description, "some metadata", "inserted and saved the metadadata");
-  assert.ok(gMetadataStore[0][0].expired_at, "an expiry time was added");
   assert.ok(gMetadataStore[0][0].favicon_height, "added a favicon_height");
   assert.ok(gMetadataStore[0][0].favicon_width, "added a favicon_width");
   assert.equal(gMetadataStore[0][0].metadata_source, "MetadataService", "a metadata source was added");


### PR DESCRIPTION
We no longer need to expire metadata because we are making assumptions that it will be long lived in our future designs for higlights.