### PR TITLE
fix(systemaddon): Fallback to link title for topsite title.

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -23,10 +23,19 @@ class TopSite extends React.Component {
       action_position: this.props.index
     }));
   }
+  _selectTileTitle(link) {
+    const title = link.pinTitle || shortURL(link);
+
+    if (title.length > 0) {
+      return title;
+    }
+
+    return link.title;
+  }
   render() {
     const {link, index, dispatch} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === index;
-    const title = link.pinTitle || shortURL(link);
+    const title = this._selectTileTitle(link);
     const screenshotClassName = `screenshot${link.screenshot ? " active" : ""}`;
     const topSiteOuterClassName = `top-site-outer${isContextMenuOpen ? " active" : ""}`;
     const style = {backgroundImage: (link.screenshot ? `url(${link.screenshot})` : "none")};

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -23,19 +23,10 @@ class TopSite extends React.Component {
       action_position: this.props.index
     }));
   }
-  _selectTileTitle(link) {
-    const title = link.pinTitle || shortURL(link);
-
-    if (title.length > 0) {
-      return title;
-    }
-
-    return link.title;
-  }
   render() {
     const {link, index, dispatch} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === index;
-    const title = this._selectTileTitle(link);
+    const title = link.pinTitle || shortURL(link);
     const screenshotClassName = `screenshot${link.screenshot ? " active" : ""}`;
     const topSiteOuterClassName = `top-site-outer${isContextMenuOpen ? " active" : ""}`;
     const style = {backgroundImage: (link.screenshot ? `url(${link.screenshot})` : "none")};

--- a/system-addon/content-src/lib/short-url.js
+++ b/system-addon/content-src/lib/short-url.js
@@ -22,5 +22,6 @@ module.exports = function shortURL(link) {
   // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
   const eTLDLength = (eTLD || "").length || (hostname.match(/\.com$/) && 3);
   const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
-  return hostname.slice(0, eTLDExtra).toLowerCase() || hostname;
+  // If URL and hostname are not present fallback to page title.
+  return hostname.slice(0, eTLDExtra).toLowerCase() || hostname || link.title;
 };

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -47,6 +47,14 @@ describe("<TopSite>", () => {
 
     assert.equal(titleEl.text(), "foobar");
   });
+  it("should fallback to link title for file:// protocol", () => {
+    link.url = "file:///Users/voprea/Work/activity-stream/logs/coverage/system-addon/report-html/index.html";
+    link.title = "Code coverage report";
+    const wrapper = shallow(<TopSite link={link} />);
+    const titleEl = wrapper.find(".title");
+
+    assert.equal(titleEl.text(), link.title);
+  });
   it("should render the pinTitle if set", () => {
     link.isPinned = true;
     link.pinnedIndex = 7;


### PR DESCRIPTION
<img width="263" alt="screen shot 2017-07-17 at 11 17 16" src="https://user-images.githubusercontent.com/810040/28262311-db63c2c2-6ae2-11e7-87ce-fd5a1fab5273.png">

@aaronrbenson do you think this is acceptable? Showing title when we can't get a URL. This happens when you open a file from your computer instead of accessing a website, there might be other scenarios but edge cases basically.

Fixes #2857 