### PR TITLE
feat(mc): #2684 Add Prefs feed, panel UI, and reducer

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -13,7 +13,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   // This indicates the type of interaction
-  "event": ["CLICK", "SEARCH", "BLOCK", "DELETE", "OPEN_NEW_WINDOW", "OPEN_PRIVATE_WINDOW", "BOOKMARK_DELETE", "BOOKMARK_ADD"],
+  "event": ["CLICK", "SEARCH", "BLOCK", "DELETE", "OPEN_NEW_WINDOW", "OPEN_PRIVATE_WINDOW", "BOOKMARK_DELETE", "BOOKMARK_ADD", "OPEN_NEWTAB_PREFS", "CLOSE_NEWTAB_PREFS"],
 
   // Optional field indicating the UI component type
   "source": "TOP_SITES",
@@ -158,6 +158,36 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "OPEN_PRIVATE_WINDOW",
   "source": "TOP_SITES",
   "action_position": 2,
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Opening the new tab preferences pane
+
+```js
+{
+  "event": "OPEN_NEWTAB_PREFS",
+  
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US"
+}
+```
+
+#### Closing the new tab preferences pane
+
+```js
+{
+  "event": "CLOSE_NEWTAB_PREFS",
   
   // Basic metadata
   "action": "activity_stream_event",

--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -36,7 +36,10 @@ const actionTypes = [
   "PLACES_HISTORY_CLEARED",
   "PLACES_LINK_BLOCKED",
   "PLACES_LINK_DELETED",
+  "PREFS_INITIAL_VALUES",
+  "PREF_CHANGED",
   "SCREENSHOT_UPDATED",
+  "SET_PREF",
   "TELEMETRY_PERFORMANCE_EVENT",
   "TELEMETRY_UNDESIRED_EVENT",
   "TELEMETRY_USER_EVENT",
@@ -160,6 +163,11 @@ function PerfEvent(data, importContext = globalImportContext) {
   return importContext === UI_CODE ? SendToMain(action) : action;
 }
 
+function SetPref(name, value, importContext = globalImportContext) {
+  const action = {type: actionTypes.SET_PREF, data: {name, value}};
+  return importContext === UI_CODE ? SendToMain(action) : action;
+}
+
 this.actionTypes = actionTypes;
 
 this.actionCreators = {
@@ -168,7 +176,8 @@ this.actionCreators = {
   UndesiredEvent,
   PerfEvent,
   SendToContent,
-  SendToMain
+  SendToMain,
+  SetPref
 };
 
 // These are helpers to test for certain kinds of actions

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -21,6 +21,10 @@ const INITIAL_STATE = {
     initialized: false,
     // The history (and possibly default) links
     rows: []
+  },
+  Prefs: {
+    initialized: false,
+    values: {}
   }
 };
 
@@ -91,7 +95,21 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
   }
 }
 
+function Prefs(prevState = INITIAL_STATE.Prefs, action) {
+  let newValues;
+  switch (action.type) {
+    case at.PREFS_INITIAL_VALUES:
+      return Object.assign({}, prevState, {initialized: true, values: action.data});
+    case at.PREF_CHANGED:
+      newValues = Object.assign({}, prevState.values);
+      newValues[action.data.name] = action.data.value;
+      return Object.assign({}, prevState, {values: newValues});
+    default:
+      return prevState;
+  }
+}
+
 this.INITIAL_STATE = INITIAL_STATE;
-this.reducers = {TopSites, App};
+this.reducers = {TopSites, App, Prefs};
 
 this.EXPORTED_SYMBOLS = ["reducers", "INITIAL_STATE"];

--- a/system-addon/content-src/activity-stream.scss
+++ b/system-addon/content-src/activity-stream.scss
@@ -108,3 +108,4 @@ a {
 @import './components/TopSites/TopSites';
 @import './components/Search/Search';
 @import './components/ContextMenu/ContextMenu';
+@import './components/PreferencesPane/PreferencesPane';

--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -3,6 +3,7 @@ const {connect} = require("react-redux");
 const {addLocaleData, IntlProvider} = require("react-intl");
 const TopSites = require("content-src/components/TopSites/TopSites");
 const Search = require("content-src/components/Search/Search");
+const PreferencesPane = require("content-src/components/PreferencesPane/PreferencesPane");
 
 // Locales that should be displayed RTL
 const RTL_LIST = ["ar", "he", "fa", "ur"];
@@ -34,7 +35,10 @@ class Base extends React.Component {
   }
 
   render() {
-    let {locale, strings, initialized} = this.props.App;
+    const props = this.props;
+    const {locale, strings, initialized} = props.App;
+    const prefs = props.Prefs.values;
+
     if (!initialized) {
       return null;
     }
@@ -42,12 +46,13 @@ class Base extends React.Component {
     return (<IntlProvider key={locale} locale={locale} messages={strings}>
         <div className="outer-wrapper">
           <main>
-            <Search />
-            <TopSites />
+            {prefs.showSearch && <Search />}
+            {prefs.showTopSites && <TopSites />}
           </main>
+          <PreferencesPane />
         </div>
       </IntlProvider>);
   }
 }
 
-module.exports = connect(state => ({App: state.App}))(Base);
+module.exports = connect(state => ({App: state.App, Prefs: state.Prefs}))(Base);

--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -1,0 +1,84 @@
+const React = require("react");
+const {connect} = require("react-redux");
+const {injectIntl, FormattedMessage} = require("react-intl");
+const classNames = require("classnames");
+const {actionCreators: ac} = require("common/Actions.jsm");
+
+const PreferencesInput = props => (
+  <section>
+    <input type="checkbox" id={props.prefName} name={props.prefName} checked={props.value} onChange={props.onChange} className={props.className} />
+    <label htmlFor={props.prefName}>
+      <FormattedMessage id={props.titleStringId} />
+    </label>
+    {props.descStringId && <p className="prefs-input-description"><FormattedMessage id={props.descStringId} /></p>}
+  </section>
+);
+
+class PreferencesPane extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {visible: false};
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.togglePane = this.togglePane.bind(this);
+  }
+  componentDidMount() {
+    document.addEventListener("click", this.handleClickOutside);
+  }
+  componentWillUnmount() {
+    document.removeEventListener("click", this.handleClickOutside);
+  }
+  handleClickOutside(event) {
+    // if we are showing the sidebar and there is a click outside, close it.
+    if (this.state.visible && !this.refs.wrapper.contains(event.target)) {
+      this.togglePane();
+    }
+  }
+  handleChange(event) {
+    const target = event.target;
+    this.props.dispatch(ac.SetPref(target.name, target.checked));
+  }
+  togglePane() {
+    this.setState({visible: !this.state.visible});
+    const event = this.state.visible ? "CLOSE_NEWTAB_PREFS" : "OPEN_NEWTAB_PREFS";
+    this.props.dispatch(ac.UserEvent({event}));
+  }
+  render() {
+    const props = this.props;
+    const prefs = props.Prefs.values;
+    const isVisible = this.state.visible;
+    return (
+      <div className="prefs-pane-wrapper" ref="wrapper">
+        <div className="prefs-pane-button">
+          <button
+            className={classNames("prefs-button icon", isVisible ? "icon-dismiss" : "icon-settings")}
+            title={props.intl.formatMessage({id: isVisible ? "settings_pane_done_button" : "settings_pane_button_label"})}
+            onClick={this.togglePane} />
+        </div>
+        <div className="prefs-pane">
+          <div className={classNames("sidebar", {hidden: !isVisible})}>
+            <div className="prefs-modal-inner-wrapper">
+              <h1><FormattedMessage id="settings_pane_header" /></h1>
+              <p><FormattedMessage id="settings_pane_body" /></p>
+
+              <PreferencesInput className="showSearch" prefName="showSearch" value={prefs.showSearch} onChange={this.handleChange}
+                titleStringId="settings_pane_search_header" descStringId="settings_pane_search_body" />
+
+              <PreferencesInput className="showTopSites" prefName="showTopSites" value={prefs.showTopSites} onChange={this.handleChange}
+                titleStringId="settings_pane_topsites_header" descStringId="settings_pane_topsites_body" />
+
+            </div>
+            <section className="actions">
+              <button className="done" onClick={this.togglePane}>
+                <FormattedMessage id="settings_pane_done_button" />
+              </button>
+            </section>
+          </div>
+        </div>
+      </div>);
+  }
+}
+
+module.exports = connect(state => ({Prefs: state.Prefs}))(injectIntl(PreferencesPane));
+module.exports.PreferencesPane = PreferencesPane;
+module.exports.PreferencesInput = PreferencesInput;

--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -1,0 +1,170 @@
+.prefs-pane {
+  font-size: 13px;
+
+  .sidebar {
+    background: $white;
+    border-left: solid 1px $faintest-black;
+    box-shadow: $sidebar-shadow;
+    min-height: 100%;
+    offset-inline-end: 0;
+    padding: 40px;
+    position: fixed;
+    top: 0;
+    transition: 0.1s cubic-bezier(0, 0, 0, 1);
+    transition-property: left, right;
+    width: 400px;
+    z-index: 12000;
+
+    &.hidden {
+      offset-inline-end: -400px;
+    }
+
+    h1 {
+      border-bottom: solid 1px $faintest-black;
+      font-size: 24px;
+      margin: 0;
+      padding: 20px 0;
+    }
+  }
+
+  .prefs-modal-inner-wrapper {
+    section {
+      margin: 20px 0;
+
+      p {
+        margin: 5px 0 5px 30px;
+      }
+
+      label {
+        position: relative;
+
+        input {
+          offset-inline-start: -30px;
+          position: absolute;
+          top: 0;
+        }
+      }
+
+      > label {
+        font-size: 16px;
+        font-weight: bold;
+      }
+
+      .options {
+        background: $bg-grey;
+        border: solid 1px $faintest-black;
+        border-radius: $border-radius;
+        margin: 15px 0;
+        margin-inline-start: 30px;
+        padding: 10px;
+
+        label {
+          background-position: 35px center;
+          background-repeat: no-repeat;
+          display: inline-block;
+          font-weight: normal;
+          height: 21px;
+          line-height: 21px;
+          padding-inline-start: 63px;
+          width: 100%;
+
+          &:dir(rtl) {
+            background-position: 217px center;
+          }
+        }
+      }
+
+      &.disabled {
+        .options {
+          opacity: 0.5;
+        }
+      }
+    }
+  }
+
+  .actions {
+    padding: 15px 0;
+  }
+
+  // CSS styled checkbox
+  [type='checkbox']:not(:checked),
+  [type='checkbox']:checked {
+    offset-inline-start: -9999px;
+    position: absolute;
+  }
+
+  [type='checkbox']:not(:checked) + label,
+  [type='checkbox']:checked + label {
+    cursor: pointer;
+    padding: 0 30px;
+    position: relative;
+  }
+
+  [type='checkbox']:not(:checked) + label::before,
+  [type='checkbox']:checked + label::before {
+    background: $white;
+    border: 1px solid $checkbox-border;
+    border-radius: $border-radius;
+    content: '';
+    height: 21px;
+    offset-inline-start: 0;
+    position: absolute;
+    top: 0;
+    width: 21px;
+  }
+
+  // checkmark
+  [type='checkbox']:not(:checked) + label::after,
+  [type='checkbox']:checked + label::after {
+    background: url('chrome://global/skin/in-content/check.svg#check') no-repeat center center; // sass-lint:disable-line no-url-domains
+    content: '';
+    height: 21px;
+    offset-inline-start: 0;
+    position: absolute;
+    top: 0;
+    width: 21px;
+  }
+
+  // checkmark changes
+  [type='checkbox']:not(:checked) + label::after {
+    opacity: 0;
+  }
+
+  [type='checkbox']:checked + label::after {
+    opacity: 1;
+  }
+
+  // hover
+  [type='checkbox'] + label:hover::before {
+    border: 1px solid $checkbox-blue;
+  }
+
+  // accessibility
+  [type='checkbox']:checked:focus + label::before,
+  [type='checkbox']:not(:checked):focus + label::before {
+    border: 1px dotted $checkbox-blue;
+  }
+}
+
+.prefs-pane-button {
+  button {
+    background-color: transparent;
+    border: 0;
+    cursor: pointer;
+    opacity: 0.7;
+    padding: 15px;
+    position: fixed;
+    right: 15px;
+    top: 15px;
+    z-index: 12001;
+
+    &:hover {
+      background-color: $very-light-grey;
+    }
+
+    &:dir(rtl) {
+      left: 5px;
+      right: auto;
+    }
+  }
+}

--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -34,4 +34,9 @@
  &.icon-new-window-private {
    background-image: url('#{$image-path}glyph-newWindow-private-16.svg');
  }
+
+ &.icon-settings {
+   background-image: url('#{$image-path}glyph-settings-16.svg');
+ }
+
 }

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -48,4 +48,6 @@ $context-menu-border-radius: 5px;
 $context-menu-outer-padding: 5px;
 $context-menu-item-padding: 3px 12px;
 
+$sidebar-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08);
+
 $image-path: 'assets/';

--- a/system-addon/data/content/assets/glyph-settings-16.svg
+++ b/system-addon/data/content/assets/glyph-settings-16.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="none" stroke="#4d4d4d" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M8 1v3M8 12v3M4.5 11.5l-1.45 1.45M12.95 3.05L11 5M1 8h3M12 8h3"/><circle cx="8" cy="8" r="4"/><path d="M3.05 3.05L5 5M11 11l1.95 1.95"/></g></svg>

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -23,6 +23,9 @@ XPCOMUtils.defineLazyModuleGetter(this, "NewTabInit",
 XPCOMUtils.defineLazyModuleGetter(this, "PlacesFeed",
   "resource://activity-stream/lib/PlacesFeed.jsm");
 
+XPCOMUtils.defineLazyModuleGetter(this, "PrefsFeed",
+  "resource://activity-stream/lib/PrefsFeed.jsm");
+
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetryFeed",
   "resource://activity-stream/lib/TelemetryFeed.jsm");
 
@@ -54,6 +57,12 @@ const PREFS_CONFIG = [
     init: () => new PlacesFeed()
   },
   {
+    name: "feeds.prefs",
+    title: "Preferences",
+    value: true,
+    init: () => new PrefsFeed(PREFS_CONFIG.map(pref => pref.name))
+  },
+  {
     name: "feeds.telemetry",
     title: "Relays telemetry-related actions to TelemetrySender",
     value: true,
@@ -65,8 +74,16 @@ const PREFS_CONFIG = [
     value: true,
     init: () => new TopSitesFeed()
   },
-  // End feeds
-
+  {
+    name: "showSearch",
+    title: "Show the Search bar on the New Tab page",
+    value: true
+  },
+  {
+    name: "showTopSites",
+    title: "Show the Top Sites section on the New Tab page",
+    value: true
+  },
   {
     name: "telemetry",
     title: "Enable system error and usage data collection",
@@ -133,4 +150,5 @@ this.ActivityStream = class ActivityStream {
   }
 };
 
+this.PREFS_CONFIG = PREFS_CONFIG;
 this.EXPORTED_SYMBOLS = ["ActivityStream"];

--- a/system-addon/lib/PrefsFeed.jsm
+++ b/system-addon/lib/PrefsFeed.jsm
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const {utils: Cu} = Components;
+const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "Prefs",
+  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
+
+this.PrefsFeed = class PrefsFeed {
+  constructor(prefNames) {
+    this._prefNames = prefNames;
+    this._prefs = new Prefs();
+    this._observers = new Map();
+  }
+  onPrefChanged(name, value) {
+    this.store.dispatch(ac.BroadcastToContent({type: at.PREF_CHANGED, data: {name, value}}));
+  }
+  init() {
+    const values = {};
+
+    // Set up listeners for each activity stream pref
+    for (const name of this._prefNames) {
+      const handler = value => {
+        this.onPrefChanged(name, value);
+      };
+      this._observers.set(name, handler, this);
+      this._prefs.observe(name, handler);
+      values[name] = this._prefs.get(name);
+    }
+
+    // Set the initial state of all prefs in redux
+    this.store.dispatch(ac.BroadcastToContent({type: at.PREFS_INITIAL_VALUES, data: values}));
+  }
+  removeListeners() {
+    for (const name of this._prefNames) {
+      this._prefs.ignore(name, this._observers.get(name));
+    }
+    this._observers.clear();
+  }
+  onAction(action) {
+    switch (action.type) {
+      case at.INIT:
+        this.init();
+        break;
+      case at.UNINIT:
+        this.removeListeners();
+        break;
+      case at.SET_PREF:
+        this._prefs.set(action.data.name, action.data.value);
+        break;
+    }
+  }
+};
+
+this.EXPORTED_SYMBOLS = ["PrefsFeed"];

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -33,6 +33,8 @@ const UserEventAction = Joi.object().keys({
       "DELETE",
       "OPEN_NEW_WINDOW",
       "OPEN_PRIVATE_WINDOW",
+      "OPEN_NEWTAB_PREFS",
+      "CLOSE_NEWTAB_PREFS",
       "BOOKMARK_DELETE",
       "BOOKMARK_ADD"
     ]).required(),

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -1,5 +1,5 @@
 const {reducers, INITIAL_STATE} = require("common/Reducers.jsm");
-const {TopSites, App} = reducers;
+const {TopSites, App, Prefs} = reducers;
 const {actionTypes: at} = require("common/Actions.jsm");
 
 describe("Reducers", () => {
@@ -105,6 +105,45 @@ describe("Reducers", () => {
         const action = {type: event, data: {url: "bar.com"}};
         const nextState = TopSites(oldState, action);
         assert.deepEqual(nextState.rows, [{url: "foo.com"}]);
+      });
+    });
+  });
+  describe("Prefs", () => {
+    function prevState(custom = {}) {
+      return Object.assign({}, INITIAL_STATE.Prefs, custom);
+    }
+    it("should have the correct initial state", () => {
+      const state = Prefs(undefined, {});
+      assert.deepEqual(state, INITIAL_STATE.Prefs);
+    });
+    describe("PREFS_INITIAL_VALUES", () => {
+      it("should return a new object", () => {
+        const state = Prefs(undefined, {type: at.PREFS_INITIAL_VALUES, data: {}});
+        assert.notEqual(INITIAL_STATE.Prefs, state, "should not modify INITIAL_STATE");
+      });
+      it("should set initalized to true", () => {
+        const state = Prefs(undefined, {type: at.PREFS_INITIAL_VALUES, data: {}});
+        assert.isTrue(state.initialized);
+      });
+      it("should set .values", () => {
+        const newValues = {foo: 1, bar: 2};
+        const state = Prefs(undefined, {type: at.PREFS_INITIAL_VALUES, data: newValues});
+        assert.equal(state.values, newValues);
+      });
+    });
+    describe("PREF_CHANGED", () => {
+      it("should return a new Prefs object", () => {
+        const state = Prefs(undefined, {type: at.PREF_CHANGED, data: {name: "foo", value: 2}});
+        assert.notEqual(INITIAL_STATE.Prefs, state, "should not modify INITIAL_STATE");
+      });
+      it("should set the changed pref", () => {
+        const state = Prefs(prevState({foo: 1}), {type: at.PREF_CHANGED, data: {name: "foo", value: 2}});
+        assert.equal(state.values.foo, 2);
+      });
+      it("should return a new .pref object instead of mutating", () => {
+        const oldState = prevState({foo: 1});
+        const state = Prefs(oldState, {type: at.PREF_CHANGED, data: {name: "foo", value: 2}});
+        assert.notEqual(oldState.values, state.values);
       });
     });
   });

--- a/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
+++ b/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
@@ -1,0 +1,86 @@
+const React = require("react");
+const {shallow} = require("enzyme");
+const {shallowWithIntl} = require("test/unit/utils");
+const {FormattedMessage} = require("react-intl");
+const {PreferencesPane, PreferencesInput} = require("content-src/components/PreferencesPane/PreferencesPane");
+const {actionCreators: ac} = require("common/Actions.jsm");
+
+describe("<PreferencesInput>", () => {
+  const testStringIds = {
+    titleStringId: "settings_pane_search_header",
+    descStringId: "settings_pane_search_body"
+  };
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<PreferencesInput prefName="foo" {...testStringIds} />);
+  });
+
+  it("should set the name and id on the input and the 'for' attribute on the label to props.prefName", () => {
+    const inputProps = wrapper.find("input").props();
+    const labelProps = wrapper.find("label").props();
+    assert.propertyVal(inputProps, "name", "foo");
+    assert.propertyVal(inputProps, "name", "foo");
+    assert.propertyVal(labelProps, "htmlFor", "foo");
+  });
+  it("should set the checked value of the input to props.value", () => {
+    wrapper = shallow(<PreferencesInput prefName="foo" value={true} {...testStringIds} />);
+    assert.propertyVal(wrapper.find("input").props(), "checked", true);
+  });
+  it("should render a FormattedString in the label with id=titleStringId", () => {
+    assert.propertyVal(wrapper.find("label").find(FormattedMessage).props(), "id", testStringIds.titleStringId);
+  });
+  it("should render a FormattedString in the description with id=descStringId", () => {
+    assert.propertyVal(wrapper.find(".prefs-input-description").find(FormattedMessage).props(), "id", testStringIds.descStringId);
+  });
+  it("should not render the description element if no descStringId is given", () => {
+    wrapper = shallow(<PreferencesInput prefName="foo" titleStringId="bar" />);
+    assert.lengthOf(wrapper.find(".prefs-input-description"), 0);
+  });
+});
+
+describe("<PreferencesPane>", () => {
+  let wrapper;
+  let dispatch;
+  beforeEach(() => {
+    dispatch = sinon.spy();
+    const fakePrefs = {values: {showSearch: true, showTopSites: true}};
+    wrapper = shallowWithIntl(<PreferencesPane dispatch={dispatch} Prefs={fakePrefs} />);
+  });
+  it("should hide the sidebar and show a settings icon by default", () => {
+    assert.isTrue(wrapper.find(".sidebar").hasClass("hidden"));
+    assert.isTrue(wrapper.find(".prefs-button").hasClass("icon-settings"));
+  });
+  it("should show the sidebar and show a dismiss icon if state.visible is true", () => {
+    wrapper.setState({visible: true});
+
+    assert.isFalse(wrapper.find(".sidebar").hasClass("hidden"));
+    assert.isTrue(wrapper.find(".prefs-button").hasClass("icon-dismiss"));
+  });
+  it("should toggle state.visible when the top corner button is clicked and send the right telemetry", () => {
+    const button = wrapper.find(".prefs-button");
+    assert.isFalse(wrapper.state("visible"));
+
+    button.simulate("click", {});
+    assert.isTrue(wrapper.state("visible"));
+    assert.calledWith(dispatch, ac.UserEvent({event: "OPEN_NEWTAB_PREFS"}));
+
+    dispatch.reset();
+
+    button.simulate("click", {});
+    assert.isFalse(wrapper.state("visible"));
+    assert.calledWith(dispatch, ac.UserEvent({event: "CLOSE_NEWTAB_PREFS"}));
+  });
+  it("the sidebar should be closed when done button is clicked", () => {
+    wrapper.setState({visible: true});
+    assert.isFalse(wrapper.find(".sidebar").hasClass("hidden"));
+
+    wrapper.find("button.done").simulate("click");
+    assert.isTrue(wrapper.find(".sidebar").hasClass("hidden"));
+  });
+  it("should dispatch a SetPref action when a PreferencesInput is clicked", () => {
+    const showSearchWrapper = wrapper.find(".showSearch");
+    showSearchWrapper.simulate("change", {target: {name: "showSearch", checked: false}});
+    assert.calledOnce(dispatch);
+    assert.calledWith(dispatch, ac.SetPref("showSearch", false));
+  });
+});

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -15,7 +15,8 @@ describe("ActivityStream", () => {
       "lib/NewTabInit.jsm": {NewTabInit: Fake},
       "lib/PlacesFeed.jsm": {PlacesFeed: Fake},
       "lib/TelemetryFeed.jsm": {TelemetryFeed: Fake},
-      "lib/TopSitesFeed.jsm": {TopSitesFeed: Fake}
+      "lib/TopSitesFeed.jsm": {TopSitesFeed: Fake},
+      "lib/PrefsFeed.jsm": {PrefsFeed: Fake}
     }));
     as = new ActivityStream();
     sandbox.stub(as.store, "init");
@@ -99,6 +100,10 @@ describe("ActivityStream", () => {
     });
     it("should create a Telemetry feed", () => {
       const feed = as.feeds["feeds.telemetry"]();
+      assert.instanceOf(feed, Fake);
+    });
+    it("should create a Prefs feed", () => {
+      const feed = as.feeds["feeds.prefs"]();
       assert.instanceOf(feed, Fake);
     });
   });

--- a/system-addon/test/unit/lib/PrefsFeed.test.js
+++ b/system-addon/test/unit/lib/PrefsFeed.test.js
@@ -1,0 +1,54 @@
+const {PrefsFeed} = require("lib/PrefsFeed.jsm");
+const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
+
+const FAKE_PREFS = [{name: "foo", value: 1}, {name: "bar", value: 2}];
+
+describe("PrefsFeed", () => {
+  let feed;
+  beforeEach(() => {
+    feed = new PrefsFeed(FAKE_PREFS.map(p => p.name));
+    feed.store = {dispatch: sinon.spy()};
+    feed._prefs = {
+      get: sinon.spy(item => FAKE_PREFS.filter(p => p.name === item)[0].value),
+      set: sinon.spy(),
+      observe: sinon.spy(),
+      ignore: sinon.spy()
+    };
+  });
+  it("should set a pref when a SET_PREF action is received", () => {
+    feed.onAction(ac.SetPref("foo", 2));
+    assert.calledWith(feed._prefs.set, "foo", 2);
+  });
+  it("should dispatch PREFS_INITIAL_VALUES on init", () => {
+    feed.onAction({type: at.INIT});
+    assert.calledOnce(feed.store.dispatch);
+    assert.equal(feed.store.dispatch.firstCall.args[0].type, at.PREFS_INITIAL_VALUES);
+    assert.deepEqual(feed.store.dispatch.firstCall.args[0].data, {foo: 1, bar: 2});
+  });
+  it("should add one observer per pref on init", () => {
+    feed.onAction({type: at.INIT});
+    FAKE_PREFS.forEach(pref => {
+      assert.calledWith(feed._prefs.observe, pref.name);
+      assert.isTrue(feed._observers.has(pref.name));
+    });
+  });
+  it("should call onPrefChanged when an observer is called", () => {
+    sinon.stub(feed, "onPrefChanged");
+    feed.onAction({type: at.INIT});
+    const handlerForFoo = feed._observers.get("foo");
+
+    handlerForFoo(true);
+
+    assert.calledWith(feed.onPrefChanged, "foo", true);
+  });
+  it("should remove all observers on uninit", () => {
+    feed.onAction({type: at.UNINIT});
+    FAKE_PREFS.forEach(pref => {
+      assert.calledWith(feed._prefs.ignore, pref.name);
+    });
+  });
+  it("should send a PREF_CHANGED action when onPrefChanged is called", () => {
+    feed.onPrefChanged("foo", 2);
+    assert.calledWith(feed.store.dispatch, ac.BroadcastToContent({type: at.PREF_CHANGED, data: {name: "foo", value: 2}}));
+  });
+});


### PR DESCRIPTION
This patch adds the Prefs panel to the system add-on, as well as a feed that watches changes for all activity-stream-related prefs and writes them to a`Prefs` reducer.

To manually test this, click on the gear in the top right hand corner and try flipping the prefs.