### PR TITLE
feat(mc): Add profile age, telemetryEnabled to snippets

### DIFF
--- a/docs/v2-system-addon/snippets.md
+++ b/docs/v2-system-addon/snippets.md
@@ -36,3 +36,13 @@ where possible.
 `snippets-last-update`: The last time snippets were updated.
 
 `snippets`: The cached payload of the response from the snippets server.
+
+`appData.snippetsURL`: The URL at from which snippets are fetched
+
+`appData.version`: The current version of snippets
+
+`appData.profileCreatedWeeksAgo`: The date the user's profile was created
+
+`appData.profileResetWeeksAgo`: The date the user's profile was reset. `null` if the profile hasn't been reset.
+
+`appData.telemetryEnabled`: Is telemetry enabled for the user?

--- a/system-addon/content-src/activity-stream.jsx
+++ b/system-addon/content-src/activity-stream.jsx
@@ -18,10 +18,7 @@ const snippets = new SnippetsProvider();
 const unsubscribe = store.subscribe(() => {
   const state = store.getState();
   if (state.Snippets.initialized) {
-    snippets.init({
-      snippetsURL: state.Snippets.snippetsURL,
-      version: state.Snippets.version
-    });
+    snippets.init({appData: state.Snippets});
     unsubscribe();
   }
 });

--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -5,19 +5,25 @@
 
 const {utils: Cu} = Components;
 
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/Console.jsm");
 const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+
+XPCOMUtils.defineLazyModuleGetter(this, "ProfileAge",
+  "resource://gre/modules/ProfileAge.jsm");
 
 // Url to fetch snippets, in the urlFormatter service format.
 const SNIPPETS_URL_PREF = "browser.aboutHomeSnippets.updateUrl";
+const TELEMETRY_PREF = "datareporting.healthreport.uploadEnabled";
 
 // Should be bumped up if the snippets content format changes.
 const STARTPAGE_VERSION = 4;
 
