### PR TITLE
fix(contextmenu): Closes #3188 Default Top Sites should be dismissable

### DIFF
--- a/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
+++ b/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
@@ -3,7 +3,7 @@ const {injectIntl} = require("react-intl");
 const ContextMenu = require("content-src/components/ContextMenu/ContextMenu");
 const {actionCreators: ac} = require("common/Actions.jsm");
 const linkMenuOptions = require("content-src/lib/link-menu-options");
-const DEFAULT_SITE_MENU_OPTIONS = ["CheckPinTopSite", "Separator", "OpenInNewWindow", "OpenInPrivateWindow"];
+const DEFAULT_SITE_MENU_OPTIONS = ["CheckPinTopSite", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl"];
 
 class LinkMenu extends React.Component {
   getOptions() {

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -51,7 +51,8 @@ this.TopSitesFeed = class TopSitesFeed {
   }
   async getLinksWithDefaults(action) {
     let frecent = await NewTabUtils.activityStreamLinks.getTopSites();
-    const defaultUrls = DEFAULT_TOP_SITES.map(site => site.url);
+    const notBlockedDefaultSites = DEFAULT_TOP_SITES.filter(site => !NewTabUtils.blockedLinks.isBlocked({url: site.url}));
+    const defaultUrls = notBlockedDefaultSites.map(site => site.url);
     let pinned = NewTabUtils.pinnedLinks.links;
     pinned = pinned.map(site => site && Object.assign({}, site, {
       isDefault: defaultUrls.indexOf(site.url) !== -1,
@@ -66,7 +67,7 @@ this.TopSitesFeed = class TopSitesFeed {
 
     // Group together websites that require deduping.
     let topsitesGroup = [];
-    for (const group of [pinned, frecent, DEFAULT_TOP_SITES]) {
+    for (const group of [pinned, frecent, notBlockedDefaultSites]) {
       topsitesGroup.push(group.filter(site => site).map(site => Object.assign({}, site, {hostname: shortURL(site)})));
     }
 

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -40,14 +40,16 @@ describe("<LinkMenu>", () => {
   it("should show the correct options for default sites", () => {
     wrapper = shallowWithIntl(<LinkMenu site={{url: "", isDefault: true}} options={["CheckBookmark"]} source={"TOP_SITES"} dispatch={() => {}} />);
     const options = wrapper.find(ContextMenu).props().options;
-    assert.ok(options.length === 4);
+    assert.ok(options.length === 6);
     assert.ok(["menu_action_pin", "menu_action_unpin"].includes(options[0].id));
     assert.ok(options[1].type === "separator");
     assert.ok(options[2].id === "menu_action_open_new_window");
     assert.ok(options[3].id === "menu_action_open_private_window");
-    // Double check that dismiss and delete options are not included
+    assert.ok(options[4].type === "separator");
+    assert.ok(options[5].id === "menu_action_dismiss");
+    // Double check that delete options are not included for default top sites
     options.filter(o => o.type !== "separator").forEach(o => {
-      assert.notInclude(["menu_action_dismiss", "menu_action_delete"], o.id);
+      assert.notInclude(["menu_action_delete"], o.id);
     });
   });
   it("should show Unpin option for a pinned site if CheckPinTopSite in options list", () => {


### PR DESCRIPTION
allows you to dismiss, but not delete, default top sites