### PR TITLE
fix(systemaddon): Use margin-inline-end/start for migration component

### DIFF
--- a/system-addon/content-src/components/ManualMigration/ManualMigration.scss
+++ b/system-addon/content-src/components/ManualMigration/ManualMigration.scss
@@ -9,7 +9,9 @@
   justify-content: space-between;
 
   p {
-    margin: 0 4px 0 12px;
+    margin: 0;
+    margin-inline-end: 4px;
+    margin-inline-start: 12px;
     align-self: center;
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Follow up from: https://github.com/mozilla/activity-stream/pull/3008#pullrequestreview-52925047