+const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
+
 this.SnippetsFeed = class SnippetsFeed {
   constructor() {
-    this._onUrlChange = this._onUrlChange.bind(this);
+    this._refresh = this._refresh.bind(this);
   }
   get snippetsURL() {
     const updateURL = Services
@@ -25,23 +31,36 @@ this.SnippetsFeed = class SnippetsFeed {
       .replace("%STARTPAGE_VERSION%", STARTPAGE_VERSION);
     return Services.urlFormatter.formatURL(updateURL);
   }
-  init() {
+  async getProfileInfo() {
+    const profileAge = new ProfileAge(null, null);
+    const createdDate = await profileAge.created;
+    const resetDate = await profileAge.reset;
+    return {
+      createdWeeksAgo:  Math.floor((Date.now() - createdDate) / ONE_WEEK),
+      resetWeeksAgo: resetDate ? Math.floor((Date.now() - resetDate) / ONE_WEEK) : null
+    };
+  }
+  async _refresh() {
+    const profileInfo = await this.getProfileInfo();
     const data = {
       snippetsURL: this.snippetsURL,
-      version: STARTPAGE_VERSION
+      version: STARTPAGE_VERSION,
+      profileCreatedWeeksAgo: profileInfo.createdWeeksAgo,
+      profileResetWeeksAgo: profileInfo.resetWeeksAgo,
+      telemetryEnabled: Services.prefs.getBoolPref(TELEMETRY_PREF)
     };
+
     this.store.dispatch(ac.BroadcastToContent({type: at.SNIPPETS_DATA, data}));
-    Services.prefs.addObserver(SNIPPETS_URL_PREF, this._onUrlChange);
+  }
+  async init() {
+    await this._refresh();
+    Services.prefs.addObserver(SNIPPETS_URL_PREF, this._refresh);
+    Services.prefs.addObserver(TELEMETRY_PREF, this._refresh);
   }
   uninit() {
     this.store.dispatch({type: at.SNIPPETS_RESET});
-    Services.prefs.removeObserver(SNIPPETS_URL_PREF, this._onUrlChange);
-  }
-  _onUrlChange() {
-    this.store.dispatch(ac.BroadcastToContent({
-      type: at.SNIPPETS_DATA,
-      data: {snippetsURL: this.snippetsURL}
-    }));
+    Services.prefs.removeObserver(SNIPPETS_URL_PREF, this._refresh);
+    Services.prefs.removeObserver(TELEMETRY_PREF, this._refresh);
   }
   onAction(action) {
     switch (action.type) {

--- a/system-addon/test/unit/content-src/lib/snippets.test.js
+++ b/system-addon/test/unit/content-src/lib/snippets.test.js
@@ -127,10 +127,14 @@ describe("SnippetsProvider", () => {
 
       assert.calledOnce(snippets._showDefaultSnippets);
     });
+    it("should set each item in .appData in gSnippetsMap as appData.{item}", async () => {
+      await snippets.init({connect: false, appData: {foo: 123, bar: "hello"}});
+      assert.equal(snippets.snippetsMap.get("appData.foo"), 123);
+      assert.equal(snippets.snippetsMap.get("appData.bar"), "hello");
+    });
   });
   describe("#_refreshSnippets", () => {
     let clock;
-    const validOptions = {connect: false, version: 4, snippetsURL: "foo.com"};
     beforeEach(() => {
       clock = sinon.useFakeTimers();
       snippets = new SnippetsProvider();
@@ -141,28 +145,28 @@ describe("SnippetsProvider", () => {
     });
     it("should clear gSnippetsMap if the cached version is different than the current version or missing", async () => {
       sandbox.spy(global.gSnippetsMap, "clear");
-      snippets.init(Object.assign({}, validOptions, {version: 5}));
+      await snippets.init({connect: false, appData: {version: 5, snippetsURL: "foo.com"}});
       assert.calledOnce(global.gSnippetsMap.clear);
 
       global.gSnippetsMap.clear.reset();
       global.gSnippetsMap.delete("snippets-cached-version");
-      await snippets.init(Object.assign({}, validOptions, {version: 5}));
+      await snippets.init({connect: false, appData: {version: 5, snippetsURL: "foo.com"}});
       assert.calledOnce(global.gSnippetsMap.clear);
     });
     it("should not clear gSnippetsMap if the cached version the same as the current version", async () => {
       sandbox.spy(global.gSnippetsMap, "clear");
-      await snippets.init(validOptions);
+      await snippets.init({connect: false, appData: {version: 4, snippetsURL: "foo.com"}});
       assert.notCalled(global.gSnippetsMap.clear);
     });
     it("should fetch new data if no last update time was cached", async () => {
-      await snippets.init(validOptions);
+      await snippets.init({connect: false, appData: {version: 4, snippetsURL: "foo.com"}});
       assert.calledOnce(global.fetch);
     });
     it("should fetch new data if it has been at least SNIPPETS_UPDATE_INTERVAL_MS since the last update", async () => {
       global.gSnippetsMap.set("snippets-last-update", Date.now());
       clock.tick(SNIPPETS_UPDATE_INTERVAL_MS + 1);
 
-      await snippets.init(validOptions);
+      await snippets.init({connect: false, appData: {version: 4, snippetsURL: "foo.com"}});
 
       assert.calledOnce(global.fetch);
     });
@@ -171,7 +175,7 @@ describe("SnippetsProvider", () => {
 
       clock.tick(5);
 
-      await snippets.init(validOptions);
+      await snippets.init({connect: false, appData: {version: 4, snippetsURL: "foo.com"}});
 
       assert.notCalled(global.fetch);
     });
@@ -179,7 +183,7 @@ describe("SnippetsProvider", () => {
       clock.tick(7);
       global.fetch.returns(Promise.resolve({status: 200, text: () => Promise.resolve("foo123")}));
 
-      await snippets.init(Object.assign({}, validOptions, {version: 5}));
+      await snippets.init({connect: false, appData: {version: 5, snippetsURL: "foo.com"}});
 
       assert.equal(global.gSnippetsMap.get("snippets"), "foo123");
       assert.equal(global.gSnippetsMap.get("snippets-last-update"), 7);
@@ -189,7 +193,7 @@ describe("SnippetsProvider", () => {
       sandbox.stub(global.console, "error");
       global.fetch.returns(Promise.reject({status: 400}));
 
-      await snippets.init(Object.assign({}, validOptions, {version: 5}));
+      await snippets.init({connect: false, appData: {version: 5, snippetsURL: "foo.com"}});
 
       assert.calledOnce(global.console.error);
     });

--- a/system-addon/test/unit/lib/SnippetsFeed.test.js
+++ b/system-addon/test/unit/lib/SnippetsFeed.test.js
@@ -1,29 +1,60 @@
 const {SnippetsFeed} = require("lib/SnippetsFeed.jsm");
-const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
+const {actionTypes: at} = require("common/Actions.jsm");
+const {GlobalOverrider} = require("test/unit/utils");
+
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+let overrider = new GlobalOverrider();
 
 describe("SnippetsFeed", () => {
   let sandbox;
+  let clock;
   beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    overrider.set({
+      ProfileAge: class ProfileAge {
+        constructor() {
+          this.created = Promise.resolve(0);
+          this.reset = Promise.resolve(WEEK_IN_MS);
+        }
+      }
+    });
     sandbox = sinon.sandbox.create();
   });
   afterEach(() => {
+    clock.restore();
+    overrider.restore();
     sandbox.restore();
   });
-  it("should dispatch the right version and snippetsURL on INIT", () => {
+  it("should dispatch a SNIPPETS_DATA action with the right data on INIT", async () => {
     const url = "foo.com/%STARTPAGE_VERSION%";
     sandbox.stub(global.Services.prefs, "getStringPref").returns(url);
+    sandbox.stub(global.Services.prefs, "getBoolPref").returns(true);
     const feed = new SnippetsFeed();
     feed.store = {dispatch: sandbox.stub()};
 
-    feed.onAction({type: at.INIT});
+    clock.tick(WEEK_IN_MS * 2);
 
-    assert.calledWith(feed.store.dispatch, ac.BroadcastToContent({
-      type: at.SNIPPETS_DATA,
-      data: {
-        snippetsURL: "foo.com/4",
-        version: 4
-      }
-    }));
+    await feed.init();
+
+    assert.calledOnce(feed.store.dispatch);
+
+    const action = feed.store.dispatch.firstCall.args[0];
+    assert.propertyVal(action, "type", at.SNIPPETS_DATA);
+    assert.isObject(action.data);
+    assert.propertyVal(action.data, "snippetsURL", "foo.com/4");
+    assert.propertyVal(action.data, "version", 4);
+    assert.propertyVal(action.data, "profileCreatedWeeksAgo", 2);
+    assert.propertyVal(action.data, "profileResetWeeksAgo", 1);
+    assert.propertyVal(action.data, "telemetryEnabled", true);
+  });
+  it("should call .init on an INIT aciton", () => {
+    const feed = new SnippetsFeed();
+    sandbox.stub(feed, "init");
+    feed.store = {dispatch: sandbox.stub()};
+
+    feed.onAction({type: at.INIT});
+    assert.calledOnce(feed.init);
   });
   it("should call .init when a FEED_INIT happens for feeds.snippets", () => {
     const feed = new SnippetsFeed();
@@ -41,20 +72,5 @@ describe("SnippetsFeed", () => {
     feed.uninit();
 
     assert.calledWith(feed.store.dispatch, {type: at.SNIPPETS_RESET});
-  });
-  describe("_onUrlChange", () => {
-    it("should dispatch a new snippetsURL", () => {
-      const url = "boo.com/%STARTPAGE_VERSION%";
-      sandbox.stub(global.Services.prefs, "getStringPref").returns(url);
-      const feed = new SnippetsFeed();
-      feed.store = {dispatch: sandbox.stub()};
-
-      feed._onUrlChange();
-
-      assert.calledWith(feed.store.dispatch, ac.BroadcastToContent({
-        type: at.SNIPPETS_DATA,
-        data: {snippetsURL: "boo.com/4"}
-      }));
-    });
   });
 });

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -43,6 +43,7 @@ overrider.set({
       addObserver() {},
       removeObserver() {},
       getStringPref() {},
+      getBoolPref() {},
       getDefaultBranch() {
         return {
           setBoolPref() {},


### PR DESCRIPTION
This PR adds information about profile age and telemetry to `gSnippetsMap` for use by snippet payloads.
