### PR TITLE
fix(mc): Wait until delayed startup instead of startup complete

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -14,7 +14,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "Services",
   "resource://gre/modules/Services.jsm");
 
 const ACTIVITY_STREAM_ENABLED_PREF = "browser.newtabpage.activity-stream.enabled";
-const BROWSER_READY_NOTIFICATION = "browser-ui-startup-complete";
+const BROWSER_READY_NOTIFICATION = "browser-delayed-startup-finished";
 const REASON_SHUTDOWN_ON_PREF_CHANGE = "PREF_OFF";
 const REASON_STARTUP_ON_PREF_CHANGE = "PREF_ON";
 const RESOURCE_BASE = "resource://activity-stream";


### PR DESCRIPTION
Fix #2741. r?@sarracini

Matches the notifications from `nsBrowserGlue` https://dxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserGlue.js#324-328