### PR TITLE
chore(mc): #2870 Relax coverage requirements for lines/branches/statements

### DIFF
--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -31,8 +31,8 @@ module.exports = function(config) {
       // This will make karma fail if coverage reporting is less than the minimums here
       check: !isTDD && {
         global: {
-          statements: 100,
-          lines: 100,
+          statements: 90,
+          lines: 90,
           functions: 100,
           branches: 90
         }


### PR DESCRIPTION
A few people have been complaining that maintaining 100% code coverage is quite cumbersome in some cases. How do we feel about reducing our coverage of lines/branches/statements? Should we consider something else? Suggestions/opinions welcome.

@sarracini @Mardak @dmose @piatra @csadilek @AdamHillier @rlr?