### PR TITLE
fix(testpilot): Fixes #2613 Typo in Top Sites Editor

### DIFF
--- a/locales/en-GB/strings.properties
+++ b/locales/en-GB/strings.properties
@@ -77,8 +77,8 @@ settings_pane_done_button=Done
 # dialog.
 edit_topsites_button_text=Edit
 edit_topsites_button_label=Customise your Top Sites section
-edit_topsites_showmore_button=Show more
-edit_topsites_showless_button=Show less
+edit_topsites_showmore_button=Show More
+edit_topsites_showless_button=Show Fewer
 edit_topsites_done_button=Done
 edit_topsites_pin_button=Pin this site
 edit_topsites_edit_button=Edit this site

--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -99,8 +99,8 @@ settings_pane_done_button=Done
 # dialog.
 edit_topsites_button_text=Edit
 edit_topsites_button_label=Customize your Top Sites section
-edit_topsites_showmore_button=Show more
-edit_topsites_showless_button=Show less
+edit_topsites_showmore_button=Show More
+edit_topsites_showless_button=Show Fewer
 edit_topsites_done_button=Done
 edit_topsites_pin_button=Pin this site
 edit_topsites_unpin_button=Unpin this site


### PR DESCRIPTION
Fixed in en-GB and en-US. Also capitalised `Show More` for consistency.