### PR TITLE
fix (style): #2708 fix top site icon truncation during collapse animation

### DIFF
--- a/content-src/components/CollapsibleSection/CollapsibleSection.scss
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.scss
@@ -17,6 +17,10 @@
     max-height: 500px;
     transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);
 
+    // This is so the top sites favicon doesn't get clipped during animation:
+    margin-inline-start: -7px;
+    padding: 0 7px;
+
     &.animating {
       overflow: hidden;
     }


### PR DESCRIPTION
Before:
<img src="https://d2ppvlu71ri8gs.cloudfront.net/items/3K432O1a3P0X1J0C3q2v/Screen%20Recording%202017-06-13%20at%2011.10%20AM.gif?v=05251f40" />

After:
<img src="https://d2ppvlu71ri8gs.cloudfront.net/items/1h3g1X2O3Z3s3l2j0U1J/Screen%20Recording%202017-06-13%20at%2011.09%20AM.gif?v=eeca819d" />

Fixes #2708