### PR TITLE
fix(styles): Use Photon grey-90 for dark-grey and action buttons

### DIFF
--- a/system-addon/content-src/activity-stream.scss
+++ b/system-addon/content-src/activity-stream.scss
@@ -10,7 +10,7 @@ body,
 
 body {
   background: $bg-color;
-  color: $dark-grey;
+  color: $grey-90;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Ubuntu', 'Helvetica Neue', sans-serif;
   font-size: 16px;
 }
@@ -85,7 +85,7 @@ a {
     background: $default-button-bg;
     border: solid 1px $default-button-border;
     border-radius: 5px;
-    color: $mid-light-grey;
+    color: $grey-90;
     cursor: pointer;
     padding: 10px 30px;
 

--- a/system-addon/content-src/components/ContextMenu/_ContextMenu.scss
+++ b/system-addon/content-src/components/ContextMenu/_ContextMenu.scss
@@ -38,7 +38,7 @@
           color: $white;
 
           a {
-            color: $dark-grey;
+            color: $grey-90;
           }
 
           &:hover, &:focus {

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -3,7 +3,7 @@ $bg-grey: #FBFBFB;
 $very-light-grey: #EBEBEB;
 $light-grey: #A0A0A0;
 $mid-light-grey: #858585;
-$dark-grey: #383E49;
+$grey-90: #0C0C0D;
 $link-blue: #00AFF7;
 $star-blue: #2B99FF;
 $black: #000;


### PR DESCRIPTION
Fix #2978. r?@dmose Further photon matching to be done #2979 

<img width="759" alt="image" src="https://user-images.githubusercontent.com/438537/28647749-e33dc92e-721d-11e7-8dff-0347de802ef7.png">
