### PR TITLE
fix(init): Wait until we have strings to render/update

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -14,7 +14,7 @@ const INITIAL_STATE = {
     // The locale of the browser
     locale: "",
     // Localized strings with defaults
-    strings: {},
+    strings: null,
     // The version of the system-addon
     version: null
   },

--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -35,14 +35,16 @@ class Base extends React.Component {
   }
 
   updateTitle({strings}) {
-    document.title = strings.newtab_page_title;
+    if (strings) {
+      document.title = strings.newtab_page_title;
+    }
   }
 
   render() {
     const props = this.props;
     const {locale, strings, initialized} = props.App;
     const prefs = props.Prefs.values;
-    if (!initialized) {
+    if (!initialized || !strings) {
       return null;
     }
 


### PR DESCRIPTION
Fix #3092 and address some of #3090.

Here's how startup renders 10x slowed down:
 https://ed.agadak.net/as/activity-stream.startup.strings.10x.webm