### PR TITLE
Add hostname to pinned links.

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -55,7 +55,10 @@ this.TopSitesFeed = class TopSitesFeed {
     let frecent = await NewTabUtils.activityStreamLinks.getTopSites();
     const defaultUrls = DEFAULT_TOP_SITES.map(site => site.url);
     let pinned = NewTabUtils.pinnedLinks.links;
-    pinned = pinned.map(site => site && Object.assign({}, site, {isDefault: defaultUrls.indexOf(site.url) !== -1}));
+    pinned = pinned.map(site => site && Object.assign({}, site, {
+      isDefault: defaultUrls.indexOf(site.url) !== -1,
+      hostname: shortURL(site)
+    }));
 
     if (!frecent) {
       frecent = [];

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -178,6 +178,16 @@ describe("Top Sites Feed", () => {
         // Frecent results are removed and only pinned are kept.
         assert.lengthOf(sites, 2);
       });
+      it("should return sites that have a title", async () => {
+        // Simulate a pinned link with no pinTitle.
+        fakeNewTabUtils.pinnedLinks.links = [{url: "https://github.com/mozilla/activity-stream"}];
+
+        const sites = await feed.getLinksWithDefaults();
+
+        for (const site of sites) {
+          assert.isDefined(site.pinTitle || site.hostname);
+        }
+      });
       it("should check against null entries", async () => {
         fakeNewTabUtils.pinnedLinks.links = [null];
 


### PR DESCRIPTION
Should fix https://github.com/mozilla/activity-stream/issues/3071
What I think is happening:
- When we call [`insertPinned`](https://github.com/mozilla/activity-stream/blob/master/system-addon/lib/TopSitesFeed.jsm#L74) we call it with `pinned` which do not have the hostname property. If it happens that the pinTitle is missing then we end up with `title = undefined`.