### PR TITLE
Bug #3221 topsite etld

### DIFF
--- a/system-addon/lib/ShortURL.jsm
+++ b/system-addon/lib/ShortURL.jsm
@@ -40,14 +40,13 @@ this.shortURL = function shortURL(link) {
     return "";
   }
   const {eTLD} = link;
-  const asciiHost = (link.hostname || new URL(link.url).hostname).replace(/^www\./i, "");
-  const hostname = handleIDNHost(asciiHost);
+  const hostname = (link.hostname || new URL(link.url).hostname).replace(/^www\./i, "");
 
   // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
   const eTLDLength = (eTLD || "").length || (hostname.match(/\.com$/) && 3);
   const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
   // If URL and hostname are not present fallback to page title.
-  return hostname.slice(0, eTLDExtra).toLowerCase() || hostname || link.title || link.url;
+  return handleIDNHost(hostname.slice(0, eTLDExtra).toLowerCase() || hostname) || link.title || link.url;
 };
 
 this.EXPORTED_SYMBOLS = ["shortURL"];

--- a/system-addon/test/unit/lib/ShortUrl.test.js
+++ b/system-addon/test/unit/lib/ShortUrl.test.js
@@ -26,10 +26,10 @@ describe("shortURL", () => {
   });
 
   it("should call convertToDisplayIDN when calling shortURL", () => {
-    shortURL({hostname: "com.blah.com", eTLD: "com"});
+    const hostname = shortURL({hostname: "com.blah.com", eTLD: "com"});
 
     assert.calledOnce(IDNStub);
-    assert.calledWithExactly(IDNStub, "com.blah.com", {});
+    assert.calledWithExactly(IDNStub, hostname, {});
   });
 
   it("should use the hostname, if provided", () => {


### PR DESCRIPTION
`eTLD` information required to trim the hostname comes in puny code form. The fix is to just handle the i18n at the end when we have the final hostname.

fixes #3221