### PR TITLE
fix(tests): Add mochitests that run successfully whether enabled or not

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -76,8 +76,10 @@ function init(reason) {
  * @param  {type} reason Reason for uninitialization. Could be uninstall, upgrade, or PREF_OFF
  */
 function uninit(reason) {
+  // Make sure to only uninit once in case both pref change and shutdown happen
   if (activityStream) {
     activityStream.uninit(reason);
+    activityStream = null;
   }
 }
 

--- a/system-addon/test/functional/mochitest/.eslintrc.js
+++ b/system-addon/test/functional/mochitest/.eslintrc.js
@@ -1,41 +1,5 @@
 module.exports = {
-  "globals": {
-    "add_task": false,
-    "Assert": false,
-    "BrowserOpenTab": false,
-    "BrowserTestUtils": false,
-    "content": false,
-    "ContentTask": false,
-    "ContentTaskUtils": false,
-    "Components": false,
-    "EventUtils": false,
-    "executeSoon": false,
-    "expectUncaughtException": false,
-    "export_assertions": false,
-    "extractJarToTmp": false,
-    "finish": false,
-    "getJar": false,
-    "getRootDirectory": false,
-    "getTestFilePath": false,
-    "gBrowser": false,
-    "gTestPath": false,
-    "info": false,
-    "is": false,
-    "isnot": false,
-    "ok": false,
-    "OpenBrowserWindow": false,
-    "Preferences": false,
-    "registerCleanupFunction": false,
-    "requestLongerTimeout": false,
-    "Services": false,
-    "SimpleTest": false,
-    "SpecialPowers": false,
-    "TestUtils": false,
-    "todo": false,
-    "todo_is": false,
-    "todo_isnot": false,
-    "waitForClipboard": false,
-    "waitForExplicitFinish": false,
-    "waitForFocus": false
-  }
+  "extends": [
+    "plugin:mozilla/browser-test"
+  ]
 };

--- a/system-addon/test/functional/mochitest/browser.ini
+++ b/system-addon/test/functional/mochitest/browser.ini
@@ -1,7 +1,9 @@
 [DEFAULT]
 support-files =
   blue_page.html
+  head.js
 
 [browser_as_load_location.js]
+[browser_as_render.js]
 [browser_getScreenshots.js]
 skip-if=true # issue 2851

--- a/system-addon/test/functional/mochitest/browser_as_render.js
+++ b/system-addon/test/functional/mochitest/browser_as_render.js
@@ -1,0 +1,29 @@
+"use strict";
+
+test_newtab(function test_render_search() {
+  let search = content.document.getElementById("newtab-search-text");
+  ok(search, "Got the search box");
+  isnot(search.placeholder, "search_web_placeholder", "Search box is localized");
+});
+
+test_newtab(function test_render_topsites() {
+  let topSites = content.document.querySelector(".top-sites-list");
+  ok(topSites, "Got the top sites section");
+});
+
+test_newtab({
+  async before({pushPrefs}) {
+    await pushPrefs(["browser.newtabpage.activity-stream.showTopSites", false]);
+  },
+  test: function test_render_no_topsites() {
+    let topSites = content.document.querySelector(".top-sites-list");
+    ok(!topSites, "No top sites section");
+  }
+});
+
+// This next test runs immediately after test_render_no_topsites to make sure
+// the topsites pref is restored
+test_newtab(function test_render_topsites_again() {
+  let topSites = content.document.querySelector(".top-sites-list");
+  ok(topSites, "Got the top sites section again");
+});

--- a/system-addon/test/functional/mochitest/head.js
+++ b/system-addon/test/functional/mochitest/head.js
@@ -1,0 +1,95 @@
+"use strict";
+
+function popPrefs() {
+  return SpecialPowers.popPrefEnv();
+}
+function pushPrefs(...prefs) {
+  return SpecialPowers.pushPrefEnv({set: prefs});
+}
+
+// Activity Stream tests expect it to be enabled, and make sure to clear out any
+// preloaded browsers that might have about:newtab that we don't want to test
+const ACTIVITY_STREAM_PREF = "browser.newtabpage.activity-stream.enabled";
+pushPrefs([ACTIVITY_STREAM_PREF, true]);
+gBrowser.removePreloadedBrowser();
+
+/**
+ * Helper to wait for potentially preloaded browsers to "load" where a preloaded
+ * page has already loaded and won't trigger "load", and a "load"ed page might
+ * not necessarily have had all its javascript/render logic executed.
+ */
+async function waitForPreloaded(browser) {
+  let readyState = await ContentTask.spawn(browser, {}, () => content.document.readyState);
+  if (readyState !== "complete") {
+    await BrowserTestUtils.browserLoaded(browser);
+  }
+}
+
+/**
+ * Helper to run Activity Stream about:newtab test tasks in content.
+ *
+ * @param testInfo {Function|Object}
+ *   {Function} This parameter will be used as if the function were called with
+ *              an Object with this parameter as "test" key's value.
+ *   {Object} The following keys are expected:
+ *     before {Function} Optional. Runs before and returns an arg for "test"
+ *     test   {Function} The test to run in the about:newtab content task taking
+ *                       an arg from "before" and returns a result to "after"
+ *     after  {Function} Optional. Runs after and with the result of "test"
+ */
+function test_newtab(testInfo) { // eslint-disable-line no-unused-vars
+  // Extract any test parts or default to just the single content task
+  let {before, test: contentTask, after} = testInfo;
+  if (!before) {
+    before = () => ({});
+  }
+  if (!contentTask) {
+    contentTask = testInfo;
+  }
+  if (!after) {
+    after = () => {};
+  }
+
+  // Helper to push prefs for just this test and pop them when done
+  let needPopPrefs = false;
+  let scopedPushPrefs = async(...args) => {
+    needPopPrefs = true;
+    await pushPrefs(...args);
+  };
+  let scopedPopPrefs = async() => {
+    if (needPopPrefs) {
+      await popPrefs();
+    }
+  };
+
+  // Make the test task with optional before/after and content task to run in a
+  // new tab that opens and closes.
+  let testTask = async() => {
+    // Open about:newtab without using the default load listener
+    let tab = await BrowserTestUtils.openNewForegroundTab(gBrowser, "about:newtab", false);
+
+    // Specially wait for potentially preloaded browsers
+    let browser = tab.linkedBrowser;
+    await waitForPreloaded(browser);
+
+    // Wait for React to render something
+    await BrowserTestUtils.waitForCondition(() => ContentTask.spawn(browser, {},
+      () => content.document.getElementById("root").children.length),
+      "Should render activity stream content");
+
+    // Chain together before -> contentTask -> after data passing
+    try {
+      let contentArg = await before({pushPrefs: scopedPushPrefs, tab});
+      let contentResult = await ContentTask.spawn(browser, contentArg, contentTask);
+      await after(contentResult);
+    } finally {
+      // Clean up for next tests
+      await scopedPopPrefs();
+      await BrowserTestUtils.removeTab(tab);
+    }
+  };
+
+  // Copy the name of the content task to identify the test
+  Object.defineProperty(testTask, "name", {value: contentTask.name});
+  add_task(testTask);
+}


### PR DESCRIPTION
Fix #2880. r?@dmose Beefs up `as_load_location` to work preloaded or not and activity-stream.enabled or not. Adds a `head.js` that turns on activity-stream with a set of basic actual react rendering tests covering some of those itemized in #2127. Also cleans up eslint to use the fancy "plugin:mozilla/browser-test" that auto-globalizes-head.js helpers (and other test globals).

Try looks good when a-s.enabled: https://treeherder.mozilla.org/#/jobs?repo=try&revision=2b1081f19bfc7b5adbd761e347a26fd264b55783
And disabled: https://treeherder.mozilla.org/#/jobs?repo=try&revision=34f4c5cf8fbe1c0e2933c429e270e03817b55b2c