### PR TITLE
fix(systemaddon): Closes #2918 Reuse check.svg from firefox

### DIFF
--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -75,6 +75,6 @@
   }
 
   &.icon-check {
-    background-image: url('#{$image-path}glyph-check-16.svg');
+    background-image: url('chrome://browser/skin/check.svg');
   }
 }

--- a/system-addon/data/content/assets/glyph-check-16.svg
+++ b/system-addon/data/content/assets/glyph-check-16.svg
@@ -1,6 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="context-fill" d="M6 14a1 1 0 0 1-.707-.293l-3-3a1 1 0 0 1 1.414-1.414l2.157 2.157 6.316-9.023a1 1 0 0 1 1.639 1.146l-7 10a1 1 0 0 1-.732.427A.863.863 0 0 1 6 14z"/>
-</svg>


### PR DESCRIPTION
Re-use the existing check.svg so that pine can be happy again