### PR TITLE
Revert "feat(systemaddon): Closes #2821 Implement clear history"

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -131,9 +131,6 @@ this.TopSitesFeed = class TopSitesFeed {
       case at.OPEN_PRIVATE_WINDOW:
         this.openNewWindow(action, true);
         break;
-      case at.PLACES_HISTORY_CLEARED:
-        this.refresh(action);
-        break;
       case at.TOP_SITES_PIN:
         this.pin(action);
         break;

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -203,10 +203,5 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.unpin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.unpin, unpinAction.data.site);
     });
-    it("should call refresh if we clear history with PLACES_HISTORY_CLEARED", () => {
-      sinon.stub(feed, "refresh");
-      feed.onAction({type: at.PLACES_HISTORY_CLEARED});
-      assert.calledOnce(feed.refresh);
-    });
   });
 });


### PR DESCRIPTION
Reverts mozilla/activity-stream#2822

This is breaking any test that clears history:
https://treeherder.mozilla.org/#/jobs?repo=pine&revision=9b6d236e412509e7972c064458dfca6a30917f25&selectedJob=112428374&filter-resultStatus=testfailed&filter-resultStatus=busted&filter-resultStatus=exception&filter-classifiedState=unclassified

This didn't actually work because refresh tries to `SendToContent` but history clearing is triggered independent of a page, so we probably want `BroadcastToContent` instead from `refresh`