### PR TITLE
fix(mc): (nobug) Stringify telemetry sender payload

### DIFF
--- a/system-addon/lib/TelemetrySender.jsm
+++ b/system-addon/lib/TelemetrySender.jsm
@@ -82,7 +82,7 @@ TelemetrySender.prototype = {
     if (!this.enabled) {
       return Promise.resolve();
     }
-    return fetch(this._pingEndpoint, {method: "POST", body: data}).then(response => {
+    return fetch(this._pingEndpoint, {method: "POST", body: JSON.stringify(data)}).then(response => {
       if (!response.ok) {
         Cu.reportError(`Ping failure with HTTP response code: ${response.status}`);
       }

--- a/system-addon/test/unit/lib/TelemetrySender.test.js
+++ b/system-addon/test/unit/lib/TelemetrySender.test.js
@@ -165,7 +165,7 @@ describe("TelemetrySender", () => {
 
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, fakeEndpointUrl,
-        {method: "POST", body: fakePingJSON});
+        {method: "POST", body: JSON.stringify(fakePingJSON)});
     });
 
     it("should log HTTP failures using Cu.reportError", async () => {


### PR DESCRIPTION
Because `[Object object]` is not a particularly useful ping