### PR TITLE
fix(css): Closes #3076 Context string is vertically aligned

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -114,7 +114,6 @@
     color: $light-grey;
     font-size: 11px;
     display: flex;
-    align-items: center;
   }
 
   .card-context-icon {


### PR DESCRIPTION
I think the font size is already 14px, so the only outstanding issue left is the vertical alignment of the icon with the label. Removing this fixes that
![vertical align](https://user-images.githubusercontent.com/7219526/29421029-c33c511a-8341-11e7-835d-f689b53fd0b5.png)
