### PR TITLE
fix(sections): Conditionally set the state to avoid unnecessary renders

### DIFF
--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -12,18 +12,29 @@ class Section extends React.Component {
     this.state = {infoActive: false};
   }
 
+  /**
+   * Take a truthy value to conditionally change the infoActive state.
+   */
+  _setInfoState(nextActive) {
+    const infoActive = !!nextActive;
+    if (infoActive !== this.state.infoActive) {
+      this.setState(Object.assign({}, this.state, {infoActive}));
+    }
+  }
+
   onInfoEnter() {
-    this.setState({infoActive: true});
+    // We're getting focus or hover, so info state should be true if not yet.
+    this._setInfoState(true);
   }
 
   onInfoLeave(event) {
-    // If we have a related target, check to see if it is within the current
-    // target (section-info-option) to keep infoActive true. False otherwise.
-    this.setState({
-      infoActive: event && event.relatedTarget && (
-        event.relatedTarget.compareDocumentPosition(event.currentTarget) &
-          Node.DOCUMENT_POSITION_CONTAINS)
-    });
+    // We currently have an active (true) info state, so keep it true only if we
+    // have a related event target that is contained "within" the current target
+    // (section-info-option) as itself or a descendant. Set to false otherwise.
+    this._setInfoState(event && event.relatedTarget && (
+      event.relatedTarget === event.currentTarget ||
+      (event.relatedTarget.compareDocumentPosition(event.currentTarget) &
+        Node.DOCUMENT_POSITION_CONTAINS)));
   }
 
   render() {

--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -46,7 +46,7 @@
       line-height: 120%;
       width: 320px;
       right: 0;
-      top: 34px;
+      top: 23px; // set high enough so there's no cursor gap from the icon
       margin-top: -4px;
       margin-right: -4px;
       padding: 24px;


### PR DESCRIPTION
Fix #3180. r?@k88hudson Conditionally set state. This also fixes some unnecessary `setState` by moving the `div` closer to the `span`/icon:

<img width="348" alt="image" src="https://user-images.githubusercontent.com/438537/29348391-8032045a-8210-11e7-9b68-fd9d70b27235.png">

The PR is based on a master from before the revert. I suppose a separate commit reverting the revert instead of all together could simplify uplifting.