### PR TITLE
docs(mc): Add getting started documentation

### DIFF
--- a/docs/v2-system-addon/1.GETTING_STARTED.md
+++ b/docs/v2-system-addon/1.GETTING_STARTED.md
@@ -1,0 +1,87 @@
+# Activity Stream (System add-on)
+
+## Where to ask questions
+
+- Most of the core dev team can be found on the `#activity-stream` mozilla irc channel.
+  You can also direct message the core team (`dmose`, `emtwo`, `jkerim`, `k88hudson`, `Mardak`, `nanj`, `r1cky`, `ursula`)
+  or our manager (`tspurway`)
+- Our Mozilla slack channel is #activitystream
+- File issues/questions on Github: https://github.com/mozilla/activity-stream/issues. We typically triage new issues every Monday.
+
+## Testing in Firefox Nightly
+
+If you just want to see the current version of Activity Stream in Firefox, you can
+install [Firefox Nightly](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly)
+go to `about:config`, and set the `browser.newtabpage.activity-stream.enabled` pref
+to `true`.
+
+## Prerequisites for development
+
+### Operating system
+
+The Activity Stream development environment is designed to work on Mac and Linux.
+If you need to develop on Windows, you might want to reach out on IRC (#activity-stream)
+if you run into any problems.
+
+### Software
+
+- Node.js 6.9.1+ (On Mac, the best way to install Node.js is to use the [install link on the Node.js homepage](https://nodejs.org/en/))
+- npm (packaged with Node.js)
+
+### activity-stream
+
+You will need to to clone Activity Stream to a local directory from the `master`
+branch of our Github repository: https://github.com/mozilla/activity-stream
+
+```
+git clone https://github.com/mozilla/activity-stream.git
+```
+
+### Mozilla Central
+You will need a local copy of Mozilla Central in a directory named `mozilla-central`.
+That directory should be a sibling of of your local `activity-stream` directory (like so):
+
+```
+/
+  mozilla-central/
+  activity-stream/
+```
+
+Check out [these docs on artifact builds](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Artifact_builds)
+for instructions about how to download and configure Mozilla Central if you have
+never done so before.
+
+## Source code and PRs
+
+The latest copy of the source code for Activity Stream can be found in the `system-addon/`
+subdirectory of `activity-stream`.
+
+The current version of Activity Stream that is shipped with Firefox nightly can
+be found in `mozilla-central/browser/extensions/activity-stream`. Keep in mind that
+some of these files are generated, so if you intend on editing any files, you should
+do so in the Github version.
+
+PRs should be sent against the master branch of https://github.com/mozilla/activity-stream,
+NOT against mozilla central.
+
+## Building
+
+1. Install required dependencies by running `npm install`.
+2. To build Activity Stream, run `npm run buildmc` from the root of the
+`activity-stream` directory. This will build the js and css files and copy them
+into the `browser/extensions/activity-stream` directory inside Mozilla Central.
+3. Build and run Firefox from the `mozilla-central` directory by running `./mach build && ./mach run`.
+
+## Continuous development
+
+Running `npm run startmc` will start a process that watches files in `activity-stream`
+and continuously builds/copies changes to `mozilla-central`. You will
+still need to rebuild Firefox (`./mach build`) if you change `.jsm` files.
+
+## Running unit tests
+
+Run `npm run testmc` to run the unit tests with karma/mocha. The source code for these
+tests can be found in `system-addon/test/unit/`.
+
+Our unit tests expect 100% code coverage, so if you see any missing coverage,
+you can inspect the coverage report by running `npm run testmc && npm run debugcoverage`.


### PR DESCRIPTION
There are some people who need to work with our code base outside of our team, so I started on some general documentation for the system add-on: