### PR TITLE
fix(styles): Use message-box for font (including sizing) for Top Sites title

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -133,10 +133,10 @@
     }
 
     .title {
+      font: message-box;
       height: $top-sites-title-height;
       line-height: $top-sites-title-height;
       text-align: center;
-      font-size: 11px;
       width: $top-sites-size;
       position: relative;
 


### PR DESCRIPTION
Fix #2975. r?@sarracini This makes the font bigger on Linux matching a <tab>'s label. The change doesn't affect the look on Mac.

Double checking with @bryanbell that this screenshot looks okay:
![screen shot 2017-08-10 at 7 05 48 am](https://user-images.githubusercontent.com/438537/29174702-f4211028-7d9b-11e7-8f9b-2dcf6c7b185b.png)
