### PR TITLE
chore(mc): #2572 Add Telemetry for search, Top Sites clicks

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -1,0 +1,197 @@
+# Metrics we collect
+
+This is an overview of the different kinds of data we collect in Activity Stream experiment. See [data_dictionary.md](data_dictionary.md) for more details for each field.
+
+## User event pings
+
+These pings are captured when a user **performs some kind of interaction** in the add-on.
+
+### Basic shape
+
+A user event ping includes some basic metadata (tab id, addon version, etc.) as well as variable fields which indicate the location and action of the event.
+
+```js
+{
+  // This indicates the type of interaction
+  "event": ["CLICK", "SEARCH", "BLOCK", "DELETE", "OPEN_NEW_WINDOW", "OPEN_PRIVATE_WINDOW", "BOOKMARK_DELETE", "BOOKMARK_ADD"],
+
+  // Optional field indicating the UI component type
+  "source": "TOP_SITES",
+
+  // Optional field if there is more than one of a component type on a page.
+  // It is zero-indexed.
+  // For example, clicking the second Highlight would result in an action_position of 1
+  "action_position": 1,
+
+  // Basic metadata
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "action": "activity_stream_event"
+}
+```
+
+### Types of user interactions
+
+#### Performing a search
+
+```js
+{
+  "event": "SEARCH",
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Clicking a top site item
+
+```js
+{
+  "event": "CLICK",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Deleting an item from history
+
+```js
+{
+  "event": "DELETE",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Blocking a site
+
+```js
+{
+  "event": "BLOCK",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Bookmarking a link
+
+```js
+{
+  "event": "BOOKMARK_ADD",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Removing a bookmark from a link
+
+```js
+{
+  "event": "BOOKMARK_DELETE",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Opening a link in a new window
+
+```js
+{
+  "event": "OPEN_NEW_WINDOW",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Opening a link in a new private window
+
+```js
+{
+  "event": "OPEN_PRIVATE_WINDOW",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+## Session end pings
+
+When a session ends, the browser will send a `"activity_stream_session"` ping to our metrics servers. This ping contains the length of the session, a unique reason for why the session ended, and some additional metadata.
+
+### Basic event
+
+All `"activity_stream_session"` pings have the following basic shape. Some fields are variable.
+
+```js
+  "action": "activity_stream_session",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "page": ["about:newtab" | "about:home"],
+  "session_duration": 4199
+}
+```
+
+### What causes a session end?
+
+Here are different scenarios that cause a session end event to be sent:
+
+1. After a search
+2. Clicking on something that causes navigation (top site, highlight, etc.)
+3. Closing the browser
+5. Refreshing
+6. Navigating to a new URL via the url bar or file menu

--- a/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
+++ b/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
@@ -1,7 +1,7 @@
 const React = require("react");
 const {injectIntl} = require("react-intl");
 const ContextMenu = require("content-src/components/ContextMenu/ContextMenu");
-const {actionTypes, actionCreators} = require("common/Actions.jsm");
+const {actionTypes, actionCreators: ac} = require("common/Actions.jsm");
 
 class LinkMenu extends React.Component {
   getBookmarkStatus(site) {
@@ -9,12 +9,14 @@ class LinkMenu extends React.Component {
       id: "menu_action_remove_bookmark",
       icon: "bookmark-remove",
       action: "DELETE_BOOKMARK_BY_ID",
-      data: site.bookmarkGuid
+      data: site.bookmarkGuid,
+      userEvent: "BOOKMARK_DELETE"
     } : {
       id: "menu_action_bookmark",
       icon: "bookmark",
       action: "BOOKMARK_URL",
-      data: site.url
+      data: site.url,
+      userEvent: "BOOKMARK_ADD"
     });
   }
   getDefaultContextMenu(site) {
@@ -22,17 +24,19 @@ class LinkMenu extends React.Component {
       id: "menu_action_open_new_window",
       icon: "new-window",
       action: "OPEN_NEW_WINDOW",
-      data: {url: site.url}
+      data: {url: site.url},
+      userEvent: "OPEN_NEW_WINDOW"
     },
     {
       id: "menu_action_open_private_window",
       icon: "new-window-private",
       action: "OPEN_PRIVATE_WINDOW",
-      data: {url: site.url}
+      data: {url: site.url},
+      userEvent: "OPEN_PRIVATE_WINDOW"
     }];
   }
   getOptions() {
-    const {dispatch, site} = this.props;
+    const {dispatch, site, index, source} = this.props;
 
     // default top sites have a limited set of context menu options
     let options = this.getDefaultContextMenu(site);
@@ -48,21 +52,30 @@ class LinkMenu extends React.Component {
           id: "menu_action_dismiss",
           icon: "dismiss",
           action: "BLOCK_URL",
-          data: site.url
+          data: site.url,
+          userEvent: "BLOCK"
         },
         {
           id: "menu_action_delete",
           icon: "delete",
           action: "DELETE_HISTORY_URL",
-          data: site.url
+          data: site.url,
+          userEvent: "DELETE"
         }];
     }
     options.forEach(option => {
-      let {action, data, id, type} = option;
+      const {action, data, id, type, userEvent} = option;
       // Convert message ids to localized labels and add onClick function
       if (!type && id) {
         option.label = this.props.intl.formatMessage(option);
-        option.onClick = () => (dispatch(actionCreators.SendToMain({type: actionTypes[action], data})));
+        option.onClick = () => {
+          dispatch(ac.SendToMain({type: actionTypes[action], data}));
+          dispatch(ac.UserEvent({
+            event: userEvent,
+            source,
+            action_position: index
+          }));
+        };
       }
     });
 

--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -2,7 +2,7 @@
 const React = require("react");
 const {connect} = require("react-redux");
 const {FormattedMessage, injectIntl} = require("react-intl");
-const {actionTypes, actionCreators} = require("common/Actions.jsm");
+const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
 
 class Search extends React.Component {
   constructor(props) {
@@ -24,7 +24,8 @@ class Search extends React.Component {
       searchPurpose: "newtab",
       healthReportKey: "newtab"
     };
-    this.props.dispatch(actionCreators.SendToMain({type: actionTypes.PERFORM_SEARCH, data: searchData}));
+    this.props.dispatch(ac.SendToMain({type: at.PERFORM_SEARCH, data: searchData}));
+    this.props.dispatch(ac.UserEvent({event: "SEARCH"}));
   }
   onClick(event) {
     const {currentEngine} = this.props.Search;

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -3,6 +3,8 @@ const {connect} = require("react-redux");
 const {FormattedMessage} = require("react-intl");
 const shortURL = require("content-src/lib/short-url");
 const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
+const {actionCreators: ac} = require("common/Actions.jsm");
+const TOP_SITES_SOURCE = "TOP_SITES";
 
 class TopSite extends React.Component {
   constructor(props) {
@@ -12,6 +14,13 @@ class TopSite extends React.Component {
   toggleContextMenu(event, index) {
     this.setState({showContextMenu: true, activeTile: index});
   }
+  trackClick() {
+    this.props.dispatch(ac.UserEvent({
+      event: "CLICK",
+      source: TOP_SITES_SOURCE,
+      action_position: this.props.index
+    }));
+  }
   render() {
     const {link, index, dispatch} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === index;
@@ -20,7 +29,7 @@ class TopSite extends React.Component {
     const topSiteOuterClassName = `top-site-outer${isContextMenuOpen ? " active" : ""}`;
     const style = {backgroundImage: (link.screenshot ? `url(${link.screenshot})` : "none")};
     return (<li className={topSiteOuterClassName} key={link.url}>
-        <a href={link.url}>
+        <a onClick={() => this.trackClick()} href={link.url}>
           <div className="tile" aria-hidden={true}>
               <span className="letter-fallback">{title[0]}</span>
               <div className={screenshotClassName} style={style} />
@@ -39,7 +48,8 @@ class TopSite extends React.Component {
           visible={isContextMenuOpen}
           onUpdate={val => this.setState({showContextMenu: val})}
           site={link}
-          index={index} />
+          index={index}
+          source={TOP_SITES_SOURCE} />
     </li>);
   }
 }
@@ -47,7 +57,11 @@ class TopSite extends React.Component {
 const TopSites = props => (<section>
   <h3 className="section-title"><FormattedMessage id="header_top_sites" /></h3>
   <ul className="top-sites-list">
-    {props.TopSites.rows.map((link, index) => <TopSite dispatch={props.dispatch} key={link.url} link={link} index={index} />)}
+    {props.TopSites.rows.map((link, index) => <TopSite
+      key={link.url}
+      dispatch={props.dispatch}
+      link={link}
+      index={index} />)}
   </ul>
 </section>);
 

--- a/system-addon/test/.eslintrc.js
+++ b/system-addon/test/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   "globals": {
     "assert": true,
-    "sinon": true
+    "sinon": true,
+    "chai": true
   }
 };

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -34,4 +34,29 @@ describe("<LinkMenu>", () => {
     assert.ok(!middleItem.first);
     assert.ok(!middleItem.last);
   });
+  describe(".onClick", () => {
+    const FAKE_INDEX = 3;
+    const FAKE_SOURCE = "TOP_SITES";
+    const dispatch = sinon.stub();
+    const options = shallowWithIntl(<LinkMenu site={{url: ""}} dispatch={dispatch} index={FAKE_INDEX} source={FAKE_SOURCE} />)
+      .find(ContextMenu).props().options;
+    afterEach(() => dispatch.reset());
+    options.filter(o => o.type !== "separator").forEach(option => {
+      it(`should fire a ${option.action} action for ${option.id}`, () => {
+        option.onClick();
+        assert.calledTwice(dispatch);
+        assert.propertyVal(dispatch.firstCall.args[0], "type", option.action);
+        if (option.data) {
+          assert.propertyVal(dispatch.firstCall.args[0], "data", option.data);
+        }
+      });
+      it(`should fire a UserEvent action for ${option.id}`, () => {
+        option.onClick();
+        const action = dispatch.secondCall.args[0];
+        assert.isUserEventAction(action);
+        assert.propertyVal(action.data, "source", FAKE_SOURCE);
+        assert.propertyVal(action.data, "action_position", FAKE_INDEX);
+      });
+    });
+  });
 });

--- a/system-addon/test/unit/content-src/components/Search.test.jsx
+++ b/system-addon/test/unit/content-src/components/Search.test.jsx
@@ -23,7 +23,6 @@ describe("<Search>", () => {
     function clickButtonAndGetAction(wrapper) {
       const dispatch = wrapper.prop("dispatch");
       wrapper.find(".search-button").simulate("click");
-      assert.calledOnce(dispatch);
       return dispatch.firstCall.args[0];
     }
     it("should send a SendToMain action with type PERFORM_SEARCH when you click the search button", () => {
@@ -50,8 +49,19 @@ describe("<Search>", () => {
 
       assert.propertyVal(action.data, "searchString", "hello123");
     });
-  });
+    it("should send a UserEvent action", () => {
+      const dispatch = sinon.spy();
+      const wrapper = mountWithIntl(<Search {...DEFAULT_PROPS} dispatch={dispatch} />);
+      wrapper.setState({searchString: "hello123"});
 
+      clickButtonAndGetAction(wrapper);
+
+      assert.calledTwice(dispatch);
+      const action = dispatch.secondCall.args[0];
+      assert.isUserEventAction(action);
+      assert.propertyVal(action.data, "event", "SEARCH");
+    });
+  });
   it("should update state.searchString on a change event", () => {
     const wrapper = mountWithIntl(<Search {...DEFAULT_PROPS} />);
     const inputEl = wrapper.find("#search-input");

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -94,4 +94,27 @@ describe("<TopSite>", () => {
     const linkMenuProps = wrapper.find(LinkMenu).props();
     ["visible", "onUpdate", "site", "index"].forEach(prop => assert.property(linkMenuProps, prop));
   });
+  describe("#trackClick", () => {
+    it("should call dispatch when the link is clicked", () => {
+      const dispatch = sinon.stub();
+      const wrapper = shallow(<TopSite link={link} index={3} dispatch={dispatch} />);
+
+      wrapper.find("a").simulate("click", {});
+
+      assert.calledOnce(dispatch);
+    });
+    it("should dispatch a UserEventAction with the right data", () => {
+      const dispatch = sinon.stub();
+      const wrapper = shallow(<TopSite link={link} index={3} dispatch={dispatch} />);
+
+      wrapper.find("a").simulate("click", {});
+
+      const action = dispatch.firstCall.args[0];
+      assert.isUserEventAction(action);
+
+      assert.propertyVal(action.data, "event", "CLICK");
+      assert.propertyVal(action.data, "source", "TOP_SITES");
+      assert.propertyVal(action.data, "action_position", 3);
+    });
+  });
 });

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -6,8 +6,7 @@ const {
   UndesiredPing,
   UserEventPing,
   PerfPing,
-  SessionPing,
-  assertMatchesSchema
+  SessionPing
 } = require("test/schemas/pings");
 
 const FAKE_TELEMETRY_ID = "foo123";
@@ -103,7 +102,7 @@ describe("TelemetryFeed", () => {
     describe("#createPing", () => {
       it("should create a valid base ping without a session if no portID is supplied", () => {
         const ping = instance.createPing();
-        assertMatchesSchema(ping, BasePing);
+        assert.validate(ping, BasePing);
         assert.notProperty(ping, "session_id");
       });
       it("should create a valid base ping with session info if a portID is supplied", () => {
@@ -114,7 +113,7 @@ describe("TelemetryFeed", () => {
 
         // Create a ping referencing the session
         const ping = instance.createPing(portID);
-        assertMatchesSchema(ping, BasePing);
+        assert.validate(ping, BasePing);
 
         // Make sure we added the right session-related stuff to the ping
         assert.propertyVal(ping, "session_id", sessionID);
@@ -130,7 +129,7 @@ describe("TelemetryFeed", () => {
         const ping = instance.createUserEvent(action);
 
         // Is it valid?
-        assertMatchesSchema(ping, UserEventPing);
+        assert.validate(ping, UserEventPing);
         // Does it have the right session_id?
         assert.propertyVal(ping, "session_id", session.session_id);
       });
@@ -141,7 +140,7 @@ describe("TelemetryFeed", () => {
         const ping = instance.createUndesiredEvent(action);
 
         // Is it valid?
-        assertMatchesSchema(ping, UndesiredPing);
+        assert.validate(ping, UndesiredPing);
         // Does it have the right value?
         assert.propertyVal(ping, "value", 10);
       });
@@ -153,7 +152,7 @@ describe("TelemetryFeed", () => {
         const ping = instance.createUndesiredEvent(action);
 
         // Is it valid?
-        assertMatchesSchema(ping, UndesiredPing);
+        assert.validate(ping, UndesiredPing);
         // Does it have the right session_id?
         assert.propertyVal(ping, "session_id", session.session_id);
         // Does it have the right value?
@@ -166,7 +165,7 @@ describe("TelemetryFeed", () => {
         const ping = instance.createPerformanceEvent(action);
 
         // Is it valid?
-        assertMatchesSchema(ping, PerfPing);
+        assert.validate(ping, PerfPing);
         // Does it have the right value?
         assert.propertyVal(ping, "value", 100);
       });
@@ -178,7 +177,7 @@ describe("TelemetryFeed", () => {
         const ping = instance.createPerformanceEvent(action);
 
         // Is it valid?
-        assertMatchesSchema(ping, PerfPing);
+        assert.validate(ping, PerfPing);
         // Does it have the right session_id?
         assert.propertyVal(ping, "session_id", session.session_id);
         // Does it have the right value?
@@ -193,7 +192,7 @@ describe("TelemetryFeed", () => {
           session_duration: 12345
         });
         // Is it valid?
-        assertMatchesSchema(ping, SessionPing);
+        assert.validate(ping, SessionPing);
         assert.propertyVal(ping, "session_id", FAKE_UUID);
         assert.propertyVal(ping, "page", "about:newtab");
         assert.propertyVal(ping, "session_duration", 12345);

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -1,10 +1,13 @@
 const {GlobalOverrider} = require("test/unit/utils");
+const {chaiAssertions} = require("test/schemas/pings");
 
 const req = require.context(".", true, /\.test\.js$/);
 const files = req.keys();
 
 // This exposes sinon assertions to chai.assert
 sinon.assert.expose(assert, {prefix: ""});
+
+chai.use(chaiAssertions);
 
 let overrider = new GlobalOverrider();
 overrider.set({


### PR DESCRIPTION
This patch adds telemetry for Top Sites and their context menu options, and search.

I also added an assertion for testing user event actions which can be used like so:

```
assert.isUserEventAction(someAction);
```