### PR TITLE
fix(systemaddon): All links blocked by NewTabUtils. Closes #2941

### DIFF
--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -78,7 +78,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
         .then(body => {
           let items = JSON.parse(body).list;
           items = items
-            .filter(s => !NewTabUtils.blockedLinks.isBlocked(s.dedupe_url))
+            .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.dedupe_url}))
             .map(s => ({
               "guid": s.id,
               "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -180,7 +180,7 @@ describe("Top Stories Feed", () => {
     it("should exclude blocked (dismissed) URLs", async () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
-      globals.set("NewTabUtils", {blockedLinks: {isBlocked: url => url === "blocked"}});
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: site => site.url === "blocked"}});
 
       const response = `{"list": [{"dedupe_url" : "blocked"}, {"dedupe_url" : "not_blocked"}]}`;
       instance.stories_endpoint = "stories-endpoint";


### PR DESCRIPTION
The "offending" hash value is caused by blocking undefined. So, at some point the call to ```blockURL``` was implemented incorrectly, passing a string instead of ```{url: value}```. This caused the hash value in the ```browser.newtabpage.blocked``` list. This is no longer a problem in Activity Stream.

Now, I have made a similar mistake when calling ```isBlocked``` passing the url instead of ```{url: value}```. If now undefined was previously blocked, all URLs will appear blocked.