### PR TITLE
fix(system-addon): Return a topsite label for localhost. Closes #2814

### DIFF
--- a/system-addon/content-src/lib/short-url.js
+++ b/system-addon/content-src/lib/short-url.js
@@ -22,5 +22,5 @@ module.exports = function shortURL(link) {
   // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
   const eTLDLength = (eTLD || "").length || (hostname.match(/\.com$/) && 3);
   const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
-  return hostname.slice(0, eTLDExtra).toLowerCase();
+  return hostname.slice(0, eTLDExtra).toLowerCase() || hostname;
 };

--- a/system-addon/test/unit/content-src/lib/short-url.test.js
+++ b/system-addon/test/unit/content-src/lib/short-url.test.js
@@ -25,4 +25,8 @@ describe("shortURL", () => {
   it("should convert to lowercase", () => {
     assert.equal(shortURL({url: "HTTP://FOO.COM", eTLD: "com"}), "foo");
   });
+
+  it("should return hostname for localhost", () => {
+    assert.equal(shortURL({url: "http://localhost:8000/", eTLD: "localhost"}), "localhost");
+  });
 });


### PR DESCRIPTION
The issue is that localhost has eTLD set to localhost. This results in `shortURL` to slice it completely returning an empty string. This change returns hostname which always exists given a valid URL. Should guard against similar scenarios with custom/special DNS entries.