### PR TITLE
fix(channel): Always simulate an init for existing ports

### DIFF
--- a/system-addon/lib/ActivityStreamMessageChannel.jsm
+++ b/system-addon/lib/ActivityStreamMessageChannel.jsm
@@ -136,8 +136,10 @@ this.ActivityStreamMessageChannel = class ActivityStreamMessageChannel {
 
     // Some pages might have already loaded, so we won't get the usual message
     for (const {loaded, portID} of this.channel.messagePorts) {
+      const simulatedMsg = {target: {portID}};
+      this.onNewTabInit(simulatedMsg);
       if (loaded) {
-        this.onNewTabLoad({target: {portID}});
+        this.onNewTabLoad(simulatedMsg);
       }
     }
   }

--- a/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
@@ -80,6 +80,16 @@ describe("ActivityStreamMessageChannel", () => {
         mm.createChannel();
         assert.notCalled(global.AboutNewTab.override);
       });
+      it("should simluate init for existing ports", () => {
+        sinon.stub(mm, "onActionFromContent");
+        RPmessagePorts.push({loaded: false, portID: "inited"});
+        RPmessagePorts.push({loaded: true, portID: "loaded"});
+
+        mm.createChannel();
+
+        assert.calledWith(mm.onActionFromContent.firstCall, {type: at.NEW_TAB_INIT}, "inited");
+        assert.calledWith(mm.onActionFromContent.secondCall, {type: at.NEW_TAB_INIT}, "loaded");
+      });
       it("should simluate load for loaded ports", () => {
         sinon.stub(mm, "onActionFromContent");
         RPmessagePorts.push({loaded: true, portID: "foo"});


### PR DESCRIPTION
Fix #3163. r?@k88hudson Just call `onNewTabInit` similar to calling `onNewTabLoad` when inheriting pages.