### PR TITLE
chore(favicon): Closes #3123 Show the Firefox (or Nightly) logo

### DIFF
--- a/system-addon/data/content/activity-stream.html
+++ b/system-addon/data/content/activity-stream.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'; img-src http: https: data: blob:; style-src 'unsafe-inline'; child-src 'none'; object-src 'none'; report-uri https://tiles.services.mozilla.com/v4/links/activity-stream/csp">
     <title></title>
+    <link rel="icon" type="image/png" id="favicon" href="chrome://branding/content/icon32.png"/>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />
     <link rel="stylesheet" href="resource://activity-stream/data/content/activity-stream.css" />
   </head>


### PR DESCRIPTION
🎉 easy peasy Fix #3123.