### PR TITLE
Topsites telemetry fixes (#3105)

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -120,13 +120,17 @@ class TopSitesPerfTimer extends React.Component {
    * Call the given callback after the upcoming frame paints.
    *
    * @note Both setTimeout and requestAnimationFrame are throttled when the page
-   * is hidden, so this will give incorrect results in that case.  We'll want to
-   * filter out preloaded tabs, and otherwise, this is presumably, a fairly rare
-   * case that will get lost in the noise.  If we decide that it's important to
-   * find out when something that's hidden has "painted", however, another
-   * option is to post a message to this window. That should happen even faster
-   * than setTimeout, and, at least as of this writing, it's not throttled in
-   * hidden windows in Firefox.
+   * is hidden, so this callback may get called up to a second or so after the
+   * requestAnimationFrame "paint" for hidden tabs.
+   *
+   * Newtabs hidden while loading will presumably be fairly rare (other than
+   * preloaded tabs, which we will be filtering out on the server side), so such
+   * cases should get lost in the noise.
+   *
+   * If we decide that it's important to find out when something that's hidden
+   * has "painted", however, another option is to post a message to this window.
+   * That should happen even faster than setTimeout, and, at least as of this
+   * writing, it's not throttled in hidden windows in Firefox.
    *
    * @param {Function} callback
    *

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -117,21 +117,23 @@ class TopSitesPerfTimer extends React.Component {
   }
 
   /**
-   * Call the given callback after the upcoming frame paints.  We're using
-   * a Promise rather than a setTimeout or double rFA, as Promise resolution
-   * is faster, as of this writing (Firefox 57 Nightly) - see #3105 for
-   * details.
+   * Call the given callback after the upcoming frame paints.
+   *
+   * @note Both setTimeout and requestAnimationFrame are throttled when the page
+   * is hidden, so this will give incorrect results in that case.  We'll want to
+   * filter out preloaded tabs, and otherwise, this is presumably, a fairly rare
+   * case that will get lost in the noise.  If we decide that it's important to
+   * find out when something that's hidden has "painted", however, another
+   * option is to post a message to this window. That should happen even faster
+   * than setTimeout, and, at least as of this writing, it's not throttled in
+   * hidden windows in Firefox.
    *
    * @param {Function} callback
    *
    * @returns void
    */
   _afterFramePaint(callback) {
-    new Promise(resolve => requestAnimationFrame(resolve))
-      .then(callback).catch(reason => {
-        // eslint-disable-next-line no-console
-        console.warn("_afterFramePaint Promise rejected, reason:", reason);
-      });
+    requestAnimationFrame(() => setTimeout(callback, 0));
   }
 
   _maybeSendPaintedEvent() {

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -149,12 +149,11 @@ class TopSitesPerfTimer extends React.Component {
       return;
     }
 
-    // And if we haven't, we're doing so now, so remember that.
-    // Even if something goes wrong in the callback, we can't
-    // try again, as we'd be sending back the wrong data, and we
-    // have to do it here, so that other calls to this method
-    // while waiting for the next frame won't also try to handle
-    // handle it.
+    // And if we haven't, we're doing so now, so remember that. Even if
+    // something goes wrong in the callback, we can't try again, as we'd be
+    // sending back the wrong data, and we have to do it here, so that other
+    // calls to this method while waiting for the next frame won't also try to
+    // handle handle it.
     this._timestampHandled = true;
 
     this._afterFramePaint(this._sendPaintedEvent);

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -119,6 +119,9 @@ describe("<TopSitesPerfTimer>", () => {
 
   describe("#_afterFramePaint", () => {
     it("should call callback after the requestAnimationFrame callback returns", done => {
+      // Setting the callback to done is the test that it does finally get
+      // called at the correct time, after the event loop ticks again.
+      // If it doesn't get called, this test will time out.
       this.callback = () => done();
       sandbox.spy(this, "callback");
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -142,7 +142,7 @@ describe("<TopSitesPerfTimer>", () => {
       assert.calledWithExactly(perfSvc.mark, "topsites_first_painted_ts");
     });
 
-    it("should send a SAVE_SESSION_PERF_DATA message with the result of perfSvc.getMostRecentAbsMarkStartByName two frames after mount", () => {
+    it("should send a SAVE_SESSION_PERF_DATA message with the result of perfSvc.getMostRecentAbsMarkStartByName", () => {
       sandbox.stub(perfSvc, "getMostRecentAbsMarkStartByName")
         .withArgs("topsites_first_painted_ts").returns(777);
       const spy = sandbox.spy(DEFAULT_PROPS, "dispatch");

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -81,15 +81,39 @@ describe("<TopSitesPerfTimer>", () => {
 
       assert.notCalled(stub);
     });
-    it("should not call _onNextFrame if this._timestampSent is true", () => {
+
+    it("should not call _onNextFrame if this._timestampHandled is true", () => {
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
       const instance = wrapper.instance();
       const stub = sandbox.stub(instance, "_onNextFrame");
-      instance._timestampSent = true;
+      instance._timestampHandled = true;
 
       instance._maybeSendPaintedEvent();
 
       assert.notCalled(stub);
+    });
+
+    it("should set this._timestampHandled=true when called with Topsites.initialized === true", () => {
+      const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
+      const instance = wrapper.instance();
+      sandbox.stub(instance, "_onNextFrame");
+      instance._timestampHandled = false;
+
+      instance._maybeSendPaintedEvent();
+
+      assert.isTrue(instance._timestampHandled);
+    });
+    it("should not set this._timestampHandled=true when called with Topsites.initialized === false", () => {
+      let props = {};
+      Object.assign(props, DEFAULT_PROPS, {TopSites: {initialized: false}});
+      const wrapper = shallow(<TopSitesPerfTimer {...props} />);
+      const instance = wrapper.instance();
+      sandbox.stub(instance, "_onNextFrame");
+      instance._timestampHandled = false;
+
+      instance._maybeSendPaintedEvent();
+
+      assert.isFalse(instance._timestampHandled);
     });
   });
 
@@ -118,16 +142,6 @@ describe("<TopSitesPerfTimer>", () => {
 
       assert.calledOnce(perfSvc.mark);
       assert.calledWithExactly(perfSvc.mark, "topsites_first_painted_ts");
-    });
-
-    it("should set this._timestamp_sent to true", () => {
-      const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
-      const instance = wrapper.instance();
-      assert.isFalse(instance._timestampSent);
-
-      wrapper.instance()._sendPaintedEvent();
-
-      assert.isTrue(instance._timestampSent);
     });
 
     it("should send a SAVE_SESSION_PERF_DATA message with the result of perfSvc.getMostRecentAbsMarkStartByName two frames after mount", () => {

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -61,31 +61,31 @@ describe("<TopSitesPerfTimer>", () => {
   });
 
   describe("#_maybeSendPaintedEvent", () => {
-    it("should call _onNextFrame if props.TopSites.initialized is true", () => {
+    it("should call _afterFramePaint if props.TopSites.initialized is true", () => {
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
       const instance = wrapper.instance();
-      const stub = sandbox.stub(instance, "_onNextFrame");
+      const stub = sandbox.stub(instance, "_afterFramePaint");
 
       instance._maybeSendPaintedEvent();
 
       assert.calledOnce(stub);
       assert.calledWithExactly(stub, instance._sendPaintedEvent);
     });
-    it("should not call _onNextFrame if props.TopSites.initialized is false", () => {
+    it("should not call _afterFramePaint if props.TopSites.initialized is false", () => {
       sandbox.stub(DEFAULT_PROPS.TopSites, "initialized").value(false);
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
       const instance = wrapper.instance();
-      const stub = sandbox.stub(instance, "_onNextFrame");
+      const stub = sandbox.stub(instance, "_afterFramePaint");
 
       instance._maybeSendPaintedEvent();
 
       assert.notCalled(stub);
     });
 
-    it("should not call _onNextFrame if this._timestampHandled is true", () => {
+    it("should not call _afterFramePaint if this._timestampHandled is true", () => {
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
       const instance = wrapper.instance();
-      const stub = sandbox.stub(instance, "_onNextFrame");
+      const stub = sandbox.stub(instance, "_afterFramePaint");
       instance._timestampHandled = true;
 
       instance._maybeSendPaintedEvent();
@@ -96,7 +96,7 @@ describe("<TopSitesPerfTimer>", () => {
     it("should set this._timestampHandled=true when called with Topsites.initialized === true", () => {
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
       const instance = wrapper.instance();
-      sandbox.stub(instance, "_onNextFrame");
+      sandbox.stub(instance, "_afterFramePaint");
       instance._timestampHandled = false;
 
       instance._maybeSendPaintedEvent();
@@ -108,7 +108,7 @@ describe("<TopSitesPerfTimer>", () => {
       Object.assign(props, DEFAULT_PROPS, {TopSites: {initialized: false}});
       const wrapper = shallow(<TopSitesPerfTimer {...props} />);
       const instance = wrapper.instance();
-      sandbox.stub(instance, "_onNextFrame");
+      sandbox.stub(instance, "_afterFramePaint");
       instance._timestampHandled = false;
 
       instance._maybeSendPaintedEvent();
@@ -117,19 +117,17 @@ describe("<TopSitesPerfTimer>", () => {
     });
   });
 
-  describe("#_onNextFrame", () => {
-    it("should call callback one frame after the current one", () => {
-      const callback = sandbox.spy();
+  describe("#_afterFramePaint", () => {
+    it("should call callback after the requestAnimationFrame callback returns", done => {
+      this.callback = () => done();
+      sandbox.spy(this, "callback");
       const wrapper = shallow(<TopSitesPerfTimer {...DEFAULT_PROPS} />);
-
       const instance = wrapper.instance();
-      instance._onNextFrame(callback);
 
-      mockRaf.step({count: 1});
-      assert.notCalled(callback);
+      instance._afterFramePaint(this.callback);
 
+      assert.notCalled(this.callback);
       mockRaf.step({count: 1});
-      assert.calledOnce(callback);
     });
   });
 


### PR DESCRIPTION
This does two things: 

* avoids extra marks that corrupt topsites_first_painted_ts fix #3105 
* switches to using RFA + Promise instead of double RFA to make painting times more precise.

The part that is easily testable is the extra marks: 

1. start up the browser
2. start the profiler
3. open a new tab
4. capture the profile
5. In the profile, switch to the Markers view
6. Enter "User Timing" in the filter textbox
7. Go through the main and all content processes
8. There should be one, or at most two, topsites_first_painted_ts

There should be exactly two topsites_first_painted_ts.

r? Mardak