### PR TITLE
use Services.telemetry.canRecordBase, enable snippets by default

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -147,7 +147,7 @@ const FEEDS_DATA = [
     name: "snippets",
     factory: () => new SnippetsFeed(),
     title: "Gets snippets data",
-    value: false
+    value: true
   },
   {
     name: "systemtick",

--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -15,6 +15,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "ProfileAge",
 // Url to fetch snippets, in the urlFormatter service format.
 const SNIPPETS_URL_PREF = "browser.aboutHomeSnippets.updateUrl";
 const ONBOARDING_FINISHED_PREF = "browser.onboarding.notification.finished";
+const FXA_USERNAME_PREF = "services.sync.username";
 
 // Should be bumped up if the snippets content format changes.
 const STARTPAGE_VERSION = 5;
@@ -48,7 +49,8 @@ this.SnippetsFeed = class SnippetsFeed {
       profileCreatedWeeksAgo: profileInfo.createdWeeksAgo,
       profileResetWeeksAgo: profileInfo.resetWeeksAgo,
       telemetryEnabled: Services.telemetry.canRecordBase,
-      onboardingFinished: Services.prefs.getBoolPref(ONBOARDING_FINISHED_PREF)
+      onboardingFinished: Services.prefs.getBoolPref(ONBOARDING_FINISHED_PREF),
+      fxaccount: Services.prefs.prefHasUserValue(FXA_USERNAME_PREF)
     };
 
     this.store.dispatch(ac.BroadcastToContent({type: at.SNIPPETS_DATA, data}));
@@ -63,10 +65,12 @@ this.SnippetsFeed = class SnippetsFeed {
     await this._refresh();
     Services.prefs.addObserver(ONBOARDING_FINISHED_PREF, this._refresh);
     Services.prefs.addObserver(SNIPPETS_URL_PREF, this._refresh);
+    Services.prefs.addObserver(FXA_USERNAME_PREF, this._refresh);
   }
   uninit() {
     Services.prefs.removeObserver(ONBOARDING_FINISHED_PREF, this._refresh);
     Services.prefs.removeObserver(SNIPPETS_URL_PREF, this._refresh);
+    Services.prefs.removeObserver(FXA_USERNAME_PREF, this._refresh);
     this.store.dispatch({type: at.SNIPPETS_RESET});
   }
   onAction(action) {

--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -14,7 +14,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "ProfileAge",
 
 // Url to fetch snippets, in the urlFormatter service format.
 const SNIPPETS_URL_PREF = "browser.aboutHomeSnippets.updateUrl";
-const TELEMETRY_PREF = "datareporting.healthreport.uploadEnabled";
 const ONBOARDING_FINISHED_PREF = "browser.onboarding.notification.finished";
 
 // Should be bumped up if the snippets content format changes.
@@ -48,22 +47,26 @@ this.SnippetsFeed = class SnippetsFeed {
       version: STARTPAGE_VERSION,
       profileCreatedWeeksAgo: profileInfo.createdWeeksAgo,
       profileResetWeeksAgo: profileInfo.resetWeeksAgo,
-      telemetryEnabled: Services.prefs.getBoolPref(TELEMETRY_PREF),
+      telemetryEnabled: Services.telemetry.canRecordBase,
       onboardingFinished: Services.prefs.getBoolPref(ONBOARDING_FINISHED_PREF)
     };
 
     this.store.dispatch(ac.BroadcastToContent({type: at.SNIPPETS_DATA, data}));
   }
+  _refreshCanRecordBase() {
+    // TODO: There is currently no way to listen for changes to this value, so
+    // we are just refreshing it on every new tab instead. A bug is filed
+    // here to fix this: https://bugzilla.mozilla.org/show_bug.cgi?id=1386318
+    this.store.dispatch({type: at.SNIPPETS_DATA, data: {telemetryEnabled: Services.telemetry.canRecordBase}});
+  }
   async init() {
     await this._refresh();
     Services.prefs.addObserver(ONBOARDING_FINISHED_PREF, this._refresh);
     Services.prefs.addObserver(SNIPPETS_URL_PREF, this._refresh);
-    Services.prefs.addObserver(TELEMETRY_PREF, this._refresh);
   }
   uninit() {
     Services.prefs.removeObserver(ONBOARDING_FINISHED_PREF, this._refresh);
     Services.prefs.removeObserver(SNIPPETS_URL_PREF, this._refresh);
-    Services.prefs.removeObserver(TELEMETRY_PREF, this._refresh);
     this.store.dispatch({type: at.SNIPPETS_RESET});
   }
   onAction(action) {
@@ -73,6 +76,9 @@ this.SnippetsFeed = class SnippetsFeed {
         break;
       case at.FEED_INIT:
         if (action.data === "feeds.snippets") { this.init(); }
+        break;
+      case at.NEW_TAB_INIT:
+        this._refreshCanRecordBase();
         break;
     }
   }

--- a/system-addon/test/unit/lib/SnippetsFeed.test.js
+++ b/system-addon/test/unit/lib/SnippetsFeed.test.js
@@ -1,6 +1,8 @@
 const {SnippetsFeed} = require("lib/SnippetsFeed.jsm");
 const {actionTypes: at} = require("common/Actions.jsm");
 const {GlobalOverrider} = require("test/unit/utils");
+const {createStore, combineReducers} = require("redux");
+const {reducers} = require("common/Reducers.jsm");
 
 const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -8,6 +10,7 @@ let overrider = new GlobalOverrider();
 
 describe("SnippetsFeed", () => {
   let sandbox;
+  let store;
   let clock;
   beforeEach(() => {
     clock = sinon.useFakeTimers();
@@ -20,6 +23,8 @@ describe("SnippetsFeed", () => {
       }
     });
     sandbox = sinon.sandbox.create();
+    store = createStore(combineReducers(reducers));
+    sinon.spy(store, "dispatch");
   });
   afterEach(() => {
     clock.restore();
@@ -30,34 +35,39 @@ describe("SnippetsFeed", () => {
     const url = "foo.com/%STARTPAGE_VERSION%";
     sandbox.stub(global.Services.prefs, "getStringPref").returns(url);
     sandbox.stub(global.Services.prefs, "getBoolPref")
-      .withArgs("datareporting.healthreport.uploadEnabled")
-      .returns(true)
       .withArgs("browser.onboarding.notification.finished")
       .returns(false);
+    sandbox.stub(global.Services.telemetry, "canRecordBase").value(false);
 
     const feed = new SnippetsFeed();
-    feed.store = {dispatch: sandbox.stub()};
-
+    feed.store = store;
     clock.tick(WEEK_IN_MS * 2);
 
     await feed.init();
 
-    assert.calledOnce(feed.store.dispatch);
+    const state = store.getState().Snippets;
 
-    const action = feed.store.dispatch.firstCall.args[0];
-    assert.propertyVal(action, "type", at.SNIPPETS_DATA);
-    assert.isObject(action.data);
-    assert.propertyVal(action.data, "snippetsURL", "foo.com/5");
-    assert.propertyVal(action.data, "version", 5);
-    assert.propertyVal(action.data, "profileCreatedWeeksAgo", 2);
-    assert.propertyVal(action.data, "profileResetWeeksAgo", 1);
-    assert.propertyVal(action.data, "telemetryEnabled", true);
-    assert.propertyVal(action.data, "onboardingFinished", false);
+    assert.propertyVal(state, "snippetsURL", "foo.com/5");
+    assert.propertyVal(state, "version", 5);
+    assert.propertyVal(state, "profileCreatedWeeksAgo", 2);
+    assert.propertyVal(state, "profileResetWeeksAgo", 1);
+    assert.propertyVal(state, "telemetryEnabled", false);
+    assert.propertyVal(state, "onboardingFinished", false);
+  });
+  it("should update telemetryEnabled on each new tab", () => {
+    sandbox.stub(global.Services.telemetry, "canRecordBase").value(false);
+    const feed = new SnippetsFeed();
+    feed.store = store;
+
+    feed.onAction({type: at.NEW_TAB_INIT});
+
+    const state = store.getState().Snippets;
+    assert.propertyVal(state, "telemetryEnabled", false);
   });
   it("should call .init on an INIT aciton", () => {
     const feed = new SnippetsFeed();
     sandbox.stub(feed, "init");
-    feed.store = {dispatch: sandbox.stub()};
+    feed.store = store;
 
     feed.onAction({type: at.INIT});
     assert.calledOnce(feed.init);
@@ -65,7 +75,7 @@ describe("SnippetsFeed", () => {
   it("should call .init when a FEED_INIT happens for feeds.snippets", () => {
     const feed = new SnippetsFeed();
     sandbox.stub(feed, "init");
-    feed.store = {dispatch: sandbox.stub()};
+    feed.store = store;
 
     feed.onAction({type: at.FEED_INIT, data: "feeds.snippets"});
 
@@ -73,7 +83,7 @@ describe("SnippetsFeed", () => {
   });
   it("should dispatch a SNIPPETS_RESET on uninit", () => {
     const feed = new SnippetsFeed();
-    feed.store = {dispatch: sandbox.stub()};
+    feed.store = store;
 
     feed.uninit();
 

--- a/system-addon/test/unit/lib/SnippetsFeed.test.js
+++ b/system-addon/test/unit/lib/SnippetsFeed.test.js
@@ -37,6 +37,9 @@ describe("SnippetsFeed", () => {
     sandbox.stub(global.Services.prefs, "getBoolPref")
       .withArgs("browser.onboarding.notification.finished")
       .returns(false);
+    sandbox.stub(global.Services.prefs, "prefHasUserValue")
+      .withArgs("services.sync.username")
+      .returns(true);
     sandbox.stub(global.Services.telemetry, "canRecordBase").value(false);
 
     const feed = new SnippetsFeed();
@@ -53,6 +56,7 @@ describe("SnippetsFeed", () => {
     assert.propertyVal(state, "profileResetWeeksAgo", 1);
     assert.propertyVal(state, "telemetryEnabled", false);
     assert.propertyVal(state, "onboardingFinished", false);
+    assert.propertyVal(state, "fxaccount", true);
   });
   it("should update telemetryEnabled on each new tab", () => {
     sandbox.stub(global.Services.telemetry, "canRecordBase").value(false);

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -28,6 +28,10 @@ overrider.set({
   fetch() {},
   Preferences: FakePrefs,
   Services: {
+    telemetry: {
+      canRecordBase: true,
+      canRecordExtended: true
+    },
     locale: {
       getAppLocalesAsLangTags() {},
       getRequestedLocale() {},


### PR DESCRIPTION
Fix #3056 and fix #3007.

I've updated the PR to also fix TelemetrySender and related tests, as well as updating the value on every new tab init.'

I also snuck a `.hasFxAccount` property into snippets data