### PR TITLE
feat (systemaddon): #3133 edit hover menu: pin and dismiss buttons

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -5,6 +5,9 @@
   $top-sites-vertical-space: 18px;
   $screenshot-size: cover;
   $tippy-top-size: 96px;
+  $edit-menu-button-size: 25px;
+  $edit-menu-button-border: 1px solid $faint-black;
+  $edit-menu-button-boxshadow: 0 2px 0 $faintest-black;
 
   list-style: none;
   margin: 0;
@@ -157,6 +160,57 @@
         span {
           padding: 0 13px;
         }
+      }
+    }
+
+    .edit-menu {
+      background: $white;
+      border: $edit-menu-button-border;
+      border-radius: $edit-menu-button-size / 2;
+      box-shadow: $edit-menu-button-boxshadow;
+      height: $edit-menu-button-size;
+      position: absolute;
+      offset-inline-end: -($edit-menu-button-size / 2);
+      opacity: 0;
+      overflow: hidden;
+      top: -($edit-menu-button-size / 2);
+      transform: scale(0.25);
+      transition-property: transform, opacity;
+      transition-duration: 200ms;
+      z-index: 1000;
+
+      &:focus,
+      &:active {
+        transform: scale(1);
+        opacity: 1;
+      }
+
+      button {
+        border: 0;
+        border-right: $edit-menu-button-border;
+        background-color: $white;
+        cursor: pointer;
+        height: 100%;
+        width: $edit-menu-button-size;
+
+        &:hover {
+          background-color: $bg-grey;
+        }
+
+        &:last-child:dir(ltr) {
+          border-right: 0;
+        }
+
+        &:first-child:dir(rtl) {
+          border-right: 0;
+        }
+      }
+    }
+
+    &:hover, &:focus, &.active {
+      .edit-menu {
+        transform: scale(1);
+        opacity: 1;
       }
     }
   }


### PR DESCRIPTION
This adds some hover buttons for the Top Sites edit modal:
<img width="483" alt="screen shot 2017-08-15 at 3 06 41 pm" src="https://user-images.githubusercontent.com/36629/29331732-756c6190-81cb-11e7-9cf3-5eda9ac93a4e.png">

Default (first run) sites only get a Pin button since we don't allow dismissing them:
<img width="486" alt="screen shot 2017-08-15 at 3 07 06 pm" src="https://user-images.githubusercontent.com/36629/29331748-80505a80-81cb-11e7-874b-536baa3ef04b.png">

Fixes #3133