### PR TITLE
fix(mc): Closes #2548 Send a dummy content message to trigger ContentSearch initialization

### DIFF
--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -11,6 +11,12 @@ class Search extends React.Component {
     this.onClick = this.onClick.bind(this);
     this.onChange = this.onChange.bind(this);
   }
+
+  componentWillMount() {
+    // Trigger initialization of ContentSearch in case it hasn't happened yet
+    dispatchEvent(new CustomEvent("ContentSearchClient", {detail: {}}));
+  }
+
   performSearch(options) {
     let searchData = {
       engineName: options.engineName,

--- a/system-addon/test/unit/lib/SearchFeed.test.js
+++ b/system-addon/test/unit/lib/SearchFeed.test.js
@@ -20,8 +20,9 @@ describe("Search Feed", () => {
   afterEach(() => globals.reset());
   after(() => globals.restore());
 
-  it("should call get state (with true) from the content search provider on INIT", () => {
-    feed.onAction({type: at.INIT});
+  it("should call get state (with true) from the content search provider on INIT", async() => {
+    await feed.onAction({type: at.INIT});
+
     // calling currentStateObj with 'true' allows us to return a data uri for the
     // icon, instead of an array buffer
     assert.calledWith(global.ContentSearch.currentStateObj, true);
@@ -41,19 +42,25 @@ describe("Search Feed", () => {
     feed.onAction({type: at.UNINIT});
     assert.calledOnce(feed.removeObservers);
   });
-  it("should call services.obs.addObserver on INIT", () => {
+  it("should add event handlers on INIT", () => {
     feed.onAction({type: at.INIT});
+
     assert.calledOnce(global.Services.obs.addObserver);
+    assert.calledOnce(global.Services.mm.addMessageListener);
   });
-  it("should call services.obs.removeObserver on UNINIT", () => {
+  it("should remove event handlers on UNINIT", () => {
     feed.onAction({type: at.UNINIT});
+
     assert.calledOnce(global.Services.obs.removeObserver);
+    assert.calledOnce(global.Services.mm.removeMessageListener);
   });
-  it("should dispatch one event with the state", () => (
-    feed.getState().then(() => {
-      assert.calledOnce(feed.store.dispatch);
-    })
-  ));
+  it("should dispatch one event with the state", async() => {
+    feed.contentSearch = Promise.resolve(global.ContentSearch);
+
+    await feed.getState();
+
+    assert.calledOnce(feed.store.dispatch);
+  });
   it("should perform a search on PERFORM_SEARCH", () => {
     sinon.stub(feed, "performSearch");
     feed.onAction({_target: {browser: {}}, type: at.PERFORM_SEARCH});

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -26,6 +26,10 @@ overrider.set({
   fetch: overrider.sandbox.stub(),
   Services: {
     locale: {getRequestedLocale: overrider.sandbox.stub()},
+    mm: {
+      addMessageListener: overrider.sandbox.spy((msg, cb) => cb()),
+      removeMessageListener: overrider.sandbox.spy()
+    },
     obs: {
       addObserver: overrider.sandbox.spy(),
       removeObserver: overrider.sandbox.spy()


### PR DESCRIPTION
Fix #2548. @sarracini @k88hudson There must be a better way to do this…?

note: there's two commits with different approaches. The former eagerly inits `ContentSearch` on activity stream init and the latter only inits when the search is rendered/mounted.