### PR TITLE
fix(build): Add in prebuildmc task

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "mochitest": "(cd ../mozilla-central && ./mach mochitest --setpref browser.newtabpage.activity-stream.enabled=true  --extra-mozinfo-json=$PWD/browser/extensions/activity-stream/test/mozinfo.json browser/extensions/activity-stream/test/functional/mochitest )",
     "mochitest-debug": "(cd ../mozilla-central && ./mach mochitest --jsdebugger --setpref browser.newtabpage.activity-stream.enabled=true --extra-mozinfo-json=$PWD/browser/extensions/activity-stream/test/mozinfo.json browser/extensions/activity-stream/test/functional/mochitest )",
     "buildmc": "npm-run-all buildmc:*",
-    "buildmc:clean": "rimraf ../mozilla-central/browser/extensions/activity-stream",
+    "prebuildmc": "rimraf ../mozilla-central/browser/extensions/activity-stream",
     "buildmc:webpack": "webpack --config webpack.system-addon.config.js",
     "buildmc:css": "node-sass system-addon/content-src/activity-stream.scss -o system-addon/data/content",
     "buildmc:copy": "cpx \"system-addon/{bootstrap.js,install.rdf.in,jar.mn,moz.build,README.md,{common,data,lib,test,vendor}/**/{,.}*}\" ../mozilla-central/browser/extensions/activity-stream",

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -46,7 +46,7 @@ scripts:
 
 # buildmc: Export the bootstraped add-on to mozilla central
   buildmc:
-    clean: rimraf ../mozilla-central/browser/extensions/activity-stream
+    pre: rimraf ../mozilla-central/browser/extensions/activity-stream
     webpack: webpack --config webpack.system-addon.config.js
     css: node-sass system-addon/content-src/activity-stream.scss -o system-addon/data/content
     # Copy over all of the mozilla-central directory except content-src


### PR DESCRIPTION
 Sorry, I missed this in review! The `startmc` task is currently broken on master