### PR TITLE
fix(init): Let content know things are initialized and fix "early" issues

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -37,7 +37,7 @@ const INITIAL_STATE = {
 function App(prevState = INITIAL_STATE.App, action) {
   switch (action.type) {
     case at.INIT:
-      return Object.assign({}, action.data || {}, {initialized: true});
+      return Object.assign({}, prevState, action.data || {}, {initialized: true});
     case at.LOCALE_UPDATED: {
       if (!action.data) {
         return prevState;

--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -27,7 +27,8 @@ class Base extends React.Component {
       this.updateTitle(this.props.App), {once: true});
   }
   componentWillUpdate({App}) {
-    if (App.locale !== this.props.App.locale) {
+    // Early loads might not have locale yet, so wait until we do
+    if (App.locale && App.locale !== this.props.App.locale) {
       addLocaleDataForReactIntl(App);
       this.updateTitle(App);
     }

--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -22,10 +22,13 @@ class PreferencesPane extends React.Component {
     this.togglePane = this.togglePane.bind(this);
 
     // TODO This is temporary until sections register their PreferenceInput component automatically
-    try {
-      this.topStoriesOptions = JSON.parse(props.Prefs.values["feeds.section.topstories.options"]);
-    } catch (e) {
-      console.error("Problem parsing feeds.section.topstories.options", e); // eslint-disable-line no-console
+    const optionJSON = props.Prefs.values["feeds.section.topstories.options"];
+    if (optionJSON) {
+      try {
+        this.topStoriesOptions = JSON.parse(optionJSON);
+      } catch (e) {
+        console.error("Problem parsing feeds.section.topstories.options", e); // eslint-disable-line no-console
+      }
     }
   }
   componentDidMount() {

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -8,7 +8,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 
 // NB: Eagerly load modules that will be loaded/constructed/initialized in the
 // common case to avoid the overhead of wrapping and detecting lazy loading.
-const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 const {DefaultPrefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const {LocalizationFeed} = Cu.import("resource://activity-stream/lib/LocalizationFeed.jsm", {});
 const {ManualMigration} = Cu.import("resource://activity-stream/lib/ManualMigration.jsm", {});
@@ -197,11 +197,12 @@ this.ActivityStream = class ActivityStream {
     this._updateDynamicPrefs();
     this._defaultPrefs.init();
 
+    // Hook up the store and let all feeds and pages initialize
     this.store.init(this.feeds);
-    this.store.dispatch({
+    this.store.dispatch(ac.BroadcastToContent({
       type: at.INIT,
       data: {version: this.options.version}
-    });
+    }));
 
     this.initialized = true;
   }

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -9,14 +9,18 @@ describe("Reducers", () => {
       const nextState = App(undefined, {type: "FOO"});
       assert.equal(nextState, INITIAL_STATE.App);
     });
-    it("should not set initialized to true on INIT", () => {
+    it("should set initialized to true on INIT", () => {
       const nextState = App(undefined, {type: "INIT"});
+
       assert.propertyVal(nextState, "initialized", true);
     });
     it("should set initialized, version, and locale on INIT", () => {
       const action = {type: "INIT", data: {version: "1.2.3"}};
+
       const nextState = App(undefined, action);
+
       assert.propertyVal(nextState, "version", "1.2.3");
+      assert.propertyVal(nextState, "locale", INITIAL_STATE.App.locale);
     });
     it("should not update state for empty action.data on LOCALE_UPDATED", () => {
       const nextState = App(undefined, {type: at.LOCALE_UPDATED});

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -1,4 +1,5 @@
 const injector = require("inject!lib/ActivityStream.jsm");
+const {CONTENT_MESSAGE_TYPE} = require("common/Actions.jsm");
 
 const REASON_ADDON_UNINSTALL = 6;
 
@@ -62,6 +63,14 @@ describe("ActivityStream", () => {
       assert.calledOnce(as.store.dispatch);
       const action = as.store.dispatch.firstCall.args[0];
       assert.propertyVal(action.data, "version", "1.2.3");
+    });
+    it("should emit an INIT event to content", () => {
+      sandbox.stub(as.store, "dispatch");
+
+      as.init();
+
+      const action = as.store.dispatch.firstCall.args[0];
+      assert.equal(action.meta.to, CONTENT_MESSAGE_TYPE);
     });
   });
   describe("#uninit", () => {


### PR DESCRIPTION
Fix #3054 with https://bugzilla.mozilla.org/show_bug.cgi?id=1386445 but this can land separately. When the bug lands, it will allow activity stream to load earlier, and some things don't quite work right when running earlier. Those are fixed here mostly small fixes checking if things actually exist before using them.

One meaningful change is `ac.BroadcastToContent({` of `INIT` that causes the page/content's `Reducer` to actually set `initialized` on the `App` state, which also needed a fix to pull in `INITIAL_STATE.App` as `prevState`