### PR TITLE
Fix(l10n): closes #3003, makes locale fallback work

### DIFF
--- a/system-addon/lib/LocalizationFeed.jsm
+++ b/system-addon/lib/LocalizationFeed.jsm
@@ -30,7 +30,14 @@ this.LocalizationFeed = class LocalizationFeed {
   }
 
   updateLocale() {
-    let locale = Services.locale.getRequestedLocale() || DEFAULT_LOCALE;
+    // Just take the first element in the result array, as it should be
+    // the best locale
+    let locale = Services.locale.negotiateLanguages(
+      Services.locale.getAppLocalesAsLangTags(), // desired locales
+      Object.keys(this.allStrings), // available locales
+      DEFAULT_LOCALE // fallback
+    )[0];
+
     let strings = this.allStrings[locale];
 
     // Use the default strings for any that are missing

--- a/system-addon/test/unit/lib/LocalizationFeed.test.js
+++ b/system-addon/test/unit/lib/LocalizationFeed.test.js
@@ -25,8 +25,6 @@ describe("Localization Feed", () => {
     sandbox = globals.sandbox;
     feed = new LocalizationFeed();
     feed.store = {dispatch: sinon.spy()};
-
-    sandbox.stub(global.Services.locale, "getRequestedLocale");
   });
   afterEach(() => {
     globals.restore();
@@ -50,6 +48,8 @@ describe("Localization Feed", () => {
 
     it("should dispatch with locale and strings for default", () => {
       const locale = DEFAULT_LOCALE;
+      sandbox.stub(global.Services.locale, "negotiateLanguages")
+        .returns([locale]);
       feed.updateLocale();
 
       assert.calledOnce(feed.store.dispatch);
@@ -60,7 +60,8 @@ describe("Localization Feed", () => {
     });
     it("should use strings for other locale", () => {
       const locale = "it";
-      global.Services.locale.getRequestedLocale.returns(locale);
+      sandbox.stub(global.Services.locale, "negotiateLanguages")
+        .returns([locale]);
 
       feed.updateLocale();
 
@@ -72,7 +73,8 @@ describe("Localization Feed", () => {
     });
     it("should use some fallback strings for partial locale", () => {
       const locale = "ru";
-      global.Services.locale.getRequestedLocale.returns(locale);
+      sandbox.stub(global.Services.locale, "negotiateLanguages")
+        .returns([locale]);
 
       feed.updateLocale();
 
@@ -87,8 +89,8 @@ describe("Localization Feed", () => {
     });
     it("should use all default strings for unknown locale", () => {
       const locale = "xyz";
-      global.Services.locale.getRequestedLocale.returns(locale);
-
+      sandbox.stub(global.Services.locale, "negotiateLanguages")
+        .returns([locale]);
       feed.updateLocale();
 
       assert.calledOnce(feed.store.dispatch);

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -28,7 +28,11 @@ overrider.set({
   fetch() {},
   Preferences: FakePrefs,
   Services: {
-    locale: {getRequestedLocale() {}},
+    locale: {
+      getAppLocalesAsLangTags() {},
+      getRequestedLocale() {},
+      negotiateLanguages() {}
+    },
     urlFormatter: {formatURL: str => str},
     mm: {
       addMessageListener: (msg, cb) => cb(),


### PR DESCRIPTION
Fix #3003. How to test:

1. download a de-DE nightly build
2. in about:config, set the various appropriate *xpinstall* prefs to false
3. `npm run packagemc`
4. from about:addons, use the gear dropdown menu to install the .xpi
5. open a new tab, verify that the words are in german rather than English
