### PR TITLE
Group duplicate bookmarks as 1 item

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -784,6 +784,7 @@ Links.prototype = {
                     AND b.fk = p.id
                     AND p.last_visit_date IS NOT NULL
                     ORDER BY b.lastModified DESC
+                    GROUP BY p.guid
                     LIMIT ${limit}`;
 
     let links = yield this.executePlacesQuery(sqlQuery, {columns, params: {type: Bookmarks.TYPE_BOOKMARK}});

--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -783,8 +783,8 @@ Links.prototype = {
                     WHERE type = :type
                     AND b.fk = p.id
                     AND p.last_visit_date IS NOT NULL
-                    ORDER BY b.lastModified DESC
                     GROUP BY p.guid
+                    ORDER BY b.lastModified DESC
                     LIMIT ${limit}`;
 
     let links = yield this.executePlacesQuery(sqlQuery, {columns, params: {type: Bookmarks.TYPE_BOOKMARK}});


### PR DESCRIPTION
When you add labels to bookmarks it saves 1 bookmark per label (in the places.db) When displaying spotlight items the key prop used in React is places.guid (which is the same for all items) so it only gets rendered once. But the .slice(0, 3) call on `sites` already happened so you end up actually showing `3 - (number of duplicates)` items.