### PR TITLE
fix(sidebar): Closes #3192 Minimize sidebar repaints during animation

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -11,12 +11,16 @@
     position: fixed;
     top: 0;
     transition: 0.1s cubic-bezier(0, 0, 0, 1);
-    transition-property: left, right;
+    transition-property: transform;
     width: 400px;
     z-index: 12000;
 
     &.hidden {
-      offset-inline-end: -400px;
+      transform: translateX(100%);
+
+      &:dir(rtl) {
+        transform: translateX(-100%);
+      }
     }
 
     h1 {


### PR DESCRIPTION
just uses transform. tested in rtl 👍 Fix #3192