### PR TITLE
fix(content): Use dir=auto for various context-provided text

### DIFF
--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -43,8 +43,8 @@ class Card extends React.Component {
           <div className="card-details">
             <div className="card-host-name"> {hostname} </div>
             <div className={`card-text${link.image ? "" : " full-height"}`}>
-              <h4 className="card-title"> {link.title} </h4>
-              <p className="card-description"> {link.description} </p>
+              <h4 className="card-title" dir="auto"> {link.title} </h4>
+              <p className="card-description" dir="auto"> {link.description} </p>
             </div>
             <div className="card-context">
               <span className={`card-context-icon icon icon-${icon}`} />

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -51,7 +51,7 @@ class TopSite extends React.Component {
           </div>
           <div className={`title ${link.isPinned ? "pinned" : ""}`}>
             {link.isPinned && <div className="icon icon-pin-small" />}
-            <span>{title}</span>
+            <span dir="auto">{title}</span>
           </div>
         </a>
         <button className="context-menu-button" onClick={this.onMenuButtonClick}>

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -39,6 +39,11 @@ describe("<TopSite>", () => {
     const wrapper = shallow(<TopSite link={link} />);
     assert.propertyVal(wrapper.find("a").props(), "href", "https://www.foobar.org");
   });
+  it("should have rtl direction automatically set for text", () => {
+    const wrapper = shallow(<TopSite link={link} />);
+
+    assert.isTrue(wrapper.find("[dir='auto']").length > 0);
+  });
   it("should render a shortened title based off the url", () => {
     link.url = "https://www.foobar.org";
     link.eTLD = "org";


### PR DESCRIPTION
Fix #2923. r?@rlr 

As an example with auto and not:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/438537/28545669-c645c63e-707c-11e7-9d82-0e60261225e4.png">
