### PR TITLE
feat(performance): #2539 Add perf telemetry + infrastructure

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -109,6 +109,8 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `highlight_type` | [Optional] Either ["bookmarks", "recommendation", "history"]. | :one:
 | `ip` | [Auto populated by Onyx] The IP address of the client. | :two:
 | `locale` | [Auto populated by Onyx] The browser chrome's language (eg. en-US). | :two:
+| `load_trigger_ts` | [Optional] DOMHighResTimeStamp of the action perceived by the user to trigger the load of this page. | :one:
+| `load_trigger_type` | [Optional] Currently only "menu_plus_or_keyboard" allowed. | :one:
 | `metadata_source` | [Optional] The source of which we computed metadata. Either (`MetadataService` or `Local` or `TippyTopProvider`). | :one:
 | `page` | [Required] Either ["NEW_TAB", "HOME"]. | :one:
 | `recommender_type` | [Optional] The type of recommendation that is being shown, if any. | :one:
@@ -128,7 +130,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `topsites_screenshot` | [Optional] The size of the Topsites set with screenshot metadata. | :one:
 | `topsites_tippytop` | [Optional] The size of the Topsites set with TippyTop metadata. | :one:
 | `user_prefs` | [optional] The encoded integer of user's preferences. | :one: & :four:
-
+| `visibility_event_rcvd_ts` | [Optional] DOMHighResTimeStamp of when the page itself receives an event that document.visibilityState == visible. | :one:
 
 **Where:**
 

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -225,3 +225,30 @@ Here are different scenarios that cause a session end event to be sent:
 3. Closing the browser
 5. Refreshing
 6. Navigating to a new URL via the url bar or file menu
