### PR TITLE
feat(content): #2600 Add telemetry on the 'Read More' links for Pocket

### DIFF
--- a/content-src/components/PocketStories/PocketStories.js
+++ b/content-src/components/PocketStories/PocketStories.js
@@ -5,6 +5,7 @@ const {FormattedMessage} = require("react-intl");
 const {SpotlightItem, renderPlaceholderList} = require("components/Spotlight/Spotlight");
 const {actions} = require("common/action-manager");
 const {pocket_read_more_endpoint, pocket_learn_more_endpoint, pocket_survey_link} = require("../../../pocket.json");
+const {POCKET_TOPICS_LENGTH} = require("common/constants");
 
 const PocketStories = React.createClass({
   onClickFactory(index, story) {
@@ -22,6 +23,20 @@ const PocketStories = React.createClass({
         click: 0,
         tiles: [{id: story.guid, pos: index}]
       }));
+    };
+  },
+
+  onTopicClick(index, topic, topic_url) {
+    return () => {
+      let payload = {
+        event: "CLICK",
+        page: this.props.page,
+        source: "RECOMMENDED",
+        action_position: index,
+        recommender_type: topic,
+        url: topic_url
+      };
+      this.props.dispatch(actions.NotifyEvent(payload));
     };
   },
 
@@ -46,17 +61,22 @@ const PocketStories = React.createClass({
       );
   },
 
-  renderReadMoreTopic(topic, url) {
-    return (<li><a key={topic} className="pocket-read-more-link" href={url}>{topic}</a></li>);
+  renderReadMoreTopic(index, topic, url) {
+    return (<li><a key={topic}
+      onClick={this.onTopicClick(index, topic, url)}
+      className="pocket-read-more-link"
+      href={url}>{topic}</a></li>);
   },
 
   renderReadMoreTopics() {
     return (
       <div className="pocket-read-more">
         <span><FormattedMessage id="pocket_read_more" /></span>
-        <ul>{this.props.topics.map(t => this.renderReadMoreTopic(t.name, t.url))}</ul>
+        <ul>{this.props.topics.map((t, i) => this.renderReadMoreTopic(i, t.name, t.url))}</ul>
 
-        <a className="pocket-read-even-more" href={pocket_read_more_endpoint}>
+        <a className="pocket-read-even-more"
+           onClick={this.onTopicClick(POCKET_TOPICS_LENGTH, "trending", pocket_read_more_endpoint)}
+           href={pocket_read_more_endpoint}>
           <FormattedMessage id="pocket_read_even_more" />
           <span className="pocket-read-even-more-logo" />
         </a>

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -12,7 +12,7 @@ module.exports = {
     "error": false
   },
   "PocketTopics": {
-    "rows": faker.createRows({length: POCKET_TOPICS_LENGTH}),
+    "rows": faker.createRows({length: POCKET_TOPICS_LENGTH}).map((t, i) => Object.assign({}, t, {name: `name_${i}`})),
     "error": false
   },
   "TopSites": {

--- a/content-test/components/PocketStories.test.js
+++ b/content-test/components/PocketStories.test.js
@@ -2,6 +2,7 @@ const ConnectedSpotlight = require("components/Spotlight/Spotlight");
 const {SpotlightItem} = ConnectedSpotlight;
 
 const {POCKET_STORIES_LENGTH, POCKET_TOPICS_LENGTH} = require("common/constants");
+const {pocket_read_more_endpoint} = require("../../pocket.json");
 const ConnectedPocketStories = require("components/PocketStories/PocketStories");
 const {PocketStories} = ConnectedPocketStories;
 
@@ -69,6 +70,38 @@ describe("PocketStories", () => {
       instance = renderWithProvider(<PocketStories page={"NEW_TAB"} dispatch={dispatch}
         stories={fakePocketStories} topics={fakePocketTopics} />);
       TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
+    });
+    it("should fire a click event when a topic is clicked", done => {
+      function dispatch(a) {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.event, "CLICK");
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "RECOMMENDED");
+          assert.equal(a.data.action_position, 1);
+          assert.equal(a.data.recommender_type, fakePocketTopics[1].name);
+          assert.equal(a.data.url, fakePocketTopics[1].url);
+          done();
+        }
+      }
+      instance = renderWithProvider(<PocketStories page={"NEW_TAB"} dispatch={dispatch}
+        stories={fakePocketStories} topics={fakePocketTopics} />);
+      TestUtils.Simulate.click(TestUtils.scryRenderedDOMComponentsWithClass(instance, "pocket-read-more-link")[1]);
+    });
+    it("should fire a click event when 'read more' is clicked", done => {
+      function dispatch(a) {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.event, "CLICK");
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "RECOMMENDED");
+          assert.equal(a.data.action_position, POCKET_TOPICS_LENGTH);
+          assert.equal(a.data.recommender_type, "trending");
+          assert.equal(a.data.url, pocket_read_more_endpoint);
+          done();
+        }
+      }
+      instance = renderWithProvider(<PocketStories page={"NEW_TAB"} dispatch={dispatch}
+        stories={fakePocketStories} topics={fakePocketTopics} />);
+      TestUtils.Simulate.click(TestUtils.scryRenderedDOMComponentsWithClass(instance, "pocket-read-even-more")[0]);
     });
   });
 


### PR DESCRIPTION
After discussion, we decided the simplest way is to use default events as "impression stats" won't add much value (trending topic don't seem to change much.)