### PR TITLE
fix(systemaddon): Refresh TopsitesFeed when blocking to keep 12 Topsites

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -154,6 +154,9 @@ this.TopSitesFeed = class TopSitesFeed {
       case at.PLACES_HISTORY_CLEARED:
         this.refresh();
         break;
+      case at.BLOCK_URL: // Topsite blocked, we want to get a new one in.
+        this.refresh();
+        break;
       case at.PREF_CHANGED:
         if (action.data.name === DEFAULT_SITES_PREF) {
           this.refreshDefaults(action.data.value);

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -358,5 +358,10 @@ describe("Top Sites Feed", () => {
       await feed.onAction({type: at.INIT});
       assert.calledOnce(feed.refresh);
     });
+    it("should call refresh on BLOCK_URL action", async () => {
+      sinon.stub(feed, "refresh");
+      await feed.onAction({type: at.BLOCK_URL});
+      assert.calledOnce(feed.refresh);
+    });
   });
 });


### PR DESCRIPTION
Closes #3220.

Call refresh when a topsite is blocked.