+
+
+### Session performance data
+
+This data is held in a child object of the `activity_stream_session` event called `perf`.  All fields suffixed by `_ts` are type `DOMHighResTimeStamp` (aka a double of milliseconds, with a 5 microsecond precision) with 0 being the [timeOrigin](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp#The_time_origin) of the browser's hidden chrome window.
+
+An example might look like this:
+
+```javascript
+perf: {
+  // Timestamp of the action perceived by the user to trigger the load
+  // of this page.
+  //
+  // Not required at least for error cases where the
+  // observer event doesn't fire
+  "load_trigger_ts": 1,
+
+  // What was the perceived trigger of the load action:
+  "load_trigger_type": [
+    "menu_plus_or_keyboard" // newtab only
+  ],
+
+  // when the page itself receives an event that document.visibilityStat=visible
+  // TO BE IMPLEMENTED: https://github.com/mozilla/activity-stream/issues/2539
+  "visibility_event_rcvd_ts": 2,
+}
+```

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "sass-lint": "1.10.1",
     "shelljs": "0.7.6",
     "simple-git": "1.65.0",
-    "sinon": "2.1.0",
+    "sinon": "2.3.4",
     "style-loader": "0.13.1",
     "svgo": "0.7.1",
     "webpack": "2.2.1",

--- a/system-addon/common/PerfService.jsm
+++ b/system-addon/common/PerfService.jsm
@@ -4,9 +4,10 @@
 let usablePerfObj;
 
 let Cu;
+const isRunningInChrome = typeof Window === "undefined";
 
 /* istanbul ignore if */
-if (typeof Window === "undefined") {
+if (isRunningInChrome) {
   Cu = Components.utils;
 } else {
   Cu = {import() {}};
@@ -15,7 +16,7 @@ if (typeof Window === "undefined") {
 Cu.import("resource://gre/modules/Services.jsm");
 
 /* istanbul ignore if */
-if (typeof Window === "undefined") {
+if (isRunningInChrome) {
   // Borrow the high-resolution timer from the hidden window....
   usablePerfObj = Services.appShell.hiddenDOMWindow.performance;
 } else { // we must be running in content space

--- a/system-addon/common/PerfService.jsm
+++ b/system-addon/common/PerfService.jsm
@@ -13,8 +13,6 @@ if (typeof Window === "undefined") {
 }
 
 Cu.import("resource://gre/modules/Services.jsm");
-// XXX only if profiling turned on by pref
-Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
 
 /* istanbul ignore if */
 if (typeof Window === "undefined") {

--- a/system-addon/common/PerfService.jsm
+++ b/system-addon/common/PerfService.jsm
@@ -4,6 +4,8 @@
 let usablePerfObj;
 
 let Cu;
+
+/* istanbul ignore if */
 if (typeof Window === "undefined") {
   Cu = Components.utils;
 } else {
@@ -14,7 +16,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 // XXX only if profiling turned on by pref
 Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
 
-// if we're running in an addon module
+/* istanbul ignore if */
 if (typeof Window === "undefined") {
   // Borrow the high-resolution timer from the hidden window....
   usablePerfObj = Services.appShell.hiddenDOMWindow.performance;

--- a/system-addon/common/PerfService.jsm
+++ b/system-addon/common/PerfService.jsm
@@ -1,0 +1,94 @@
+/* globals Services */
+"use strict";
+
+let usablePerfObj;
+
+let Cu;
+if (typeof Window === "undefined") {
+  Cu = Components.utils;
+} else {
+  Cu = {import() {}};
+}
+
+Cu.import("resource://gre/modules/Services.jsm");
+// XXX only if profiling turned on by pref
+Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
+
+// if we're running in an addon module
+if (typeof Window === "undefined") {
+  // Borrow the high-resolution timer from the hidden window....
+  usablePerfObj = Services.appShell.hiddenDOMWindow.performance;
+} else { // we must be running in content space
+  usablePerfObj = performance;
+}
+
+this._PerfService = function _PerfService(options) {
+  // For testing, so that we can use a fake Window.performance object with
+  // known state.
+  if (options && options.performanceObj) {
+    this._perf = options.performanceObj;
+  } else {
+    this._perf = usablePerfObj;
+  }
+};
+
+_PerfService.prototype = {
+  /**
+   * Calls the underlying mark() method on the appropriate Window.performance
+   * object to add a mark with the given name to the appropriate performance
+   * timeline.
+   *
+   * @param  {String} name  the name to give the current mark
+   * @return {void}
+   */
+  mark: function mark(str) {
+    this._perf.mark(str);
+  },
+
+  /**
+   * Calls the underlying getEntriesByName on the appropriate Window.performance
+   * object.
+   *
+   * @param  {String} name
+   * @param  {String} type eg "mark"
+   * @return {Array}       Performance* objects
+   */
+  getEntriesByName: function getEntriesByName(name, type) {
+    return this._perf.getEntriesByName(name, type);
+  },
+
+  /**
+   * The timeOrigin property from the appropriate performance object.
+   * Used to ensure that timestamps from the add-on code and the content code
+   * are comparable.
+   *
+   * @return {Number} A double of milliseconds with a precision of 0.5us.
+   */
+  get timeOrigin() {
+    return this._perf.timeOrigin;
+  },
+
+  /**
+   * This returns the startTime from the most recen!t performance.mark()
+   * with the given name.
+   *
+   * @param  {String} name  the name to lookup the start time for
+   *
+   * @return {Number}       the returned start time, as a DOMHighResTimeStamp
+   *
+   * @throws {Error}        "No Marks with the name ..." if none are available
+   */
+  getMostRecentAbsMarkStartByName(name) {
+    let entries = this.getEntriesByName(name, "mark");
+
+    if (!entries.length) {
+      throw new Error(`No marks with the name ${name}`);
+    }
+
+    let mostRecentEntry = entries[entries.length - 1];
+    return this._perf.timeOrigin + mostRecentEntry.startTime;
+  }
+};
+
+this.perfService = new _PerfService();
+this.EXPORTED_SYMBOLS = ["_PerfService", "perfService"];

--- a/system-addon/content-src/lib/detect-user-session-start.js
+++ b/system-addon/content-src/lib/detect-user-session-start.js
@@ -9,7 +9,7 @@ module.exports = class DetectUserSessionStart {
     // Overrides for testing
     this.sendAsyncMessage = options.sendAsyncMessage || window.sendAsyncMessage;
     this.document = options.document || document;
-    this.perfService = options.perfService || perfSvc;
+    this._perfService = options.perfService || perfSvc;
     this._onVisibilityChange = this._onVisibilityChange.bind(this);
   }
 
@@ -36,9 +36,9 @@ module.exports = class DetectUserSessionStart {
    *              visibility-change-event time in ms from the UNIX epoch.
    */
   _sendEvent() {
-    this.perfService.mark("visibility-change-event");
+    this._perfService.mark("visibility-change-event");
 
-    let absVisChangeTime = this.perfService
+    let absVisChangeTime = this._perfService
         .getMostRecentAbsMarkStartByName("visibility-change-event");
 
     this.sendAsyncMessage("ActivityStream:ContentToMain", {

--- a/system-addon/content-src/lib/detect-user-session-start.js
+++ b/system-addon/content-src/lib/detect-user-session-start.js
@@ -1,4 +1,5 @@
 const {actionTypes: at} = require("common/Actions.jsm");
+const {perfService: perfSvc} = require("common/PerfService.jsm");
 
 const VISIBLE = "visible";
 const VISIBILITY_CHANGE_EVENT = "visibilitychange";
@@ -8,7 +9,7 @@ module.exports = class DetectUserSessionStart {
     // Overrides for testing
     this.sendAsyncMessage = options.sendAsyncMessage || window.sendAsyncMessage;
     this.document = options.document || document;
-
+    this.perfService = options.perfService || perfSvc;
     this._onVisibilityChange = this._onVisibilityChange.bind(this);
   }
 
@@ -30,11 +31,20 @@ module.exports = class DetectUserSessionStart {
   }
 
   /**
-   * _sendEvent - Sends a message to the main process to indicate the current tab
-   *             is now visible to the user.
+   * _sendEvent - Sends a message to the main process to indicate the current
+   *              tab is now visible to the user, includes the
+   *              visibility-change-event time in ms from the UNIX epoch.
    */
   _sendEvent() {
-    this.sendAsyncMessage("ActivityStream:ContentToMain", {type: at.NEW_TAB_VISIBLE});
+    this.perfService.mark("visibility-change-event");
+
+    let absVisChangeTime = this.perfService
+        .getMostRecentAbsMarkStartByName("visibility-change-event");
+
+    this.sendAsyncMessage("ActivityStream:ContentToMain", {
+      type: at.NEW_TAB_VISIBLE,
+      data: {absVisibilityChangeTime: absVisChangeTime}
+    });
   }
 
   /**

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -11,8 +11,6 @@ const {perfService} = Cu.import("resource://activity-stream/common/PerfService.j
 
 Cu.import("resource://gre/modules/ClientID.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-
-// XXX only when preffed on?
 Cu.import("resource://gre/modules/Services.jsm");
 
 XPCOMUtils.defineLazyServiceGetter(this, "gUUIDGenerator",

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -48,8 +48,25 @@ this.TelemetryFeed = class TelemetryFeed {
    *                                   document.visibilityState becoming visible
    */
   addSession(id, absVisChangeTime) {
-    // XXX note that there is a race condition here; we're assuming that the
-    // most recent tab
+    // XXX note that there is a race condition here; we're assuming that no
+    // other tab will be interleaving calls to browserOpenNewtabStart and
+    // addSession on this object.  For manually created windows, it's hard to
+    // imagine us hitting this race condition.
+    //
+    // However, for session restore, where multiple windows with multiple tabs
+    // might be restored much closer together in time, it's somewhat less hard,
+    // though it should still be pretty rare.
+    //
+    // The fix to this would be making all of the load-trigger notifications
+    // return some data with their notifications, and somehow propagate that
+    // data through closures into the tab itself so that we could match them
+    //
+    // As of this writing (very early days of system add-on perf telemetry),
+    // the hypothesis is that hitting this race should be so rare that makes
+    // more sense to live with the slight data inaccuracy that it would
+    // introduce, rather than doing the correct by complicated thing.  It may
+    // well be worth reexamining this hypothesis after we have more experience
+    // with the data.
     let absBrowserOpenTabStart =
       perfService.getMostRecentAbsMarkStartByName("browser-open-newtab-start");
 

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -37,8 +37,8 @@ this.TelemetryFeed = class TelemetryFeed {
     const id = await ClientID.getClientID();
     this.telemetryClientId = id;
   }
+
   browserOpenTabStart() {
-    // XXX comment on race condition here
     perfService.mark("browser-open-tab-start");
   }
 
@@ -50,6 +50,7 @@ this.TelemetryFeed = class TelemetryFeed {
    *                                   document.visibilityState becoming visible
    */
   addSession(id, absVisChangeTime) {
+    // XXX note that there is a race condition here; test for this?
     let absBrowserOpenTabStart =
       perfService.getMostRecentAbsMarkStartByName("browser-open-tab-start");
 

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -60,7 +60,7 @@ this.TelemetryFeed = class TelemetryFeed {
       perf: {
         load_trigger_ts: absBrowserOpenTabStart,
         load_trigger_type: "menu_plus_or_keyboard",
-        visibility_event_fired: absVisChangeTime
+        visibility_event_rcvd_ts: absVisChangeTime
       }
     });
 
@@ -146,7 +146,8 @@ this.TelemetryFeed = class TelemetryFeed {
         session_id: session.session_id,
         page: session.page,
         session_duration: session.session_duration,
-        action: "activity_stream_session"
+        action: "activity_stream_session",
+        perf: session.perf
       }
     );
   }

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -29,7 +29,7 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   async init() {
-    Services.obs.addObserver(this.browserOpenTabStart, "browser-open-tab-start");
+    Services.obs.addObserver(this.browserOpenNewtabStart, "browser-open-newtab-start");
 
     // TelemetrySender adds pref observers, so we initialize it after INIT
     this.telemetrySender = new TelemetrySender();
@@ -38,8 +38,8 @@ this.TelemetryFeed = class TelemetryFeed {
     this.telemetryClientId = id;
   }
 
-  browserOpenTabStart() {
-    perfService.mark("browser-open-tab-start");
+  browserOpenNewtabStart() {
+    perfService.mark("browser-open-newtab-start");
   }
 
   /**
@@ -50,9 +50,10 @@ this.TelemetryFeed = class TelemetryFeed {
    *                                   document.visibilityState becoming visible
    */
   addSession(id, absVisChangeTime) {
-    // XXX note that there is a race condition here; test for this?
+    // XXX note that there is a race condition here; we're assuming that the
+    // most recent tab
     let absBrowserOpenTabStart =
-      perfService.getMostRecentAbsMarkStartByName("browser-open-tab-start");
+      perfService.getMostRecentAbsMarkStartByName("browser-open-newtab-start");
 
     this.sessions.set(id, {
       start_time: Components.utils.now(),
@@ -181,8 +182,8 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   uninit() {
-    Services.obs.removeObserver(this.browserOpenTabStart,
-      "browser-open-tab-start");
+    Services.obs.removeObserver(this.browserOpenNewtabStart,
+      "browser-open-newtab-start");
 
     this.telemetrySender.uninit();
     this.telemetrySender = null;

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -6,7 +6,6 @@ const {interfaces: Ci, utils: Cu} = Components;
 
 Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.importGlobalProperties(["fetch"]);
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
 

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -15,9 +15,9 @@ Cu.import("resource://gre/modules/UITelemetry.jsm");
 // installed.  Though maybe we should just forcibly disable the old add-on?
 const PREF_BRANCH = "browser.newtabpage.activity-stream.";
 
-const ENDPOINT_PREF = "telemetry.ping.endpoint";
-const TELEMETRY_PREF = "telemetry";
-const LOGGING_PREF = "telemetry.log";
+const ENDPOINT_PREF = `${PREF_BRANCH}telemetry.ping.endpoint`;
+const TELEMETRY_PREF = `${PREF_BRANCH}telemetry`;
+const LOGGING_PREF = `${PREF_BRANCH}telemetry.log`;
 
 /**
  * Observe various notifications and send them to a telemetry endpoint.
@@ -32,7 +32,7 @@ const LOGGING_PREF = "telemetry.log";
  *
  */
 function TelemetrySender(args) {
-  let prefArgs = {branch: PREF_BRANCH};
+  let prefArgs = {};
   if (args) {
     if ("prefInitHook" in args) {
       prefArgs.initHook = args.prefInitHook;

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -8,7 +8,6 @@ Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.importGlobalProperties(["fetch"]);
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
-Cu.import("resource://gre/modules/UITelemetry.jsm");
 
 // This is intentionally a different pref-branch than the SDK-based add-on
 // used, to avoid extra weirdness for people who happen to have the SDK-based
@@ -27,22 +26,12 @@ const LOGGING_PREF = `${PREF_BRANCH}telemetry.log`;
  *                   inside the Prefs constructor. Typically used from tests
  *                   to save off a pointer to a fake Prefs instance so that
  *                   stubs and spies can be inspected by the test code.
- * @param {Function} args.UITelemetry - if present will be used instead of the
- *                   global UITelemetry from UITelemtry.jsm
- *
  */
 function TelemetrySender(args) {
   let prefArgs = {};
   if (args) {
     if ("prefInitHook" in args) {
       prefArgs.initHook = args.prefInitHook;
-    }
-
-    /* istanbul ignore else */
-    if ("UITelemetry" in args) {
-      this._UITelemetry = args.UITelemetry;
-    } else {
-      this._UITelemetry = UITelemetry;
     }
   }
 
@@ -61,7 +50,7 @@ function TelemetrySender(args) {
 
 TelemetrySender.prototype = {
   get enabled() {
-    return this._enabled && this._UITelemetry.enabled;
+    return this._enabled;
   },
 
   _onLoggingPrefChange(prefVal) {

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -18,6 +18,8 @@ const ENDPOINT_PREF = `${PREF_BRANCH}telemetry.ping.endpoint`;
 const TELEMETRY_PREF = `${PREF_BRANCH}telemetry`;
 const LOGGING_PREF = `${PREF_BRANCH}telemetry.log`;
 
+const FHR_UPLOAD_ENABLED_PREF = "datareporting.healthreport.uploadEnabled";
+
 /**
  * Observe various notifications and send them to a telemetry endpoint.
  *
@@ -41,6 +43,10 @@ function TelemetrySender(args) {
   this._onTelemetryPrefChange = this._onTelemetryPrefChange.bind(this);
   this._prefs.observe(TELEMETRY_PREF, this._onTelemetryPrefChange);
 
+  this._fhrEnabled = this._prefs.get(FHR_UPLOAD_ENABLED_PREF);
+  this._onFhrPrefChange = this._onFhrPrefChange.bind(this);
+  this._prefs.observe(FHR_UPLOAD_ENABLED_PREF, this._onFhrPrefChange);
+
   this.logging = this._prefs.get(LOGGING_PREF);
   this._onLoggingPrefChange = this._onLoggingPrefChange.bind(this);
   this._prefs.observe(LOGGING_PREF, this._onLoggingPrefChange);
@@ -50,7 +56,7 @@ function TelemetrySender(args) {
 
 TelemetrySender.prototype = {
   get enabled() {
-    return this._enabled;
+    return this._enabled && this._fhrEnabled;
   },
 
   _onLoggingPrefChange(prefVal) {
@@ -59,6 +65,10 @@ TelemetrySender.prototype = {
 
   _onTelemetryPrefChange(prefVal) {
     this._enabled = prefVal;
+  },
+
+  _onFhrPrefChange(prefVal) {
+    this._fhrEnabled = prefVal;
   },
 
   async sendPing(data) {
@@ -84,6 +94,7 @@ TelemetrySender.prototype = {
     try {
       this._prefs.ignore(TELEMETRY_PREF, this._onTelemetryPrefChange);
       this._prefs.ignore(LOGGING_PREF, this._onLoggingPrefChange);
+      this._prefs.ignore(FHR_UPLOAD_ENABLED_PREF, this._onFhrPrefChange);
     } catch (e) {
       Cu.reportError(e);
     }
@@ -93,6 +104,7 @@ TelemetrySender.prototype = {
 this.TelemetrySender = TelemetrySender;
 this.TelemetrySenderConstants = {
   ENDPOINT_PREF,
+  FHR_UPLOAD_ENABLED_PREF,
   TELEMETRY_PREF,
   LOGGING_PREF
 };

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -65,14 +65,34 @@ const SessionPing = Joi.object().keys(Object.assign({}, baseKeys, {
   session_id: baseKeys.session_id.required(),
   page: baseKeys.page.required(),
   session_duration: Joi.number().integer().required(),
-  action: Joi.valid("activity_stream_session").required()
+  action: Joi.valid("activity_stream_session").required(),
+  perf: Joi.object().keys({
+    // Timestamp of the action perceived by the user to trigger the load
+    // of this page.
+    //
+    // Not required at least for error cases where the
+    // observer event doesn't fire
+    load_trigger_ts: Joi.number().positive(),
+    // What was the perceived trigger of the load action?
+    //
+    // Not required at least for error cases where the observer event
+    // doesn't fire
+    load_trigger_type: Joi.valid(["menu_plus_or_keyboard"]),
+    // When the page itself receives an event that document.visibilityState
+    // == visible.
+    //
+    // Not required at least for the (error?) case where the
+    // visibility_event doesn't fire.  (It's not clear whether this
+    // can happen in practice, but if it does, we'd like to know about it).
+    visibility_event_rcvd_ts: Joi.number().positive()
+  }).required()
 }));
 
 function chaiAssertions(_chai, utils) {
   const {Assertion} = _chai;
 
   Assertion.addMethod("validate", function(schema, schemaName) {
-    const {error} = Joi.validate(this._obj, schema);
+    const {error} = Joi.validate(this._obj, schema, {allowUnknown: false});
     this.assert(
       !error,
       `Expected to be ${schemaName ? `a valid ${schemaName}` : "valid"} but there were errors: ${error}`

--- a/system-addon/test/unit/common/PerfService.test.js
+++ b/system-addon/test/unit/common/PerfService.test.js
@@ -1,0 +1,84 @@
+/* globals assert, beforeEach, describe, it */
+const {_PerfService} = require("common/PerfService.jsm");
+const {FakePerformance} = require("test/unit/utils.js");
+
+let perfService;
+
+describe("_PerfService", () => {
+  let sandbox;
+  let fakePerfObj;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    fakePerfObj = new FakePerformance();
+    perfService = new _PerfService({performanceObj: fakePerfObj});
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("#getEntriesByName", () => {
+    it("should call getEntriesByName on the appropriate Window.performance",
+    () => {
+      sandbox.spy(fakePerfObj, "getEntriesByName");
+
+      perfService.getEntriesByName("monkey", "mark");
+
+      assert.calledOnce(fakePerfObj.getEntriesByName);
+      assert.calledWithExactly(fakePerfObj.getEntriesByName, "monkey", "mark");
+    });
+
+    it("should return entries with the given name", () => {
+      sandbox.spy(fakePerfObj, "getEntriesByName");
+      perfService.mark("monkey");
+      perfService.mark("dog");
+
+      let marks = perfService.getEntriesByName("monkey", "mark");
+
+      assert.isArray(marks);
+      assert.lengthOf(marks, 1);
+      assert.propertyVal(marks[0], "name", "monkey");
+    });
+  });
+
+  describe("#getMostRecentAbsMarkStartByName", () => {
+    it("should throw an error if there is no mark with the given name", () => {
+      function bogusGet() {
+        perfService.getMostRecentAbsMarkStartByName("rheeeet");
+      }
+
+      assert.throws(bogusGet, Error, /No marks with the name/);
+    });
+
+    it("should return the Number from the most recent mark with the given name + the time origin",
+      () => {
+        perfService.mark("dog");
+        perfService.mark("dog");
+
+        let absMarkStart = perfService.getMostRecentAbsMarkStartByName("dog");
+
+        // 2 because we want the result of the 2nd call to mark, and an instance
+        // of FakePerformance just returns the number of time mark has been
+        // called.
+        assert.equal(absMarkStart - perfService.timeOrigin, 2);
+      });
+  });
+
+  describe("#mark", () => {
+    it("should call the wrapped version of mark", () => {
+      sandbox.spy(fakePerfObj, "mark");
+
+      perfService.mark("monkey");
+
+      assert.calledOnce(fakePerfObj.mark);
+      assert.calledWithExactly(fakePerfObj.mark, "monkey");
+    });
+  });
+
+  describe("#timeOrigin", () => {
+    it("should get the origin of the wrapped performance object", () => {
+      assert.equal(perfService.timeOrigin, 10000); // fake origin from utils.js
+    });
+  });
+});

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -57,12 +57,12 @@ describe("TelemetryFeed", () => {
       await instance.init();
       assert.equal(instance.telemetryClientId, FAKE_TELEMETRY_ID);
     });
-    it("should make this.browserOpenTabStart() observe browser-open-tab-start", async () => {
+    it("should make this.browserOpenNewtabStart() observe browser-open-newtab-start", async () => {
       sandbox.spy(Services.obs, "addObserver");
       await instance.init();
       assert.calledOnce(Services.obs.addObserver);
       assert.calledWithExactly(Services.obs.addObserver,
-        instance.browserOpenTabStart, "browser-open-tab-start");
+        instance.browserOpenNewtabStart, "browser-open-newtab-start");
     });
   });
   describe("#addSession", () => {
@@ -87,14 +87,14 @@ describe("TelemetryFeed", () => {
       assert.equal(session.page, "about:newtab"); // This is hardcoded for now.
     });
   });
-  describe("#browserOpenTabStart", () => {
-    it("should call perfService.mark with browser-open-tab-start", () => {
+  describe("#browserOpenNewtabStart", () => {
+    it("should call perfService.mark with browser-open-newtab-start", () => {
       sandbox.stub(perfService, "mark");
 
-      instance.browserOpenTabStart();
+      instance.browserOpenNewtabStart();
 
       assert.calledOnce(perfService.mark);
-      assert.calledWithExactly(perfService.mark, "browser-open-tab-start");
+      assert.calledWithExactly(perfService.mark, "browser-open-newtab-start");
     });
   });
 
@@ -244,7 +244,7 @@ describe("TelemetryFeed", () => {
       assert.calledOnce(stub);
       assert.isNull(instance.telemetrySender);
     });
-    it("should make this.browserOpenTabStart() stop observing browser-open-tab-start", async () => {
+    it("should make this.browserOpenNewtabStart() stop observing browser-open-newtab-start", async () => {
       await instance.init();
       sandbox.spy(Services.obs, "removeObserver");
       sandbox.stub(instance.telemetrySender, "uninit");
@@ -253,7 +253,7 @@ describe("TelemetryFeed", () => {
 
       assert.calledOnce(Services.obs.removeObserver);
       assert.calledWithExactly(Services.obs.removeObserver,
-        instance.browserOpenTabStart, "browser-open-tab-start");
+        instance.browserOpenNewtabStart, "browser-open-newtab-start");
     });
   });
   describe("#onAction", () => {

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -219,7 +219,12 @@ describe("TelemetryFeed", () => {
         const ping = instance.createSessionEndEvent({
           session_id: FAKE_UUID,
           page: "about:newtab",
-          session_duration: 12345
+          session_duration: 12345,
+          perf: {
+            load_trigger_ts: 10,
+            load_trigger_type: "menu_plus_or_keyboard",
+            visibility_event_rcvd_ts: 20
+          }
         });
         // Is it valid?
         assert.validate(ping, SessionPing);

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -59,7 +59,9 @@ describe("TelemetryFeed", () => {
     });
     it("should make this.browserOpenNewtabStart() observe browser-open-newtab-start", async () => {
       sandbox.spy(Services.obs, "addObserver");
+
       await instance.init();
+
       assert.calledOnce(Services.obs.addObserver);
       assert.calledWithExactly(Services.obs.addObserver,
         instance.browserOpenNewtabStart, "browser-open-newtab-start");

--- a/system-addon/test/unit/lib/TelemetrySender.test.js
+++ b/system-addon/test/unit/lib/TelemetrySender.test.js
@@ -48,22 +48,54 @@ describe("TelemetrySender", () => {
     assert.calledOnce(global.Preferences);
   });
 
-  it("should set the enabled prop to false if the pref is false", () => {
-    FakePrefs.prototype.prefs = {};
-    FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
+  describe("#enabled", () => {
+    it("should return false if the enabled pref is false", () => {
+      FakePrefs.prototype.prefs = {};
+      FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
 
-    tSender = new TelemetrySender(tsArgs);
+      tSender = new TelemetrySender(tsArgs);
 
-    assert.isFalse(tSender.enabled);
-  });
+      assert.isFalse(tSender.enabled);
+    });
 
-  it("should set the enabled prop to true if the pref is true", () => {
-    FakePrefs.prototype.prefs = {};
-    FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
+    it("should return true if the enabled pref is true", () => {
+      FakePrefs.prototype.prefs = {};
+      FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
 
-    tSender = new TelemetrySender(tsArgs);
+      tSender = new TelemetrySender(tsArgs);
 
-    assert.isTrue(tSender.enabled);
+      assert.isTrue(tSender.enabled);
+    });
+
+    describe("telemetry.enabled pref changes from true to false", () => {
+      beforeEach(() => {
+        FakePrefs.prototype.prefs = {};
+        FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
+        tSender = new TelemetrySender(tsArgs);
+        assert.propertyVal(tSender, "enabled", true);
+      });
+
+      it("should set the enabled property to false", () => {
+        fakePrefs.set(TELEMETRY_PREF, false);
+
+        assert.propertyVal(tSender, "enabled", false);
+      });
+    });
+
+    describe("telemetry.enabled pref changes from false to true", () => {
+      beforeEach(() => {
+        FakePrefs.prototype.prefs = {};
+        FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
+        tSender = new TelemetrySender(tsArgs);
+        assert.propertyVal(tSender, "enabled", false);
+      });
+
+      it("should set the enabled property to true", () => {
+        fakePrefs.set(TELEMETRY_PREF, true);
+
+        assert.propertyVal(tSender, "enabled", true);
+      });
+    });
   });
 
   describe("#sendPing()", () => {
@@ -152,36 +184,6 @@ describe("TelemetrySender", () => {
   });
 
   describe("Misc pref changes", () => {
-    describe("telemetry changes from true to false", () => {
-      beforeEach(() => {
-        FakePrefs.prototype.prefs = {};
-        FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
-        tSender = new TelemetrySender(tsArgs);
-        assert.propertyVal(tSender, "enabled", true);
-      });
-
-      it("should set the enabled property to false", () => {
-        fakePrefs.set(TELEMETRY_PREF, false);
-
-        assert.propertyVal(tSender, "enabled", false);
-      });
-    });
-
-    describe("telemetry changes from false to true", () => {
-      beforeEach(() => {
-        FakePrefs.prototype.prefs = {};
-        FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
-        tSender = new TelemetrySender(tsArgs);
-        assert.propertyVal(tSender, "enabled", false);
-      });
-
-      it("should set the enabled property to true", () => {
-        fakePrefs.set(TELEMETRY_PREF, true);
-
-        assert.propertyVal(tSender, "enabled", true);
-      });
-    });
-
     describe("performance.log changes from false to true", () => {
       it("should change this.logging from false to true", () => {
         FakePrefs.prototype.prefs = {};

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -1,4 +1,4 @@
-const {GlobalOverrider, FakePrefs} = require("test/unit/utils");
+const {GlobalOverrider, FakePrefs, FakePerformance} = require("test/unit/utils");
 const {chaiAssertions} = require("test/schemas/pings");
 
 const req = require.context(".", true, /\.test\.jsx?$/);
@@ -10,6 +10,7 @@ sinon.assert.expose(assert, {prefix: ""});
 chai.use(chaiAssertions);
 
 let overrider = new GlobalOverrider();
+
 overrider.set({
   Components: {
     interfaces: {},
@@ -31,6 +32,7 @@ overrider.set({
       addMessageListener: (msg, cb) => cb(),
       removeMessageListener() {}
     },
+    appShell: {hiddenDOMWindow: {performance: new FakePerformance()}},
     obs: {
       addObserver() {},
       removeObserver() {}

--- a/system-addon/test/unit/utils.js
+++ b/system-addon/test/unit/utils.js
@@ -116,6 +116,46 @@ FakePrefs.prototype = {
   }
 };
 
+function FakePerformance() {}
+FakePerformance.prototype = {
+  marks: new Map(),
+  now() {
+    return window.performance.now();
+  },
+  timing: {navigationStart: 222222},
+  get timeOrigin() {
+    return 10000;
+  },
+  // XXX assumes type == "mark"
+  getEntriesByName(name, type) {
+    if (this.marks.has(name)) {
+      return this.marks.get(name);
+    }
+    return [];
+  },
+  callsToMark: 0,
+
+  /**
+   * @note The "startTime" for each mark is simply the number of times mark
+   * has been called in this object.
+   */
+  mark(name) {
+    let markObj = {
+      name,
+      "entryType": "mark",
+      "startTime": ++this.callsToMark,
+      "duration": 0
+    };
+
+    if (this.marks.has(name)) {
+      this.marks.get(name).push(markObj);
+      return;
+    }
+
+    this.marks.set(name, [markObj]);
+  }
+};
+
 /**
  * addNumberReducer - a simple dummy reducer for testing that adds a number
  */
@@ -142,6 +182,7 @@ function mountWithIntl(node) {
 }
 
 module.exports = {
+  FakePerformance,
   FakePrefs,
   GlobalOverrider,
   addNumberReducer,


### PR DESCRIPTION
This adds basic performance telemetry infrastructure and the first bits of telemetry that use it for the new tab.  I suspect it'll mostly be easier to review the individual commits.

How to test if it's working

1. Edit [system-addon/lib/Activity-Stream.jsm](system-addon/lib/Activity-Stream.jsm) and 
set the `telemetry.log` preference value to `true`.
2. `npm run startmc`
3. `cd ../mozilla-central && ./mach build && ./mach run`
4. Open the Browser Console
5. Create a new tab
6. Close it
7. Make sure the logged session ping has an appropriate .perf object
