### PR TITLE
fix(mc): Turn off processPrelaunch when preffing on activity stream

### DIFF
--- a/mozilla-central-patches/enable-mc-as.diff
+++ b/mozilla-central-patches/enable-mc-as.diff
@@ -8,6 +8,13 @@ diff --git a/browser/app/profile/firefox.js b/browser/app/profile/firefox.js
 +pref("browser.newtabpage.activity-stream.enabled", true);
  
  // Enable the DOM fullscreen API.
+@@ -1625,5 +1625,5 @@ pref("browser.esedbreader.loglevel", "Error");
+ pref("browser.laterrun.enabled", false);
+ 
+-pref("dom.ipc.processPrelaunch.enabled", true);
++pref("dom.ipc.processPrelaunch.enabled", false);
+ 
+ #ifdef EARLY_BETA_OR_EARLIER
 diff --git a/browser/extensions/activity-stream/moz.build b/browser/extensions/activity-stream/moz.build
 --- a/browser/extensions/activity-stream/moz.build
 +++ b/browser/extensions/activity-stream/moz.build


### PR DESCRIPTION
Fix #2785. r?@dmose

This will turn things on for `pine`. And when we actually turn on in mozilla-central, we can get rid of this patch (as it will be the patch being reviewed by mconley to pref on for Nightly.