### PR TITLE
fix(systemaddon): Add margin below empty state placeholder

### DIFF
--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -83,6 +83,7 @@
     display: flex;
     border: solid 1px $faintest-black;
     border-radius: $border-radius;
+    margin-bottom: 16px;
 
     .empty-state {
       margin: auto;


### PR DESCRIPTION
Minor fix to add some space below the empty state placeholder:

<img width="869" alt="screen shot 2017-07-20 at 4 59 13 pm" src="https://user-images.githubusercontent.com/472523/28438752-3b6ab892-6d6d-11e7-8033-c256f82fb287.png">
