### PR TITLE
feat(content): #2466 Enable pocket pref for all users

### DIFF
--- a/addon/ExperimentProvider.js
+++ b/addon/ExperimentProvider.js
@@ -70,6 +70,9 @@ exports.ExperimentProvider = class ExperimentProvider {
   enroll(experimentId, variant) {
     this._experimentId = variant.id;
     prefService.set(PREF_PREFIX + experimentId, variant.value);
+    if (experimentId === "pocket") {
+      simplePrefs.prefs.showPocket = true;
+    }
     this.emit("experimentEnrolled", {id: experimentId, variant});
   }
 

--- a/addon/Feeds/PocketStoriesFeed.js
+++ b/addon/Feeds/PocketStoriesFeed.js
@@ -42,11 +42,7 @@ module.exports = class PocketStoriesFeed extends PocketFeed {
    */
   getData() {
     return Task.spawn(function*() {
-      const experiments = this.store.getState().Experiments.values;
-      let stories = [];
-      if (experiments.pocket) {
-        stories = yield this._fetchStories();
-      }
+      let stories = yield this._fetchStories();
       stories = stories.map(s => ({
         "recommended": true,
         "title": s.title,

--- a/addon/Feeds/PocketTopicsFeed.js
+++ b/addon/Feeds/PocketTopicsFeed.js
@@ -33,11 +33,7 @@ module.exports = class PocketTopicsFeed extends PocketFeed {
    */
   getData() {
     return Task.spawn(function*() {
-      const experiments = this.store.getState().Experiments.values;
-      let topics = [];
-      if (experiments.pocket) {
-        topics = yield this._fetchTopics();
-      }
+      let topics = yield this._fetchTopics();
       return am.actions.Response("POCKET_TOPICS_RESPONSE", topics);
     }.bind(this));
   }

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -20,7 +20,7 @@ const ACTION_NOTIF = "user-action-event";
 const PERFORMANCE_NOTIF = "performance-event";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
 const UNDESIRED_NOTIF = "undesired-event";
-const USER_PREFS = ["showSearch", "showTopSites", "showPocketStories", "showHighlights", "showMoreTopSites"];
+const USER_PREFS = ["showSearch", "showTopSites", "showPocket", "showHighlights", "showMoreTopSites"];
 
 function TabTracker(options) {
   this._tabData = {};

--- a/common/constants.js
+++ b/common/constants.js
@@ -43,7 +43,7 @@ module.exports = {
     "showTopSites": 1 << 1,
     "showHighlights": 1 << 2,
     "showMoreTopSites": 1 << 3,
-    "showPocketStories": 1 << 4
+    "showPocket": 1 << 4
   },
 
   // The minimum size to consider an icon high res

--- a/content-src/components/HighlightContext/types.js
+++ b/content-src/components/HighlightContext/types.js
@@ -21,6 +21,6 @@ module.exports = {
   },
   stories: {
     intlID: "type_label_recommended",
-    icon: "bookmark"
+    icon: "topic"
   }
 };

--- a/content-src/components/LinkMenu/LinkMenu.js
+++ b/content-src/components/LinkMenu/LinkMenu.js
@@ -28,7 +28,7 @@ const LinkMenu = React.createClass({
     }
   },
   getOptions() {
-    const {site, allowBlock, dispatch, experiments} = this.props;
+    const {site, allowBlock, dispatch, prefs} = this.props;
     const isNotDefault = site.type !== FIRST_RUN_TYPE;
 
     let deleteOptions;
@@ -58,7 +58,7 @@ const LinkMenu = React.createClass({
     }
 
     let pocketOption = [];
-    if (experiments && experiments.values.pocket) {
+    if (prefs && prefs.showPocket) {
       pocketOption = [
         {
           ref: "saveToPocket",
@@ -115,12 +115,12 @@ LinkMenu.propTypes = {
   visible: React.PropTypes.bool,
   onUpdate: React.PropTypes.func.isRequired,
   allowBlock: React.PropTypes.bool,
+  prefs: React.PropTypes.object,
   site: React.PropTypes.shape({
     url: React.PropTypes.string.isRequired,
     bookmarkGuid: React.PropTypes.string,
     recommended: React.PropTypes.bool
   }).isRequired,
-  experiments: React.PropTypes.object,
 
   // This is for events
   page: React.PropTypes.string,

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -80,8 +80,7 @@ const NewTabPage = React.createClass({
   },
   render() {
     const props = this.props;
-    const {showSearch, showTopSites, showPocketStories, showHighlights, showMoreTopSites} = props.Prefs.prefs;
-    const pocketExperimentIsOn = props.Experiments.values.pocket;
+    const {showSearch, showTopSites, showPocket, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
     return (<main className="new-tab">
       <div className="new-tab-wrapper">
@@ -106,23 +105,23 @@ const NewTabPage = React.createClass({
                 allowEdit={!!props.Experiments.values.editTopSites} />
             </section>
           }
-          {showPocketStories && pocketExperimentIsOn &&
+          {showPocket &&
             <section>
               <PocketStories placeholder={!this.props.isReady} page={PAGE_NAME}
                 length={POCKET_STORIES_LENGTH} stories={props.PocketStories.rows}
-                topics={props.PocketTopics.rows} experiments={props.Experiments} />
+                topics={props.PocketTopics.rows} prefs={props.Prefs.prefs} />
             </section>
           }
           {showHighlights &&
             <section>
               <Spotlight placeholder={!this.props.isReady} page={PAGE_NAME}
                 length={HIGHLIGHTS_LENGTH} sites={props.Highlights.rows}
-                experiments={props.Experiments} />
+                prefs={props.Prefs.prefs} />
             </section>
           }
         </div>
       </div>
-      <PreferencesPane Prefs={props.Prefs} Experiments={props.Experiments} />
+      <PreferencesPane Prefs={props.Prefs} />
     </main>);
   }
 });

--- a/content-src/components/PocketStories/PocketStories.js
+++ b/content-src/components/PocketStories/PocketStories.js
@@ -30,8 +30,8 @@ const PocketStories = React.createClass({
           source="RECOMMENDED"
           onClick={this.onClickFactory(i, story)}
           dispatch={this.props.dispatch}
-          experiments={this.props.experiments}
-          {...story} />
+          {...story}
+          prefs={this.props.prefs} />
       );
   },
 
@@ -76,8 +76,8 @@ PocketStories.propTypes = {
   page: React.PropTypes.string.isRequired,
   stories: React.PropTypes.array.isRequired,
   topics: React.PropTypes.array.isRequired,
-  experiments: React.PropTypes.object.isRequired,
-  length: React.PropTypes.number
+  length: React.PropTypes.number,
+  prefs: React.PropTypes.object
 };
 
 module.exports = connect(justDispatch)(PocketStories);

--- a/content-src/components/PreferencesPane/PreferencesPane.js
+++ b/content-src/components/PreferencesPane/PreferencesPane.js
@@ -34,8 +34,7 @@ const PreferencesPane = React.createClass({
   },
   render() {
     const props = this.props;
-    const {showSearch, showTopSites, showPocketStories, showHighlights, showMoreTopSites} = props.Prefs.prefs;
-    const pocketExperimentIsOn = props.Experiments.values.pocket;
+    const {showSearch, showTopSites, showPocket, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
     return (
       <div className="prefs-pane-wrapper" ref="wrapper">
@@ -72,15 +71,13 @@ const PreferencesPane = React.createClass({
                     </label>
                   </div>
                 </section>
-                {pocketExperimentIsOn &&
-                   <section>
-                    <input ref="showPocketStoriesCheckbox" type="checkbox" id="showPocketStories" name="showPocketStories" checked={showPocketStories} onChange={this.handleChange} />
-                    <label htmlFor="showPocketStories">
-                      <FormattedMessage id="settings_pane_pocketstories_header" />
-                    </label>
-                    <p><FormattedMessage id="settings_pane_pocketstories_body" /></p>
-                  </section>
-                }
+                <section>
+                  <input ref="showPocketCheckbox" type="checkbox" id="showPocket" name="showPocket" checked={showPocket} onChange={this.handleChange} />
+                  <label htmlFor="showPocket">
+                    <FormattedMessage id="settings_pane_pocketstories_header" />
+                  </label>
+                  <p><FormattedMessage id="settings_pane_pocketstories_body" /></p>
+                </section>
                 <section>
                   <input ref="showHighlightsCheckbox" type="checkbox" id="showHighlights" name="showHighlights" checked={showHighlights} onChange={this.handleChange} />
                   <label htmlFor="showHighlights">

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -72,7 +72,7 @@ const SpotlightItem = React.createClass({
         page={this.props.page}
         index={this.props.index}
         source={this.props.source}
-        experiments={this.props.experiments} />
+        prefs={this.props.prefs} />
     </li>);
   }
 });
@@ -101,7 +101,7 @@ SpotlightItem.propTypes = {
   description: React.PropTypes.string,
   onClick: React.PropTypes.func,
   dispatch: React.PropTypes.func.isRequired,
-  experiments: React.PropTypes.object.isRequired
+  prefs: React.PropTypes.object
 };
 
 function renderPlaceholderList() {
@@ -148,8 +148,8 @@ const Spotlight = React.createClass({
           source="FEATURED"
           onClick={this.onClickFactory(i, site)}
           dispatch={this.props.dispatch}
-          experiments={this.props.experiments}
-          {...site} />
+          {...site}
+          prefs={this.props.prefs} />
       );
   },
 
@@ -166,8 +166,8 @@ const Spotlight = React.createClass({
 Spotlight.propTypes = {
   page: React.PropTypes.string.isRequired,
   sites: React.PropTypes.array.isRequired,
-  experiments: React.PropTypes.object.isRequired,
-  length: React.PropTypes.number
+  length: React.PropTypes.number,
+  prefs: React.PropTypes.object
 };
 
 module.exports = connect(justDispatch)(Spotlight);

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -44,7 +44,7 @@ module.exports = {
       "showSearch": true,
       "showTopSites": true,
       "showHighlights": true,
-      "showPocketStories": true
+      "showPocket": true
     },
     "error": false
   },

--- a/content-test/addon/ExperimentProvider.test.js
+++ b/content-test/addon/ExperimentProvider.test.js
@@ -413,5 +413,13 @@ describe("ExperimentProvider", () => {
       experimentProvider.enroll(experimentId, variant);
       assert.calledWith(experimentProvider.emit, "experimentEnrolled", {id: experimentId, variant});
     });
+    it("should set pocket pref on pocket experiment enrollment", () => {
+      setup();
+      assert.isUndefined(simplePrefs.prefs.showPocket);
+      const experimentId = "pocket";
+      const variant = {description: "Pocket experiment", id: "pocket_01", threshold: 0.5, value: true};
+      experimentProvider.enroll(experimentId, variant);
+      assert.isTrue(simplePrefs.prefs.showPocket);
+    });
   });
 });

--- a/content-test/addon/Feeds/PocketStoriesFeed.test.js
+++ b/content-test/addon/Feeds/PocketStoriesFeed.test.js
@@ -19,17 +19,7 @@ describe("PocketStoriesFeed", () => {
     assert.equal(time.minutes(), 30);
   });
   describe("#getData", () => {
-    it("should not fetch stories if experiment is disabled", () => {
-      instance._fetchStories = sinon.spy();
-      return instance.getData()
-        .then(action => {
-          assert.isObject(action);
-          assert.equal(action.type, "POCKET_STORIES_RESPONSE");
-          assert.notCalled(instance._fetchStories);
-          assert.lengthOf(action.data, 0);
-        });
-    });
-    it("should fetch stories if experiment is enabled", () => {
+    it("should fetch stories and send response event", () => {
       instance._fetchStories = sinon.mock().returns([{"title": "test"}]);
       reduxState = {Experiments: {values: {pocket: true}}};
       return instance.getData()

--- a/content-test/addon/Feeds/PocketTopicsFeed.test.js
+++ b/content-test/addon/Feeds/PocketTopicsFeed.test.js
@@ -19,19 +19,8 @@ describe("PocketTopicsFeed", () => {
     assert.equal(time.hours(), 3);
   });
   describe("#getData", () => {
-    it("should not fetch topics if experiment is disabled", () => {
-      instance._fetchTopics = sinon.spy();
-      return instance.getData()
-        .then(action => {
-          assert.isObject(action);
-          assert.equal(action.type, "POCKET_TOPICS_RESPONSE");
-          assert.notCalled(instance._fetchTopics);
-          assert.lengthOf(action.data, 0);
-        });
-    });
-    it("should fetch topics if experiment is enabled", () => {
-      instance._fetchTopics = sinon.mock().returns([{"title": "test"}]);
-      reduxState = {Experiments: {values: {pocket: true}}};
+    it("should fetch topics and send response event", () => {
+      instance._fetchTopics = sinon.mock().returns([{"category": "test"}]);
       return instance.getData()
         .then(action => {
           assert.isObject(action);

--- a/content-test/components/LinkMenu.test.js
+++ b/content-test/components/LinkMenu.test.js
@@ -64,7 +64,7 @@ describe("LinkMenu", () => {
   });
 
   it("should show pocket option if experiment is on", () => {
-    let props = Object.assign({}, DEFAULT_PROPS, {"experiments": {"values": {"pocket": true}}});
+    let props = Object.assign({}, DEFAULT_PROPS, {"prefs": {"showPocket": true}});
     let pocketInstance = renderWithProvider(<LinkMenu {...props} />);
     let [pocketContextMenu] = TestUtils.scryRenderedComponentsWithType(pocketInstance, ContextMenu);
     assert.ok(pocketContextMenu);
@@ -146,7 +146,7 @@ describe("LinkMenu", () => {
       event: "NOTIFY_SAVE_TO_POCKET",
       eventData: {url: DEFAULT_PROPS.site.url, title: DEFAULT_PROPS.site.title},
       userEvent: "SAVE_TO_POCKET",
-      props: {"experiments": {"values": {"pocket": true}}}
+      props: {"prefs": {"showPocket": true}}
     });
   });
 });

--- a/content-test/components/PreferencesPane.test.js
+++ b/content-test/components/PreferencesPane.test.js
@@ -6,7 +6,7 @@ const DEFAULT_PREFS = {
   "showTopSites": true,
   "showMoreTopSites": false,
   "showHighlights": true,
-  "showPocketStories": true
+  "showPocket": false
 };
 
 describe("PreferencesPane", () => {
@@ -83,21 +83,15 @@ describe("PreferencesPane", () => {
     assert.equal(0, wrapper.ref("sidebar").length);
   });
 
-  it("the pocket stories checkbox should be checked by default", () => {
-    setup({}, {pocket: true});
+  it("the pocket stories checkbox should be checked if pref is on", () => {
+    setup({showPocket: true});
     wrapper.ref("prefs-button").simulate("click");
-    assert.isTrue(wrapper.ref("showPocketStoriesCheckbox").prop("checked"));
+    assert.isTrue(wrapper.ref("showPocketCheckbox").prop("checked"));
   });
 
   it("the pocket stories checkbox should be unchecked if pref is off", () => {
-    setup({showPocketStories: false}, {pocket: true});
+    setup({showPocket: false});
     wrapper.ref("prefs-button").simulate("click");
-    assert.isFalse(wrapper.ref("showPocketStoriesCheckbox").prop("checked"));
-  });
-
-  it("the pocket stories checkbox should not be rendered if experiment is off", () => {
-    setup({showPocketStories: false}, {pocket: false});
-    wrapper.ref("prefs-button").simulate("click");
-    assert.equal(0, wrapper.ref("showPocketStoriesCheckbox").length);
+    assert.isFalse(wrapper.ref("showPocketCheckbox").prop("checked"));
   });
 });

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -146,6 +146,6 @@ The Activity Stream addon sends various types of pings to the backend (HTTPS POS
 | `showTopSites` | 2 |
 | `showHighlights` | 4 |
 | `showMoreTopSites` | 8 |
-| `showPocketStories` | 16 |
+| `showPocket` | 16 |
 
 Each item above could be combined with other items through bitwise OR operation

--- a/package.json
+++ b/package.json
@@ -185,10 +185,10 @@
       "value": true
     },
     {
-      "name": "showPocketStories",
+      "name": "showPocket",
       "title": "Show the Trending Stories section by Pocket on the New Tab page",
       "type": "bool",
-      "value": true
+      "value": false
     },
     {
       "name": "showHighlights",


### PR DESCRIPTION
This makes sure pocket is available to all users, but prefed off for the control group. The preference pane allows to opt-in to the experiment.

Had to put the condition to set the simplePrefs.prefs.showPocket into enroll() directly, as discussed, as the "experimentEnrolled" event is firing too late in this case.