### PR TITLE
fix(mc): Catch content dispatch errors to prevent RemotePage reporting them (and leaking)

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -107,6 +107,9 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
       });
       return hasMatch ? Object.assign({}, prevState, {rows: newRows}) : prevState;
     case at.PLACES_BOOKMARK_ADDED:
+      if (!action.data) {
+        return prevState;
+      }
       newRows = prevState.rows.map(site => {
         if (site && site.url === action.data.url) {
           const {bookmarkGuid, bookmarkTitle, lastModified} = action.data;
@@ -116,6 +119,9 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
       });
       return Object.assign({}, prevState, {rows: newRows});
     case at.PLACES_BOOKMARK_REMOVED:
+      if (!action.data) {
+        return prevState;
+      }
       newRows = prevState.rows.map(site => {
         if (site && site.url === action.data.url) {
           const newSite = Object.assign({}, site);

--- a/system-addon/content-src/lib/init-store.js
+++ b/system-addon/content-src/lib/init-store.js
@@ -56,7 +56,12 @@ module.exports = function initStore(reducers) {
   );
 
   addMessageListener(INCOMING_MESSAGE_NAME, msg => {
-    store.dispatch(msg.data);
+    try {
+      store.dispatch(msg.data);
+    } catch (ex) {
+      console.error("Content msg:", msg, "Dispatch error: ", ex); // eslint-disable-line no-console
+      dump(`Content msg: ${JSON.stringify(msg)}\nDispatch error: ${ex}\n${ex.stack}`);
+    }
   });
 
   return store;

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -78,6 +78,10 @@ describe("Reducers", () => {
       // old row is unchanged
       assert.equal(nextState.rows[0], oldState.rows[0]);
     });
+    it("should not update state for empty action.data on PLACES_BOOKMARK_ADDED", () => {
+      const nextState = TopSites(undefined, {type: at.PLACES_BOOKMARK_ADDED});
+      assert.equal(nextState, INITIAL_STATE.TopSites);
+    });
     it("should remove a bookmark on PLACES_BOOKMARK_REMOVED", () => {
       const oldState = {
         rows: [{url: "foo.com"}, {
@@ -98,6 +102,10 @@ describe("Reducers", () => {
 
       // old row is unchanged
       assert.deepEqual(nextState.rows[0], oldState.rows[0]);
+    });
+    it("should not update state for empty action.data on PLACES_BOOKMARK_REMOVED", () => {
+      const nextState = TopSites(undefined, {type: at.PLACES_BOOKMARK_REMOVED});
+      assert.equal(nextState, INITIAL_STATE.TopSites);
     });
     it("should remove a link on PLACES_LINK_BLOCKED and PLACES_LINK_DELETED", () => {
       const events = [at.PLACES_LINK_BLOCKED, at.PLACES_LINK_DELETED];

--- a/system-addon/test/unit/lib/init-store.test.js
+++ b/system-addon/test/unit/lib/init-store.test.js
@@ -24,6 +24,16 @@ describe("initStore", () => {
     callback(message);
     assert.calledWith(store.dispatch, message.data);
   });
+  it("should log errors from failed messages", () => {
+    const callback = global.addMessageListener.firstCall.args[1];
+    globals.sandbox.stub(global.console, "error");
+    globals.sandbox.stub(store, "dispatch").throws(Error("failed"));
+
+    const message = {name: initStore.INCOMING_MESSAGE_NAME, data: {type: "FOO"}};
+    callback(message);
+
+    assert.calledOnce(global.console.error);
+  });
   it("should replace the state if a MERGE_STORE_ACTION is dispatched", () => {
     store.dispatch({type: initStore.MERGE_STORE_ACTION, data: {number: 42}});
     assert.deepEqual(store.getState(), {number: 42});


### PR DESCRIPTION
Fix #2829 with the narrow fix to handle `null` action data when reducing. More broadly catches exception on dispatch to prevent them from mysteriously leaking from RemotePageManager. r?@k88hudson 

Unfortunately, this doesn't fix the current `onboarding` leak.