### PR TITLE
fix(content): #2637 Pocket info modal needs a faster fade-in-out

### DIFF
--- a/content-src/components/PocketStories/PocketStories.scss
+++ b/content-src/components/PocketStories/PocketStories.scss
@@ -37,7 +37,7 @@
     .pocket-info div {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 1s, opacity 0.7s ease-in-out;
+      transition: visibility 0.5s, opacity 0.5s ease-in-out;
     }
 
     .pocket-info:hover div {


### PR DESCRIPTION

![take7 mov](https://cloud.githubusercontent.com/assets/472523/26511276/5323bbd2-422f-11e7-803e-5f673d292456.gif)

