### PR TITLE
feat(mc): Add telemetry for Pocket

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -5,6 +5,7 @@ The Activity Stream system add-on sends various types of pings to the backend (H
 - an `event` ping that records specific data about individual user interactions while interacting with Activity Stream
 - a `performance` ping that records specific performance related events
 - an `undesired` ping that records data about bad app states and missing data
+- an `impression_stats` ping that records data about Pocket impressions and user interactions
 
 Schema definitions/validations that can be used for tests can be found in `system-addon/test/schemas/pings.js`.
 
@@ -95,6 +96,39 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "date": "2016-03-07"
 }
 ```
+# Example Activity Stream `impression_stats` Logs
+
+```js
+{
+  "action": "activity_stream_impression_stats",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "source": "pocket",
+  "page": "about:newtab",
+  "tiles": [{"id": 10000}, {"id": 10001}, {"id": 10002}]
+}
+```
+
+```js
+{
+  "action": "activity_stream_impression_stats",
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "source": "pocket",
+  "page": "about:newtab",
+
+  // "pos" is the 0-based index to record the tile's position in the Pocket section.
+  "tiles": [{"id": 10000, "pos": 0}],
+
+  // A 0-based index to record which tile in the "tiles" list that the user just interacted with.
+  "click|block|pocket": 0
+}
+```
+
 
 | KEY | DESCRIPTION | &nbsp; |
 |-----|-------------|:-----:|
@@ -133,6 +167,10 @@ and losing focus. | :one:
 | `topsites_tippytop` | [Optional] The size of the Topsites set with TippyTop metadata. | :one:
 | `user_prefs` | [optional] The encoded integer of user's preferences. | :one: & :four:
 | `visibility_event_rcvd_ts` | [Optional][Server Counter][Server Alert for too many omissions] DOMHighResTimeStamp of when the page itself receives an event that document.visibilityState == visible. | :one:
+| `tiles` | [Required] A list of tile objects for the Pocket articles. Each tile object mush have a ID, and optionally a "pos" property to indicate the tile position | :one:
+| `click` | [Optional] An integer to record the 0-based index when user clicks on a Pocket tile. | :one:
+| `block` | [Optional] An integer to record the 0-based index when user blocks a Pocket tile. | :one:
+| `pocket` | [Optional] An integer to record the 0-based index when user saves a Pocket tile to Pocket. | :one:
 
 **Where:**
 

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -279,3 +279,48 @@ perf: {
   "topsites_first_painted_ts": 5,
 }
 ```
+
+## Top Story pings
+
+When Top Story (currently powered by Pocket) is enabled in Activity Stream, the browser will send following `activity_stream_impression_stats` to our metrics servers.
+
+### Impression stats
+
+This reports all the Pocket recommended articles (a list of `id`s) when the user opens a newtab.
+
+```js
+{
+  "action": "activity_stream_impression_stats",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "source": "pocket",
+  "page": "about:newtab",
+  "tiles": [{"id": 10000}, {"id": 10001}, {"id": 10002}]
+}
+```
+
+### Click/block/save_to_pocket ping
+
+This reports the user's interaction with those Pocket tiles.
+
+```js
+{
+  "action": "activity_stream_impression_stats",
+
+  // both "client_id" and "session_id" are set to "n/a" in this ping.
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "source": "pocket",
+  "page": "about:newtab",
+
+  // "pos" is the 0-based index to record the tile's position in the Pocket section.
+  "tiles": [{"id": 10000, "pos": 0}],
+
+  // A 0-based index to record which tile in the "tiles" list that the user just interacted with.
+  "click|block|pocket": 0
+}
+```

