### PR TITLE
fix(mc): Stop observing the same branch observed

### DIFF
--- a/system-addon/lib/ActivityStreamPrefs.jsm
+++ b/system-addon/lib/ActivityStreamPrefs.jsm
@@ -25,7 +25,7 @@ this.Prefs = class Prefs extends Preferences {
   }
   ignoreBranch(listener) {
     const observer = this._branchObservers.get(listener);
-    this._prefBranch.removeObserver(this._branchName, observer);
+    this._prefBranch.removeObserver("", observer);
     this._branchObservers.delete(listener);
   }
   observeBranch(listener) {

--- a/system-addon/lib/Store.jsm
+++ b/system-addon/lib/Store.jsm
@@ -123,10 +123,10 @@ this.Store = class Store {
    * @return {type}  description
    */
   uninit() {
+    this._prefs.ignoreBranch(this);
     this.feeds.forEach(feed => this.uninitFeed(feed));
     this.feeds.clear();
     this._feedFactories = null;
-    this._prefs.ignoreBranch(this);
     this._messageChannel.destroyChannel();
   }
 };

--- a/system-addon/test/unit/lib/ActivityStreamPrefs.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamPrefs.test.js
@@ -37,6 +37,7 @@ describe("ActivityStreamPrefs", () => {
       });
       it("should add an observer", () => {
         assert.calledOnce(p._prefBranch.addObserver);
+        assert.calledWith(p._prefBranch.addObserver, "");
       });
       it("should store the listener", () => {
         assert.equal(p._branchObservers.size, 1);
@@ -61,7 +62,8 @@ describe("ActivityStreamPrefs", () => {
       it("should remove the observer", () => {
         p.ignoreBranch(listener);
 
-        assert.calledOnce(p._prefBranch.addObserver);
+        assert.calledOnce(p._prefBranch.removeObserver);
+        assert.calledWith(p._prefBranch.removeObserver, p._prefBranch.addObserver.firstCall.args[0]);
       });
       it("should remove the listener", () => {
         assert.equal(p._branchObservers.size, 1);


### PR DESCRIPTION
r?@k88hudson Didn't actually remove the observer on uninit. Also has `ignoreBranch` be the first thing on `uninit` just in case something triggered pref changes during `uninit`.