### PR TITLE
fix (systemaddon): #2958 vertically align section title

### DIFF
--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -27,4 +27,8 @@ main {
   font-weight: bold;
   text-transform: uppercase;
   margin: 0 0 $section-title-bottom-margin;
+
+  span {
+    vertical-align: middle;
+  }
 }


### PR DESCRIPTION
The icon was vertically aligned to the middle and the text was aligned to the top. This makes them both aligned to the middle.

r? @sarracini 

Fixes #2958