### PR TITLE
chore(tests): Re-enable getScreenshots test with bug 1387682 fixed

### DIFF
--- a/system-addon/test/functional/mochitest/browser.ini
+++ b/system-addon/test/functional/mochitest/browser.ini
@@ -6,4 +6,3 @@ support-files =
 [browser_as_load_location.js]
 [browser_as_render.js]
 [browser_getScreenshots.js]
-skip-if=true # issue 2851


### PR DESCRIPTION
Fix #3100. r=@sarracini already reviewed as part of https://hg.mozilla.org/integration/autoland/rev/02f357c8e980 but can't land until that makes it to mozilla-central.