### PR TITLE
Change margin on Manual Migration message for better RTL support

### DIFF
--- a/system-addon/content-src/components/ManualMigration/ManualMigration.scss
+++ b/system-addon/content-src/components/ManualMigration/ManualMigration.scss
@@ -16,7 +16,8 @@
   }
 
   .icon {
-    margin: 0 12px 0 0;
+    margin: 0;
+    margin-inline-end: 12px;
     align-self: center;
   }
 }
@@ -31,8 +32,7 @@
     align-self: center;
     padding: 0 12px;
     height: 24px;
-    margin-inline-end: 0;
-    margin-right: 12px;
+    margin-inline-end: 12px;
     font-size: 13px;
     min-width: 100px;
     white-space: nowrap;


### PR DESCRIPTION
Also see https://bugzilla.mozilla.org/show_bug.cgi?id=1385235
issue #2787 introduced a migration request message for new profiles. Unfortunately, this looks worse on RTL builds than on LTR. 

![ltr import offer](https://user-images.githubusercontent.com/50206/28717021-b70b63b6-73a8-11e7-8ad3-e636324bd0d8.jpg)
![rtl import offer](https://user-images.githubusercontent.com/50206/28717020-b7082ec6-73a8-11e7-9ce1-9da2da3024e6.jpg)

The change I am suggesting included using margin-inline-end correctly, so the same rules will apply correctly to both LTR and RTL builds.

![fixed wip](https://user-images.githubusercontent.com/50206/28717120-28871440-73a9-11e7-9416-d20a60e9e37d.png)

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1385235