### PR TITLE
feat(l10n): Use strings from multiple locales in order of negotiated languages

### DIFF
--- a/system-addon/lib/LocalizationFeed.jsm
+++ b/system-addon/lib/LocalizationFeed.jsm
@@ -30,21 +30,18 @@ this.LocalizationFeed = class LocalizationFeed {
   }
 
   updateLocale() {
-    // Just take the first element in the result array, as it should be
-    // the best locale
-    let locale = Services.locale.negotiateLanguages(
+    // Order locales based on what we have available with fallback always first
+    const locales = Services.locale.negotiateLanguages(
       Services.locale.getAppLocalesAsLangTags(), // desired locales
       Object.keys(this.allStrings), // available locales
       DEFAULT_LOCALE // fallback
-    )[0];
+    ).reverse();
 
-    let strings = this.allStrings[locale];
+    // Start with default (first) locale then merge in strings of better locales
+    const strings = Object.assign({}, ...locales.map(l => this.allStrings[l]));
 
-    // Use the default strings for any that are missing
-    if (locale !== DEFAULT_LOCALE) {
-      strings = Object.assign({}, this.allStrings[DEFAULT_LOCALE], strings || {});
-    }
-
+    // Use the best (last) locale as the primary locale
+    const locale = locales.pop();
     this.store.dispatch(ac.BroadcastToContent({
       type: at.LOCALE_UPDATED,
       data: {

--- a/system-addon/test/unit/lib/LocalizationFeed.test.js
+++ b/system-addon/test/unit/lib/LocalizationFeed.test.js
@@ -61,7 +61,7 @@ describe("Localization Feed", () => {
     it("should use strings for other locale", () => {
       const locale = "it";
       sandbox.stub(global.Services.locale, "negotiateLanguages")
-        .returns([locale]);
+        .returns([locale, DEFAULT_LOCALE]);
 
       feed.updateLocale();
 
@@ -74,7 +74,7 @@ describe("Localization Feed", () => {
     it("should use some fallback strings for partial locale", () => {
       const locale = "ru";
       sandbox.stub(global.Services.locale, "negotiateLanguages")
-        .returns([locale]);
+        .returns([locale, DEFAULT_LOCALE]);
 
       feed.updateLocale();
 
@@ -87,16 +87,33 @@ describe("Localization Feed", () => {
         too: TEST_STRINGS[DEFAULT_LOCALE].too
       });
     });
-    it("should use all default strings for unknown locale", () => {
-      const locale = "xyz";
+    it("should use multiple fallback strings before default", () => {
+      const primaryLocale = "ru";
+      const secondaryLocale = "it";
       sandbox.stub(global.Services.locale, "negotiateLanguages")
-        .returns([locale]);
+        .returns([primaryLocale, secondaryLocale, DEFAULT_LOCALE]);
+
       feed.updateLocale();
 
       assert.calledOnce(feed.store.dispatch);
       const arg = feed.store.dispatch.firstCall.args[0];
       assert.propertyVal(arg, "type", at.LOCALE_UPDATED);
-      assert.propertyVal(arg.data, "locale", locale);
+      assert.propertyVal(arg.data, "locale", primaryLocale);
+      assert.deepEqual(arg.data.strings, {
+        foo: TEST_STRINGS[primaryLocale].foo,
+        too: TEST_STRINGS[secondaryLocale].too
+      });
+    });
+    it("should use all default strings for unknown locale", () => {
+      sandbox.stub(global.Services.locale, "negotiateLanguages")
+        .returns([DEFAULT_LOCALE]);
+
+      feed.updateLocale();
+
+      assert.calledOnce(feed.store.dispatch);
+      const arg = feed.store.dispatch.firstCall.args[0];
+      assert.propertyVal(arg, "type", at.LOCALE_UPDATED);
+      assert.propertyVal(arg.data, "locale", DEFAULT_LOCALE);
       assert.deepEqual(arg.data.strings, TEST_STRINGS[DEFAULT_LOCALE]);
     });
   });


### PR DESCRIPTION
Fix #3052. r?@dmose Needed to update the test to have `negotiateLanguages` correctly return the default as part of the array. Also a slight behavior change of using the best negotiated language as the locale instead of what would have been returned by `getRequestedLocale`, e.g., "xyz" in the test.

Here's a screenshot of pretending bn-IN had a top sites string of "Llocs principals" then falling back to bn-BD (see search) then en-US (see migration):

<img width="167" alt="image" src="https://user-images.githubusercontent.com/438537/29546614-52dddf58-86aa-11e7-8d77-3a1982e01984.png">
