### PR TITLE
style(mc): Fix view more stories alignment on windows

### DIFF
--- a/system-addon/content-src/components/Topics/_Topics.scss
+++ b/system-addon/content-src/components/Topics/_Topics.scss
@@ -2,7 +2,7 @@
   $topic-grey: #BFC0C7;
   $topic-blue: #008EA4;
 
-  font-size: 13px;
+  font-size: 12px;
   color: $topic-grey;
   margin-top: $topic-margin-top;
   line-height: 1.6;
@@ -55,6 +55,7 @@
     background-image: url('#{$image-path}topic-show-more-12.svg');
     background-repeat: no-repeat;
     vertical-align: middle;
+    background-position-y: 1px;
   }
 
 }


### PR DESCRIPTION
These CSS adjustments for Topics are the only way I found to get relatively consistent rendering of the "View More Stories" anchor on Windows/Mac/Ubuntu, using the provided svg.

Other alternative is to adjust the svg or get rid of it (it's not localizable anyway to RTL)

Before (bad alignment of ">" on Win):
![windows-broken](https://user-images.githubusercontent.com/472523/28840422-e3e9881c-76c4-11e7-8b8b-5df666d74903.png)

After adjustments (Win/Mac/Ubuntu):
![windows-fixed](https://user-images.githubusercontent.com/472523/28840433-ea156710-76c4-11e7-8dba-25aaa0bf5df5.png)

![mac-fixed](https://user-images.githubusercontent.com/472523/28840435-ed102928-76c4-11e7-9341-d9b995895cd9.png)

<img width="829" alt="screen shot 2017-08-01 at 2 20 56 pm" src="https://user-images.githubusercontent.com/472523/28840481-19e5aba8-76c5-11e7-8162-969112c07a0d.png">






