### PR TITLE
fix(l10n): Add better localization notes for section strings

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -69,8 +69,8 @@ search_header={search_engine_name} Search
 search_web_placeholder=Search the Web
 search_settings=Change Search Settings
 
-# LOCALIZATION NOTE (section_info_option): This is the screenreader only text
-# for the section helper text.
+# LOCALIZATION NOTE (section_info_option): This is the screenreader text for the
+# (?) icon that would show a section's description with optional feedback link.
 section_info_option=Info
 
 # LOCALIZATION NOTE (welcome_*): This is shown as a modal dialog, typically on a
@@ -139,7 +139,11 @@ pocket_feedback_header=The best of the web, curated by over 25 million people.
 # (pocket_feedback_header) to provide more information about Pocket.
 pocket_feedback_body=Pocket, a part of the Mozilla family, will help connect you to high-quality content that you may not have found otherwise.
 pocket_send_feedback=Send Feedback
-empty_state_topstories=You’ve caught up. Check back later for more top stories from Pocket. Can’t wait? Select a popular topic to find more great stories from around the web.
+
+# LOCALIZATION NOTE (topstories_empty_state): When there are no recommendations,
+# in the space that would have shown a few stories, this is shown instead.
+# {provider} is replaced by the name of the content provider for this section.
+topstories_empty_state=You’ve caught up. Check back later for more top stories from {provider}. Can’t wait? Select a popular topic to find more great stories from around the web.
 
 # LOCALIZATION NOTE (manual_migration_explanation): This message is show to encourage users to
 # import their browser profile from another browsers they might be using.

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -49,7 +49,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
           }
         },
         emptyState: {
-          message: {id: "empty_state_topstories"},
+          message: {id: "topstories_empty_state", values: {provider: options.provider_name}},
           icon: "check"
         }
       };

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -61,7 +61,7 @@ describe("Top Stories Feed", () => {
           }
         },
         emptyState: {
-          message: {id: "empty_state_topstories"},
+          message: {id: "topstories_empty_state", values: {provider: "test-provider"}},
           icon: "check"
         }
       };


### PR DESCRIPTION
Fix #2934. r?@sarracini Replaced the hardcoded "Pocket" with `{provider}` and added notes.