### PR TITLE
fix(systemaddon): Prevent migration button text from wrapping.

### DIFF
--- a/system-addon/content-src/components/ManualMigration/ManualMigration.scss
+++ b/system-addon/content-src/components/ManualMigration/ManualMigration.scss
@@ -34,6 +34,7 @@
     margin-inline-end: 0;
     margin-right: 12px;
     font-size: 13px;
-    width: 106px;
+    min-width: 100px;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
Closes #2955.