### PR TITLE
system-addon(tests): Closes #2348 Re-enable browser_UsageTelemetry_content.js

### DIFF
--- a/mozilla-central-patches/disable-usage-telemetry-tests.diff
+++ b/mozilla-central-patches/disable-usage-telemetry-tests.diff
@@ -1,7 +1,0 @@
-diff --git a/browser/modules/test/browser/browser.ini b/browser/modules/test/browser/browser.ini
---- a/browser/modules/test/browser/browser.ini
-+++ b/browser/modules/test/browser/browser.ini
-@@ -44,2 +44,3 @@ support-files =
- [browser_UsageTelemetry_content.js]
-+skip-if = true # disabled on pine until we have newtab search implemented
- [browser_UsageTelemetry_content_aboutHome.js]

--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -23,8 +23,13 @@ class Search extends React.Component {
   }
   onInputMount(input) {
     if (input) {
+      // The first "newtab" parameter here is called the "healthReportKey" and needs
+      // to be "newtab" so that BrowserUsageTelemetry.jsm knows to handle events with
+      // this name, and can add the appropriate telemetry probes for search. Without the
+      // correct name, certain tests like browser_UsageTelemetry_content.js will fail (See
+      // github ticket #2348 for more details)
       this.controller = new ContentSearchUIController(input, input.parentNode,
-        "activity", "newtab");
+        "newtab", "newtab");
       addEventListener("ContentSearchClient", this);
     } else {
       this.controller = null;
@@ -32,13 +37,18 @@ class Search extends React.Component {
     }
   }
 
+  /*
+   * Do not change the ID on the input field, as legacy newtab code
+   * specifically looks for the id 'newtab-search-text' on input fields
+   * in order to execute searches in various tests
+   */
   render() {
     return (<form className="search-wrapper">
-      <label htmlFor="search-input" className="search-label">
+      <label htmlFor="newtab-search-text" className="search-label">
         <span className="sr-only"><FormattedMessage id="search_web_placeholder" /></span>
       </label>
       <input
-        id="search-input"
+        id="newtab-search-text"
         maxLength="256"
         placeholder={this.props.intl.formatMessage({id: "search_web_placeholder"})}
         ref={this.onInputMount}


### PR DESCRIPTION
Change the source to be "newtab" so it can be recognized in BrowserUsageTelemetry.jsm and we get the search events properly. Also change the id on the input to "newtab-search-text" (which is what the test looks for). As a consequence this fixes the browser_UsageTelemetry_content.js test, so we can re-enable it on pine 

cc @Mardak there's no reason this *needs* to be "activity", right?