### PR TITLE
feat(systemaddon): Get Pocket feed for the appropriate locale. Closes…

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -75,9 +75,9 @@ const PREFS_CONFIG = new Map([
   ["feeds.section.topstories.options", {
     title: "Configuration options for top stories feed",
     value: `{
-      "stories_endpoint": "https://getpocket.com/v3/firefox/global-recs?consumer_key=$apiKey",
+      "stories_endpoint": "https://getpocket.com/v3/firefox/global-recs?consumer_key=$apiKey&locale_lang=$locale",
       "stories_referrer": "https://getpocket.com/recommendations",
-      "topics_endpoint": "https://getpocket.com/v3/firefox/trending-topics?consumer_key=$apiKey",
+      "topics_endpoint": "https://getpocket.com/v3/firefox/trending-topics?consumer_key=$apiKey&locale_lang=$locale",
       "read_more_endpoint": "https://getpocket.com/explore/trending?src=ff_new_tab",
       "learn_more_endpoint": "https://getpocket.com/firefox_learnmore?src=ff_newtab",
       "survey_link": "https://www.surveymonkey.com/r/newtabffx",

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -28,8 +28,10 @@ this.TopStoriesFeed = class TopStoriesFeed {
       const prefs = new Prefs();
       const options = JSON.parse(prefs.get("feeds.section.topstories.options"));
       const apiKey = this._getApiKeyFromPref(options.api_key_pref);
-      this.stories_endpoint = this._produceUrlWithApiKey(options.stories_endpoint, apiKey);
-      this.topics_endpoint = this._produceUrlWithApiKey(options.topics_endpoint, apiKey);
+      const locale = Services.locale.getRequestedLocale();
+      this.stories_endpoint = this._produceFinalEndpointUrl(options.stories_endpoint, apiKey, locale);
+      this.topics_endpoint = this._produceFinalEndpointUrl(options.topics_endpoint, apiKey, locale);
+
       this.read_more_endpoint = options.read_more_endpoint;
       this.stories_referrer = options.stories_referrer;
 
@@ -138,16 +140,17 @@ this.TopStoriesFeed = class TopStoriesFeed {
     return new Prefs().get(apiKeyPref) || Services.prefs.getCharPref(apiKeyPref);
   }
 
-  _produceUrlWithApiKey(url, apiKey) {
+  _produceFinalEndpointUrl(url, apiKey, locale) {
     if (!url) {
       return url;
     }
-
     if (url.includes("$apiKey") && !apiKey) {
       throw new Error(`An API key was specified but none configured: ${url}`);
     }
-
-    return url.replace("$apiKey", apiKey);
+    if (url.includes("$locale") && !locale) {
+      throw new Error(`A locale was specified but none detected: ${url}`);
+    }
+    return url.replace("$apiKey", apiKey).replace("$locale", locale);
   }
 
   // Need to remove parenthesis from image URLs as React will otherwise

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -15,9 +15,9 @@ describe("Top Stories Feed", () => {
 
   beforeEach(() => {
     FakePrefs.prototype.prefs["feeds.section.topstories.options"] = `{
-      "stories_endpoint": "https://somedomain.org/stories?key=$apiKey",
+      "stories_endpoint": "https://somedomain.org/stories?key=$apiKey&locale=$locale",
       "stories_referrer": "https://somedomain.org/referrer",
-      "topics_endpoint": "https://somedomain.org/topics?key=$apiKey",
+      "topics_endpoint": "https://somedomain.org/topics?key=$apiKey&locale=$locale",
       "survey_link": "https://www.surveymonkey.com/r/newtabffx",
       "api_key_pref": "apiKeyPref",
       "provider_name": "test-provider",
@@ -27,6 +27,7 @@ describe("Top Stories Feed", () => {
     FakePrefs.prototype.prefs.apiKeyPref = "test-api-key";
 
     globals = new GlobalOverrider();
+    globals.set("Services", {locale: {getRequestedLocale: () => "en-CA"}});
     clock = sinon.useFakeTimers();
 
     ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, SECTION_ID} = injector({"lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs}}));
@@ -43,9 +44,9 @@ describe("Top Stories Feed", () => {
     });
     it("should initialize endpoints based on prefs", () => {
       instance.onAction({type: at.INIT});
-      assert.equal("https://somedomain.org/stories?key=test-api-key", instance.stories_endpoint);
+      assert.equal("https://somedomain.org/stories?key=test-api-key&locale=en-CA", instance.stories_endpoint);
       assert.equal("https://somedomain.org/referrer", instance.stories_referrer);
-      assert.equal("https://somedomain.org/topics?key=test-api-key", instance.topics_endpoint);
+      assert.equal("https://somedomain.org/topics?key=test-api-key&locale=en-CA", instance.topics_endpoint);
     });
     it("should register section", () => {
       const expectedSectionOptions = {
@@ -105,12 +106,24 @@ describe("Top Stories Feed", () => {
       assert.called(Components.utils.reportError);
     });
     it("should report error for missing api key", () => {
-      let fakeServices = {prefs: {getCharPref: sinon.spy()}};
+      let fakeServices = {prefs: {getCharPref: sinon.spy()}, locale: {getRequestedLocale: sinon.spy()}};
       globals.set("Services", fakeServices);
       globals.sandbox.spy(global.Components.utils, "reportError");
       FakePrefs.prototype.prefs["feeds.section.topstories.options"] = `{
         "stories_endpoint": "https://somedomain.org/stories?key=$apiKey",
         "topics_endpoint": "https://somedomain.org/topics?key=$apiKey"
+      }`;
+      instance.init();
+
+      assert.called(Components.utils.reportError);
+    });
+    it("should report error for missing locale", () => {
+      let fakeServices = {locale: {getRequestedLocale: sinon.spy()}};
+      globals.set("Services", fakeServices);
+      globals.sandbox.spy(global.Components.utils, "reportError");
+      FakePrefs.prototype.prefs["feeds.section.topstories.options"] = `{
+        "stories_endpoint": "https://somedomain.org/stories?locale=$locale",
+        "topics_endpoint": "https://somedomain.org/topics?locale=$locale"
       }`;
       instance.init();
 


### PR DESCRIPTION
Fix #2974.

Currently requesting other locales than en-* will return the exact same content, so there's no harm in putting this in now. Once other language feeds are ready they should just work (we won't need any client-side changes then).

Relying on accept-lang is possible in a future endpoint version, but in the meantime let's use the locale_lang request parameter. This is also consistent with A-S lang settings, as there we're not relying on accept-lang, but on general.useragent.locale. 

