### PR TITLE
fix(content): Enhance #2708 fix to avoid line wrapping of Highlights

### DIFF
--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -23,6 +23,8 @@
   &.collapsible-section {
     .section-body {
       max-height: 975px;
+      margin-inline-start: 0;
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
Today's fix of #2708 causes Highlights and Top Stories to break into a new line after the second tile.
This commit fixes that.

<img width="880" alt="screen shot 2017-06-13 at 7 37 43 pm" src="https://user-images.githubusercontent.com/472523/27110023-5e2c96cc-5074-11e7-96ae-0f231d002631.png">