### PR TITLE
fix(mc): Allow notification tests to run now that AutoMigrate is off

### DIFF
--- a/mozilla-central-patches/disable-undo-notification-tests.diff
+++ b/mozilla-central-patches/disable-undo-notification-tests.diff
@@ -1,9 +1,0 @@
-diff --git a/browser/components/migration/tests/browser/browser.ini b/browser/components/migration/tests/browser/browser.ini
---- a/browser/components/migration/tests/browser/browser.ini
-+++ b/browser/components/migration/tests/browser/browser.ini
-@@ -1,3 +1,5 @@
- [browser_undo_notification.js]
-+skip-if = true # disable until activity-stream handles the appropriate messages
- [browser_undo_notification_wording.js]
-+skip-if = true # disable until activity-stream handles the appropriate messages
- [browser_undo_notification_multiple_dismissal.js]


### PR DESCRIPTION
Fix #2365. r?@dmose 