### PR TITLE
tests(mc): #2344 Reenable tiles tests

### DIFF
--- a/mozilla-central-patches/disable-tiles-tests.diff
+++ b/mozilla-central-patches/disable-tiles-tests.diff
@@ -1,7 +1,0 @@
-diff --git a/browser/base/moz.build b/browser/base/moz.build
---- a/browser/base/moz.build
-+++ b/browser/base/moz.build
-@@ -21,3 +21,2 @@ BROWSER_CHROME_MANIFESTS += [
-     'content/test/general/browser.ini',
--    'content/test/newtab/browser.ini',
-     'content/test/pageinfo/browser.ini',


### PR DESCRIPTION
Fix #2344. Now that https://bugzilla.mozilla.org/show_bug.cgi?id=1369875 has landed, we should be able to reenable tiles tests