### PR TITLE
feat (content): #2385 collapse highlights on section title click

### DIFF
--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -21,7 +21,7 @@ const PERFORMANCE_NOTIF = "performance-event";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
 const UNDESIRED_NOTIF = "undesired-event";
 const IMPRESSION_NOTIF = "impression-stats";
-const USER_PREFS = ["showSearch", "showTopSites", "showPocket", "showHighlights", "showMoreTopSites"];
+const USER_PREFS = ["showSearch", "showTopSites", "showPocket", "showHighlights", "showMoreTopSites", "collapseHighlights"];
 
 function TabTracker(options) {
   this._tabData = {};

--- a/common/constants.js
+++ b/common/constants.js
@@ -43,7 +43,8 @@ module.exports = {
     "showTopSites": 1 << 1,
     "showHighlights": 1 << 2,
     "showMoreTopSites": 1 << 3,
-    "showPocket": 1 << 4
+    "showPocket": 1 << 4,
+    "collapseHighlights": 1 << 5
   },
 
   // The minimum size to consider an icon high res

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -12,6 +12,7 @@ const setFavicon = require("lib/set-favicon");
 const PAGE_NAME = "NEW_TAB";
 const {HIGHLIGHTS_LENGTH, TOP_SITES_DEFAULT_LENGTH, TOP_SITES_SHOWMORE_LENGTH, POCKET_STORIES_LENGTH} = require("common/constants");
 const {injectIntl} = require("react-intl");
+const classNames = require("classnames");
 
 const NewTabPage = React.createClass({
   getInitialState() {
@@ -83,7 +84,7 @@ const NewTabPage = React.createClass({
     const {showSearch, showTopSites, showPocket, showHighlights, showMoreTopSites} = props.Prefs.prefs;
 
     return (<main className="new-tab">
-      <div className="new-tab-wrapper">
+      <div className={classNames("new-tab-wrapper", {"show-highlights": showHighlights})}>
         {showSearch &&
           <section>
             <Search />

--- a/content-src/components/NewTabPage/NewTabPage.scss
+++ b/content-src/components/NewTabPage/NewTabPage.scss
@@ -3,6 +3,12 @@
   max-width: $wrapper-max-width;
   margin: auto;
   padding: $wrapper-vertical-padding 0;
+
+  &.show-highlights {
+    // if we are showing highlights, we want to stay top aligned to avoid everything
+    // jumping up and down when changing between collapsed/uncollapsed
+    margin-top: 0;
+  }
 }
 
 @keyframes fadeIn {

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -123,6 +123,9 @@ const Spotlight = React.createClass({
       placeholder: false
     };
   },
+  getInitialState() {
+    return {isAnimating: false};
+  },
   onClickFactory(index, site) {
     return () => {
       let payload = {
@@ -152,11 +155,23 @@ const Spotlight = React.createClass({
           prefs={this.props.prefs} />
       );
   },
-
+  handleHeaderClick() {
+    this.setState({isAnimating: true});
+    this.props.dispatch(actions.NotifyPrefChange("collapseHighlights", !this.props.prefs.collapseHighlights));
+  },
+  handleTransitionEnd() {
+    this.setState({isAnimating: false});
+  },
   render() {
+    const isCollapsed = this.props.prefs.collapseHighlights;
+    const isAnimating = this.state.isAnimating;
+
     return (<section className="spotlight">
-      <h3 className="section-title"><FormattedMessage id="header_highlights" /></h3>
-      <ul className="spotlight-list">
+      <h3 className="section-title" ref="section-title" onClick={this.handleHeaderClick}>
+        <FormattedMessage id="header_highlights" />
+        <span className={classNames("icon", {"icon-arrowhead-down": !isCollapsed, "icon-arrowhead-up": isCollapsed})} />
+      </h3>
+      <ul ref="spotlight-list" className={classNames("spotlight-list", {"collapsed": isCollapsed, "animating": isAnimating})} onTransitionEnd={this.handleTransitionEnd}>
         {this.props.placeholder ? renderPlaceholderList() : this.renderSiteList()}
       </ul>
     </section>);

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -2,11 +2,17 @@
   margin-inline-end: -$base-gutter;
 
   .section-title {
+    cursor: pointer;
+
     // Compensate for margin on spotlight-items.  Once spotlight-list can be a
     // a CSS grid (firefox 51); we should be able to ditch this.
     //
     // XXX figure out if similar hack is needed for bottom of spotlight-list
     margin: 0 0 7px;
+
+    .icon {
+      margin: -5px 0 0 8px;
+    }
   }
 
   ul.spotlight-list {
@@ -16,6 +22,20 @@
     list-style: none;
     margin: 0;
     padding: 0;
+
+    // max-height needs to be set to a value larger than it will ever reasonably get.
+    // We then transition on max-height, since we can't transition height to/from auto.
+    max-height: 975px;
+    transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);
+
+    &.collapsed {
+      max-height: 0;
+      overflow: hidden;
+    }
+
+    &.animating {
+      overflow: hidden;
+    }
   }
 }
 

--- a/content-src/static/img/glyph-arrowhead-down-12.svg
+++ b/content-src/static/img/glyph-arrowhead-down-12.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12" height="12" viewBox="0 0 12 12">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #6E707E;
+      }
+    </style>
+  </defs>
+  <title> Arrow Head - Down - 12</title>
+  <path class="cls-1" d="M6,9a1,1,0,0,1-.707-.293l-3-3A1,1,0,0,1,3.707,4.293L6,6.586,8.293,4.293A1,1,0,0,1,9.707,5.707l-3,3A1,1,0,0,1,6,9Z"/>
+</svg>

--- a/content-src/static/img/glyph-arrowhead-up-12.svg
+++ b/content-src/static/img/glyph-arrowhead-up-12.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12" height="12" viewBox="0 0 12 12">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #6E707E;
+      }
+    </style>
+  </defs>
+  <title>Arrow Head - Up - 12</title>
+  <path class="cls-1" d="M6,3a1,1,0,0,0-.707.293l-3,3A1,1,0,0,0,3.707,7.707L6,5.414,8.293,7.707A1,1,0,0,0,9.707,6.293l-3-3A1,1,0,0,0,6,3Z"/>
+</svg>

--- a/content-src/styles/icons.scss
+++ b/content-src/styles/icons.scss
@@ -111,4 +111,16 @@
   &.icon-trending {
     background-image: url('#{$image-path}trending-icon.svg');
   }
+
+  &.icon-arrowhead-down {
+    background-image: url('#{$image-path}glyph-arrowhead-down-12.svg');
+    height: 12px;
+    width: 12px;
+  }
+
+  &.icon-arrowhead-up {
+    background-image: url('#{$image-path}glyph-arrowhead-up-12.svg');
+    height: 12px;
+    width: 12px;
+  }
 }

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -21,7 +21,7 @@ describe("Spotlight", () => {
 
   describe("valid sites", () => {
     beforeEach(() => {
-      instance = renderWithProvider(<Spotlight sites={fakeSpotlightItems} />);
+      instance = renderWithProvider(<Spotlight sites={fakeSpotlightItems} prefs={{}} />);
       el = ReactDOM.findDOMNode(instance);
     });
 
@@ -31,6 +31,10 @@ describe("Spotlight", () => {
     it("should render a SpotlightItem for each item", () => {
       const children = TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem);
       assert.equal(children.length, 3);
+    });
+    it("should not show any SpotlightItems if collapseHighlights pref is true", () => {
+      instance = renderWithProvider(<Spotlight sites={fakeSpotlightItems} prefs={{collapseHighlights: true}} />);
+      assert.ok(instance.refs["spotlight-list"].className.indexOf("collapsed") >= 0);
     });
   });
 
@@ -47,8 +51,19 @@ describe("Spotlight", () => {
           done();
         }
       }
-      instance = renderWithProvider(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSpotlightItems} />);
+      instance = renderWithProvider(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSpotlightItems} prefs={{}} />);
       TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
+    });
+    it("should fire a pref change event when section title is clicked", done => {
+      function dispatch(a) {
+        if (a.type === "NOTIFY_PREF_CHANGE") {
+          assert.equal(a.data.name, "collapseHighlights");
+          assert.equal(a.data.value, true);
+          done();
+        }
+      }
+      instance = renderWithProvider(<Spotlight dispatch={dispatch} sites={fakeSpotlightItems} prefs={{isCollapsed: false}} />);
+      TestUtils.Simulate.click(instance.refs["section-title"]);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -202,6 +202,12 @@
       "title": "Show an extra row of Top Sites on the New Tab page",
       "type": "bool",
       "value": false
+    },
+    {
+      "name": "collapseHighlights",
+      "title": "Collapse the Highlights on the New Tab page leaving only section title visible",
+      "type": "bool",
+      "value": false
     }
   ],
   "repository": "mozilla/activity-stream",


### PR DESCRIPTION
A new customization feature to collapse Highlights by clicking on the section header.

<img src="https://d2ppvlu71ri8gs.cloudfront.net/items/3Q2P1B2C3W320h462v1D/Screen%20Recording%202017-05-04%20at%2004.39%20PM.gif" />

Fixes #2385 