### PR TITLE
Port short url code and add tests for react components in system add-on

### DIFF
--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -51,10 +51,18 @@ module.exports = function(config) {
       resolveLoader: {alias: {inject: path.join(__dirname, "loaders/inject-loader")}},
       // This resolve config allows us to import with paths relative to the system-addon/ directory, e.g. "lib/ActivityStream.jsm"
       resolve: {
+        extensions: [".js", ".jsx"],
         modules: [
           PATHS.systemAddonDirectory,
           "node_modules"
         ]
+      },
+      externals: {
+        // enzyme needs these for backwards compatibility with 0.13.
+        // see https://github.com/airbnb/enzyme/blob/master/docs/guides/webpack.md#using-enzyme-with-webpack
+        "react/addons": true,
+        "react/lib/ReactContext": true,
+        "react/lib/ExecutionEnvironment": true
       },
       module: {
         rules: [
@@ -73,6 +81,12 @@ module.exports = function(config) {
                 ]
               }
             }]
+          },
+          {
+            test: /\.jsx?$/,
+            exclude: /node_modules/,
+            loader: "babel-loader",
+            options: {presets: ["react"]}
           },
           {
             enforce: "post",

--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -35,9 +35,10 @@ class Search extends React.Component {
         onChange={this.onChange}
         maxLength="256"
         placeholder="Search the Web" />
-        <button title="Submit search" onClick={this.onClick} />
+        <button className="search-button" title="Submit search" onClick={this.onClick} />
     </form>);
   }
 }
 
 module.exports = connect(state => ({Search: state.Search}))(Search);
+module.exports._unconnected = Search;

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -2,25 +2,28 @@ const React = require("react");
 const {connect} = require("react-redux");
 const shortURL = require("content-src/lib/short-url");
 
+const TopSite = props => {
+  const title = shortURL(props);
+  const className = `screenshot${props.screenshot ? " active" : ""}`;
+  const style = {backgroundImage: props.screenshot ? `url(${props.screenshot})` : "none"};
+  return (<li className="top-site">
+    <a href={props.url}>
+      <div className="tile" aria-hidden={true}>
+        <span className="letter-fallback">{title[0]}</span>
+        <div className={className} style={style} />
+      </div>
+      <div className="title">{title}</div>
+    </a>
+  </li>);
+};
+
 const TopSites = props => (<section>
   <h3 className="section-title">Top Sites</h3>
   <ul className="top-sites-list">
-    {props.TopSites.rows.map(link => {
-      const title = shortURL(link);
-      const className = `screenshot${link.screenshot ? " active" : ""}`;
-      const style = {backgroundImage: (link.screenshot ? `url(${link.screenshot})` : "none")};
-      return (<li key={link.url}>
-        <a href={link.url}>
-          <div className="tile" aria-hidden={true}>
-            <span className="letter-fallback">{title[0]}</span>
-            <div className={className} style={style} />
-          </div>
-          <div className="title">{title}</div>
-        </a>
-      </li>);
-    })}
+    {props.TopSites.rows.map(link => <TopSite key={link.url} {...link} />)}
   </ul>
 </section>);
 
 module.exports = connect(state => ({TopSites: state.TopSites}))(TopSites);
 module.exports._unconnected = TopSites;
+module.exports.TopSite = TopSite;

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -1,15 +1,12 @@
 const React = require("react");
 const {connect} = require("react-redux");
