### PR TITLE
fix(styles): Adjust spacing to be 40px around each section

### DIFF
--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -1,7 +1,7 @@
 .outer-wrapper {
   display: flex;
   flex-grow: 1;
-  padding: $wrapper-top-padding $base-gutter $base-gutter;
+  padding: $section-spacing $base-gutter $base-gutter;
   height: 100%;
 }
 
@@ -26,7 +26,8 @@ main {
   }
 
   section {
-    margin-bottom: $section-margin;
+    margin-bottom: $section-spacing;
+    position: relative;
   }
 }
 

--- a/system-addon/content-src/components/ManualMigration/_ManualMigration.scss
+++ b/system-addon/content-src/components/ManualMigration/_ManualMigration.scss
@@ -2,7 +2,7 @@
   background: rgba(215, 215, 219, .5);
   font-size: 13px;
   border-radius: 2px;
-  margin-bottom: $search-margin-bottom;
+  margin-bottom: $section-spacing;
   padding: 20px;
   text-align: center;
 

--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -1,8 +1,6 @@
 .search-wrapper {
   $search-bg-color: #FFF;
   $search-border-radius: 4px;
-  $search-margin-top: 52px;
-  $search-margin-bottom: $search-margin-bottom;
   $search-height: 36px;
   $search-input-left-label-width: 35px;
   $search-input-border-color: #BFBFBF;
@@ -55,7 +53,7 @@
   cursor: default;
   display: flex;
   position: relative;
-  margin: 0 0 $search-margin-bottom;
+  margin: 0 0 $section-spacing;
   width: 100%;
   height: $search-height;
 

--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -4,13 +4,10 @@
     height: 16px;
     margin-bottom: 18px;
 
-    .section-title {
-      float: left;
-    }
-
     .section-info-option {
-      float: right;
-      margin-top: 14px;
+      offset-inline-end: 0;
+      position: absolute;
+      top: 0;
     }
 
     .info-option-icon {
@@ -72,7 +69,6 @@
   }
 
   .section-list {
-    clear: both;
     margin: 0;
     display: grid;
     grid-template-columns: repeat(auto-fit, $card-width);

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -137,7 +137,7 @@
 
     .title {
       font: message-box;
-      height: $top-sites-title-height;
+      height: 20px;
       line-height: $top-sites-title-height;
       text-align: center;
       width: $top-sites-size;
@@ -214,10 +214,6 @@
       }
     }
   }
-}
-
-.top-sites {
-  position: relative;
 }
 
 .edit-topsites-wrapper {

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -23,13 +23,12 @@ $info-option-link-color: #0A84FF;
 $section-empty-grey: rgba($light-grey, 0.4);
 
 $base-gutter: 32px;
-$section-margin: 32px;
+$section-spacing: 40px;
 $grid-unit: 96px; // 1 top site
 
 $icon-size: 16px;
 $smaller-icon-size: 12px;
 
-$wrapper-top-padding: 62px;
 $wrapper-default-width: $grid-unit * 2 + $base-gutter * 1; // 2 top sites
 $wrapper-max-width-small: $grid-unit * 3 + $base-gutter * 2; // 3 top sites
 $wrapper-max-width-medium: $grid-unit * 4 + $base-gutter * 3; // 4 top sites
@@ -63,8 +62,6 @@ $context-menu-item-padding: 3px 12px;
 
 $sidebar-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08);
 $inner-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-
-$search-margin-bottom: 40px;
 
 $image-path: 'assets/';
 


### PR DESCRIPTION
Fix #2738. This change is on top of #3225 to fix the .scss file naming. This changes the float of stories to just absolutely position the (?) like how top sites edit button.

@aaronrbenson Here's some screenshots of before/after at 1344 x 768px window with first run (onboarding and migration) and ongoing. Potentially we can tighten the space between top sites and pocket as there's whitespace around the site label that is in addition to the 40px spacing.

before screenshot of first run user:
![before firstrun](https://user-images.githubusercontent.com/438537/29650180-0b2f9d04-884e-11e7-8468-2743472e8792.png)

after screenshot of first run user:
![after firstrun](https://user-images.githubusercontent.com/438537/29650188-11f8d8d0-884e-11e7-87d1-aa1c535bcc68.png)

before screenshot of ongoing user:
![before ongoing](https://user-images.githubusercontent.com/438537/29650191-18782eb8-884e-11e7-98cd-549f9e6e1e6b.png)

after screenshot of ongoing user:
![after ongoing](https://user-images.githubusercontent.com/438537/29650195-20604868-884e-11e7-813a-cd22e168c1bd.png)
