### PR TITLE
chore(npm): Add debugcoverage task that opens coverage html report

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "testmc:unit": "karma start karma.mc.config.js || (cat logs/coverage/system-addon/text.txt && exit 2)",
     "posttestmc": "cat logs/coverage/system-addon/text-summary.txt",
     "tddmc": "karma start karma.mc.config.js --tdd",
+    "debugcoverage": "open logs/coverage/system-addon/report-html/index.html",
     "start": "npm-run-all --parallel start:*",
     "prestart": "npm run clean && npm run copyTestImages && npm run preparePocketJson",
     "start:static": "npm run bundle:static -- -w",

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -70,6 +70,8 @@ scripts:
 
   tddmc: karma start karma.mc.config.js --tdd
 
+  debugcoverage: open logs/coverage/system-addon/report-html/index.html
+
 # start: Start watching/compiling assets,
   start:
     _parallel: true


### PR DESCRIPTION
I thought this might be a helpful shortcut for people debugging coverage reports.

Test by running `npm run debugcoverage` after running tests, and you should see the report show up in a browser. 

/cc @Mardak @dmose @sarracini 