### PR TITLE
fix(mc): Optimize startup init by avoiding overhead and lazy loading

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -12,9 +12,11 @@ XPCOMUtils.defineLazyModuleGetter(this, "Preferences",
 
 XPCOMUtils.defineLazyModuleGetter(this, "Services",
   "resource://gre/modules/Services.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "setTimeout",
+  "resource://gre/modules/Timer.jsm");
 
 const ACTIVITY_STREAM_ENABLED_PREF = "browser.newtabpage.activity-stream.enabled";
-const BROWSER_READY_NOTIFICATION = "browser-delayed-startup-finished";
+const BROWSER_READY_NOTIFICATION = "sessionstore-windows-restored";
 const REASON_SHUTDOWN_ON_PREF_CHANGE = "PREF_OFF";
 const REASON_STARTUP_ON_PREF_CHANGE = "PREF_ON";
 const RESOURCE_BASE = "resource://activity-stream";
@@ -113,7 +115,8 @@ function observe(subject, topic, data) {
   switch (topic) {
     case BROWSER_READY_NOTIFICATION:
       Services.obs.removeObserver(observe, BROWSER_READY_NOTIFICATION);
-      onBrowserReady();
+      // Avoid running synchronously during this event that's used for timing
+      setTimeout(() => onBrowserReady());
       break;
   }
 }

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -4,12 +4,11 @@
 "use strict";
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
-Cu.importGlobalProperties(["fetch"]);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.importGlobalProperties(["fetch"]);
 
 XPCOMUtils.defineLazyModuleGetter(this, "Preferences",
   "resource://gre/modules/Preferences.jsm");
-
 XPCOMUtils.defineLazyModuleGetter(this, "Services",
   "resource://gre/modules/Services.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "setTimeout",

--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -17,7 +17,13 @@ const globalImportContext = typeof Window === "undefined" ? BACKGROUND_PROCESS :
 // Export for tests
 this.globalImportContext = globalImportContext;
 
-const actionTypes = [
+// Create an object that avoids accidental differing key/value pairs:
+// {
+//   INIT: "INIT",
+//   UNINIT: "UNINIT"
+// }
+const actionTypes = {};
+for (const type of [
   "BLOCK_URL",
   "BOOKMARK_URL",
   "DELETE_BOOKMARK_BY_ID",
@@ -45,13 +51,9 @@ const actionTypes = [
   "TELEMETRY_USER_EVENT",
   "TOP_SITES_UPDATED",
   "UNINIT"
-// The line below creates an object like this:
-// {
-//   INIT: "INIT",
-//   UNINIT: "UNINIT"
-// }
-// It prevents accidentally adding a different key/value name.
-].reduce((obj, type) => { obj[type] = type; return obj; }, {});
+]) {
+  actionTypes[type] = type;
+}
 
 // Helper function for creating routed actions between content and main
 // Not intended to be used by consumers

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -4,33 +4,20 @@
 "use strict";
 
 const {utils: Cu} = Components;
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-const {Store} = Cu.import("resource://activity-stream/lib/Store.jsm", {});
+
+// NB: Eagerly load modules that will be loaded/constructed/initialized in the
+// common case to avoid the overhead of wrapping and detecting lazy loading.
 const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+const {DefaultPrefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
+const {LocalizationFeed} = Cu.import("resource://activity-stream/lib/LocalizationFeed.jsm", {});
+const {NewTabInit} = Cu.import("resource://activity-stream/lib/NewTabInit.jsm", {});
+const {PlacesFeed} = Cu.import("resource://activity-stream/lib/PlacesFeed.jsm", {});
+const {PrefsFeed} = Cu.import("resource://activity-stream/lib/PrefsFeed.jsm", {});
+const {Store} = Cu.import("resource://activity-stream/lib/Store.jsm", {});
+const {TelemetryFeed} = Cu.import("resource://activity-stream/lib/TelemetryFeed.jsm", {});
+const {TopSitesFeed} = Cu.import("resource://activity-stream/lib/TopSitesFeed.jsm", {});
 
 const REASON_ADDON_UNINSTALL = 6;
-
-XPCOMUtils.defineLazyModuleGetter(this, "DefaultPrefs",
-  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
-
-// Feeds
-XPCOMUtils.defineLazyModuleGetter(this, "LocalizationFeed",
-  "resource://activity-stream/lib/LocalizationFeed.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "NewTabInit",
-  "resource://activity-stream/lib/NewTabInit.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "PlacesFeed",
-  "resource://activity-stream/lib/PlacesFeed.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "PrefsFeed",
-  "resource://activity-stream/lib/PrefsFeed.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "TelemetryFeed",
-  "resource://activity-stream/lib/TelemetryFeed.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "TopSitesFeed",
-  "resource://activity-stream/lib/TopSitesFeed.jsm");
 
 const PREFS_CONFIG = [
   {
@@ -41,8 +28,6 @@ const PREFS_CONFIG = [
   // When you add a feed pref here:
   // 1. The pref should be prefixed with "feeds."
   // 2. The init property should be a function that instantiates your Feed
-  // 3. You should use XPCOMUtils.defineLazyModuleGetter to import the Feed,
-  //    so it isn't loaded until the feed is enabled.
   {
     name: "feeds.localization",
     title: "Initialize strings and detect locale for Activity Stream",

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -93,7 +93,7 @@ const PREFS_CONFIG = [
 
 const feeds = {};
 for (const pref of PREFS_CONFIG) {
-  if (pref.name.match(/^feeds\./)) {
+  if (pref.name.startsWith("feeds.")) {
     feeds[pref.name] = pref.init;
   }
 }

--- a/system-addon/lib/ActivityStreamMessageChannel.jsm
+++ b/system-addon/lib/ActivityStreamMessageChannel.jsm
@@ -5,20 +5,10 @@
 "use strict";
 
 const {utils: Cu} = Components;
+Cu.import("resource:///modules/AboutNewTab.jsm");
+Cu.import("resource://gre/modules/RemotePageManager.jsm");
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-
-const {
-  actionUtils: au,
-  actionCreators: ac,
-  actionTypes: at
-} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
-
-XPCOMUtils.defineLazyModuleGetter(this, "AboutNewTab",
-  "resource:///modules/AboutNewTab.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "RemotePages",
-  "resource://gre/modules/RemotePageManager.jsm");
+const {actionCreators: ac, actionTypes: at, actionUtils: au} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
 const ABOUT_NEW_TAB_URL = "about:newtab";
 

--- a/system-addon/lib/ActivityStreamPrefs.jsm
+++ b/system-addon/lib/ActivityStreamPrefs.jsm
@@ -18,9 +18,22 @@ this.Prefs = class Prefs extends Preferences {
   constructor(branch = ACTIVITY_STREAM_PREF_BRANCH) {
     super({branch});
     this._branchName = branch;
+    this._branchObservers = new Map();
   }
   get branchName() {
     return this._branchName;
+  }
+  ignoreBranch(listener) {
+    const observer = this._branchObservers.get(listener);
+    this._prefBranch.removeObserver(this._branchName, observer);
+    this._branchObservers.delete(listener);
+  }
+  observeBranch(listener) {
+    const observer = (subject, topic, pref) => {
+      listener.onPrefChanged(pref, this.get(pref));
+    };
+    this._prefBranch.addObserver("", observer);
+    this._branchObservers.set(listener, observer);
   }
 };
 
@@ -29,8 +42,8 @@ this.DefaultPrefs = class DefaultPrefs {
   /**
    * DefaultPrefs - A helper for setting and resetting default prefs for the add-on
    *
-   * @param  {Array} config An array of configuration objects with the following properties:
-   *         {string} .name The name of the pref
+   * @param  {Map} config A Map with {string} key of the pref name and {object}
+   *                      value with the following pref properties:
    *         {string} .title (optional) A description of the pref
    *         {bool|string|number} .value The default value for the pref
    * @param  {string} branch (optional) The pref branch (defaults to ACTIVITY_STREAM_PREF_BRANCH)
@@ -64,8 +77,8 @@ this.DefaultPrefs = class DefaultPrefs {
    * init - Set default prefs for all prefs in the config
    */
   init() {
-    for (const pref of this._config) {
-      this._setDefaultPref(pref.name, pref.value);
+    for (const pref of this._config.keys()) {
+      this._setDefaultPref(pref, this._config.get(pref).value);
     }
   }
 
@@ -73,8 +86,8 @@ this.DefaultPrefs = class DefaultPrefs {
    * reset - Resets all user-defined prefs for prefs in ._config to their defaults
    */
   reset() {
-    for (const pref of this._config) {
-      this.branch.clearUserPref(pref.name);
+    for (const name of this._config.keys()) {
+      this.branch.clearUserPref(name);
     }
   }
 };

--- a/system-addon/lib/LocalizationFeed.jsm
+++ b/system-addon/lib/LocalizationFeed.jsm
@@ -4,13 +4,10 @@
 "use strict";
 
 const {utils: Cu} = Components;
-const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
-
+Cu.import("resource://gre/modules/Services.jsm");
 Cu.importGlobalProperties(["fetch"]);
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "Services",
-  "resource://gre/modules/Services.jsm");
+const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
 // What is our default locale for the app?
 const DEFAULT_LOCALE = "en-US";

--- a/system-addon/lib/NewTabInit.jsm
+++ b/system-addon/lib/NewTabInit.jsm
@@ -4,7 +4,8 @@
 "use strict";
 
 const {utils: Cu} = Components;
-const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+
+const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
 /**
  * NewTabInit - A placeholder for now. This will send a copy of the state to all

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -150,8 +150,14 @@ class PlacesFeed {
   }
 
   addObservers() {
-    PlacesUtils.history.addObserver(this.historyObserver, true);
-    PlacesUtils.bookmarks.addObserver(this.bookmarksObserver, true);
+    // NB: Directly get services without importing the *BIG* PlacesUtils module
+    Cc["@mozilla.org/browser/nav-history-service;1"]
+      .getService(Ci.nsINavHistoryService)
+      .addObserver(this.historyObserver, true);
+    Cc["@mozilla.org/browser/nav-bookmarks-service;1"]
+      .getService(Ci.nsINavBookmarksService)
+      .addObserver(this.bookmarksObserver, true);
+
     Services.obs.addObserver(this, LINK_BLOCKED_EVENT);
   }
 

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -3,17 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu, interfaces: Ci} = Components;
-const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
-
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
 XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "PlacesUtils",
   "resource://gre/modules/PlacesUtils.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "Services",
-  "resource://gre/modules/Services.jsm");
 
 const LINK_BLOCKED_EVENT = "newtab-linkBlocked";
 

--- a/system-addon/lib/PrefsFeed.jsm
+++ b/system-addon/lib/PrefsFeed.jsm
@@ -4,11 +4,9 @@
 "use strict";
 
 const {utils: Cu} = Components;
-const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "Prefs",
-  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
+const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 
 this.PrefsFeed = class PrefsFeed {
   constructor(prefNames) {

--- a/system-addon/lib/PrefsFeed.jsm
+++ b/system-addon/lib/PrefsFeed.jsm
@@ -9,24 +9,21 @@ const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-str
 const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 
 this.PrefsFeed = class PrefsFeed {
-  constructor(prefNames) {
-    this._prefNames = prefNames;
+  constructor(prefMap) {
+    this._prefMap = prefMap;
     this._prefs = new Prefs();
-    this._observers = new Map();
   }
   onPrefChanged(name, value) {
-    this.store.dispatch(ac.BroadcastToContent({type: at.PREF_CHANGED, data: {name, value}}));
+    if (this._prefMap.has(name)) {
+      this.store.dispatch(ac.BroadcastToContent({type: at.PREF_CHANGED, data: {name, value}}));
+    }
   }
   init() {
-    const values = {};
+    this._prefs.observeBranch(this);
 
-    // Set up listeners for each activity stream pref
-    for (const name of this._prefNames) {
-      const handler = value => {
-        this.onPrefChanged(name, value);
-      };
-      this._observers.set(name, handler, this);
-      this._prefs.observe(name, handler);
+    // Get the initial value of each activity stream pref
+    const values = {};
+    for (const name of this._prefMap.keys()) {
       values[name] = this._prefs.get(name);
     }
 
@@ -34,10 +31,7 @@ this.PrefsFeed = class PrefsFeed {
     this.store.dispatch(ac.BroadcastToContent({type: at.PREFS_INITIAL_VALUES, data: values}));
   }
   removeListeners() {
-    for (const name of this._prefNames) {
-      this._prefs.ignore(name, this._observers.get(name));
-    }
-    this._observers.clear();
+    this._prefs.ignoreBranch(this);
   }
   onAction(action) {
     switch (action.type) {

--- a/system-addon/lib/Store.jsm
+++ b/system-addon/lib/Store.jsm
@@ -5,13 +5,10 @@
 
 const {utils: Cu} = Components;
 
-const {redux} = Cu.import("resource://activity-stream/vendor/Redux.jsm", {});
-const {reducers} = Cu.import("resource://activity-stream/common/Reducers.jsm", {});
 const {ActivityStreamMessageChannel} = Cu.import("resource://activity-stream/lib/ActivityStreamMessageChannel.jsm", {});
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-
-XPCOMUtils.defineLazyModuleGetter(this, "Prefs",
-  "resource://activity-stream/lib/ActivityStreamPrefs.jsm");
+const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
+const {reducers} = Cu.import("resource://activity-stream/common/Reducers.jsm", {});
+const {redux} = Cu.import("resource://activity-stream/vendor/Redux.jsm", {});
 
 /**
  * Store - This has a similar structure to a redux store, but includes some extra

--- a/system-addon/lib/Store.jsm
+++ b/system-addon/lib/Store.jsm
@@ -30,11 +30,9 @@ this.Store = class Store {
     this._middleware = this._middleware.bind(this);
     // Bind each redux method so we can call it directly from the Store. E.g.,
     // store.dispatch() will call store._store.dispatch();
-    ["dispatch", "getState", "subscribe"].forEach(method => {
-      this[method] = function(...args) {
-        return this._store[method](...args);
-      }.bind(this);
-    });
+    for (const method of ["dispatch", "getState", "subscribe"]) {
+      this[method] = (...args) => this._store[method](...args);
+    }
     this.feeds = new Map();
     this._feedFactories = null;
     this._prefs = new Prefs();
@@ -51,10 +49,14 @@ this.Store = class Store {
    *               it calls each feed's .onAction method, if one
    *               is defined.
    */
-  _middleware(store) {
+  _middleware() {
     return next => action => {
       next(action);
-      this.feeds.forEach(s => s.onAction && s.onAction(action));
+      for (const store of this.feeds.values()) {
+        if (store.onAction) {
+          store.onAction(action);
+        }
+      }
     };
   }
 

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -6,19 +6,21 @@
 "use strict";
 
 const {interfaces: Ci, utils: Cu} = Components;
-const {actionTypes: at, actionUtils: au} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
-const {perfService} = Cu.import("resource://activity-stream/common/PerfService.jsm", {});
-
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+const {actionTypes: at, actionUtils: au} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+
+XPCOMUtils.defineLazyModuleGetter(this, "ClientID",
+  "resource://gre/modules/ClientID.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "perfService",
+  "resource://activity-stream/common/PerfService.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "TelemetrySender",
+  "resource://activity-stream/lib/TelemetrySender.jsm");
 
 XPCOMUtils.defineLazyServiceGetter(this, "gUUIDGenerator",
   "@mozilla.org/uuid-generator;1",
   "nsIUUIDGenerator");
-XPCOMUtils.defineLazyModuleGetter(this, "ClientID",
-  "resource://gre/modules/ClientID.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "TelemetrySender",
-  "resource://activity-stream/lib/TelemetrySender.jsm");
 
 this.TelemetryFeed = class TelemetryFeed {
   constructor(options) {

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -9,35 +9,44 @@ const {interfaces: Ci, utils: Cu} = Components;
 const {actionTypes: at, actionUtils: au} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 const {perfService} = Cu.import("resource://activity-stream/common/PerfService.jsm", {});
 
-Cu.import("resource://gre/modules/ClientID.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
 XPCOMUtils.defineLazyServiceGetter(this, "gUUIDGenerator",
   "@mozilla.org/uuid-generator;1",
   "nsIUUIDGenerator");
+XPCOMUtils.defineLazyModuleGetter(this, "ClientID",
+  "resource://gre/modules/ClientID.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetrySender",
   "resource://activity-stream/lib/TelemetrySender.jsm");
 
 this.TelemetryFeed = class TelemetryFeed {
   constructor(options) {
     this.sessions = new Map();
-    this.telemetryClientId = null;
-    this.telemetrySender = null;
   }
 
-  async init() {
+  init() {
     Services.obs.addObserver(this.browserOpenNewtabStart, "browser-open-newtab-start");
-
-    // TelemetrySender adds pref observers, so we initialize it after INIT
-    this.telemetrySender = new TelemetrySender();
-
-    const id = await ClientID.getClientID();
-    this.telemetryClientId = id;
   }
 
   browserOpenNewtabStart() {
     perfService.mark("browser-open-newtab-start");
+  }
+
+  /**
+   * Lazily get the Telemetry id promise
+   */
+  get telemetryClientId() {
+    Object.defineProperty(this, "telemetryClientId", {value: ClientID.getClientID()});
+    return this.telemetryClientId;
+  }
+
+  /**
+   * Lazily initialize TelemetrySender to send pings
+   */
+  get telemetrySender() {
+    Object.defineProperty(this, "telemetrySender", {value: new TelemetrySender()});
+    return this.telemetrySender;
   }
 
   /**
@@ -112,10 +121,10 @@ this.TelemetryFeed = class TelemetryFeed {
    * @param  {string} id The portID of the session, if a session is relevant (optional)
    * @return {obj}    A telemetry ping
    */
-  createPing(portID) {
+  async createPing(portID) {
     const appInfo = this.store.getState().App;
     const ping = {
-      client_id: this.telemetryClientId,
+      client_id: await this.telemetryClientId,
       addon_version: appInfo.version,
       locale: appInfo.locale
     };
@@ -131,34 +140,34 @@ this.TelemetryFeed = class TelemetryFeed {
     return ping;
   }
 
-  createUserEvent(action) {
+  async createUserEvent(action) {
     return Object.assign(
-      this.createPing(au.getPortIdOfSender(action)),
+      await this.createPing(au.getPortIdOfSender(action)),
       action.data,
       {action: "activity_stream_user_event"}
     );
   }
 
-  createUndesiredEvent(action) {
+  async createUndesiredEvent(action) {
     return Object.assign(
-      this.createPing(au.getPortIdOfSender(action)),
+      await this.createPing(au.getPortIdOfSender(action)),
       {value: 0}, // Default value
       action.data,
       {action: "activity_stream_undesired_event"}
     );
   }
 
-  createPerformanceEvent(action) {
+  async createPerformanceEvent(action) {
     return Object.assign(
-      this.createPing(au.getPortIdOfSender(action)),
+      await this.createPing(au.getPortIdOfSender(action)),
       action.data,
       {action: "activity_stream_performance_event"}
     );
   }
 
-  createSessionEndEvent(session) {
+  async createSessionEndEvent(session) {
     return Object.assign(
-      this.createPing(),
+      await this.createPing(),
       {
         session_id: session.session_id,
         page: session.page,
@@ -169,8 +178,8 @@ this.TelemetryFeed = class TelemetryFeed {
     );
   }
 
-  sendEvent(event) {
-    this.telemetrySender.sendPing(event);
+  async sendEvent(eventPromise) {
+    this.telemetrySender.sendPing(await eventPromise);
   }
 
   onAction(action) {
@@ -201,8 +210,10 @@ this.TelemetryFeed = class TelemetryFeed {
     Services.obs.removeObserver(this.browserOpenNewtabStart,
       "browser-open-newtab-start");
 
-    this.telemetrySender.uninit();
-    this.telemetrySender = null;
+    // Only uninit if the getter has initialized it
+    if (Object.prototype.hasOwnProperty.call(this, "telemetrySender")) {
+      this.telemetrySender.uninit();
+    }
     // TODO: Send any unfinished sessions
   }
 };

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const {interfaces: Ci, utils: Cu} = Components;
-
 Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]);
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/Console.jsm"); // eslint-disable-line no-console
+
+XPCOMUtils.defineLazyModuleGetter(this, "console",
+  "resource://gre/modules/Console.jsm");
 
 // This is intentionally a different pref-branch than the SDK-based add-on
 // used, to avoid extra weirdness for people who happen to have the SDK-based

--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -71,7 +71,7 @@ TelemetrySender.prototype = {
     this._fhrEnabled = prefVal;
   },
 
-  async sendPing(data) {
+  sendPing(data) {
     if (this.logging) {
       // performance related pings cause a lot of logging, so we mute them
       if (data.action !== "activity_stream_performance") {

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -14,22 +14,21 @@ const TOP_SITES_SHOWMORE_LENGTH = 12;
 const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
 const DEFAULT_TOP_SITES = [];
 
-// Add default sites if any based on the pref
-try {
-  let sites = new Prefs().get("default.sites").split(",");
-  sites.filter(url => url).forEach(url => {
-    DEFAULT_TOP_SITES.push({
-      isDefault: true,
-      url
-    });
-  });
-} catch (e) {
-  // Use no defaults if something went wrong
-}
-
 this.TopSitesFeed = class TopSitesFeed {
   constructor() {
     this.lastUpdated = 0;
+  }
+  init() {
+    // Add default sites if any based on the pref
+    let sites = new Prefs().get("default.sites");
+    if (sites) {
+      for (const url of sites.split(",")) {
+        DEFAULT_TOP_SITES.push({
+          isDefault: true,
+          url
+        });
+      }
+    }
   }
   async getScreenshot(url) {
     let screenshot = await PreviewProvider.getThumbnail(url);
@@ -71,6 +70,9 @@ this.TopSitesFeed = class TopSitesFeed {
   onAction(action) {
     let realRows;
     switch (action.type) {
+      case at.INIT:
+        this.init();
+        break;
       case at.NEW_TAB_LOAD:
         // Only check against real rows returned from history, not default ones.
         realRows = this.store.getState().TopSites.rows.filter(row => !row.isDefault);

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -4,11 +4,15 @@
 "use strict";
 
 const {utils: Cu} = Components;
-const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 
-Cu.import("resource://gre/modules/NewTabUtils.jsm");
-Cu.import("resource:///modules/PreviewProvider.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
+  "resource://gre/modules/NewTabUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PreviewProvider",
+  "resource:///modules/PreviewProvider.jsm");
 
 const TOP_SITES_SHOWMORE_LENGTH = 12;
 const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -83,27 +83,27 @@ describe("ActivityStream", () => {
   });
   describe("feeds", () => {
     it("should create a Localization feed", () => {
-      const feed = as.feeds["feeds.localization"]();
+      const feed = as.feeds.get("feeds.localization")();
       assert.instanceOf(feed, Fake);
     });
     it("should create a NewTabInit feed", () => {
-      const feed = as.feeds["feeds.newtabinit"]();
+      const feed = as.feeds.get("feeds.newtabinit")();
       assert.instanceOf(feed, Fake);
     });
     it("should create a Places feed", () => {
-      const feed = as.feeds["feeds.places"]();
+      const feed = as.feeds.get("feeds.places")();
       assert.instanceOf(feed, Fake);
     });
     it("should create a TopSites feed", () => {
-      const feed = as.feeds["feeds.topsites"]();
+      const feed = as.feeds.get("feeds.topsites")();
       assert.instanceOf(feed, Fake);
     });
     it("should create a Telemetry feed", () => {
-      const feed = as.feeds["feeds.telemetry"]();
+      const feed = as.feeds.get("feeds.telemetry")();
       assert.instanceOf(feed, Fake);
     });
     it("should create a Prefs feed", () => {
-      const feed = as.feeds["feeds.prefs"]();
+      const feed = as.feeds.get("feeds.prefs")();
       assert.instanceOf(feed, Fake);
     });
   });

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -28,6 +28,16 @@ describe("PlacesFeed", () => {
       history: {addObserver: sandbox.spy(), removeObserver: sandbox.spy()},
       bookmarks: {TYPE_BOOKMARK, addObserver: sandbox.spy(), removeObserver: sandbox.spy()}
     });
+    global.Components.classes["@mozilla.org/browser/nav-history-service;1"] = {
+      getService() {
+        return global.PlacesUtils.history;
+      }
+    };
+    global.Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"] = {
+      getService() {
+        return global.PlacesUtils.bookmarks;
+      }
+    };
     sandbox.spy(global.Services.obs, "addObserver");
     sandbox.spy(global.Services.obs, "removeObserver");
     sandbox.spy(global.Components.utils, "reportError");

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -33,12 +33,27 @@ describe("Top Sites Feed", () => {
     clock.restore();
   });
 
-  it("should have default sites with .isDefault = true", () => {
-    assert.ok(DEFAULT_TOP_SITES.length);
-    DEFAULT_TOP_SITES.forEach(link => assert.propertyVal(link, "isDefault", true));
+  describe("#init", () => {
+    it("should add defaults on INIT", () => {
+      feed.onAction({type: at.INIT});
+      assert.ok(DEFAULT_TOP_SITES.length);
+    });
+    it("should have default sites with .isDefault = true", () => {
+      feed.init();
+      DEFAULT_TOP_SITES.forEach(link => assert.propertyVal(link, "isDefault", true));
+    });
+    it("should add no defaults on empty pref", () => {
+      FakePrefs.prototype.prefs["default.sites"] = "";
+      feed.init();
+      assert.equal(DEFAULT_TOP_SITES.length, 0);
+    });
   });
 
   describe("#getLinksWithDefaults", () => {
+    beforeEach(() => {
+      feed.init();
+    });
+
     it("should get the links from NewTabUtils", async () => {
       const result = await feed.getLinksWithDefaults();
       assert.deepEqual(result, links);

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -13,6 +13,7 @@ let overrider = new GlobalOverrider();
 
 overrider.set({
   Components: {
+    classes: {},
     interfaces: {},
     utils: {
       import() {},

--- a/system-addon/test/unit/utils.js
+++ b/system-addon/test/unit/utils.js
@@ -104,6 +104,9 @@ FakePrefs.prototype = {
       delete this.observers[prefName];
     }
   },
+  _prefBranch: {},
+  observeBranch(listener) {},
+  ignoreBranch(listener) {},
 
   prefs: {},
   get(prefName) { return this.prefs[prefName]; },


### PR DESCRIPTION
Fix #2750 and fix #2759. r?@k88hudson I've pushed various separate commits that optimize in various ways. Try runs seem to confirm fixing the `sessionrestore` Talos regression.

https://treeherder.mozilla.org/perf.html#/compare?originalProject=try&originalRevision=99adfb3d3f9edb5de25fb9325a25c9a149a1548c&newProject=try&newRevision=368b0dd9c3e2b68fbd6048f551a24cf53129088e&framework=1

Local profiles show it reducing the running time of `bootstrap.js`'s `observe` from 40ms to 20ms.

Here's a description of commits:

Defer loading until after sessionrestore: Looks like we can wait until later without affecting the ability to restore about:newtab or open Firefox directly to about:newtab

Convert looping to for-of: Various microbenchmarks seem to have .forEach being faster after it gets optimized over millions of runs, but profiling on the initial and small number of iterations seems to be better to avoid the callback.

Load default top sites loading on init instead of on import: This is needed to eagerly load feeds where loading at the top level assumes default prefs are already set, so loading pref on `INIT` guarantees that defaults are ready.

Lazily load sender/id from TelemetryFeed: This avoids starting up TelemetrySender (which gets and observes a number prefs) and the async await ID request until a ping needs to actually be sent.

Eager and lazy import as appropriate: Avoid the overhead of lazy getters if we're going to just load the module anyway on import/`constructor`/`INIT` and defer things that won't be used immediately.

Use prefix string check instead of regex: Avoids the regex.

Delay loading of PlacesUtils with direct services: Sometimes PlacesUtils gets called during restore, but if not, we don't want to be the one to trigger it, so grab the service directly.

Rework CONFIGs as Maps to observe whole branch instead of individual prefs: Instead of setting up observers for every single pref, get notified for anything in the branch and check if it's something we care about for `Store` and `PrefsFeed`. Also spits out `PREFS_CONFIG` and `FEEDS_CONFIG` as `Map`s to optimize some usage within each of `Store` and `PrefsFeed`.

Work around webpack/babel confusing istanbul: Not sure if you have a suggested `karma.mc.config.js` tweak to avoid this, but without, coverage thinks we're missing statements because destructured assignment results in an added helper function with unused code.