### PR TITLE
Add bookmarks from pocket to recent bookmarks

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -225,7 +225,12 @@ ActivityStreams.prototype = {
   _respondToPlacesRequests({msg, worker}) {
     switch (msg.type) {
       case am.type("NOTIFY_BOOKMARK_ADD"):
-        PlacesProvider.links.asyncAddBookmark(msg.data);
+        PlacesProvider.links.asyncAddBookmark(msg.data.url);
+
+        // Request metadata for the new bookmark if it has been added from PocketStories.
+        if (msg.data.source === "RECOMMENDED") {
+          this._pageScraper.asyncFetchLinks([{url: msg.data.url}], msg.type);
+        }
         break;
       case am.type("NOTIFY_BOOKMARK_DELETE"):
         PlacesProvider.links.asyncDeleteBookmark(msg.data);

--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -229,7 +229,7 @@ ActivityStreams.prototype = {
 
         // Request metadata for the new bookmark if it has been added from PocketStories.
         if (msg.data.source === "RECOMMENDED") {
-          this._pageScraper.asyncFetchLinks([{url: msg.data.url}], msg.type);
+          this._pageScraper.asyncFetchLinks([{url: msg.data.url}], msg.type, true);
         }
         break;
       case am.type("NOTIFY_BOOKMARK_DELETE"):

--- a/addon/Feeds/BookmarksFeed.js
+++ b/addon/Feeds/BookmarksFeed.js
@@ -62,6 +62,10 @@ module.exports = class BookmarksFeed extends Feed {
         }
       }
 
+      // Filter out bookmarks that don't have metadata and images.
+      // This will prevent default bookmarks with no visits from showing up.
+      links = links.filter(l => l.hasMetadata && l.images && l.images.length);
+
       return am.actions.Response("BOOKMARKS_RESPONSE", links);
     }.bind(this));
   }

--- a/addon/PlacesProvider.js
+++ b/addon/PlacesProvider.js
@@ -782,8 +782,8 @@ Links.prototype = {
                     FROM moz_bookmarks b, moz_places p
                     WHERE type = :type
                     AND b.fk = p.id
-                    AND p.last_visit_date IS NOT NULL
                     AND (SELECT guid FROM moz_bookmarks WHERE id = (SELECT parent FROM moz_bookmarks WHERE id = b.parent)) != "tags________"
+                    AND url_hash NOT BETWEEN hash("place", "prefix_lo") AND hash("place", "prefix_hi")
                     ORDER BY b.lastModified DESC
                     LIMIT ${limit}`;
 

--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -149,8 +149,8 @@ function NotifyUpdateSearchString(searchString) {
   return Notify("NOTIFY_UPDATE_SEARCH_STRING", {searchString}, {skipMasterStore: true});
 }
 
-function NotifyBookmarkAdd(url) {
-  return Notify("NOTIFY_BOOKMARK_ADD", url);
+function NotifyBookmarkAdd(data) {
+  return Notify("NOTIFY_BOOKMARK_ADD", data);
 }
 
 function NotifyBookmarkDelete(bookmarkGuid) {

--- a/content-src/components/LinkMenu/LinkMenu.js
+++ b/content-src/components/LinkMenu/LinkMenu.js
@@ -96,7 +96,7 @@ const LinkMenu = React.createClass({
         label: this.props.intl.formatMessage({id: "menu_action_bookmark"}),
         icon: "bookmark",
         userEvent: "BOOKMARK_ADD",
-        onClick: () => dispatch(actions.NotifyBookmarkAdd(site.url))
+        onClick: () => dispatch(actions.NotifyBookmarkAdd({url: site.url, source: this.props.source}))
       }),
       {type: "separator"},
       {

--- a/content-test/components/LinkMenu.test.js
+++ b/content-test/components/LinkMenu.test.js
@@ -130,7 +130,8 @@ describe("LinkMenu", () => {
     checkOption({
       ref: "addBookmark",
       event: "NOTIFY_BOOKMARK_ADD",
-      eventData: DEFAULT_PROPS.site.url,
+      // Event source defined by DEFAULT_PROPS.
+      eventData: {url: DEFAULT_PROPS.site.url, source: "ACTIVITY_FEED"},
       userEvent: "BOOKMARK_ADD"
     });
     checkOption({

--- a/content-test/components/PocketStories.test.js
+++ b/content-test/components/PocketStories.test.js
@@ -54,6 +54,11 @@ describe("PocketStories", () => {
       el = ReactDOM.findDOMNode(emptyInstance);
       assert.notOk(el);
     });
+    it("should pass correct source value to SpotlightItems", () => {
+      const children = TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem);
+
+      assert.equal(children[0].props.source, "RECOMMENDED");
+    });
   });
 
   describe("actions", () => {

--- a/test/test-PageScraper.js
+++ b/test/test-PageScraper.js
@@ -96,6 +96,21 @@ exports.test_fetch_links_parses_HTML_once = function*(assert) {
   assert.equal(parseCallCount, 1, "we did not parse the same link again");
 };
 
+exports.test_force_fetch_items = function*(assert) {
+  gPageScraper._asyncSaveMetadata = link => {
+    mockPreviewProvider.processAndInsertMetadata(link, "Local");
+  };
+  let link = [{url: "https://www.foo.com"}];
+
+  // attempt to parse and save a page and make sure we parsed once
+  yield gPageScraper.asyncFetchLinks(link);
+  assert.equal(parseCallCount, 1, "we parsed the HTML once");
+
+  // Force fetch links bypass `asyncLinkExist` check.
+  yield gPageScraper.asyncFetchLinks(link, "eventType", true);
+  assert.equal(parseCallCount, 2, "we added the same link again because forceFetch is true");
+};
+
 exports.test_fetch_links_locally_and_save_them = function*(assert) {
   // we don't care about checking if the link should be saved - we want to save it
   gPageScraper._asyncSaveMetadata = link => {


### PR DESCRIPTION
 Explanation:
Previous version of the `getBookmarks` query filtered by `last_visit_date` IS NOT NULL. 
This excluded default bookmarks but also Pocket Stories that you would bookmark.
With this fix we try to fetch metadata information when a bookmark is added. If the page is visited it will just hit the Metadata store cache, otherwise (as for Pocket Stories) it will make a network request.
And filtering for the section happens based on metadata & images being present.
If you happen to actually visit a default bookmark page and metadata is present then yes the link will show up in the Bookmarks section.

Alternative solution included `PlacesUtils` module and added a "fake" visit in `moz_places` with current timestamp when you added a bookmark.

Fixes #2718