### PR TITLE
fix(systemaddon): Remove pinTitle from sites, currently not being used.

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -67,7 +67,6 @@ function insertPinned(links, pinned) {
   newLinks = newLinks.map(link => {
     if (link && link.isPinned) {
       delete link.isPinned;
-      delete link.pinTitle;
       delete link.pinIndex;
     }
     return link;
@@ -76,7 +75,7 @@ function insertPinned(links, pinned) {
   // Then insert them in their specified location
   pinned.forEach((val, index) => {
     if (!val) { return; }
-    let link = Object.assign({}, val, {isPinned: true, pinIndex: index, pinTitle: val.title});
+    let link = Object.assign({}, val, {isPinned: true, pinIndex: index});
     if (index > newLinks.length) {
       newLinks[index] = link;
     } else {

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -39,7 +39,7 @@ class TopSite extends React.Component {
   render() {
     const {link, index, dispatch} = this.props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === index;
-    const title = link.pinTitle || link.hostname;
+    const title = link.hostname;
     const topSiteOuterClassName = `top-site-outer${isContextMenuOpen ? " active" : ""}`;
     const {tippyTopIcon} = link;
     let imageClassName;

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -124,7 +124,7 @@ describe("Reducers", () => {
       const oldState = {rows: [{url: "foo.com"}, {url: "bar.com"}]};
       const action = {type: at.PINNED_SITES_UPDATED, data: [{url: "baz.com", title: "baz"}]};
       const nextState = TopSites(oldState, action);
-      assert.deepEqual(nextState.rows, [{url: "baz.com", title: "baz", isPinned: true, pinIndex: 0, pinTitle: "baz"}, {url: "foo.com"}, {url: "bar.com"}]);
+      assert.deepEqual(nextState.rows, [{url: "baz.com", title: "baz", isPinned: true, pinIndex: 0}, {url: "foo.com"}, {url: "bar.com"}]);
     });
   });
   describe("Prefs", () => {
@@ -332,7 +332,6 @@ describe("Reducers", () => {
       for (let index of [0, 1]) {
         assert.equal(result[index].url, pinned[index].url);
         assert.ok(result[index].isPinned);
-        assert.equal(result[index].pinTitle, pinned[index].title);
         assert.equal(result[index].pinIndex, index);
       }
       assert.deepEqual(result.slice(2), links);
@@ -349,7 +348,6 @@ describe("Reducers", () => {
       for (let index of [1, 4]) {
         assert.equal(result[index].url, pinned[index].url);
         assert.ok(result[index].isPinned);
-        assert.equal(result[index].pinTitle, pinned[index].title);
         assert.equal(result[index].pinIndex, index);
       }
       result.splice(4, 1);
@@ -362,17 +360,14 @@ describe("Reducers", () => {
       const result = insertPinned([], pinned);
       assert.equal(result[11].url, pinned[11].url);
       assert.isTrue(result[11].isPinned);
-      assert.equal(result[11].pinTitle, pinned[11].title);
       assert.equal(result[11].pinIndex, 11);
     });
     it("should unpin previously pinned links no longer in the pinned list", () => {
       const pinned = [];
       links[2].isPinned = true;
-      links[2].pinTitle = "pinned site";
       links[2].pinIndex = 2;
       const result = insertPinned(links, pinned);
       assert.notProperty(result[2], "isPinned");
-      assert.notProperty(result[2], "pinTitle");
       assert.notProperty(result[2], "pinIndex");
     });
     it("should handle a link present in both the links and pinned list", () => {

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -203,19 +203,9 @@ describe("<TopSite>", () => {
 
     assert.equal(titleEl.text(), "foobar");
   });
-  it("should render the pinTitle if set", () => {
-    link.isPinned = true;
-    link.pinnedIndex = 7;
-    link.pinTitle = "pinned";
-    const wrapper = shallow(<TopSite link={link} />);
-    const titleEl = wrapper.find(".title");
-
-    assert.equal(titleEl.text(), "pinned");
-  });
   it("should render the pin icon for pinned links", () => {
     link.isPinned = true;
     link.pinnedIndex = 7;
-    link.pinTitle = "pinned";
     const wrapper = shallow(<TopSite link={link} />);
     assert.equal(wrapper.find(".icon-pin-small").length, 1);
   });

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -179,13 +179,13 @@ describe("Top Sites Feed", () => {
         assert.lengthOf(sites, 2);
       });
       it("should return sites that have a title", async () => {
-        // Simulate a pinned link with no pinTitle.
+        // Simulate a pinned link with no title.
         fakeNewTabUtils.pinnedLinks.links = [{url: "https://github.com/mozilla/activity-stream"}];
 
         const sites = await feed.getLinksWithDefaults();
 
         for (const site of sites) {
-          assert.isDefined(site.pinTitle || site.hostname);
+          assert.isDefined(site.hostname);
         }
       });
       it("should check against null entries", async () => {


### PR DESCRIPTION
Closes #3080.
When switching your pinned sites from tiles we would store `pinTitle = site.title` which is not what we want. Currently pinTitle is not being used we just ported from Test Pilot side so I went ahead and removed it completely.