### PR TITLE
tests(mc): Patch for pine to fix browser_all_files_referenced test failure

### DIFF
--- a/mozilla-central-patches/patch-referenced.diff
+++ b/mozilla-central-patches/patch-referenced.diff
@@ -1,0 +1,34 @@
+
+# HG changeset patch
+# User Ed Lee <edilee@mozilla.com>
+# Date 1501566413 25200
+# Node ID c4d89120f88d33aea7d41b217da5b79dfd376cb0
+# Parent  3aa0d5effba37ee24342b942e39dc05e6ddaf1fb
+Bug 1386265 - Exclude tippy top images directory from browser_all_files_referenced.js. r=ursula
+
+MozReview-Commit-ID: 2zFTJ25vhTz
+
+diff --git a/browser/base/content/test/static/browser_all_files_referenced.js b/browser/base/content/test/static/browser_all_files_referenced.js
+--- a/browser/base/content/test/static/browser_all_files_referenced.js
++++ b/browser/base/content/test/static/browser_all_files_referenced.js
+@@ -18,16 +18,19 @@ var gExceptionPaths = [
+   "resource://app/defaults/preferences/",
+   "resource://gre/modules/commonjs/",
+   "resource://gre/defaults/pref/",
+   "resource://shield-recipe-client/node_modules/jexl/lib/",
+ 
+   // https://github.com/mozilla/normandy/issues/577
+   "resource://shield-recipe-client/test/",
+ 
++  // https://github.com/mozilla/activity-stream/issues/3053
++  "resource://activity-stream/data/content/tippytop/images/",
++
+   // browser/extensions/pdfjs/content/build/pdf.js#1999
+   "resource://pdf.js/web/images/",
+ ];
+ 
+ // These are not part of the omni.ja file, so we find them only when running
+ // the test on a non-packaged build.
+ if (AppConstants.platform == "macosx")
+   gExceptionPaths.push("resource://gre/res/cursors/");
+


### PR DESCRIPTION
r?@dmose If we want to fix pine and test `npm install` stuff.