### PR TITLE
fix(systemaddon): Delete unprefixed user-select in css

### DIFF
--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -48,7 +48,6 @@
       margin-top: -4px;
       margin-right: -4px;
       padding: 24px;
-      user-select: none;
       -moz-user-select: none;
     }
 


### PR DESCRIPTION
Unprefixed user-select causes Mozilla Central test failures.