### PR TITLE
fix(systemaddon): remove title from pinned site pref value

### DIFF
--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -73,7 +73,7 @@ module.exports = {
     icon: "pin",
     action: ac.SendToMain({
       type: at.TOP_SITES_PIN,
-      data: {site: {url: site.url, title: site.hostname}, index}
+      data: {site: {url: site.url}, index}
     }),
     userEvent: "PIN"
   }),

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -100,7 +100,7 @@ describe("<LinkMenu>", () => {
       menu_action_open_private_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
       menu_action_dismiss: FAKE_SITE.url,
       menu_action_delete: FAKE_SITE.url,
-      menu_action_pin: {site: {url: FAKE_SITE.url, title: FAKE_SITE.hostname}, index: FAKE_INDEX},
+      menu_action_pin: {site: {url: FAKE_SITE.url}, index: FAKE_INDEX},
       menu_action_unpin: {site: {url: FAKE_SITE.url}},
       menu_action_save_to_pocket: {site: {url: FAKE_SITE.url, title: FAKE_SITE.title}}
     };


### PR DESCRIPTION
This is a followup to pull #3091

Since we aren't using the `pinTitle` right now, we don't need to save it. We will probably need it back when we implement customization, but we should call it `label` or something less confusing at that point.

r? @piatra 