### PR TITLE
fix(mc): Slightly delay init and fix any earlier about:newtabs

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -63,11 +63,9 @@ function init(reason) {
   }
   const options = Object.assign({}, startupData || {}, ACTIVITY_STREAM_OPTIONS);
   activityStream = new ActivityStream(options);
-  try {
-    activityStream.init(reason);
-  } catch (e) {
-    Cu.reportError(e);
-  }
+  // Slightly delay the rest of initialization from constructing to avoid
+  // loading some services too early.
+  setTimeout(() => activityStream.init(reason));
 }
 
 /**


### PR DESCRIPTION
Fix #2856 as well as mostly avoid to fix #2819. This delay seems to be enough to make `browser_startup.js` happy. I tested with `./mach run about:newtab` to try to get it to open as soon as possible, and there were some instances where the page stays blank now that `RemotePages` is also slightly delayed. This seems to be what's causing #2819, so we can catch any early `about:newtab`s and fix them up.