### PR TITLE
fix(mc): Re-enable tightly-coupled search tests and correctly use newtab as the searchPurpose

### DIFF
--- a/mozilla-central-patches/disable-search-tests.diff
+++ b/mozilla-central-patches/disable-search-tests.diff
@@ -1,28 +1,8 @@
 diff --git a/browser/components/search/test/browser.ini b/browser/components/search/test/browser.ini
 --- a/browser/components/search/test/browser.ini
 +++ b/browser/components/search/test/browser.ini
-@@ -21,4 +21,6 @@ support-files =
- [browser_amazon_behavior.js]
-+skip-if = true # mozilla/activity-stream#2339
- [browser_bing.js]
- [browser_bing_behavior.js]
-+skip-if = true # mozilla/activity-stream#2339
- [browser_contextmenu.js]
-@@ -28,2 +30,3 @@ skip-if = os == "mac" # bug 967013
- [browser_ddg_behavior.js]
-+skip-if = true # mozilla/activity-stream#2339
- [browser_google.js]
 @@ -31,3 +34,3 @@ skip-if = artifact # bug 1315953
  [browser_google_codes.js]
 -skip-if = artifact # bug 1315953
 +skip-if = true # bug 1315953 / mozilla/activity-stream#2366
  [browser_google_nocodes.js]
-@@ -35,3 +38,3 @@ skip-if = artifact # bug 1315953
- [browser_google_behavior.js]
--skip-if = artifact # bug 1315953
-+skip-if = true # mozilla/activity-stream#2339
- [browser_healthreport.js]
-@@ -45,2 +48,3 @@ skip-if = artifact # bug 1315953
- [browser_yahoo_behavior.js]
-+skip-if = true # mozilla/activity-stream#2339
- [browser_abouthome_behavior.js]

--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -24,7 +24,7 @@ class Search extends React.Component {
   onInputMount(input) {
     if (input) {
       this.controller = new ContentSearchUIController(input, input.parentNode,
-        "newtab", "activity");
+        "activity", "newtab");
       addEventListener("ContentSearchClient", this);
     } else {
       this.controller = null;


### PR DESCRIPTION
Fix #2340. Don't land this until https://bugzilla.mozilla.org/show_bug.cgi?id=1371479 lands.

First change removes the disabling of search tests except for the one removed by #2366 because we're using artifact builds on `pine`.

Second change is to correctly use "newtab" as the `searchPurpose` and "activity" as `healthReportKey`. See: https://dxr.mozilla.org/mozilla-central/source/browser/base/content/contentSearchUI.js#32-35

r?@sarracini 