### PR TITLE
Let snippets payload unhide #snippets-container.

### DIFF
--- a/system-addon/content-src/lib/snippets.js
+++ b/system-addon/content-src/lib/snippets.js
@@ -191,7 +191,6 @@ class SnippetsProvider {
 
   _showRemoteSnippets() {
     const snippetsEl = document.getElementById(this.elementId);
-    const containerEl = document.getElementById(this.containerElementId);
     const payload = this.snippetsMap.get("snippets");
 
     if (!snippetsEl) {
@@ -212,11 +211,6 @@ class SnippetsProvider {
       const relocatedScript = document.createElement("script");
       relocatedScript.text = scriptEl.text;
       scriptEl.parentNode.replaceChild(relocatedScript, scriptEl);
-    }
-
-    // Unhide the container if everything went OK
-    if (containerEl) {
-      containerEl.style.display = "block";
     }
   }
 


### PR DESCRIPTION
The snippets payload is responsible to select a snippet to display. It's very
possible that no snippet qualifies. In this case #snippets-container should stay
hidden, otherwise the snippets payload will unhide it.

See also [mozmeao/snippets-service@2a2e16](https://github.com/mozmeao/snippets-service/commit/2a2e16aeaa474cfd523ded02e6f72d68eba875af#diff-050fa7fbdf0fa60913c8fc36985fa302R26)

/cc @k88hudson 