### PR TITLE
fix(mc): Use dispatch avoiding Timer.jsm to delay some startup

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -11,8 +11,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "Preferences",
   "resource://gre/modules/Preferences.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Services",
   "resource://gre/modules/Services.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "setTimeout",
-  "resource://gre/modules/Timer.jsm");
 
 const ACTIVITY_STREAM_ENABLED_PREF = "browser.newtabpage.activity-stream.enabled";
 const BROWSER_READY_NOTIFICATION = "sessionstore-windows-restored";
@@ -119,7 +117,7 @@ function observe(subject, topic, data) {
     case BROWSER_READY_NOTIFICATION:
       Services.obs.removeObserver(observe, BROWSER_READY_NOTIFICATION);
       // Avoid running synchronously during this event that's used for timing
-      setTimeout(() => onBrowserReady());
+      Services.tm.dispatchToMainThread(() => onBrowserReady());
       break;
   }
 }

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -187,7 +187,8 @@ class PlacesFeed {
   onAction(action) {
     switch (action.type) {
       case at.INIT:
-        this.addObservers();
+        // Briefly avoid loading services for observing for better startup timing
+        Services.tm.dispatchToMainThread(() => this.addObservers());
         break;
       case at.UNINIT:
         this.removeObservers();

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -48,7 +48,8 @@ overrider.set({
           clearUserPref() {}
         };
       }
-    }
+    },
+    tm: {dispatchToMainThread: cb => cb()}
   },
   XPCOMUtils: {
     defineLazyModuleGetter() {},


### PR DESCRIPTION
Fix #2856. r?@sarracini Delay `addObserver` which loads bookmark service which loads annotation service. Use `dispatchToMain` instead of loading `Timer.jsm`