--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -62,6 +62,7 @@ for (const type of [
   "SNIPPETS_DATA",
   "SNIPPETS_RESET",
   "SYSTEM_TICK",
+  "TELEMETRY_IMPRESSION_STATS",
   "TELEMETRY_PERFORMANCE_EVENT",
   "TELEMETRY_UNDESIRED_EVENT",
   "TELEMETRY_USER_EVENT",
@@ -157,7 +158,7 @@ function UserEvent(data) {
  * UndesiredEvent - A telemetry ping indicating an undesired state.
  *
  * @param  {object} data Fields to include in the ping (value, etc.)
- * @param {int} importContext (For testing) Override the import context for testing.
+ * @param  {int} importContext (For testing) Override the import context for testing.
  * @return {object} An action. For UI code, a SendToMain action.
  */
 function UndesiredEvent(data, importContext = globalImportContext) {
@@ -172,12 +173,27 @@ function UndesiredEvent(data, importContext = globalImportContext) {
  * PerfEvent - A telemetry ping indicating a performance-related event.
  *
  * @param  {object} data Fields to include in the ping (value, etc.)
- * @param {int} importContext (For testing) Override the import context for testing.
+ * @param  {int} importContext (For testing) Override the import context for testing.
  * @return {object} An action. For UI code, a SendToMain action.
  */
 function PerfEvent(data, importContext = globalImportContext) {
   const action = {
     type: actionTypes.TELEMETRY_PERFORMANCE_EVENT,
+    data
+  };
+  return importContext === UI_CODE ? SendToMain(action) : action;
+}
+
+/**
+ * ImpressionStats - A telemetry ping indicating an impression stats.
+ *
+ * @param  {object} data Fields to include in the ping
+ * @param  {int} importContext (For testing) Override the import context for testing.
+ * #return {object} An action. For UI code, a SendToMain action.
+ */
+function ImpressionStats(data, importContext = globalImportContext) {
+  const action = {
+    type: actionTypes.TELEMETRY_IMPRESSION_STATS,
     data
   };
   return importContext === UI_CODE ? SendToMain(action) : action;
@@ -195,6 +211,7 @@ this.actionCreators = {
   UserEvent,
   UndesiredEvent,
   PerfEvent,
+  ImpressionStats,
   SendToContent,
   SendToMain,
   SetPref

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -151,6 +151,31 @@ this.TelemetryFeed = class TelemetryFeed {
     return ping;
   }
 
+  /**
+   * createImpressionStats - Create a ping for an impression stats
+   *
+   * @param  {ob} action The object with data to be included in the ping.
+   *                     For some user interactions, a boolean "incognito"
+   *                     field of the "data" object could be used to empty
+   *                     all the user specific IDs with "n/a" in the ping.
+   * @return {obj}    A telemetry ping
+   */
+  async createImpressionStats(action) {
+    let ping = Object.assign(
+      await this.createPing(au.getPortIdOfSender(action)),
+      action.data,
+      {action: "activity_stream_impression_stats"}
+    );
+
+    if (ping.incognito) {
+      ping.client_id = "n/a";
+      ping.session_id = "n/a";
+      delete ping.incognito;
+    }
+
+    return ping;
+  }
+
   async createUserEvent(action) {
     return Object.assign(
       await this.createPing(au.getPortIdOfSender(action)),
@@ -207,6 +232,9 @@ this.TelemetryFeed = class TelemetryFeed {
         break;
       case at.SAVE_SESSION_PERF_DATA:
         this.saveSessionPerfData(au.getPortIdOfSender(action), action.data);
+        break;
+      case at.TELEMETRY_IMPRESSION_STATS:
+        this.sendEvent(this.createImpressionStats(action));
         break;
       case at.TELEMETRY_UNDESIRED_EVENT:
         this.sendEvent(this.createUndesiredEvent(action));

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -60,6 +60,20 @@ const UndesiredPing = Joi.object().keys(Object.assign({}, baseKeys, {
   value: Joi.number().required()
 }));
 
+const TileSchema = Joi.object().keys({
+  id: Joi.number().integer().required(),
+  pos: Joi.number().integer()
+});
+
+const ImpressionStatsPing = Joi.object().keys(Object.assign({}, baseKeys, {
+  source: Joi.string().required(),
+  action: Joi.valid("activity_stream_impression_stats").required(),
+  tiles: Joi.array().items(TileSchema).required(),
+  click: Joi.number().integer(),
+  block: Joi.number().integer(),
+  pocket: Joi.number().integer()
+}));
+
 const PerfPing = Joi.object().keys(Object.assign({}, baseKeys, {
   source: Joi.string(),
   event: Joi.string().required(),
@@ -147,6 +161,7 @@ module.exports = {
   UndesiredPing,
   UserEventPing,
   UserEventAction,
+  ImpressionStatsPing,
   PerfPing,
   SessionPing,
   chaiAssertions

--- a/system-addon/test/unit/common/Actions.test.js
+++ b/system-addon/test/unit/common/Actions.test.js
@@ -129,7 +129,7 @@ describe("ActionCreators", () => {
     it("should wrap with SendToMain if in UI code", () => {
       assert.isTrue(au.isSendToMain(ac.UndesiredEvent({action: "foo"})), "isSendToMain");
     });
-    it("should not wrap with SendToMain if in UI code", () => {
+    it("should not wrap with SendToMain if not in UI code", () => {
       const action = ac.UndesiredEvent({action: "foo"}, BACKGROUND_PROCESS);
       assert.isFalse(au.isSendToMain(action), "isSendToMain");
     });
@@ -142,8 +142,21 @@ describe("ActionCreators", () => {
     it("should wrap with SendToMain if in UI code", () => {
       assert.isTrue(au.isSendToMain(ac.PerfEvent({action: "foo"})), "isSendToMain");
     });
-    it("should not wrap with SendToMain if in UI code", () => {
+    it("should not wrap with SendToMain if not in UI code", () => {
       const action = ac.PerfEvent({action: "foo"}, BACKGROUND_PROCESS);
+      assert.isFalse(au.isSendToMain(action), "isSendToMain");
+    });
+  });
+  describe("ImpressionStats", () => {
+    it("should include the right data", () => {
+      const data = {action: "foo"};
+      assert.equal(ac.ImpressionStats(data).data, data);
+    });
+    it("should wrap with SendToMain if in UI code", () => {
+      assert.isTrue(au.isSendToMain(ac.ImpressionStats({action: "foo"})), "isSendToMain");
+    });
+    it("should not wrap with SendToMain if not in UI code", () => {
+      const action = ac.ImpressionStats({action: "foo"}, BACKGROUND_PROCESS);
       assert.isFalse(au.isSendToMain(action), "isSendToMain");
     });
   });


### PR DESCRIPTION
This closes #2898. r? @k88hudson 

@fmarier Could you take a look at the new pings defined in `data_events.md`?

@csadilek This is lite literally a direct port from the Test Pilot Pocket telemetry. Wanna take a quick look at it, please? 