### PR TITLE
fix(style): Minor adjustments after #3076 fix

### DIFF
--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -10,6 +10,7 @@
 
     .section-info-option {
       float: right;
+      margin-top: 14px;
     }
 
     .info-option-icon {
@@ -47,8 +48,7 @@
       width: 320px;
       right: 0;
       top: 34px;
-      margin-top: -4px;
-      margin-right: -4px;
+      margin-right: -1px;
       padding: 24px;
       -moz-user-select: none;
     }

--- a/system-addon/content-src/components/Topics/_Topics.scss
+++ b/system-addon/content-src/components/Topics/_Topics.scss
@@ -55,7 +55,6 @@
     background-image: url('#{$image-path}topic-show-more-12.svg');
     background-repeat: no-repeat;
     vertical-align: middle;
-    background-position-y: 1px;
   }
 
 }


### PR DESCRIPTION
Just minor tweaks after recent changes. Not sure why the ">" need another realignment but fixing it by removing code is always welcome :). Tested on Windows, too.

Before:
<img width="801" alt="before" src="https://user-images.githubusercontent.com/472523/29281353-b9ac66e6-80ec-11e7-8ce1-119988fcfbd5.png">

After:
<img width="868" alt="after" src="https://user-images.githubusercontent.com/472523/29281355-bc2d75cc-80ec-11e7-901e-96bb45b4e794.png">
