### PR TITLE
feat(content): #2486 Track impressions for Pocket

### DIFF
--- a/addon/Feeds/PocketStoriesFeed.js
+++ b/addon/Feeds/PocketStoriesFeed.js
@@ -44,12 +44,14 @@ module.exports = class PocketStoriesFeed extends PocketFeed {
     return Task.spawn(function*() {
       let stories = yield this._fetchStories();
       stories = stories.map(s => ({
+        "guid": s.id,
         "recommended": true,
         "title": s.title,
         "description": s.excerpt,
         "bestImage": {"url": this._normalizeUrl(s.image_src)},
         "url": s.dedupe_url,
-        "lastVisitDate": s.published_timestamp
+        "lastVisitDate": s.published_timestamp,
+        "pocket": true
       }));
       return am.actions.Response("POCKET_STORIES_RESPONSE", stories);
     }.bind(this));

--- a/content-src/components/LinkMenu/LinkMenu.js
+++ b/content-src/components/LinkMenu/LinkMenu.js
@@ -28,7 +28,7 @@ const LinkMenu = React.createClass({
     }
   },
   getOptions() {
-    const {site, allowBlock, dispatch, prefs} = this.props;
+    const {site, allowBlock, dispatch, prefs, index} = this.props;
     const isNotDefault = site.type !== FIRST_RUN_TYPE;
 
     let deleteOptions;
@@ -44,6 +44,13 @@ const LinkMenu = React.createClass({
           icon: "dismiss",
           userEvent: "BLOCK",
           onClick: () => {
+            if (prefs && prefs.showPocket && site.pocket) {
+              dispatch(actions.NotifyImpressionStats({
+                source: "pocket",
+                block: 0,
+                tiles: [{id: site.guid, pos: index + 1}]
+              }));
+            }
             dispatch(actions.NotifyBlockURL(site.url));
           }
         },
@@ -65,12 +72,18 @@ const LinkMenu = React.createClass({
           label: this.props.intl.formatMessage({id: "menu_action_save_to_pocket"}),
           icon: "pocket",
           userEvent: "SAVE_TO_POCKET",
-          onClick: () => dispatch(actions.NotifySaveToPocket(site.url, site.title))
+          onClick: () => {
+            dispatch(actions.NotifyImpressionStats({
+              source: "pocket",
+              pocket: 0,
+              tiles: [{id: site.guid, pos: index + 1}]
+            }));
+            dispatch(actions.NotifySaveToPocket(site.url, site.title));
+          }
         },
         {type: "separator"}
       ];
     }
-
     return pocketOption.concat([
       (site.bookmarkGuid ? {
         ref: "removeBookmark",

--- a/content-src/components/PocketStories/PocketStories.js
+++ b/content-src/components/PocketStories/PocketStories.js
@@ -16,11 +16,22 @@ const PocketStories = React.createClass({
         action_position: index
       };
       this.props.dispatch(actions.NotifyEvent(payload));
+
+      this.props.dispatch(actions.NotifyImpressionStats({
+        source: "pocket",
+        click: 0,
+        tiles: [{id: story.guid, pos: index + 1}]
+      }));
     };
   },
 
   renderStories() {
     const stories = this.props.stories.slice(0, this.props.length);
+
+    this.props.dispatch(actions.NotifyImpressionStats({
+      source: "pocket",
+      tiles: stories.map(story => ({id: story.guid}))
+    }));
 
     return stories.map((story, i) =>
         <SpotlightItem

--- a/content-test/components/PocketStories.test.js
+++ b/content-test/components/PocketStories.test.js
@@ -59,4 +59,31 @@ describe("PocketStories", () => {
       TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
     });
   });
+
+  describe("impression stats", () => {
+    it("should fire impression stats events", done => {
+      let verifiedView = false;
+      function dispatch(a) {
+        if (a.type === "NOTIFY_IMPRESSION_STATS") {
+          assert.equal(a.data.source, "pocket");
+
+          if (!verifiedView) {
+            assert.deepEqual(a.data.tiles, [
+              {id: fakePocketStories[0].guid},
+              {id: fakePocketStories[1].guid},
+              {id: fakePocketStories[2].guid}
+            ]);
+            verifiedView = true;
+          } else {
+            assert.equal(a.data.click, 0);
+            assert.deepEqual(a.data.tiles, [{id: fakePocketStories[0].guid, pos: 1}]);
+            done();
+          }
+        }
+      }
+      instance = renderWithProvider(<PocketStories page={"NEW_TAB"} dispatch={dispatch}
+        stories={fakePocketStories} topics={fakePocketTopics} />);
+      TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds the new impression tracking for Pocket plus test coverage for it.

We're tracking: views (list of tiles being displayed), clicks, save to pocket, and dismiss.