### PR TITLE
feat(topstories): Upgrade Pocket API to version 2

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -56,10 +56,10 @@ const PREFS_CONFIG = new Map([
       provider_icon: "pocket",
       provider_name: "Pocket",
       read_more_endpoint: "https://getpocket.com/explore/trending?src=ff_new_tab",
-      stories_endpoint: `https://getpocket.com/v3/firefox/global-recs?consumer_key=$apiKey&locale_lang=${args.locale}`,
+      stories_endpoint: `https://getpocket.com/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "https://getpocket.com/recommendations",
       survey_link: "https://www.surveymonkey.com/r/newtabffx",
-      topics_endpoint: `https://getpocket.com/v3/firefox/trending-topics?consumer_key=$apiKey&locale_lang=${args.locale}`
+      topics_endpoint: `https://getpocket.com/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`
     })
   }],
   ["migrationExpired", {

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -61,19 +61,19 @@ this.TopStoriesFeed = class TopStoriesFeed {
           throw new Error(`Stories endpoint returned unexpected status: ${response.status}`);
         })
         .then(body => {
-          let items = JSON.parse(body).list;
+          let items = JSON.parse(body).recommendations;
           items = items
-            .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.dedupe_url}))
+            .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
             .map(s => ({
               "guid": s.id,
-              "hostname": shortURL(Object.assign({}, s, {url: s.dedupe_url})),
+              "hostname": shortURL(Object.assign({}, s, {url: s.url})),
               "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
               "title": s.title,
               "description": s.excerpt,
               "image": this._normalizeUrl(s.image_src),
               "referrer": this.stories_referrer,
-              "url": s.dedupe_url,
-              "eTLD": this._addETLD(s.dedupe_url)
+              "url": s.url,
+              "eTLD": this._addETLD(s.url)
             }));
           return items;
         })

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -137,11 +137,11 @@ describe("Top Stories Feed", () => {
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
-      const response = `{"list": [{"id" : "1",
+      const response = `{"recommendations": [{"id" : "1",
         "title": "title",
         "excerpt": "description",
         "image_src": "image-url",
-        "dedupe_url": "rec-url",
+        "url": "rec-url",
         "published_timestamp" : "123"
       }]}`;
       const stories = [{
@@ -190,7 +190,7 @@ describe("Top Stories Feed", () => {
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: site => site.url === "blocked"}});
 
-      const response = `{"list": [{"dedupe_url" : "blocked"}, {"dedupe_url" : "not_blocked"}]}`;
+      const response = `{"recommendations": [{"url" : "blocked"}, {"url" : "not_blocked"}]}`;
       instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: true, status: 200, text: () => response});
       await instance.fetchStories();
@@ -205,7 +205,7 @@ describe("Top Stories Feed", () => {
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
       clock.restore();
       const response = JSON.stringify({
-        "list": [
+        "recommendations": [
           {"published_timestamp": Date.now() / 1000},
           {"published_timestamp": "0"},
           {"published_timestamp": (Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000}


### PR DESCRIPTION
Upgrades the Pocket endpoint to version 2 which uses a more generic payload and includes fields which will be used to experiment with recs personalization, at a later point.