### PR TITLE
feat(systemaddon): Closes #2821 Implement clear history

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -131,6 +131,9 @@ this.TopSitesFeed = class TopSitesFeed {
       case at.OPEN_PRIVATE_WINDOW:
         this.openNewWindow(action, true);
         break;
+      case at.PLACES_HISTORY_CLEARED:
+        this.refresh(action);
+        break;
       case at.TOP_SITES_PIN:
         this.pin(action);
         break;

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -203,5 +203,10 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.unpin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.unpin, unpinAction.data.site);
     });
+    it("should call refresh if we clear history with PLACES_HISTORY_CLEARED", () => {
+      sinon.stub(feed, "refresh");
+      feed.onAction({type: at.PLACES_HISTORY_CLEARED});
+      assert.calledOnce(feed.refresh);
+    });
   });
 });


### PR DESCRIPTION
Fix #2821. Just adds a listener in the feed for the history cleared action and refreshes 