### PR TITLE
fix (feeds): #2469 ignore actions before APP_INIT in Highlights Feed

### DIFF
--- a/addon/Feeds/HighlightsFeed.js
+++ b/addon/Feeds/HighlightsFeed.js
@@ -15,7 +15,7 @@ const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
 module.exports = class HighlightsFeed extends Feed {
   constructor(options) {
     super(options);
-    this.baselineRecommender = null; // Added in initializeRecommender, if the experiment is turned on
+    this.baselineRecommender = null; // Added in initializeRecommender
     this.getScreenshot = getScreenshot;
     this.missingData = false;
   }
@@ -115,6 +115,11 @@ module.exports = class HighlightsFeed extends Feed {
     }.bind(this));
   }
   onAction(state, action) {
+    // Ignore any actions that come in before APP_INIT. We aren't ready.
+    if (!this.baselineRecommender && action.type !== am.type("APP_INIT")) {
+      return;
+    }
+
     switch (action.type) {
       case am.type("APP_INIT"):
         // When the app inititalizes, create a recommender, and then refresh the data.

--- a/content-test/addon/Feeds/HighlightsFeed.test.js
+++ b/content-test/addon/Feeds/HighlightsFeed.test.js
@@ -169,6 +169,7 @@ describe("HighlightsFeed", () => {
     let store;
     beforeEach(() => {
       instance.refresh = sinon.spy();
+      instance.baselineRecommender = {scoreEntries: sinon.spy(links => links)};
       clock = sinon.useFakeTimers();
       store = createStoreWithState({});
       instance.connectStore(store);
@@ -213,7 +214,6 @@ describe("HighlightsFeed", () => {
       assert.notCalled(instance.refresh);
     });
     it("should update the coefficients if the weightedHighlightsCoefficients pref is changed", () => {
-      instance.baselineRecommender = {};
       instance.initializeRecommender = sinon.spy();
       instance.onAction(store.getState(), {type: "PREF_CHANGED_RESPONSE", data: {name: "weightedHighlightsCoefficients"}});
       assert.calledWith(instance.initializeRecommender, "coefficients were changed");


### PR DESCRIPTION
r? @sarracini and/or @jaredkerim 

The issue was that METADATA_UPDATED action was coming in before APP_INIT.

Fixes #2469 