### PR TITLE
Query experiment definitions from experimenter fixes #2100

### DIFF
--- a/addon/ActivityStreams.js
+++ b/addon/ActivityStreams.js
@@ -107,7 +107,7 @@ ActivityStreams.prototype = {
     if (!this.options.shield_variant) {
       this._experimentProvider.init();
     }
-    this._tabTracker.init(this.appURLs, this._experimentProvider.experimentId, this._store);
+    this._tabTracker.init(this.appURLs, this._experimentProvider, this._store);
     this._searchProvider.init();
     this._initializePreviewProvider(this._metadataStore, this._tabTracker, this._store);
     this._initializePageScraper(this._previewProvider, this._tabTracker);
@@ -312,11 +312,6 @@ ActivityStreams.prototype = {
     this._tabTracker.handleImpressionStats(msg.data);
   },
 
-  _handleExperimentChange(prefName) {
-    this._tabTracker.experimentId = this._experimentProvider.experimentID;
-    this.broadcast(am.actions.Response("EXPERIMENTS_RESPONSE", this._experimentProvider.data));
-  },
-
   _respondToUIChanges(args) {
     const {msg} = args;
     switch (msg.type) {
@@ -346,9 +341,6 @@ ActivityStreams.prototype = {
     this._handleCurrentEngineChanges = this._handleCurrentEngineChanges.bind(this);
     this._searchProvider.on("browser-search-engine-modified", this._handleCurrentEngineChanges);
 
-    this._handleExperimentChange = this._handleExperimentChange.bind(this);
-    this._experimentProvider.on("change", this._handleExperimentChange);
-
     // This is a collection of handlers that receive messages from content
     this._contentToAddonHandlers = (msgName, args) => {
       // Log requests first so that the requests are logged before responses
@@ -375,7 +367,6 @@ ActivityStreams.prototype = {
   _removeListeners() {
     PLACES_CHANGES_EVENTS.forEach(event => PlacesProvider.links.off(event, this._handlePlacesChanges));
     this._searchProvider.off("browser-search-engine-modified", this._handleCurrentEngineChanges);
-    this._experimentProvider.off("change", this._handleExperimentChange);
     this.off(CONTENT_TO_ADDON, this._contentToAddonHandlers);
   },
 

--- a/addon/ExperimentProvider.js
+++ b/addon/ExperimentProvider.js
@@ -1,10 +1,13 @@
 const {Cu} = require("chrome");
 const prefService = require("sdk/preferences/service");
 const simplePrefs = require("sdk/simple-prefs");
-const {PrefsTarget} = require("sdk/preferences/event-target");
+const {setTimeout} = require("sdk/timers");
 const {preferencesBranch} = require("sdk/self");
 const PREF_PREFIX = `extensions.${preferencesBranch}.experiments.`;
+const EXPERIMENTS_ENDPOINT = "experiments.endpoint";
+const EXPERIMENTS_REFRESH_TIMEOUT = 60 * 60 * 1000; // Refresh once per hour
 
+Cu.importGlobalProperties(["fetch"]);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
 XPCOMUtils.defineLazyGetter(this, "EventEmitter", () => {
@@ -13,42 +16,54 @@ XPCOMUtils.defineLazyGetter(this, "EventEmitter", () => {
 });
 
 exports.ExperimentProvider = class ExperimentProvider {
-  constructor(experiments = require("../experiments.json"), rng) {
-    this._experiments = experiments;
+  constructor(experiments = null, rng) {
+    this._testMode = false;
+    this._experiments = {};
     this._rng = rng || Math.random;
     this._data = {};
     this._experimentId = null;
-    this._target = PrefsTarget();
-    EventEmitter.decorate(this);
 
-    this._onPrefChange = this._onPrefChange.bind(this);
+    if (experiments) {
+      this._testMode = true;
+      this._experiments = experiments;
+    }
+    EventEmitter.decorate(this);
   }
 
   init() {
+    if (this._testMode) {
+      this.setupExperiments();
+    } else {
+      const experimentsEndpoint = simplePrefs.prefs[EXPERIMENTS_ENDPOINT];
+      if (experimentsEndpoint) {
+        fetch(simplePrefs.prefs[EXPERIMENTS_ENDPOINT])
+          .then(response => response.json())
+          .then(experiments => {
+            this._experiments = {};
+            this._data = {};
+            experiments.forEach(experiment => {
+              this._experiments[experiment.slug] = experiment;
+            });
+            this.setupExperiments();
+            setTimeout(this.init.bind(this), EXPERIMENTS_REFRESH_TIMEOUT);
+          })
+          .catch(e => {
+            Cu.reportError(e);
+          });
+      }
+    }
+  }
+
+  setupExperiments() {
     this.setValues();
-    Object.keys(this._experiments).forEach(experimentName => {
-      this._target.on(PREF_PREFIX + experimentName, this._onPrefChange);
-      Object.defineProperty(this._data, experimentName, {
+    Object.keys(this._experiments).forEach(experimentId => {
+      Object.defineProperty(this._data, experimentId, {
         get() {
-          return prefService.get(PREF_PREFIX + experimentName);
+          return prefService.get(PREF_PREFIX + experimentId);
         },
         enumerable: true
       });
     });
-  }
-
-  _onPrefChange(prefName) {
-    this.overrideExperimentPrefs(prefName);
-    this.emit("change", prefName);
-  }
-
-  /**
-   * This is called when experiment prefs are changed so
-   * that users are pulled out of all experiment reporting.
-   */
-  overrideExperimentPrefs(prefName) {
-    simplePrefs.prefs.experimentsOverridden = true;
-    this._experimentId = null;
   }
 
   /**
@@ -56,33 +71,30 @@ exports.ExperimentProvider = class ExperimentProvider {
    * values to their original control value.
    */
   disableAllExperiments() {
-    Object.keys(this._experiments).forEach(key => {
-      const experiment = this._experiments[key];
+    Object.keys(this._experiments).forEach(experimentId => {
+      const experiment = this._experiments[experimentId];
       const {active, control} = experiment;
       if (active) {
-        prefService.set(PREF_PREFIX + key, control.value);
+        prefService.set(PREF_PREFIX + experimentId, control.value);
       }
     });
   }
 
   enroll(experimentId, variant) {
-    this._experimentId = variant.id;
+    this._experimentId = experimentId;
     prefService.set(PREF_PREFIX + experimentId, variant.value);
-    if (experimentId === "topSitesTwoRowsDefault") {
-      simplePrefs.prefs.showMoreTopSites = true;
-    }
     this.emit("experimentEnrolled", {id: experimentId, variant});
   }
 
   setValues() {
     if (simplePrefs.prefs.experimentsOverridden) {
       console.log(`The following experiments were turned on via overrides:\n`); // eslint-disable-line no-console
-      Object.keys(this._experiments).forEach(experimentName => {
-        const {variant, control} = this._experiments[experimentName];
-        if (prefService.get(PREF_PREFIX + experimentName) === variant.value) {
-          console.log(`- ${experimentName} - \n`); // eslint-disable-line no-console
+      Object.keys(this._experiments).forEach(experimentId => {
+        const {variant, control} = this._experiments[experimentId];
+        if (prefService.get(PREF_PREFIX + experimentId) === variant.value) {
+          console.log(`- ${experimentId} - \n`); // eslint-disable-line no-console
         } else {
-          prefService.set(PREF_PREFIX + experimentName, control.value);
+          prefService.set(PREF_PREFIX + experimentId, control.value);
         }
       });
       return;
@@ -98,36 +110,36 @@ exports.ExperimentProvider = class ExperimentProvider {
     let floor = 0;
     let inExperiment;
 
-    Object.keys(this._experiments).forEach(key => {
-      const experiment = this._experiments[key];
+    Object.keys(this._experiments).forEach(experimentId => {
+      const experiment = this._experiments[experimentId];
       const {variant, control} = experiment;
 
-      if (prefService.get(PREF_PREFIX + key) === variant.value) {
+      if (prefService.get(PREF_PREFIX + experimentId) === variant.value) {
         if (experiment.active) {
           // If the user is already part of an active experiment, set the experiment id.
-          this._experimentId = variant.id;
+          this._experimentId = experimentId;
         } else {
           // If the user is part of an inactive experiment,
           // reset that experiment's pref.
-          prefService.set(PREF_PREFIX + key, control.value);
+          prefService.set(PREF_PREFIX + experimentId, control.value);
           this._experimentId = null;
         }
       }
     });
 
-    Object.keys(this._experiments).forEach(key => {
-      const experiment = this._experiments[key];
+    Object.keys(this._experiments).forEach(experimentId => {
+      const experiment = this._experiments[experimentId];
       const {variant, control} = experiment;
       const ceiling = variant.threshold + floor;
 
       // If the experiment is not new or not active you will not be assigned to it.
-      if (prefService.has(PREF_PREFIX + key) || !experiment.active) {
+      if (prefService.has(PREF_PREFIX + experimentId) || !experiment.active) {
         return;
       }
 
       // If the experiment pref is undefined, it's a new experiment. Start
       // by assuming the user will not be in it.
-      prefService.set(PREF_PREFIX + key, control.value);
+      prefService.set(PREF_PREFIX + experimentId, control.value);
 
       if (ceiling > 1) {
         throw new Error("Your variant cohort sizes should add up to less than 1.");
@@ -142,7 +154,7 @@ exports.ExperimentProvider = class ExperimentProvider {
       // randomly assign them to a variant (or control)
       inExperiment = randomNumber >= floor && randomNumber < ceiling;
       if (inExperiment) {
-        this.enroll(key, variant);
+        this.enroll(experimentId, variant);
       }
       floor = ceiling;
     });
@@ -161,14 +173,11 @@ exports.ExperimentProvider = class ExperimentProvider {
 
   destroy() {
     this._experimentId = null;
-    Object.keys(this._experiments).forEach(experimentName => {
-      this._target.removeListener(PREF_PREFIX + experimentName, this._onPrefChange);
-    });
   }
 
   clearPrefs() {
-    Object.keys(this._experiments).forEach(experimentName => {
-      prefService.reset(PREF_PREFIX + experimentName);
+    Object.keys(this._experiments).forEach(experimentId => {
+      prefService.reset(PREF_PREFIX + experimentId);
     });
     simplePrefs.prefs.experimentsOverridden = false;
   }

--- a/addon/TabTracker.js
+++ b/addon/TabTracker.js
@@ -39,9 +39,9 @@ TabTracker.prototype = {
     return this._tabData;
   },
 
-  init(trackableURLs, experimentId, store) {
+  init(trackableURLs, experimentProvider, store) {
+    this._experimentProvider = experimentProvider;
     this._trackableURLs = trackableURLs;
-    this._experimentID = experimentId;
     this._store = store;
 
     this.enabled = simplePrefs.prefs[TELEMETRY_PREF];
@@ -101,8 +101,8 @@ TabTracker.prototype = {
     this._tabData.session_id = this._tabData.session_id || String(uuid());
     payload.session_id = this._tabData.session_id;
     payload.user_prefs = this._getUserPreferences();
-    if (this._experimentID) {
-      payload.experiment_id = this._experimentID;
+    if (this._experimentProvider.experimentId) {
+      payload.experiment_id = this._experimentProvider.experimentId;
     }
   },
 
@@ -114,15 +114,11 @@ TabTracker.prototype = {
     }
   },
 
-  set experimentId(experimentId) {
-    this._experimentID = experimentId || null;
-  },
-
   isActivityStreamsURL(URL) {
     return this._trackableURLs.indexOf(URL) !== -1;
   },
 
-  handleUserEvent(payload, experimentId) {
+  handleUserEvent(payload) {
     payload.action = "activity_stream_event";
     payload.tab_id = tabs.activeTab.id;
     this._setCommonProperties(payload, tabs.activeTab.url);
@@ -132,7 +128,7 @@ TabTracker.prototype = {
     }
   },
 
-  handleUndesiredEvent(payload, experimentId) {
+  handleUndesiredEvent(payload) {
     payload.action = "activity_stream_masga_event";
     payload.tab_id = tabs.activeTab.id;
     this._setCommonProperties(payload, tabs.activeTab.url);
@@ -142,7 +138,7 @@ TabTracker.prototype = {
     Services.obs.notifyObservers(null, UNDESIRED_NOTIF, JSON.stringify(payload));
   },
 
-  handleImpressionStats(payload, experimentId) {
+  handleImpressionStats(payload) {
     payload.action = "activity_stream_impression";
     this._setCommonProperties(payload, tabs.activeTab.url);
     Services.obs.notifyObservers(null, IMPRESSION_NOTIF, JSON.stringify(payload));

--- a/package.json
+++ b/package.json
@@ -152,6 +152,13 @@
       "hidden": true
     },
     {
+      "name": "experiments.endpoint",
+      "title": "Experiments Definitions Endpoint",
+      "type": "string",
+      "value": "https://experimenter-cdn.services.mozilla.com/api/v1/activity-stream/experiments.json",
+      "hidden": true
+    },
+    {
       "name": "weightedHighlightsCoefficients",
       "title": "recommender weights",
       "description": "weightedHighlightsCoefficients",

--- a/test-prefs.json
+++ b/test-prefs.json
@@ -6,5 +6,6 @@
   "extensions.@activity-streams.previews.enabled": false,
   "extensions.@activity-streams.telemetry": true,
   "extensions.@activity-streams.telemetry.ping.endpoint": "https://onyx_tiles.stage.mozaws.net/v3/links/activity-stream",
-  "extensions.@activity-streams.experimentOverrides": ""
+  "extensions.@activity-streams.experimentOverrides": "",
+  "extensions.@activity-streams.experiments.endpoint": ""
 }

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -814,18 +814,8 @@ before(exports, function*() {
   let clientID = yield ClientID.getClientID();
   simplePrefs.prefs.telemetry = true;
   // Return 0.1 from rng will trigger the variant
-  app = getTestActivityStream({
-    clientID,
-    experiments: {
-      test: {
-        name: "foo",
-        active: true,
-        control: {value: false},
-        variant: {id: "foo_01", value: true, threshold: 0.5}
-      }
-    },
-    rng: () => 0.1
-  });
+  app = getTestActivityStream({clientID});
+  app._experimentProvider._experimentId = "foo_01";
   ACTIVITY_STREAMS_URL = app.appURLs[1];
   app._store.dispatch({type: "PLACES_STATS_UPDATED", data: {historySize: 0, bookmarksSize: 0}});
 });


### PR DESCRIPTION
Experiment Provider now has two modes, one where it is fully synchronous during unit tests and receives its experiment definitions from an external caller, and the other where it asynchronously fetches experiment definitions periodically from a remote source and reinitializes itself.