### PR TITLE
feat(systemaddon): Closes #2645 Add <meta> CSP to activity-stream.html

### DIFF
--- a/system-addon/data/content/activity-stream.html
+++ b/system-addon/data/content/activity-stream.html
@@ -2,6 +2,7 @@
 <html lang="en-us" dir="ltr">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'; img-src http: https: data: blob:; style-src 'unsafe-inline'; child-src 'none'; object-src 'none'; report-uri https://tiles.services.mozilla.com/v4/links/activity-stream/csp">
     <title></title>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />
     <link rel="stylesheet" href="resource://activity-stream/data/content/activity-stream.css" />


### PR DESCRIPTION
CSP tag on Report-Only mode which reports to a prod endpoint as per the comment in ticket fix #2645 

@dmose @Mardak @k88hudson @ncloudioj  what do we think?