### PR TITLE
feat(topstories): Hide preference section for unsupported locales

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -73,10 +73,11 @@ class PreferencesPane extends React.Component {
               <PreferencesInput className="showTopSites" prefName="showTopSites" value={prefs.showTopSites} onChange={this.handleChange}
                 titleStringId="settings_pane_topsites_header" descStringId="settings_pane_topsites_body" />
 
-              {this.topStoriesOptions && <PreferencesInput className="showTopStories" prefName="feeds.section.topstories"
-                value={prefs["feeds.section.topstories"]} onChange={this.handleChange}
-                titleStringId="header_recommended_by" titleStringValues={{provider: this.topStoriesOptions.provider_name}}
-                descStringId={this.topStoriesOptions.provider_description} />}
+              {this.topStoriesOptions && !this.topStoriesOptions.hidden &&
+                <PreferencesInput className="showTopStories" prefName="feeds.section.topstories"
+                  value={prefs["feeds.section.topstories"]} onChange={this.handleChange}
+                  titleStringId="header_recommended_by" titleStringValues={{provider: this.topStoriesOptions.provider_name}}
+                  descStringId={this.topStoriesOptions.provider_description} />}
             </div>
             <section className="actions">
               <button className="done" onClick={this.togglePane}>

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -24,13 +24,14 @@ const {TopStoriesFeed} = Cu.import("resource://activity-stream/lib/TopStoriesFee
 
 const REASON_ADDON_UNINSTALL = 6;
 
+// For now, we only want to show top stories by default to the following locales
+const showTopStoriesByDefault = ["en-US", "en-CA"].includes(Services.locale.getRequestedLocale());
 // Sections, keyed by section id
 const SECTIONS = new Map([
   ["topstories", {
     feed: TopStoriesFeed,
     prefTitle: "Fetches content recommendations from a configurable content provider",
-     // for now, we only want to show top stories by default to the following locales
-    showByDefault: ["en-US", "en-CA"].includes(Services.locale.getRequestedLocale())
+    showByDefault: showTopStoriesByDefault
   }]
 ]);
 
@@ -84,7 +85,8 @@ const PREFS_CONFIG = new Map([
       "api_key_pref": "extensions.pocket.oAuthConsumerKey",
       "provider_name": "Pocket",
       "provider_icon": "pocket",
-      "provider_description": "pocket_feedback_body"
+      "provider_description": "pocket_feedback_body",
+      "hidden": ${!showTopStoriesByDefault}
     }`
   }],
   ["migrationExpired", {


### PR DESCRIPTION
Suggestion for a simple fix of #2973.

Reason I used "hidden" (negated showByDefault) is so nobody has to reset their prefs to keep seeing top stories.