### PR TITLE
chore(mc): #2752 Refactor LinkMenu for clarity, flexibility

### DIFF
--- a/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
+++ b/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
@@ -1,86 +1,111 @@
 const React = require("react");
 const {injectIntl} = require("react-intl");
 const ContextMenu = require("content-src/components/ContextMenu/ContextMenu");
-const {actionTypes, actionCreators: ac} = require("common/Actions.jsm");
+const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
+
+const RemoveBookmark = site => ({
+  id: "menu_action_remove_bookmark",
+  icon: "bookmark-remove",
+  action: ac.SendToMain({
+    type: at.DELETE_BOOKMARK_BY_ID,
+    data: site.bookmarkGuid
+  }),
+  userEvent: "BOOKMARK_DELETE"
+});
+
+const AddBookmark = site => ({
+  id: "menu_action_bookmark",
+  icon: "bookmark",
+  action: ac.SendToMain({
+    type: at.BOOKMARK_URL,
+    data: site.url
+  }),
+  userEvent: "BOOKMARK_ADD"
+});
+
+const OpenInNewWindow = site => ({
+  id: "menu_action_open_new_window",
+  icon: "new-window",
+  action: ac.SendToMain({
+    type: at.OPEN_NEW_WINDOW,
+    data: {url: site.url}
+  }),
+  userEvent: "OPEN_NEW_WINDOW"
+});
+
+const OpenInPrivateWindow = site => ({
+  id: "menu_action_open_private_window",
+  icon: "new-window-private",
+  action: ac.SendToMain({
+    type: at.OPEN_PRIVATE_WINDOW,
+    data: {url: site.url}
+  }),
+  userEvent: "OPEN_PRIVATE_WINDOW"
+});
+
+const BlockUrl = site => ({
+  id: "menu_action_dismiss",
+  icon: "dismiss",
+  action: ac.SendToMain({
+    type: at.BLOCK_URL,
+    data: site.url
+  }),
+  userEvent: "BLOCK"
+});
+
+const DeleteUrl = site => ({
+  id: "menu_action_delete",
+  icon: "delete",
+  action: ac.SendToMain({
+    type: at.DELETE_HISTORY_URL,
+    data: site.url
+  }),
+  userEvent: "DELETE"
+});
 
 class LinkMenu extends React.Component {
-  getBookmarkStatus(site) {
-    return (site.bookmarkGuid ? {
-      id: "menu_action_remove_bookmark",
-      icon: "bookmark-remove",
-      action: "DELETE_BOOKMARK_BY_ID",
-      data: site.bookmarkGuid,
-      userEvent: "BOOKMARK_DELETE"
-    } : {
-      id: "menu_action_bookmark",
-      icon: "bookmark",
-      action: "BOOKMARK_URL",
-      data: site.url,
-      userEvent: "BOOKMARK_ADD"
-    });
-  }
-  getDefaultContextMenu(site) {
-    return [{
-      id: "menu_action_open_new_window",
-      icon: "new-window",
-      action: "OPEN_NEW_WINDOW",
-      data: {url: site.url},
-      userEvent: "OPEN_NEW_WINDOW"
-    },
-    {
-      id: "menu_action_open_private_window",
-      icon: "new-window-private",
-      action: "OPEN_PRIVATE_WINDOW",
-      data: {url: site.url},
-      userEvent: "OPEN_PRIVATE_WINDOW"
-    }];
-  }
   getOptions() {
-    const {dispatch, site, index, source} = this.props;
+    const props = this.props;
+    const {site} = props;
+    const isBookmark = site.bookmarkGuid;
+    const isDefault = site.isDefault;
 
-    // default top sites have a limited set of context menu options
-    let options = this.getDefaultContextMenu(site);
+    const options = [
 
-    // all other top sites have all the following context menu options
-    if (!site.isDefault) {
-      options = [
-        this.getBookmarkStatus(site),
-        {type: "separator"},
-        ...options,
-        {type: "separator"},
-        {
-          id: "menu_action_dismiss",
-          icon: "dismiss",
-          action: "BLOCK_URL",
-          data: site.url,
-          userEvent: "BLOCK"
-        },
-        {
-          id: "menu_action_delete",
-          icon: "delete",
-          action: "DELETE_HISTORY_URL",
-          data: site.url,
-          userEvent: "DELETE"
-        }];
-    }
-    options.forEach(option => {
-      const {action, data, id, type, userEvent} = option;
-      // Convert message ids to localized labels and add onClick function
+      // Bookmarks
+      !isDefault && (isBookmark ? RemoveBookmark(site) : AddBookmark(site)),
+      !isDefault && {type: "separator"},
+
+      // Menu items for all sites
+      OpenInNewWindow(site),
+      OpenInPrivateWindow(site),
+
+      // Blocking and deleting
+      !isDefault && {type: "separator"},
+      !isDefault && BlockUrl(site),
+      !isDefault && DeleteUrl(site)
+
+    ].filter(o => o).map(option => {
+      const {action, id, type, userEvent} = option;
       if (!type && id) {
-        option.label = this.props.intl.formatMessage(option);
+        option.label = props.intl.formatMessage(option);
         option.onClick = () => {
-          dispatch(ac.SendToMain({type: actionTypes[action], data}));
-          dispatch(ac.UserEvent({
-            event: userEvent,
-            source,
-            action_position: index
-          }));
+          props.dispatch(action);
+          if (userEvent) {
+            props.dispatch(ac.UserEvent({
+              event: userEvent,
+              source: props.source,
+              action_position: props.index
+            }));
+          }
         };
       }
+      return option;
     });
 
-    // this is for a11y - we want to know which item is the first and which item
-    // is the last, so we can close the context menu accordingly
+    // This is for accessibility to support making each item tabbable.
+    // We want to know which item is the first and which item
+    // is the last, so we can close the context menu accordingly.
     options[0].first = true;
     options[options.length - 1].last = true;
     return options;

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -45,10 +45,7 @@ describe("<LinkMenu>", () => {
       it(`should fire a ${option.action} action for ${option.id}`, () => {
         option.onClick();
         assert.calledTwice(dispatch);
-        assert.propertyVal(dispatch.firstCall.args[0], "type", option.action);
-        if (option.data) {
-          assert.propertyVal(dispatch.firstCall.args[0], "data", option.data);
-        }
+        assert.equal(dispatch.firstCall.args[0], option.action);
       });
       it(`should fire a UserEvent action for ${option.id}`, () => {
         option.onClick();


### PR DESCRIPTION
This patch refactors `LinkMenu` for more flexibility in terms of what user events can be dispatched.

It also makes `userEvent` optional.

For example, a `BOOKMARK_ADD` action that must be sent to the chrome process:

```js
const AddBookmark = site => ({
  id: "menu_action_bookmark",
  icon: "bookmark",
  action: ac.SendToMain({
    type: at.BOOKMARK_URL,
    data: site.url
  }),
  userEvent: "BOOKMARK_ADD"
});
```

or an `OPEN_DIALOG`, that should only be dispatched locally:

```js
const DeleteUrl = site => ({
  id: "menu_action_delete",
  icon: "delete",
  action: {
    type: at.OPEN_DIALOG,
    data: {...}
  }
});
```