### PR TITLE
Preparing the release of Activity Stream 1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     skip_cleanup: true
     script: bin/continuous-integration.sh prerelease
     on:
-      branch: release-1.4.0
+      branch: release-1.14.0
   - provider: script
     skip_cleanup: true
     script: bin/continuous-integration.sh shield

--- a/content-src/components/CollapsibleSection/CollapsibleSection.scss
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.scss
@@ -17,6 +17,10 @@
     max-height: 500px;
     transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);
 
+    // This is so the top sites favicon doesn't get clipped during animation:
+    margin-inline-start: -7px;
+    padding: 0 7px;
+
     &.animating {
       overflow: hidden;
     }

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -23,6 +23,8 @@
   &.collapsible-section {
     .section-body {
       max-height: 975px;
+      margin-inline-start: 0;
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
Hi all,

We are now preparing the release of A-S 1.14.0. The add-on has been made available at [pre-release channel](https://moz-activity-streams-prerelease.s3.amazonaws.com/dist/latest.html). Please install it, test it, and leave the feedback, bug reports, and other inputs in this thread.

# Highlights
* [new] Recent bookmarks section

# Release checklist
- QA
  - [x] @pdehaan 
  - [x] @SoftVision
- Product
  - [x] @nchapman 
  - [x] @aaronrbenson 
- Engineering
  - [x] @tspurway 
  - [x] @jennchaulk 

Please use the `release/block` or `release/uplift` to label the bug reports as well as other release related issues. Once you finish the review, please check off the corresponding item in the above checklist.

*Note*: checking off the item may not work, you can either modify it in place (i.e modify `[ ]` to `[x]`), or just drop a good old `r+` comment below.  

Thanks