### PR TITLE
chore(mc): Remove unneeded eslint patch that has landed

### DIFF
--- a/mozilla-central-patches/eslintignore.diff
+++ b/mozilla-central-patches/eslintignore.diff
@@ -1,9 +1,0 @@
-diff --git a/.eslintignore b/.eslintignore
---- a/.eslintignore
-+++ b/.eslintignore
-@@ -72,3 +72,4 @@ browser/extensions/pocket/content/panels/js/vendor/**
- browser/locales/**
--# vendor library files in activity-stream
-+# generated or library files in activity-stream
-+browser/extensions/activity-stream/data/content/activity-stream.bundle.js
- browser/extensions/activity-stream/vendor/**


### PR DESCRIPTION
Fix #2488. Don't merge this until https://bugzilla.mozilla.org/show_bug.cgi?id=1359481 gets to mozilla-central.