### PR TITLE
feat(pocket): Use geo and locale to determine when to enable Pocket

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -53,6 +53,12 @@ class PreferencesPane extends React.Component {
     const props = this.props;
     const prefs = props.Prefs.values;
     const isVisible = this.state.visible;
+
+    // Show prefs for top stories only if we have some top story option and
+    // either it should be shown by default or it was already turned on
+    const showTopStoriesPref = this.topStoriesOptions &&
+      (this.topStoriesOptions.shownByDefault || prefs["feeds.section.topstories"]);
+
     return (
       <div className="prefs-pane-wrapper" ref="wrapper">
         <div className="prefs-pane-button">
@@ -73,7 +79,7 @@ class PreferencesPane extends React.Component {
               <PreferencesInput className="showTopSites" prefName="showTopSites" value={prefs.showTopSites} onChange={this.handleChange}
                 titleStringId="settings_pane_topsites_header" descStringId="settings_pane_topsites_body" />
 
-              {this.topStoriesOptions && !this.topStoriesOptions.hidden &&
+              {showTopStoriesPref &&
                 <PreferencesInput className="showTopStories" prefName="feeds.section.topstories"
                   value={prefs["feeds.section.topstories"]} onChange={this.handleChange}
                   titleStringId="header_recommended_by" titleStringValues={{provider: this.topStoriesOptions.provider_name}}

--- a/system-addon/lib/NewTabInit.jsm
+++ b/system-addon/lib/NewTabInit.jsm
@@ -11,6 +11,7 @@ const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-str
  * NewTabInit - A placeholder for now. This will send a copy of the state to all
  *              newly opened tabs.
  */
+/* istanbul ignore next but should be fixed to have code coverage! */
 this.NewTabInit = class NewTabInit {
   onAction(action) {
     let newAction;

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -41,6 +41,7 @@ overrider.set({
     },
     prefs: {
       addObserver() {},
+      prefHasUserValue() {},
       removeObserver() {},
       getStringPref() {},
       getBoolPref() {},


### PR DESCRIPTION
Fix #3004. r?@k88hudson Some caveats that are mostly noted in the comment blocks:

Most users will already have a geo set, but for those with a new profile, it's possible to need to wait for geo to be set soon after first run. Unfortunately, default prefs are determined when `ActivityStream.jsm` loads, so as a quick hack, I made it detect the pref change and directly set the default for the topstories section feed.

This doesn't update the options, which are needed to remember if the section was on/off by default to show the prefs. This PR currently does not re-set the default for the options and works around this by having the prefs also appear if the section was somehow turned on (in this case, probably because the geo was just set).

Separate from that, when writing the AS.jsm load tests, it ends up trying to load NewTabInit which results in istanbul complaining that it's not tested. So for now I just added the "ignore next" as it isn't really in scope of this PR.