### PR TITLE
fix(systemaddon): Closes #2942 Update top sites header with icon

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -70,7 +70,7 @@ class TopSite extends React.Component {
 }
 
 const TopSites = props => (<section>
-  <h3 className="section-title"><FormattedMessage id="header_top_sites" /></h3>
+  <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
   <ul className="top-sites-list">
     {props.TopSites.rows.map((link, index) => link && <TopSite
       key={link.guid || link.url}

--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -67,6 +67,10 @@
     background-image: url('#{$image-path}glyph-now-16.svg');
   }
 
+  &.icon-topsites {
+    background-image: url('#{$image-path}glyph-topsites-16.svg');
+  }
+
   &.icon-pin-small {
     background-image: url('#{$image-path}glyph-pin-12.svg');
     background-size: $smaller-icon-size;

--- a/system-addon/data/content/assets/glyph-topsites-16.svg
+++ b/system-addon/data/content/assets/glyph-topsites-16.svg
@@ -1,0 +1,11 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <g fill="#4d4d4d">
+    <rect x="1" y="1" width="6" height="6" rx="1" ry="1"/>
+    <rect x="9" y="1" width="6" height="6" rx="1" ry="1"/>
+    <rect x="1" y="9" width="6" height="6" rx="1" ry="1"/>
+    <rect x="9" y="9" width="6" height="6" rx="1" ry="1"/>
+  </g>
+</svg>


### PR DESCRIPTION
Fix #2942. Adds the top sites icon to match the headers for sections