### PR TITLE
Filter out bookmark labels, reverts the changes from #2687

### DIFF
--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -783,7 +783,7 @@ Links.prototype = {
                     WHERE type = :type
                     AND b.fk = p.id
                     AND p.last_visit_date IS NOT NULL
-                    GROUP BY p.guid
+                    AND (SELECT guid FROM moz_bookmarks WHERE id = (SELECT parent FROM moz_bookmarks WHERE id = b.parent)) != "tags________"
                     ORDER BY b.lastModified DESC
                     LIMIT ${limit}`;
 


### PR DESCRIPTION
Replace GROUP BY with the correct filtering of bookmarks. Discussion here https://github.com/mozilla/activity-stream/pull/2687 