### PR TITLE
Read telemetryEnabled from Services.telemetry.canRecordBase.

### DIFF
--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -47,7 +47,7 @@ this.SnippetsFeed = class SnippetsFeed {
       version: STARTPAGE_VERSION,
       profileCreatedWeeksAgo: profileInfo.createdWeeksAgo,
       profileResetWeeksAgo: profileInfo.resetWeeksAgo,
-      telemetryEnabled: Services.prefs.getBoolPref(TELEMETRY_PREF)
+      telemetryEnabled: Services.telemetry.canRecordBase
     };
 
     this.store.dispatch(ac.BroadcastToContent({type: at.SNIPPETS_DATA, data}));


### PR DESCRIPTION
Based on suggestion given by  :gfritzsche in [Bug 1384843](https://bugzilla.mozilla.org/show_bug.cgi?id=1384843)

/cc @k88hudson 