### PR TITLE
Preparing the release of Activity Stream 1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     skip_cleanup: true
     script: bin/continuous-integration.sh prerelease
     on:
-      branch: release-1.4.0
+      branch: release-1.15.0
   - provider: script
     skip_cleanup: true
     script: bin/continuous-integration.sh shield

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="1.14.1"></a>
+## 1.14.1 (2017-07-04)
+
+* 1.14.0 changelog ([466fba6](https://github.com/mozilla/activity-stream/commit/466fba6))
+* 1.14.1 ([b212502](https://github.com/mozilla/activity-stream/commit/b212502))
+* fix(db): 2817 - Add shutdown blocker for metadata store ([78d6ddf](https://github.com/mozilla/activity-stream/commit/78d6ddf))
+
+
+
 <a name="1.14.0"></a>
 # 1.14.0 (2017-06-28)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "activity-streams",
   "description": "A rich visual history feed and a reimagined home page make it easier than ever to find exactly what you're looking for in Firefox.\n\nLearn more about this Test Pilot experiment at https://testpilot.firefox.com/.",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": "Mozilla (https://mozilla.org/)",
   "bugs": {
     "url": "https://github.com/mozilla/activity-stream/issues"


### PR DESCRIPTION
Hi all,

We are now preparing the release of A-S 1.15.0. The add-on has been made available at [pre-release channel](https://moz-activity-streams-prerelease.s3.amazonaws.com/dist/latest.html). Please install it, test it, and leave the feedback, bug reports, and other inputs in this thread.

# Highlights
* [new] Visit Again section

# Release checklist
- QA
  - [x] @pdehaan 
  - [x] @SoftVision
- Product
  - [x] @nchapman 
  - [x] @aaronrbenson 
- Engineering
  - [x] @tspurway 
  - [x] @jennchaulk 

Please use the `release/block` or `release/uplift` to label the bug reports as well as other release related issues. Once you finish the review, please check off the corresponding item in the above checklist.

*Note*: checking off the item may not work, you can either modify it in place (i.e modify `[ ]` to `[x]`), or just drop a good old `r+` comment below.  

Thanks