### PR TITLE
chore(testing): #2984 remove reference to PreviewProvider.jsm

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -12,9 +12,6 @@ const {insertPinned} = Cu.import("resource://activity-stream/common/Reducers.jsm
 
 XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm");
-// Keep a reference to PreviewProvider.jsm until it's good to remove. See #2849
-XPCOMUtils.defineLazyModuleGetter(this, "PreviewProvider",
-  "resource://app/modules/PreviewProvider.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Screenshots",
   "resource://activity-stream/lib/Screenshots.jsm");
 


### PR DESCRIPTION
This shouldn't land until https://bugzilla.mozilla.org/show_bug.cgi?id=1384977 makes its way from autoland to mozilla-central so that pine doesn't break.

r?ursula Fix #2984.