### PR TITLE
fix(tests): Intermittent test failures of PocketStories on Travis

### DIFF
--- a/content-src/components/PocketStories/PocketStories.js
+++ b/content-src/components/PocketStories/PocketStories.js
@@ -53,7 +53,7 @@ const PocketStories = React.createClass({
     return stories.map((story, i) =>
         <SpotlightItem
           index={i}
-          key={story.url || i}
+          key={story.guid || story.url || i}
           page={this.props.page}
           source="RECOMMENDED"
           onClick={this.onClickFactory(i, story)}


### PR DESCRIPTION
```
FAILED TESTS:
 PocketStories
   valid stories
     should render a SpotlightItem for each item
       Firefox 54.0.0 (Linux 0.0.0)
     expected 3 to equal 2
```

The intermittent failure occurs if the test data generated by faker.js causes a key collision for tiles. For Pocket, we use the URL as key. The URL data is generated by a random selection of tippy-top-sites, which makes collisions much more likely compared to Highlights, which use the GUID as key.

Now that we have a reliable GUID for Pocket stories we can use it as key.

