### PR TITLE
feat(topsites): Use different default sites depending on geo

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -22,6 +22,17 @@ const {TelemetryFeed} = Cu.import("resource://activity-stream/lib/TelemetryFeed.
 const {TopSitesFeed} = Cu.import("resource://activity-stream/lib/TopSitesFeed.jsm", {});
 const {TopStoriesFeed} = Cu.import("resource://activity-stream/lib/TopStoriesFeed.jsm", {});
 
+const DEFAULT_SITES = new Map([
+  // This first item is the global list fallback for any unexpected geos
+  ["", "https://www.youtube.com/,https://www.facebook.com/,https://www.wikipedia.org/,https://www.reddit.com/,https://www.amazon.com/,https://twitter.com/"],
+  ["US", "https://www.youtube.com/,https://www.facebook.com/,https://www.amazon.com/,https://www.reddit.com/,https://www.wikipedia.org/,https://twitter.com/"],
+  ["CA", "https://www.youtube.com/,https://www.facebook.com/,https://www.reddit.com/,https://www.wikipedia.org/,https://www.amazon.ca/,https://twitter.com/"],
+  ["DE", "https://www.youtube.com/,https://www.facebook.com/,https://www.amazon.de/,https://www.ebay.de/,https://www.wikipedia.org/,https://www.reddit.com/"],
+  ["PL", "https://www.youtube.com/,https://www.facebook.com/,https://allegro.pl/,https://www.wikipedia.org/,https://www.olx.pl/,https://www.wykop.pl/"],
+  ["RU", "https://vk.com/,https://www.youtube.com/,https://ok.ru/,https://www.avito.ru/,https://www.aliexpress.com/,https://www.wikipedia.org/"],
+  ["GB", "https://www.youtube.com/,https://www.facebook.com/,https://www.reddit.com/,https://www.amazon.co.uk/,https://www.bbc.co.uk/,https://www.ebay.co.uk/"],
+  ["FR", "https://www.youtube.com/,https://www.facebook.com/,https://www.wikipedia.org/,https://www.amazon.fr/,https://www.leboncoin.fr/,https://twitter.com/"]
+]);
 const GEO_PREF = "browser.search.region";
 const REASON_ADDON_UNINSTALL = 6;
 
@@ -30,7 +41,7 @@ const REASON_ADDON_UNINSTALL = 6;
 const PREFS_CONFIG = new Map([
   ["default.sites", {
     title: "Comma-separated list of default top sites to fill in behind visited sites",
-    value: "https://www.facebook.com/,https://www.youtube.com/,https://www.amazon.com/,https://www.yahoo.com/,https://www.ebay.com/,https://twitter.com/"
+    getValue: ({geo}) => DEFAULT_SITES.get(DEFAULT_SITES.has(geo) ? geo : "")
   }],
   ["feeds.section.topstories.options", {
     title: "Configuration options for top stories feed",

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -49,24 +49,37 @@ describe("Top Sites Feed", () => {
     clock.restore();
   });
 
-  describe("#init", () => {
-    it("should add defaults on INIT", () => {
-      feed.onAction({type: at.INIT});
-      assert.ok(DEFAULT_TOP_SITES.length);
+  describe("#refreshDefaults", () => {
+    it("should add defaults on PREFS_INITIAL_VALUES", () => {
+      feed.onAction({type: at.PREFS_INITIAL_VALUES, data: {"default.sites": "https://foo.com"}});
+
+      assert.isAbove(DEFAULT_TOP_SITES.length, 0);
+    });
+    it("should add defaults on PREF_CHANGED", () => {
+      feed.onAction({type: at.PREF_CHANGED, data: {name: "default.sites", value: "https://foo.com"}});
+
+      assert.isAbove(DEFAULT_TOP_SITES.length, 0);
     });
     it("should have default sites with .isDefault = true", () => {
-      feed.init();
+      feed.refreshDefaults("https://foo.com");
+
       DEFAULT_TOP_SITES.forEach(link => assert.propertyVal(link, "isDefault", true));
     });
     it("should add no defaults on empty pref", () => {
-      FakePrefs.prototype.prefs["default.sites"] = "";
-      feed.init();
+      feed.refreshDefaults("");
+
+      assert.equal(DEFAULT_TOP_SITES.length, 0);
+    });
+    it("should clear defaults", () => {
+      feed.refreshDefaults("https://foo.com");
+      feed.refreshDefaults("");
+
       assert.equal(DEFAULT_TOP_SITES.length, 0);
     });
   });
   describe("#getLinksWithDefaults", () => {
     beforeEach(() => {
-      feed.init();
+      feed.refreshDefaults("https://foo.com");
     });
 
     it("should get the links from NewTabUtils", async () => {


### PR DESCRIPTION
Fixes #2776. r?@k88hudson 

Uses the `getValue` of #3021 and updates `TopSitesFeed` to watch pref changes instead of just grabbing once on init.