-
-function displayURL(url) {
-  return new URL(url).hostname.replace(/^www./, "");
-}
+const shortURL = require("content-src/lib/short-url");
 
 const TopSites = props => (<section>
   <h3 className="section-title">Top Sites</h3>
   <ul className="top-sites-list">
     {props.TopSites.rows.map(link => {
-      const title = displayURL(link.url);
+      const title = shortURL(link);
       const className = `screenshot${link.screenshot ? " active" : ""}`;
       const style = {backgroundImage: (link.screenshot ? `url(${link.screenshot})` : "none")};
       return (<li key={link.url}>
@@ -26,3 +23,4 @@ const TopSites = props => (<section>
 </section>);
 
 module.exports = connect(state => ({TopSites: state.TopSites}))(TopSites);
+module.exports._unconnected = TopSites;

--- a/system-addon/content-src/lib/short-url.js
+++ b/system-addon/content-src/lib/short-url.js
@@ -1,0 +1,26 @@
+/**
+ * shortURL - Creates a short version of a link's url, used for display purposes
+ *            e.g. {url: http://www.foosite.com, eTLD: "com"}  =>  "foosite"
+ *
+ * @param  {obj} link A link object
+ *         {str} link.url (required)- The url of the link
+ *         {str} link.eTLD (required) - The tld of the link
+ *               e.g. for https://foo.org, the tld would be "org"
+ *               Note that this property is added in various queries for ActivityStream
+ *               via Services.eTLD.getPublicSuffix
+ *         {str} link.hostname (optional) - The hostname of the url
+ *               e.g. for http://www.hello.com/foo/bar, the hostname would be "www.hello.com"
+ * @return {str}   A short url
+ */
+module.exports = function shortURL(link) {
+  if (!link.url && !link.hostname) {
+    return "";
+  }
+  const {eTLD} = link;
+  const hostname = (link.hostname || new URL(link.url).hostname).replace(/^www\./i, "");
+
+  // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
+  const eTLDLength = (eTLD || "").length || (hostname.match(/\.com$/) && 3);
+  const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
+  return hostname.slice(0, eTLDExtra).toLowerCase();
+};

--- a/system-addon/test/unit/content-src/components/Search.test.js
+++ b/system-addon/test/unit/content-src/components/Search.test.js
@@ -1,0 +1,63 @@
+const React = require("react");
+const {shallow, mount} = require("enzyme");
+const {_unconnected: Search} = require("content-src/components/Search/Search");
+const {actionTypes: at, actionUtils: au} = require("common/Actions.jsm");
+
+const DEFAULT_PROPS = {
+  Search: {
+    currentEngine: {
+      name: "google",
+      icon: "google.jpg"
+    }
+  },
+  dispatch() {}
+};
+
+describe("<Search>", () => {
+  it("should render a Search element", () => {
+    const wrapper = shallow(<Search {...DEFAULT_PROPS} />);
+    assert.ok(wrapper.exists());
+  });
+
+  describe("#performSearch", () => {
+    function clickButtonAndGetAction(wrapper) {
+      const dispatch = wrapper.prop("dispatch");
+      wrapper.find(".search-button").simulate("click");
+      assert.calledOnce(dispatch);
+      return dispatch.firstCall.args[0];
+    }
+    it("should send a SendToMain action with type PERFORM_SEARCH when you click the search button", () => {
+      const wrapper = mount(<Search {...DEFAULT_PROPS} dispatch={sinon.spy()} />);
+
+      const action = clickButtonAndGetAction(wrapper);
+
+      assert.propertyVal(action, "type", at.PERFORM_SEARCH);
+      assert.isTrue(au.isSendToMain(action));
+    });
+    it("should send an action with the right engineName ", () => {
+      const props = {Search: {currentEngine: {name: "foo123"}}, dispatch: sinon.spy()};
+      const wrapper = mount(<Search {...props} />);
+
+      const action = clickButtonAndGetAction(wrapper);
+
+      assert.propertyVal(action.data, "engineName", "foo123");
+    });
+    it("should send an action with the right searchString ", () => {
+      const wrapper = mount(<Search {...DEFAULT_PROPS} dispatch={sinon.spy()} />);
+      wrapper.setState({searchString: "hello123"});
+
+      const action = clickButtonAndGetAction(wrapper);
+
+      assert.propertyVal(action.data, "searchString", "hello123");
+    });
+  });
+
+  it("should update state.searchString on a change event", () => {
+    const wrapper = mount(<Search {...DEFAULT_PROPS} />);
+    const inputEl = wrapper.find("#search-input");
+    // as the value in the input field changes, it will update the search string
+    inputEl.simulate("change", {target: {value: "hello"}});
+
+    assert.equal(wrapper.state().searchString, "hello");
+  });
+});

--- a/system-addon/test/unit/content-src/components/TopSites.test.js
+++ b/system-addon/test/unit/content-src/components/TopSites.test.js
@@ -1,0 +1,56 @@
+const React = require("react");
+const {shallow} = require("enzyme");
+const {_unconnected: TopSites, TopSite} = require("content-src/components/TopSites/TopSites");
+
+const DEFAULT_PROPS = {
+  TopSites: {rows: []},
+  dispatch() {}
+};
+
+describe("<TopSites>", () => {
+  it("should render a TopSites element", () => {
+    const wrapper = shallow(<TopSites {...DEFAULT_PROPS} />);
+    assert.ok(wrapper.exists());
+  });
+  it("should render a TopSite for each link with the right url", () => {
+    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
+
+    const wrapper = shallow(<TopSites {...DEFAULT_PROPS} TopSites={{rows}} />);
+
+    const links = wrapper.find(TopSite);
+    assert.lengthOf(links, 2);
+    links.forEach((link, i) => assert.equal(link.props().url, rows[i].url));
+  });
+});
+
+describe("<TopSite>", () => {
+  it("should render a TopSite", () => {
+    const wrapper = shallow(<TopSite url="https://foo.com" screenshot="foo.jpg" />);
+    assert.ok(wrapper.exists());
+  });
+  it("should add the right url", () => {
+    const wrapper = shallow(<TopSite url="https://www.foobar.org" />);
+    assert.propertyVal(wrapper.find("a").props(), "href", "https://www.foobar.org");
+  });
+  it("should render a shortened title based off the url", () => {
+    const wrapper = shallow(<TopSite url="https://www.foobar.org" eTLD={"org"} />);
+    const titleEl = wrapper.find(".title");
+
+    assert.equal(titleEl.text(), "foobar");
+  });
+  it("should render the first letter of the title as a fallback for missing screenshots", () => {
+    const wrapper = shallow(<TopSite url="https://www.foo.com" screenshot="foo.jpg" />);
+    assert.equal(wrapper.find(".letter-fallback").text(), "f");
+  });
+  it("should render a screenshot with the .active class, if it is provided", () => {
+    const wrapper = shallow(<TopSite url="https://foo.com" screenshot="foo.jpg" />);
+    const screenshotEl = wrapper.find(".screenshot");
+
+    assert.propertyVal(screenshotEl.props().style, "backgroundImage", "url(foo.jpg)");
+    assert.isTrue(screenshotEl.hasClass("active"));
+  });
+  it("should not add the .active class to the screenshot element if no screenshot prop is provided", () => {
+    const wrapper = shallow(<TopSite url="https://foo.com" />);
+    assert.isFalse(wrapper.find(".screenshot").hasClass("active"));
+  });
+});

--- a/system-addon/test/unit/content-src/lib/short-url.test.js
+++ b/system-addon/test/unit/content-src/lib/short-url.test.js
@@ -1,0 +1,28 @@
+const shortURL = require("content-src/lib/short-url");
+
+describe("shortURL", () => {
+  it("should return a blank string if url and hostname is falsey", () => {
+    assert.equal(shortURL({url: ""}), "");
+    assert.equal(shortURL({hostname: null}), "");
+  });
+
+  it("should remove the eTLD, if provided", () => {
+    assert.equal(shortURL({hostname: "com.blah.com", eTLD: "com"}), "com.blah");
+  });
+
+  it("should use the hostname, if provided", () => {
+    assert.equal(shortURL({hostname: "foo.com", url: "http://bar.com", eTLD: "com"}), "foo");
+  });
+
+  it("should get the hostname from .url if necessary", () => {
+    assert.equal(shortURL({url: "http://bar.com", eTLD: "com"}), "bar");
+  });
+
+  it("should not strip out www if not first subdomain", () => {
+    assert.equal(shortURL({hostname: "foo.www.com", eTLD: "com"}), "foo.www");
+  });
+
+  it("should convert to lowercase", () => {
+    assert.equal(shortURL({url: "HTTP://FOO.COM", eTLD: "com"}), "foo");
+  });
+});


### PR DESCRIPTION
This patch ports the code for generating short urls (e.g. `https://foo.com` => `foo`) from the test pilot add-on, which is possible now that we are using our own query that returns `eTLD`. 

I also ported relevant tests for the Search/TopSites components and added support for React/Enzyme in our karma config while I was there.