### PR TITLE
 tests(systemaddon): Fixes #2754 Improve LinkMenu test coverage

### DIFF
--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -46,6 +46,10 @@ describe("<LinkMenu>", () => {
     assert.ok(options[1].type === "separator");
     assert.ok(options[2].id === "menu_action_open_new_window");
     assert.ok(options[3].id === "menu_action_open_private_window");
+    // Double check that dismiss and delete options are not included
+    options.filter(o => o.type !== "separator").forEach(o => {
+      assert.notInclude(["menu_action_dismiss", "menu_action_delete"], o.id);
+    });
   });
   it("should show Unpin option for a pinned site if CheckPinTopSite in options list", () => {
     wrapper = shallowWithIntl(<LinkMenu site={{url: "", isPinned: true}} source={"TOP_SITES"} options={["CheckPinTopSite"]} dispatch={() => {}} />);
@@ -67,7 +71,7 @@ describe("<LinkMenu>", () => {
     const options = wrapper.find(ContextMenu).props().options;
     assert.isDefined(options.find(o => (o.id && o.id === "menu_action_bookmark")));
   });
-  it("should call intl.formatMessage with the correct arguments", () => {
+  it("should call intl.formatMessage with the correct string ids", () => {
     const FAKE_OPTIONS = ["AddBookmark", "OpenInNewWindow"];
     const intlProvider = new IntlProvider({locale: "en", messages});
     const {intl} = intlProvider.getChildContext();
@@ -113,7 +117,8 @@ describe("<LinkMenu>", () => {
         // option.action is dispatched
         assert.ok(dispatch.firstCall.calledWith(option.action));
 
-        // option.action has correct data (delete is a special case as it has to be confirmed)
+        // option.action has correct data
+        // (delete is a special case as it dispatches a nested DIALOG_OPEN-type action)
         if (option.id === "menu_action_delete") {
           assert.deepEqual(option.action.data.onConfirm[0].data, expectedActionData[option.id]);
         } else {

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -1,7 +1,11 @@
 const React = require("react");
+const {shallow} = require("enzyme");
 const {shallowWithIntl} = require("test/unit/utils");
 const {_unconnected: LinkMenu} = require("content-src/components/LinkMenu/LinkMenu");
 const ContextMenu = require("content-src/components/ContextMenu/ContextMenu");
+const {IntlProvider} = require("react-intl");
+const messages = require("data/locales.json")["en-US"];
+const shortURL = require("content-src/lib/short-url");
 
 describe("<LinkMenu>", () => {
   let wrapper;
@@ -63,19 +67,58 @@ describe("<LinkMenu>", () => {
     const options = wrapper.find(ContextMenu).props().options;
     assert.isDefined(options.find(o => (o.id && o.id === "menu_action_bookmark")));
   });
+  it("should call intl.formatMessage with the correct arguments", () => {
+    const FAKE_OPTIONS = ["AddBookmark", "OpenInNewWindow"];
+    const intlProvider = new IntlProvider({locale: "en", messages});
+    const {intl} = intlProvider.getChildContext();
+    const spy = sinon.spy(intl, "formatMessage");
+
+    // Identical to calling shallowWithIntl, but passing in the mocked intl object
+    const node = <LinkMenu site={{url: ""}} options={FAKE_OPTIONS} dispatch={() => {}} />;
+    shallow(React.cloneElement(node, {intl}), {context: {intl}});
+
+    // Called once for each option in the menu
+    assert.ok(spy.callCount === FAKE_OPTIONS.length);
+
+    // Called with correct ids both times
+    assert.ok(spy.firstCall.calledWith(sinon.match({id: "menu_action_bookmark"})));
+    assert.ok(spy.secondCall.calledWith(sinon.match({id: "menu_action_open_new_window"})));
+  });
   describe(".onClick", () => {
     const FAKE_INDEX = 3;
     const FAKE_SOURCE = "TOP_SITES";
+    const FAKE_SITE = {url: "https://foo.com", title: "bar", bookmarkGuid: 1234};
     const dispatch = sinon.stub();
     const propOptions = ["Separator", "RemoveBookmark", "AddBookmark", "OpenInNewWindow", "OpenInPrivateWindow", "BlockUrl", "DeleteUrl", "PinTopSite", "UnpinTopSite", "SaveToPocket"];
-    const options = shallowWithIntl(<LinkMenu site={{url: ""}} dispatch={dispatch} index={FAKE_INDEX} options={propOptions} source={FAKE_SOURCE} />)
+    const expectedActionData = {
+      menu_action_remove_bookmark: FAKE_SITE.bookmarkGuid,
+      menu_action_bookmark: FAKE_SITE.url,
+      menu_action_open_new_window: {url: FAKE_SITE.url},
+      menu_action_open_private_window: {url: FAKE_SITE.url},
+      menu_action_dismiss: FAKE_SITE.url,
+      menu_action_delete: FAKE_SITE.url,
+      menu_action_pin: {site: {url: FAKE_SITE.url, title: shortURL(FAKE_SITE)}, index: FAKE_INDEX},
+      menu_action_unpin: {site: {url: FAKE_SITE.url}},
+      menu_action_save_to_pocket: {site: {url: FAKE_SITE.url, title: FAKE_SITE.title}}
+    };
+
+    const options = shallowWithIntl(<LinkMenu site={FAKE_SITE} dispatch={dispatch} index={FAKE_INDEX} options={propOptions} source={FAKE_SOURCE} />)
       .find(ContextMenu).props().options;
     afterEach(() => dispatch.reset());
     options.filter(o => o.type !== "separator").forEach(option => {
-      it(`should fire a ${option.action} action for ${option.id}`, () => {
+      it(`should fire a ${option.action.type} action for ${option.id} with the expected data`, () => {
         option.onClick();
         assert.calledTwice(dispatch);
-        assert.equal(dispatch.firstCall.args[0], option.action);
+
+        // option.action is dispatched
+        assert.ok(dispatch.firstCall.calledWith(option.action));
+
+        // option.action has correct data (delete is a special case as it has to be confirmed)
+        if (option.id === "menu_action_delete") {
+          assert.deepEqual(option.action.data.onConfirm[0].data, expectedActionData[option.id]);
+        } else {
+          assert.deepEqual(option.action.data, expectedActionData[option.id]);
+        }
       });
       it(`should fire a UserEvent action for ${option.id}`, () => {
         option.onClick();


### PR DESCRIPTION
The first bullet point (correct options for default sites and bookmarks, pinning) was covered by tests added in 8647c9c. This should cover making sure actions are dispatched with the correct data and making sure `intl` gets called.