### PR TITLE
fix(systemaddon): Dedupe Topsites

### DIFF
--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -12,6 +12,11 @@ this.Dedupe = class Dedupe {
     return false;
   }
 
+  /**
+   * Removes duplicates in a list based on createKey.
+   * @param {Array} values
+   * @returns {Array}
+   */
   collection(values) {
     const valueMap = new Map();
     values.forEach(value => {

--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -1,0 +1,27 @@
+this.Dedupe = class Dedupe {
+  constructor(createKey, compare) {
+    this.createKey = createKey || this.defaultCreateKey;
+    this.compare = compare || this.defaultCompare;
+  }
+
+  defaultCreateKey(item) {
+    return item;
+  }
+
+  defaultCompare() {
+    return false;
+  }
+
+  one(values) {
+    const valueMap = new Map();
+    values.forEach(value => {
+      const key = this.createKey(value);
+      if (!valueMap.has(key) || this.compare(valueMap.get(key), value)) {
+        valueMap.set(key, value);
+      }
+    });
+    return Array.from(valueMap.values());
+  }
+};
+
+this.EXPORTED_SYMBOLS = ["Dedupe"];

--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -22,17 +22,17 @@ this.Dedupe = class Dedupe {
   group(groups) {
     const globalKeys = new Set();
     const result = [];
-    groups.forEach(values => {
+    for (const values of groups) {
       const valueMap = new Map();
-      values.forEach(value => {
+      for (const value of values) {
         const key = this.createKey(value);
         if (!globalKeys.has(key) && (!valueMap.has(key) || this.compare(valueMap.get(key), value))) {
           valueMap.set(key, value);
         }
-      });
+      }
       result.push(valueMap);
       valueMap.forEach((value, key) => globalKeys.add(key));
-    });
+    }
     return result.map(m => Array.from(m.values()));
   }
 };

--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -13,19 +13,27 @@ this.Dedupe = class Dedupe {
   }
 
   /**
-   * Removes duplicates in a list based on createKey.
-   * @param {Array} values
+   * Dedupe an array containing groups of elements.
+   * Duplicate removal favors earlier groups.
+   *
+   * @param {Array} groups Contains an arbitrary number of arrays of elements.
    * @returns {Array}
    */
-  collection(values) {
-    const valueMap = new Map();
-    values.forEach(value => {
-      const key = this.createKey(value);
-      if (!valueMap.has(key) || this.compare(valueMap.get(key), value)) {
-        valueMap.set(key, value);
-      }
+  group(groups) {
+    const globalKeys = new Set();
+    const result = [];
+    groups.forEach(values => {
+      const valueMap = new Map();
+      values.forEach(value => {
+        const key = this.createKey(value);
+        if (!globalKeys.has(key) && (!valueMap.has(key) || this.compare(valueMap.get(key), value))) {
+          valueMap.set(key, value);
+        }
+      });
+      result.push(valueMap);
+      valueMap.forEach((value, key) => globalKeys.add(key));
     });
-    return Array.from(valueMap.values());
+    return result.map(m => Array.from(m.values()));
   }
 };
 

--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -12,7 +12,7 @@ this.Dedupe = class Dedupe {
     return false;
   }
 
-  one(values) {
+  collection(values) {
     const valueMap = new Map();
     values.forEach(value => {
       const key = this.createKey(value);

--- a/system-addon/common/ShortURL.jsm
+++ b/system-addon/common/ShortURL.jsm
@@ -13,7 +13,10 @@
  *         {str} link.title (optional) - The title of the link
  * @return {str}   A short url
  */
-module.exports = function shortURL(link) {
+
+Components.utils.importGlobalProperties(["URL"]);
+
+function shortURL(link) {
   if (!link.url && !link.hostname) {
     return "";
   }
@@ -25,4 +28,8 @@ module.exports = function shortURL(link) {
   const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
   // If URL and hostname are not present fallback to page title.
   return hostname.slice(0, eTLDExtra).toLowerCase() || hostname || link.title || link.url;
-};
+}
+
+this.shortURL = shortURL;
+
+this.EXPORTED_SYMBOLS = ["shortURL"];

--- a/system-addon/common/ShortURL.jsm
+++ b/system-addon/common/ShortURL.jsm
@@ -1,3 +1,5 @@
+Components.utils.importGlobalProperties(["URL"]);
+
 /**
  * shortURL - Creates a short version of a link's url, used for display purposes
  *            e.g. {url: http://www.foosite.com, eTLD: "com"}  =>  "foosite"
@@ -13,10 +15,7 @@
  *         {str} link.title (optional) - The title of the link
  * @return {str}   A short url
  */
-
-Components.utils.importGlobalProperties(["URL"]);
-
-function shortURL(link) {
+this.shortURL = function shortURL(link) {
   if (!link.url && !link.hostname) {
     return "";
   }
@@ -28,8 +27,6 @@ function shortURL(link) {
   const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
   // If URL and hostname are not present fallback to page title.
   return hostname.slice(0, eTLDExtra).toLowerCase() || hostname || link.title || link.url;
-}
-
-this.shortURL = shortURL;
+};
 
 this.EXPORTED_SYMBOLS = ["shortURL"];

--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -1,6 +1,5 @@
 const React = require("react");
 const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
-const shortURL = require("content-src/lib/short-url");
 const {FormattedMessage} = require("react-intl");
 const cardContextTypes = require("./types");
 const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
@@ -48,15 +47,13 @@ class Card extends React.Component {
   render() {
     const {index, link, dispatch, contextMenuOptions, eventSource} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeCard === index;
-    const hostname = shortURL(link);
     const {icon, intlID} = cardContextTypes[link.type];
-
     return (<li className={`card-outer${isContextMenuOpen ? " active" : ""}`}>
       <a href={link.url} onClick={this.onLinkClick}>
         <div className="card">
           {link.image && <div className="card-preview-image" style={{backgroundImage: `url(${link.image})`}} />}
           <div className="card-details">
-            <div className="card-host-name"> {hostname} </div>
+            <div className="card-host-name"> {link.hostname} </div>
             <div className={`card-text${link.image ? "" : " full-height"}`}>
               <h4 className="card-title" dir="auto"> {link.title} </h4>
               <p className="card-description" dir="auto"> {link.description} </p>

--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -48,6 +48,7 @@ class Card extends React.Component {
     const {index, link, dispatch, contextMenuOptions, eventSource} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeCard === index;
     const {icon, intlID} = cardContextTypes[link.type];
+
     return (<li className={`card-outer${isContextMenuOpen ? " active" : ""}`}>
       <a href={link.url} onClick={this.onLinkClick}>
         <div className="card">

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -1,7 +1,6 @@
 const React = require("react");
 const {connect} = require("react-redux");
 const {FormattedMessage} = require("react-intl");
-const shortURL = require("content-src/lib/short-url");
 const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
 const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
 const {perfService: perfSvc} = require("common/PerfService.jsm");
@@ -40,7 +39,7 @@ class TopSite extends React.Component {
   render() {
     const {link, index, dispatch} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === index;
-    const title = link.pinTitle || shortURL(link);
+    const title = link.pinTitle || link.hostname;
     const topSiteOuterClassName = `top-site-outer${isContextMenuOpen ? " active" : ""}`;
     const {tippyTopIcon} = link;
     let imageClassName;

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -1,5 +1,4 @@
 const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
-const shortURL = require("content-src/lib/short-url");
 
 /**
  * List of functions that return items that can be included as menu options in a
@@ -74,7 +73,7 @@ module.exports = {
     icon: "pin",
     action: ac.SendToMain({
       type: at.TOP_SITES_PIN,
-      data: {site: {url: site.url, title: shortURL(site)}, index}
+      data: {site: {url: site.url, title: site.hostname}, index}
     }),
     userEvent: "PIN"
   }),

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -68,7 +68,7 @@ this.TopSitesFeed = class TopSitesFeed {
     // Parse site url and extract hostname.
     pinned.forEach(site => { site.hostname = shortURL(site); });
 
-    return this.dedupe.one(pinned).slice(0, TOP_SITES_SHOWMORE_LENGTH);
+    return this.dedupe.collection(pinned).slice(0, TOP_SITES_SHOWMORE_LENGTH);
   }
   async refresh(target = null) {
     const links = await this.getLinksWithDefaults();

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -30,7 +30,7 @@ this.TopSitesFeed = class TopSitesFeed {
     this.dedupe = new Dedupe(this._dedupeKey);
   }
   _dedupeKey(site) {
-    return site.hostname;
+    return site && site.hostname;
   }
   refreshDefaults(sites) {
     // Clear out the array of any previous defaults
@@ -64,12 +64,10 @@ this.TopSitesFeed = class TopSitesFeed {
     }
 
     // Group together websites that require deduping.
-    const topsitesGroup = [pinned, frecent, DEFAULT_TOP_SITES];
-    topsitesGroup.forEach(group => group.forEach(site => {
-      if (site) {
-        site.hostname = shortURL(site);
-      }
-    }));
+    let topsitesGroup = [];
+    for (const group of [pinned, frecent, DEFAULT_TOP_SITES]) {
+      topsitesGroup.push(group.filter(site => site).map(site => Object.assign({}, site, {hostname: shortURL(site)})));
+    }
 
     const dedupedGroups = this.dedupe.group(topsitesGroup);
     // Insert original pinned websites in the result of the dedupe operation.

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -32,6 +32,9 @@ this.TopSitesFeed = class TopSitesFeed {
   _dedupeKey(site) {
     return site.hostname;
   }
+  _dedupeCompare(storedValue, newValue) {
+    return newValue.isPinned;
+  }
   refreshDefaults(sites) {
     // Clear out the array of any previous defaults
     DEFAULT_TOP_SITES.length = 0;
@@ -130,15 +133,9 @@ this.TopSitesFeed = class TopSitesFeed {
     }));
   }
   onAction(action) {
-    let realRows;
     switch (action.type) {
       case at.NEW_TAB_LOAD:
-        // Only check against real rows returned from history, not default ones.
-        realRows = this.store.getState().TopSites.rows.filter(row => !row.isDefault);
         if (
-          // When a new tab is opened, if we don't have enough top sites yet, refresh the data.
-          (realRows.length < TOP_SITES_SHOWMORE_LENGTH) ||
-
           // When a new tab is opened, if the last time we refreshed the data
           // is greater than 15 minutes, refresh the data.
           (Date.now() - this.lastUpdated >= UPDATE_TIME)

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -63,6 +63,7 @@ this.TopSitesFeed = class TopSitesFeed {
       frecent = frecent.filter(link => link && link.type !== "affiliate");
     }
 
+    // Group together websites that require deduping.
     const topsitesGroup = [pinned, frecent, DEFAULT_TOP_SITES];
     topsitesGroup.forEach(group => group.forEach(site => {
       if (site) {
@@ -71,9 +72,9 @@ this.TopSitesFeed = class TopSitesFeed {
     }));
 
     const dedupedGroups = this.dedupe.group(topsitesGroup);
+    // Insert original pinned websites in the result of the dedupe operation.
     pinned = insertPinned([...dedupedGroups[1], ...dedupedGroups[2]], pinned);
 
-    // Parse site url and extract hostname.
     return pinned.slice(0, TOP_SITES_SHOWMORE_LENGTH);
   }
   async refresh(target = null) {

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -11,6 +11,7 @@ Cu.importGlobalProperties(["fetch"]);
 
 const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
+const {shortURL} = Cu.import("resource://activity-stream/common/ShortURL.jsm", {});
 
 const STORIES_UPDATE_TIME = 30 * 60 * 1000; // 30 minutes
 const TOPICS_UPDATE_TIME = 3 * 60 * 60 * 1000; // 3 hours
@@ -85,6 +86,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
             .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.dedupe_url}))
             .map(s => ({
               "guid": s.id,
+              "hostname": shortURL(Object.assign({}, s, {url: s.dedupe_url})),
               "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
               "title": s.title,
               "description": s.excerpt,

--- a/system-addon/test/unit/common/Dedupe.test.js
+++ b/system-addon/test/unit/common/Dedupe.test.js
@@ -12,7 +12,7 @@ describe("Dedupe", () => {
       "http://www.mozilla.org"
     ];
 
-    const result = instance.one(websites);
+    const result = instance.collection(websites);
 
     assert.lengthOf(result, 2);
   });
@@ -27,7 +27,7 @@ describe("Dedupe", () => {
         "http://www.mozilla.org"
       ].map(urlToSite);
 
-      const result = instance.one(websites);
+      const result = instance.collection(websites);
 
       assert.lengthOf(result, 2);
       assert.deepEqual(result[0].url, "http://www.mozilla.org");

--- a/system-addon/test/unit/common/Dedupe.test.js
+++ b/system-addon/test/unit/common/Dedupe.test.js
@@ -1,0 +1,37 @@
+const {Dedupe} = require("common/Dedupe.jsm");
+
+describe("Dedupe", () => {
+  let instance;
+  const urlToSite = url => ({url});
+
+  it("should create an instance with default comparators", () => {
+    instance = new Dedupe();
+    const websites = [
+      "http://www.mozilla.org",
+      "http://www.firefox.org",
+      "http://www.mozilla.org"
+    ];
+
+    const result = instance.one(websites);
+
+    assert.lengthOf(result, 2);
+  });
+
+  describe("one", () => {
+    it("should dedupe items by hostname", () => {
+      const dedupeKey = url => url.url;
+      instance = new Dedupe(dedupeKey);
+      const websites = [
+        "http://www.mozilla.org",
+        "http://www.firefox.org",
+        "http://www.mozilla.org"
+      ].map(urlToSite);
+
+      const result = instance.one(websites);
+
+      assert.lengthOf(result, 2);
+      assert.deepEqual(result[0].url, "http://www.mozilla.org");
+      assert.deepEqual(result[1].url, "http://www.firefox.org");
+    });
+  });
+});

--- a/system-addon/test/unit/common/Dedupe.test.js
+++ b/system-addon/test/unit/common/Dedupe.test.js
@@ -17,7 +17,7 @@ describe("Dedupe", () => {
     assert.lengthOf(result, 2);
   });
 
-  describe("one", () => {
+  describe("collection", () => {
     it("should dedupe items by hostname", () => {
       const dedupeKey = url => url.url;
       instance = new Dedupe(dedupeKey);
@@ -32,6 +32,42 @@ describe("Dedupe", () => {
       assert.lengthOf(result, 2);
       assert.deepEqual(result[0].url, "http://www.mozilla.org");
       assert.deepEqual(result[1].url, "http://www.firefox.org");
+    });
+    it("should keep pinned items", () => {
+      const dedupeKey = url => url.hostname;
+      const compareFn = (storedSite, newSite) => newSite.isPinned;
+      instance = new Dedupe(dedupeKey, compareFn);
+      const sites = [{
+        url: "http://www.mozilla.org",
+        hostname: "mozilla",
+        isPinned: true
+      }, {
+        url: "http://www.mozilla.org/about",
+        hostname: "mozilla"
+      }];
+
+      const result = instance.collection(sites);
+
+      assert.lengthOf(result, 1);
+      assert.deepEqual(result[0], sites[0]);
+    });
+    it("should keep pinned items", () => {
+      const dedupeKey = url => url.hostname;
+      const compareFn = (storedSite, newSite) => newSite.isPinned;
+      instance = new Dedupe(dedupeKey, compareFn);
+      const sites = [{
+        url: "http://www.mozilla.org",
+        hostname: "mozilla"
+      }, {
+        url: "http://www.mozilla.org/about",
+        hostname: "mozilla",
+        isPinned: true
+      }];
+
+      const result = instance.collection(sites);
+
+      assert.lengthOf(result, 1);
+      assert.deepEqual(result[0], sites[1]);
     });
   });
 });

--- a/system-addon/test/unit/common/ShortUrl.test.js
+++ b/system-addon/test/unit/common/ShortUrl.test.js
@@ -1,4 +1,4 @@
-const shortURL = require("content-src/lib/short-url");
+const {shortURL} = require("common/ShortURL.jsm");
 
 describe("shortURL", () => {
   it("should return a blank string if url and hostname is falsey", () => {
@@ -28,6 +28,15 @@ describe("shortURL", () => {
 
   it("should return hostname for localhost", () => {
     assert.equal(shortURL({url: "http://localhost:8000/", eTLD: "localhost"}), "localhost");
+  });
+
+  it("should fallback to link title if it exists", () => {
+    const link = {
+      url: "file:///Users/voprea/Work/activity-stream/logs/coverage/system-addon/report-html/index.html",
+      title: "Code coverage report"
+    };
+
+    assert.equal(shortURL(link), link.title);
   });
 
   it("should return the url if no hostname or title is provided", () => {

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -5,7 +5,6 @@ const {_unconnected: LinkMenu} = require("content-src/components/LinkMenu/LinkMe
 const ContextMenu = require("content-src/components/ContextMenu/ContextMenu");
 const {IntlProvider} = require("react-intl");
 const messages = require("data/locales.json")["en-US"];
-const shortURL = require("content-src/lib/short-url");
 
 describe("<LinkMenu>", () => {
   let wrapper;
@@ -91,7 +90,7 @@ describe("<LinkMenu>", () => {
   describe(".onClick", () => {
     const FAKE_INDEX = 3;
     const FAKE_SOURCE = "TOP_SITES";
-    const FAKE_SITE = {url: "https://foo.com", referrer: "https://foo.com/ref", title: "bar", bookmarkGuid: 1234};
+    const FAKE_SITE = {url: "https://foo.com", referrer: "https://foo.com/ref", title: "bar", bookmarkGuid: 1234, hostname: "foo"};
     const dispatch = sinon.stub();
     const propOptions = ["Separator", "RemoveBookmark", "AddBookmark", "OpenInNewWindow", "OpenInPrivateWindow", "BlockUrl", "DeleteUrl", "PinTopSite", "UnpinTopSite", "SaveToPocket"];
     const expectedActionData = {
@@ -101,7 +100,7 @@ describe("<LinkMenu>", () => {
       menu_action_open_private_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
       menu_action_dismiss: FAKE_SITE.url,
       menu_action_delete: FAKE_SITE.url,
-      menu_action_pin: {site: {url: FAKE_SITE.url, title: shortURL(FAKE_SITE)}, index: FAKE_INDEX},
+      menu_action_pin: {site: {url: FAKE_SITE.url, title: FAKE_SITE.hostname}, index: FAKE_INDEX},
       menu_action_unpin: {site: {url: FAKE_SITE.url}},
       menu_action_save_to_pocket: {site: {url: FAKE_SITE.url, title: FAKE_SITE.title}}
     };

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -177,7 +177,7 @@ describe("<TopSites>", () => {
 describe("<TopSite>", () => {
   let link;
   beforeEach(() => {
-    link = {url: "https://foo.com", screenshot: "foo.jpg"};
+    link = {url: "https://foo.com", screenshot: "foo.jpg", hostname: "foo"};
   });
 
   it("should render a TopSite", () => {
@@ -196,19 +196,12 @@ describe("<TopSite>", () => {
   });
   it("should render a shortened title based off the url", () => {
     link.url = "https://www.foobar.org";
+    link.hostname = "foobar";
     link.eTLD = "org";
     const wrapper = shallow(<TopSite link={link} />);
     const titleEl = wrapper.find(".title");
 
     assert.equal(titleEl.text(), "foobar");
-  });
-  it("should fallback to link title for file:// protocol", () => {
-    link.url = "file:///Users/voprea/Work/activity-stream/logs/coverage/system-addon/report-html/index.html";
-    link.title = "Code coverage report";
-    const wrapper = shallow(<TopSite link={link} />);
-    const titleEl = wrapper.find(".title");
-
-    assert.equal(titleEl.text(), link.title);
   });
   it("should render the pinTitle if set", () => {
     link.isPinned = true;

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -54,7 +54,7 @@ describe("Top Sites Feed", () => {
     }));
     feed = new TopSitesFeed();
     feed.store = {dispatch: sinon.spy(), getState() { return {TopSites: {rows: Array(12).fill("site")}}; }};
-    feed.dedupe.one = sites => sites;
+    feed.dedupe.collection = sites => sites;
     links = FAKE_LINKS;
     clock = sinon.useFakeTimers();
   });
@@ -102,11 +102,11 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(global.NewTabUtils.activityStreamLinks.getTopSites);
     });
     it("should call dedupe on the links", async () => {
-      feed.dedupe.one = sinon.stub().returns([]);
+      feed.dedupe.collection = sinon.stub().returns([]);
 
       await feed.getLinksWithDefaults();
 
-      assert.calledOnce(feed.dedupe.one);
+      assert.calledOnce(feed.dedupe.collection);
     });
     it("should dedupe the links by hostname", async () => {
       const site = {url: "foo", hostname: "bar"};

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -7,7 +7,6 @@ const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
 const {insertPinned} = require("common/Reducers.jsm");
 const FAKE_LINKS = new Array(TOP_SITES_SHOWMORE_LENGTH).fill(null).map((v, i) => ({url: `http://www.site${i}.com`}));
 const FAKE_SCREENSHOT = "data123";
-const {shortURL} = require("common/ShortURL.jsm");
 
 function FakeTippyTopProvider() {}
 FakeTippyTopProvider.prototype = {

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -35,7 +35,7 @@ describe("Top Stories Feed", () => {
 
     shortURLStub = sinon.stub().callsFake(site => site.url);
 
-    ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, SECTION_ID} = injector({
+    ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, SECTION_ID, FEED_PREF, SECTION_OPTIONS_PREF} = injector({
       "lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs},
       "common/ShortURL.jsm": {shortURL: shortURLStub}
     }));

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -14,6 +14,7 @@ describe("Top Stories Feed", () => {
   let instance;
   let clock;
   let globals;
+  let shortURLStub;
 
   beforeEach(() => {
     FakePrefs.prototype.prefs["feeds.section.topstories.options"] = `{
@@ -32,7 +33,12 @@ describe("Top Stories Feed", () => {
     globals.set("Services", {locale: {getRequestedLocale: () => "en-CA"}});
     clock = sinon.useFakeTimers();
 
-    ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, SECTION_ID, FEED_PREF, SECTION_OPTIONS_PREF} = injector({"lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs}}));
+    shortURLStub = sinon.stub().callsFake(site => site.url);
+
+    ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, SECTION_ID} = injector({
+      "lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs},
+      "common/ShortURL.jsm": {shortURL: shortURLStub}
+    }));
     instance = new TopStoriesFeed();
     instance.store = {getState() { return {}; }, dispatch: sinon.spy()};
     instance.storiesLastUpdated = 0;
@@ -161,7 +167,8 @@ describe("Top Stories Feed", () => {
         "image": "image-url",
         "referrer": "referrer",
         "url": "rec-url",
-        "eTLD": ""
+        "eTLD": "",
+        "hostname": "rec-url"
       }];
 
       instance.stories_endpoint = "stories-endpoint";
@@ -170,6 +177,7 @@ describe("Top Stories Feed", () => {
       await instance.fetchStories();
 
       assert.calledOnce(fetchStub);
+      assert.calledOnce(shortURLStub);
       assert.calledWithExactly(fetchStub, instance.stories_endpoint);
       assert.calledOnce(instance.store.dispatch);
       assert.propertyVal(instance.store.dispatch.firstCall.args[0], "type", at.SECTION_ROWS_UPDATE);


### PR DESCRIPTION
Fixes #2933 
Dedupe happens in the Feeds. I've added the hostname key to the site objects because it is displayed in the cards. Previously the value returned by `shortURL` was named title (especially in the tests) it but made it confusing since websites already have a title.  