### PR TITLE
fix (systemaddon): #3051 update to tippy top v1.3.1 (default sites only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "redux-thunk": "2.1.0",
     "redux-watch": "1.1.1",
     "reselect": "2.5.4",
-    "tippy-top-sites": "1.2.2"
+    "tippy-top-sites": "1.3.1"
   },
   "devDependencies": {
     "@kadira/storybook": "2.29.5",


### PR DESCRIPTION
Fix #3051. This version of tippy-top-sites only has the 16 sites that are included in our default top sites list. See https://github.com/mozilla/tippy-top-sites/blob/v1.3.1/top_sites.json

r? @Mardak 