### PR TITLE
feat(mc): #2472 Integrate default top sites

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -7,32 +7,8 @@ const {actionTypes: at} = Components.utils.import("resource://activity-stream/co
 
 const INITIAL_STATE = {
   TopSites: {
-    rows: [
-      {
-        "title": "Facebook",
-        "url": "https://www.facebook.com/"
-      },
-      {
-        "title": "YouTube",
-        "url": "https://www.youtube.com/"
-      },
-      {
-        "title": "Amazon",
-        "url": "http://www.amazon.com/"
-      },
-      {
-        "title": "Yahoo",
-        "url": "https://www.yahoo.com/"
-      },
-      {
-        "title": "eBay",
-        "url": "http://www.ebay.com"
-      },
-      {
-        "title": "Twitter",
-        "url": "https://twitter.com/"
-      }
-    ]
+    init: false,
+    rows: []
   },
   Search: {
     currentEngine: {
@@ -52,7 +28,7 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
       if (!action.data) {
         return prevState;
       }
-      return Object.assign({}, prevState, {rows: action.data});
+      return Object.assign({}, prevState, {init: true, rows: action.data});
     case at.SCREENSHOT_UPDATED:
       newRows = prevState.rows.map(row => {
         if (row.url === action.data.url) {

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -12,40 +12,65 @@ Cu.import("resource:///modules/PreviewProvider.jsm");
 
 const TOP_SITES_SHOWMORE_LENGTH = 12;
 const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
+const DEFAULT_TOP_SITES = [
+  {"url": "https://www.facebook.com/"},
+  {"url": "https://www.youtube.com/"},
+  {"url": "http://www.amazon.com/"},
+  {"url": "https://www.yahoo.com/"},
+  {"url": "http://www.ebay.com"},
+  {"url": "https://twitter.com/"}
+].map(row => Object.assign(row, {isDefault: true}));
 
 this.TopSitesFeed = class TopSitesFeed {
   constructor() {
     this.lastUpdated = 0;
   }
-  async getData(action) {
-    let newAction;
+  async getScreenshot(url) {
+    let screenshot = await PreviewProvider.getThumbnail(url);
+    const action = {type: at.SCREENSHOT_UPDATED, data: {url, screenshot}};
+    this.store.dispatch(ac.BroadcastToContent(action));
+  }
+  async getLinksWithDefaults(action) {
     let links = await PlacesProvider.links.getLinks();
-    let result;
+
     if (!links) {
-      result = [];
+      links = [];
     } else {
-      result = links.filter(link => link && link.type !== "affiliate").slice(0, 12);
+      links = links.filter(link => link && link.type !== "affiliate").slice(0, 12);
     }
-    newAction = {type: at.TOP_SITES_UPDATED, data: result};
-    // send an update to content so the preloaded tab can get the updated content
+
+    if (links.length < TOP_SITES_SHOWMORE_LENGTH) {
+      links = [...links, ...DEFAULT_TOP_SITES].slice(0, TOP_SITES_SHOWMORE_LENGTH);
+    }
+
+    return links;
+  }
+  async refresh(action) {
+    const links = await this.getLinksWithDefaults();
+    const newAction = {type: at.TOP_SITES_UPDATED, data: links};
+
+    // Send an update to content so the preloaded tab can get the updated content
     this.store.dispatch(ac.SendToContent(newAction, action.meta.fromTarget));
     this.lastUpdated = Date.now();
+
+    // Now, get a screenshot for every item
     for (let link of links) {
-      let screenshot = await PreviewProvider.getThumbnail(link.url);
-      newAction = {type: at.SCREENSHOT_UPDATED, data: {url: link.url, screenshot}};
-      this.store.dispatch(ac.BroadcastToContent(newAction));
+      this.getScreenshot(link.url);
     }
   }
   onAction(action) {
+    let realRows;
     switch (action.type) {
       case at.NEW_TAB_LOAD:
+        // Only check against real rows returned from history, not default ones.
+        realRows = this.store.getState().TopSites.rows.filter(row => !row.isDefault);
         // When a new tab is opened, if we don't have enough top sites yet, refresh the data.
-        if (this.store.getState().TopSites.rows.length < TOP_SITES_SHOWMORE_LENGTH) {
-          this.getData(action);
+        if (realRows.length < TOP_SITES_SHOWMORE_LENGTH) {
+          this.refresh(action);
         } else if (Date.now() - this.lastUpdated >= UPDATE_TIME) {
           // When a new tab is opened, if the last time we refreshed the data
           // is greater than 15 minutes, refresh the data.
-          this.getData(action);
+          this.refresh(action);
         }
         break;
     }
@@ -53,4 +78,6 @@ this.TopSitesFeed = class TopSitesFeed {
 };
 
 this.UPDATE_TIME = UPDATE_TIME;
-this.EXPORTED_SYMBOLS = ["TopSitesFeed", "UPDATE_TIME"];
+this.TOP_SITES_SHOWMORE_LENGTH = TOP_SITES_SHOWMORE_LENGTH;
+this.DEFAULT_TOP_SITES = DEFAULT_TOP_SITES;
+this.EXPORTED_SYMBOLS = ["TopSitesFeed", "UPDATE_TIME", "DEFAULT_TOP_SITES", "TOP_SITES_SHOWMORE_LENGTH"];


### PR DESCRIPTION
This patch moves default top sites from the reducer to the `TopSitesFeed`, so that defaults can take advantage of metadata extraction (so they can get screenshots, for example).