### PR TITLE
Metadata Local Refresh Experiment fixes #2358

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -268,5 +268,20 @@
       "threshold": 0.2,
       "description": "Make no calls to the metadata service"
     }
+  },
+  "metadataLocalRefresh": {
+    "name": "Metadata with local parsing and periodic refresh",
+    "active": true,
+    "description": "Process metadata locally and periodically refresh it",
+    "control": {
+      "value": false,
+      "description": "Metadata is processed locally at browse time only"
+    },
+    "variant": {
+      "id": "exp-019-metadata-local-refresh",
+      "value": true,
+      "threshold": 0.2,
+      "description": "Metadata is processed locally at browse time and periodically in a background task"
+    }
   }
 }


### PR DESCRIPTION
This experiment will test the configuration of having long metadata cache timeout, no remote service calls, and a background periodic metadata refresh task which queries the PlacesDB for all URLs which do not have metadata and fetches them in the background.

This configuration consists of:

    Long metadata cache timeout
    Local Metadata Parser
    No Metadata Service
    Periodic background refresh task
