### PR TITLE
fix(mc): Temporarily restore reference to PreviewProvider

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -12,6 +12,9 @@ const {insertPinned} = Cu.import("resource://activity-stream/common/Reducers.jsm
 
 XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm");
+// Keep a reference to PreviewProvider.jsm until it's good to remove. See #2849
+XPCOMUtils.defineLazyModuleGetter(this, "PreviewProvider",
+  "resource://app/modules/PreviewProvider.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Screenshots",
   "resource://activity-stream/lib/Screenshots.jsm");
 


### PR DESCRIPTION
Fix #2849. r?@sarracini Just adds a lazyModuleGetter that we don't end up triggering.