### PR TITLE
feat(mc): #2507 Add ActivityStreamPrefs.jsm to manage default prefs

### DIFF
--- a/docs/v2-system-addon/preferences.md
+++ b/docs/v2-system-addon/preferences.md
@@ -1,0 +1,59 @@
+# Preferences in Activity Stream
+
+## Preference branch
+
+The preference branch for activity stream is `browser.newtabpage.activity-stream.`.
+Any preferences defined in the preference configuration will be relative to that
+branch. For example, if a preference is defined with the name `foo`, the full
+preference as it is displayed in `about:config` will be `browser.newtabpage.activity-stream.foo`.
+
+## Defining new preferences
+
+All preferences for Activity Stream should be defined in the `PREFS_CONFIG` Array
+found in [lib/ActivityStream.jsm](../../system-addon/lib/ActivityStream.jsm).
+The configuration object should have a `name` (the name of the pref), a `title`
+that describes the functionality of the pref, and a `value`, the default value
+of the pref. For example:
+
+```js
+{
+  name: "telemetry.log",
+  title: "Log telemetry events in the console",
+  value: false
+}
+```
+
+## Reading, setting, and observing preferences from `.jsm`s
+
+To read/set/observe Activity Stream preferences, construct a `Prefs` instance found in [lib/ActivityStreamPrefs.jsm](../../system-addon/lib/ActivityStreamPrefs.jsm).
+
+```js
+// Import Prefs
+XPCOMUtils.defineLazyModuleGetter(this, "Prefs",
+  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
+
+// Create an instance
+const prefs = new Prefs();
+```
+
+The `Prefs` utility will set the Activity Stream branch for you by default, so you
+don't need to worry about prefixing every pref with `browser.newtabpage.activity-stream.`:
+
+```js
+const prefs = new Prefs();
+
+// This will return the value of browser.newtabpage.activity-stream.foo
+prefs.get("foo");
+
+// This will set the value of browser.newtabpage.activity-stream.foo to true
+prefs.set("foo", true)
+
+// This will call aCallback when browser.newtabpage.activity-stream.foo is changed
+prefs.observe("foo", aCallback);
+
+// This will stop listening to browser.newtabpage.activity-stream.foo
+prefs.ignore("foo", aCallback);
+```
+
+See [toolkit/modules/Preferences.jsm](https://dxr.mozilla.org/mozilla-central/source/toolkit/modules/Preferences.jsm)
+for more information about what methods are available.

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -75,7 +75,6 @@ function init(reason) {
 function uninit(reason) {
   if (activityStream) {
     activityStream.uninit(reason);
-    activityStream = null;
   }
 }
 
@@ -156,4 +155,9 @@ this.shutdown = function shutdown(data, reason) {
   modulesToUnload.forEach(Cu.unload);
 };
 
-this.uninstall = function uninstall(data, reason) {};
+this.uninstall = function uninstall(data, reason) {
+  if (activityStream) {
+    activityStream.uninstall(reason);
+    activityStream = null;
+  }
+};

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -8,6 +8,11 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 const {Store} = Cu.import("resource://activity-stream/lib/Store.jsm", {});
 const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
+const REASON_ADDON_UNINSTALL = 6;
+
+XPCOMUtils.defineLazyModuleGetter(this, "DefaultPrefs",
+  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
+
 // Feeds
 XPCOMUtils.defineLazyModuleGetter(this, "LocalizationFeed",
   "resource://activity-stream/lib/LocalizationFeed.jsm");
@@ -24,20 +29,67 @@ XPCOMUtils.defineLazyModuleGetter(this, "TelemetryFeed",
 XPCOMUtils.defineLazyModuleGetter(this, "TopSitesFeed",
   "resource://activity-stream/lib/TopSitesFeed.jsm");
 
-const feeds = {
-  // When you add a feed here:
-  // 1. The key in this object should directly refer to a pref, not including the
-  //    prefix (so "feeds.newtabinit" refers to the
-  //    "browser.newtabpage.activity-stream.feeds.newtabinit" pref)
-  // 2. The value should be a function that returns a feed.
+const PREFS_CONFIG = [
+  // When you add a feed pref here:
+  // 1. The pref should be prefixed with "feeds."
+  // 2. The init property should be a function that instantiates your Feed
   // 3. You should use XPCOMUtils.defineLazyModuleGetter to import the Feed,
   //    so it isn't loaded until the feed is enabled.
-  "feeds.localization": () => new LocalizationFeed(),
-  "feeds.newtabinit": () => new NewTabInit(),
-  "feeds.places": () => new PlacesFeed(),
-  "feeds.telemetry": () => new TelemetryFeed(),
-  "feeds.topsites": () => new TopSitesFeed()
-};
+  {
+    name: "feeds.localization",
+    title: "Initialize strings and detect locale for Activity Stream",
+    value: true,
+    init: () => new LocalizationFeed()
+  },
+  {
+    name: "feeds.newtabinit",
+    title: "Sends a copy of the state to each new tab that is opened",
+    value: true,
+    init: () => new NewTabInit()
+  },
+  {
+    name: "feeds.places",
+    title: "Listens for and relays various Places-related events",
+    value: true,
+    init: () => new PlacesFeed()
+  },
+  {
+    name: "feeds.telemetry",
+    title: "Relays telemetry-related actions to TelemetrySender",
+    value: true,
+    init: () => new TelemetryFeed()
+  },
+  {
+    name: "feeds.topsites",
+    title: "Queries places and gets metadata for Top Sites section",
+    value: true,
+    init: () => new TopSitesFeed()
+  },
+  // End feeds
+
+  {
+    name: "telemetry",
+    title: "Enable system error and usage data collection",
+    value: false
+  },
+  {
+    name: "telemetry.log",
+    title: "Log telemetry events in the console",
+    value: false
+  },
+  {
+    name: "telemetry.ping.endpoint",
+    title: "Telemetry server endpoint",
+    value: "https://tiles.services.mozilla.com/v3/links/activity-stream"
+  }
+];
+
+const feeds = {};
+for (const pref of PREFS_CONFIG) {
+  if (pref.name.match(/^feeds\./)) {
+    feeds[pref.name] = pref.init;
+  }
+}
 
 this.ActivityStream = class ActivityStream {
 
@@ -54,9 +106,11 @@ this.ActivityStream = class ActivityStream {
     this.options = options;
     this.store = new Store();
     this.feeds = feeds;
+    this._defaultPrefs = new DefaultPrefs(PREFS_CONFIG);
   }
   init() {
     this.initialized = true;
+    this._defaultPrefs.init();
     this.store.init(this.feeds);
     this.store.dispatch({
       type: at.INIT,
@@ -66,7 +120,16 @@ this.ActivityStream = class ActivityStream {
   uninit() {
     this.store.dispatch({type: at.UNINIT});
     this.store.uninit();
+
     this.initialized = false;
+  }
+  uninstall(reason) {
+    if (reason === REASON_ADDON_UNINSTALL) {
+      // This resets all prefs in the config to their default values,
+      // so we DON'T want to do this on an upgrade/downgrade, only on a
+      // real uninstall
+      this._defaultPrefs.reset();
+    }
   }
 };
 

--- a/system-addon/lib/ActivityStreamPrefs.jsm
+++ b/system-addon/lib/ActivityStreamPrefs.jsm
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+
+const ACTIVITY_STREAM_PREF_BRANCH = "browser.newtabpage.activity-stream.";
+
+this.Prefs = class Prefs extends Preferences {
+
+  /**
+   * Prefs - A wrapper around Preferences that always sets the branch to
+   *         ACTIVITY_STREAM_PREF_BRANCH
+   */
+  constructor(branch = ACTIVITY_STREAM_PREF_BRANCH) {
+    super({branch});
+    this._branchName = branch;
+  }
+  get branchName() {
+    return this._branchName;
+  }
+};
+
+this.DefaultPrefs = class DefaultPrefs {
+
+  /**
+   * DefaultPrefs - A helper for setting and resetting default prefs for the add-on
+   *
+   * @param  {Array} config An array of configuration objects with the following properties:
+   *         {string} .name The name of the pref
+   *         {string} .title (optional) A description of the pref
+   *         {bool|string|number} .value The default value for the pref
+   * @param  {string} branch (optional) The pref branch (defaults to ACTIVITY_STREAM_PREF_BRANCH)
+   */
+  constructor(config, branch = ACTIVITY_STREAM_PREF_BRANCH) {
+    this._config = config;
+    this.branch = Services.prefs.getDefaultBranch(branch);
+  }
+
+  /**
+   * _setDefaultPref - Sets the default value (not user-defined) for a given pref
+   *
+   * @param  {string} key The name of the pref
+   * @param  {type} val The default value of the pref
+   */
+  _setDefaultPref(key, val) {
+    switch (typeof val) {
+      case "boolean":
+        this.branch.setBoolPref(key, val);
+        break;
+      case "number":
+        this.branch.setIntPref(key, val);
+        break;
+      case "string":
+        this.branch.setStringPref(key, val);
+        break;
+    }
+  }
+
+  /**
+   * init - Set default prefs for all prefs in the config
+   */
+  init() {
+    for (const pref of this._config) {
+      this._setDefaultPref(pref.name, pref.value);
+    }
+  }
+
+  /**
+   * reset - Resets all user-defined prefs for prefs in ._config to their defaults
+   */
+  reset() {
+    for (const pref of this._config) {
+      this.branch.clearUserPref(pref.name);
+    }
+  }
+};
+
+this.EXPORTED_SYMBOLS = ["DefaultPrefs", "Prefs"];

--- a/system-addon/lib/Store.jsm
+++ b/system-addon/lib/Store.jsm
@@ -8,9 +8,10 @@ const {utils: Cu} = Components;
 const {redux} = Cu.import("resource://activity-stream/vendor/Redux.jsm", {});
 const {reducers} = Cu.import("resource://activity-stream/common/Reducers.jsm", {});
 const {ActivityStreamMessageChannel} = Cu.import("resource://activity-stream/lib/ActivityStreamMessageChannel.jsm", {});
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-const PREF_PREFIX = "browser.newtabpage.activity-stream.";
-Cu.import("resource://gre/modules/Preferences.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "Prefs",
+  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
 
 /**
  * Store - This has a similar structure to a redux store, but includes some extra
@@ -36,6 +37,7 @@ this.Store = class Store {
     });
     this.feeds = new Map();
     this._feedFactories = null;
+    this._prefs = new Prefs();
     this._prefHandlers = new Map();
     this._messageChannel = new ActivityStreamMessageChannel({dispatch: this.dispatch});
     this._store = redux.createStore(
@@ -93,37 +95,32 @@ this.Store = class Store {
    * @param  {string} name The name of a feed, as defined in the object passed
    *                       to Store.init
    */
-  maybeStartFeedAndListenForPrefChanges(name) {
-    const prefName = PREF_PREFIX + name;
-
-    // If the pref was never set, set it to true by default.
-    if (!Preferences.has(prefName)) {
-      Preferences.set(prefName, true);
-    }
-
+  maybeStartFeedAndListenForPrefChanges(prefName) {
     // Create a listener that turns the feed off/on based on changes
     // to the pref, and cache it so we can unlisten on shut-down.
-    const onPrefChanged = isEnabled => (isEnabled ? this.initFeed(name) : this.uninitFeed(name));
+    const onPrefChanged = isEnabled => (isEnabled ? this.initFeed(prefName) : this.uninitFeed(prefName));
     this._prefHandlers.set(prefName, onPrefChanged);
-    Preferences.observe(prefName, onPrefChanged);
+    this._prefs.observe(prefName, onPrefChanged);
 
     // TODO: This should propbably be done in a generic pref manager for Activity Stream.
     // If the pref is true, start the feed immediately.
-    if (Preferences.get(prefName)) {
-      this.initFeed(name);
+    if (this._prefs.get(prefName)) {
+      this.initFeed(prefName);
     }
   }
 
   /**
    * init - Initializes the ActivityStreamMessageChannel channel, and adds feeds.
    *
-   * @param  {array} feeds An array of objects with an optional .onAction method
+   * @param  {array} feedConstructors An array of configuration objects for feeds
+   *                 each with .name (the name of the pref for the feed) and .init,
+   *                 a function that returns an instance of the feed
    */
   init(feedConstructors) {
     if (feedConstructors) {
       this._feedFactories = feedConstructors;
-      for (const name of Object.keys(feedConstructors)) {
-        this.maybeStartFeedAndListenForPrefChanges(name);
+      for (const pref of Object.keys(feedConstructors)) {
+        this.maybeStartFeedAndListenForPrefChanges(pref);
       }
     }
     this._messageChannel.createChannel();
@@ -137,7 +134,7 @@ this.Store = class Store {
    */
   uninit() {
     this.feeds.forEach(feed => this.uninitFeed(feed));
-    this._prefHandlers.forEach((handler, pref) => Preferences.ignore(pref, handler));
+    this._prefHandlers.forEach((handler, pref) => this._prefs.ignore(pref, handler));
     this._prefHandlers.clear();
     this._feedFactories = null;
     this.feeds.clear();
@@ -145,5 +142,4 @@ this.Store = class Store {
   }
 };
 
-this.PREF_PREFIX = PREF_PREFIX;
-this.EXPORTED_SYMBOLS = ["Store", "PREF_PREFIX"];
+this.EXPORTED_SYMBOLS = ["Store"];

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -1,5 +1,7 @@
 const injector = require("inject!lib/ActivityStream.jsm");
 
+const REASON_ADDON_UNINSTALL = 6;
+
 describe("ActivityStream", () => {
   let sandbox;
   let as;
@@ -18,6 +20,8 @@ describe("ActivityStream", () => {
     as = new ActivityStream();
     sandbox.stub(as.store, "init");
     sandbox.stub(as.store, "uninit");
+    sandbox.stub(as._defaultPrefs, "init");
+    sandbox.stub(as._defaultPrefs, "reset");
   });
 
   afterEach(() => sandbox.restore());
@@ -32,6 +36,9 @@ describe("ActivityStream", () => {
     beforeEach(() => {
       as.init();
     });
+    it("should initialize default prefs", () => {
+      assert.calledOnce(as._defaultPrefs.init);
+    });
     it("should set .initialized to true", () => {
       assert.isTrue(as.initialized, ".initialized");
     });
@@ -42,6 +49,7 @@ describe("ActivityStream", () => {
       as = new ActivityStream({version: "1.2.3"});
       sandbox.stub(as.store, "init");
       sandbox.stub(as.store, "dispatch");
+      sandbox.stub(as._defaultPrefs, "init");
 
       as.init();
 
@@ -60,6 +68,16 @@ describe("ActivityStream", () => {
     });
     it("should call .store.uninit", () => {
       assert.calledOnce(as.store.uninit);
+    });
+  });
+  describe("#uninstall", () => {
+    it("should reset default prefs if the reason is REASON_ADDON_UNINSTALL", () => {
+      as.uninstall(REASON_ADDON_UNINSTALL);
+      assert.calledOnce(as._defaultPrefs.reset);
+    });
+    it("should not reset default prefs if the reason is something else", () => {
+      as.uninstall("foo");
+      assert.notCalled(as._defaultPrefs.reset);
     });
   });
   describe("feeds", () => {

--- a/system-addon/test/unit/lib/ActivityStreamPrefs.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamPrefs.test.js
@@ -1,0 +1,63 @@
+const ACTIVITY_STREAM_PREF_BRANCH = "browser.newtabpage.activity-stream.";
+const {Prefs, DefaultPrefs} = require("lib/ActivityStreamPrefs.jsm");
+
+const TEST_PREF_CONFIG = [
+  {name: "foo", value: true},
+  {name: "bar", value: "BAR"},
+  {name: "baz", value: 1}
+];
+
+describe("ActivityStreamPrefs", () => {
+  describe("Prefs", () => {
+    it("should have get, set, and observe methods", () => {
+      const p = new Prefs();
+      assert.property(p, "get");
+      assert.property(p, "set");
+      assert.property(p, "observe");
+    });
+    describe(".branchName", () => {
+      it("should return the activity stream branch by default", () => {
+        const p = new Prefs();
+        assert.equal(p.branchName, ACTIVITY_STREAM_PREF_BRANCH);
+      });
+      it("should return the custom branch name if it was passed to the constructor", () => {
+        const p = new Prefs("foo");
+        assert.equal(p.branchName, "foo");
+      });
+    });
+  });
+
+  describe("DefaultPrefs", () => {
+    describe("#init", () => {
+      let defaultPrefs;
+      beforeEach(() => {
+        defaultPrefs = new DefaultPrefs(TEST_PREF_CONFIG);
+        sinon.spy(defaultPrefs.branch, "setBoolPref");
+        sinon.spy(defaultPrefs.branch, "setStringPref");
+        sinon.spy(defaultPrefs.branch, "setIntPref");
+      });
+      it("should initialize a boolean pref", () => {
+        defaultPrefs.init();
+        assert.calledWith(defaultPrefs.branch.setBoolPref, "foo", true);
+      });
+      it("should initialize a string pref", () => {
+        defaultPrefs.init();
+        assert.calledWith(defaultPrefs.branch.setStringPref, "bar", "BAR");
+      });
+      it("should initialize a integer pref", () => {
+        defaultPrefs.init();
+        assert.calledWith(defaultPrefs.branch.setIntPref, "baz", 1);
+      });
+    });
+    describe("#reset", () => {
+      it("should clear user preferences for each pref in the config", () => {
+        const defaultPrefs = new DefaultPrefs(TEST_PREF_CONFIG);
+        sinon.spy(defaultPrefs.branch, "clearUserPref");
+        defaultPrefs.reset();
+        for (const pref of TEST_PREF_CONFIG) {
+          assert.calledWith(defaultPrefs.branch.clearUserPref, pref.name);
+        }
+      });
+    });
+  });
+});

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -1,4 +1,4 @@
-const {GlobalOverrider} = require("test/unit/utils");
+const {GlobalOverrider, FakePrefs} = require("test/unit/utils");
 const {chaiAssertions} = require("test/schemas/pings");
 
 const req = require.context(".", true, /\.test\.jsx?$/);
@@ -24,6 +24,7 @@ overrider.set({
   ContentSearchUIController: function() {}, // NB: This is a function/constructor
   dump() {},
   fetch() {},
+  Preferences: FakePrefs,
   Services: {
     locale: {getRequestedLocale() {}},
     mm: {
@@ -33,6 +34,16 @@ overrider.set({
     obs: {
       addObserver() {},
       removeObserver() {}
+    },
+    prefs: {
+      getDefaultBranch() {
+        return {
+          setBoolPref() {},
+          setIntPref() {},
+          setStringPref() {},
+          clearUserPref() {}
+        };
+      }
     }
   },
   XPCOMUtils: {


### PR DESCRIPTION
This patch adds default pref setting to Activity Stream, including for feeds. The pref configuration is stored in `ActivityStream.jsm` although theoretically this could be moved to a separate file.

The schema for prefs is pretty much the same as in `package.json`, although it does allow for different values to be set in different contexts:

```
{
  {
    name: "telemetry",
    title: "Enable system error and usage data collection",
    value: false
  },
  {
    name: "pocket",
    title: "Some other pref about pocket",
    values: {
      nightly: true, // In nightly, the default value will be true
      default: false // In other builds, the default will be false
    }
  },
}
```