### PR TITLE
feat (systemaddon): #3132 implement 1 vs 2 rows for Top Sites

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -5,6 +5,7 @@
 
 const {actionTypes: at} = Components.utils.import("resource://activity-stream/common/Actions.jsm", {});
 
+const TOP_SITES_DEFAULT_LENGTH = 6;
 const TOP_SITES_SHOWMORE_LENGTH = 12;
 
 const INITIAL_STATE = {
@@ -268,9 +269,10 @@ function Snippets(prevState = INITIAL_STATE.Snippets, action) {
 }
 
 this.INITIAL_STATE = INITIAL_STATE;
+this.TOP_SITES_DEFAULT_LENGTH = TOP_SITES_DEFAULT_LENGTH;
 this.TOP_SITES_SHOWMORE_LENGTH = TOP_SITES_SHOWMORE_LENGTH;
 
 this.reducers = {TopSites, App, Snippets, Prefs, Dialog, Sections};
 this.insertPinned = insertPinned;
 
-this.EXPORTED_SYMBOLS = ["reducers", "INITIAL_STATE", "insertPinned", "TOP_SITES_SHOWMORE_LENGTH"];
+this.EXPORTED_SYMBOLS = ["reducers", "INITIAL_STATE", "insertPinned", "TOP_SITES_DEFAULT_LENGTH", "TOP_SITES_SHOWMORE_LENGTH"];

--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -2,6 +2,7 @@ const React = require("react");
 const {connect} = require("react-redux");
 const {injectIntl, FormattedMessage} = require("react-intl");
 const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
+const {TOP_SITES_DEFAULT_LENGTH, TOP_SITES_SHOWMORE_LENGTH} = require("common/Reducers.jsm");
 
 const getFormattedMessage = message =>
   (typeof message === "string" ? <span>{message}</span> : <FormattedMessage {...message} />);
@@ -9,7 +10,7 @@ const getFormattedMessage = message =>
 const PreferencesInput = props => (
   <section>
     <input type="checkbox" id={props.prefName} name={props.prefName} checked={props.value} onChange={props.onChange} className={props.className} />
-    <label htmlFor={props.prefName}>
+    <label htmlFor={props.prefName} className={props.labelClassName}>
       {getFormattedMessage(props.titleString)}
     </label>
     {props.descString && <p className="prefs-input-description">
@@ -41,7 +42,12 @@ class PreferencesPane extends React.Component {
   }
   handlePrefChange(event) {
     const target = event.target;
-    this.props.dispatch(ac.SetPref(target.name, target.checked));
+    const {name, checked} = target;
+    let value = checked;
+    if (name === "topSitesCount") {
+      value = checked ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH;
+    }
+    this.props.dispatch(ac.SetPref(name, value));
   }
   handleSectionChange(event) {
     const target = event.target;
@@ -79,6 +85,11 @@ class PreferencesPane extends React.Component {
               <PreferencesInput className="showTopSites" prefName="showTopSites" value={prefs.showTopSites} onChange={this.handlePrefChange}
                 titleString={{id: "settings_pane_topsites_header"}} descString={{id: "settings_pane_topsites_body"}} />
 
+              <div className="options">
+                <PreferencesInput className="showMoreTopSites" prefName="topSitesCount" value={prefs.topSitesCount !== TOP_SITES_DEFAULT_LENGTH} onChange={this.handlePrefChange}
+                  titleString={{id: "settings_pane_topsites_options_showmore"}} labelClassName="icon icon-topsites" />
+              </div>
+
               {sections
                 .filter(section => !section.shouldHidePref)
                 .map(({id, title, enabled, pref}) =>
@@ -86,6 +97,11 @@ class PreferencesPane extends React.Component {
                     value={enabled} onChange={(pref && pref.feed) ? this.handlePrefChange : this.handleSectionChange}
                     titleString={(pref && pref.titleString) || title} descString={pref && pref.descString} />)}
 
+              {this.topStoriesOptions && !this.topStoriesOptions.hidden &&
+                <PreferencesInput className="showTopStories" prefName="feeds.section.topstories"
+                  value={prefs["feeds.section.topstories"]} onChange={this.handleChange}
+                  titleStringId="header_recommended_by" titleStringValues={{provider: this.topStoriesOptions.provider_name}}
+                  descStringId={this.topStoriesOptions.provider_description} />}
             </div>
             <section className="actions">
               <button className="done" onClick={this.togglePane}>

--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -53,35 +53,36 @@
         font-size: 16px;
         font-weight: bold;
       }
+    }
 
-      .options {
-        background: $background-secondary;
-        border: $border-secondary;
-        border-radius: $border-radius;
-        margin: 15px 0;
-        margin-inline-start: 30px;
-        padding: 10px;
+    .options {
+      background: $background-secondary;
+      border: $border-secondary;
+      border-radius: $border-radius;
+      margin: 15px 0;
+      margin-inline-start: 30px;
+      padding: 10px;
 
-        label {
-          background-position: 35px center;
-          background-repeat: no-repeat;
-          display: inline-block;
-          font-weight: normal;
-          height: 21px;
-          line-height: 21px;
-          padding-inline-start: 63px;
-          width: 100%;
+      label {
+        background-position: 35px center;
+        background-repeat: no-repeat;
+        display: inline-block;
+        font-size: 13px;
+        font-weight: normal;
+        height: 21px;
+        line-height: 21px;
+        width: 100%;
 
-          &:dir(rtl) {
-            background-position: 217px center;
-          }
+        &:dir(rtl) {
+          background-position: 217px center;
         }
       }
-
-      &.disabled {
-        .options {
-          opacity: 0.5;
-        }
+      [type='checkbox']:not(:checked) + label,
+      [type='checkbox']:checked + label {
+        padding-inline-start: 63px;
+      }
+      section {
+        margin: 0;
       }
     }
   }

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -248,4 +248,17 @@
     padding: 15px 30px;
   }
 
+
+  button.icon-topsites {
+    background-position: 10px center;
+    background-repeat: no-repeat;
+    height: auto;
+    margin-left: 10px;
+    padding-right: 15px;
+    width: auto;
+
+    span {
+      padding-left: 3px;
+    }
+  }
 }

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -82,6 +82,10 @@ const PREFS_CONFIG = new Map([
     title: "Show the Top Sites section on the New Tab page",
     value: true
   }],
+  ["topSitesCount", {
+    title: "Number of Top Sites to display",
+    value: 6
+  }],
   ["impressionStats.clicked", {
     title: "GUIDs of clicked Top stories items",
     value: "[]"

--- a/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
+++ b/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
@@ -101,4 +101,16 @@ describe("<PreferencesPane>", () => {
     assert.equal(section1.props().value, true);
     assert.equal(section2.props().value, false);
   });
+  it("should dispatch a SetPref with the right value for topSitesCount when unchecked", () => {
+    const showMoreTopSitesWrapper = wrapper.find(".showMoreTopSites");
+    showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesCount", checked: false}});
+    assert.calledOnce(dispatch);
+    assert.calledWith(dispatch, ac.SetPref("topSitesCount", 6));
+  });
+  it("should dispatch a SetPref with the right value for topSitesCount when checked", () => {
+    const showMoreTopSitesWrapper = wrapper.find(".showMoreTopSites");
+    showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesCount", checked: true}});
+    assert.calledOnce(dispatch);
+    assert.calledWith(dispatch, ac.SetPref("topSitesCount", 12));
+  });
 });


### PR DESCRIPTION
This adds a "Show More" button to the Edit Top Sites modal:
<img width="245" alt="screen shot 2017-08-22 at 4 24 40 pm" src="https://user-images.githubusercontent.com/36629/29585810-775d2ecc-8756-11e7-8e94-e22bff6cf4fa.png">

Clicking it expands Top Sites to two rows and the button changes to "Show Fewer" which does the opposite:
<img width="817" alt="screen shot 2017-08-22 at 4 24 47 pm" src="https://user-images.githubusercontent.com/36629/29585832-860ae2a2-8756-11e7-94c9-d8db319fd7ce.png">


Fixes #3132