### PR TITLE
chore(styles): Fix various followup style tweaks from design

### DIFF
--- a/system-addon/content-src/activity-stream.scss
+++ b/system-addon/content-src/activity-stream.scss
@@ -85,7 +85,7 @@ a {
     background: $input-secondary;
     border: $border-primary;
     border-radius: 5px;
-    color: $grey-90;
+    color: inherit;
     cursor: pointer;
     padding: 10px 30px;
 

--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -28,6 +28,7 @@
   input {
     @include search-input;
     border-radius: $search-border-radius;
+    color: inherit;
     padding: 0;
     padding-inline-end: $search-button-width;
     padding-inline-start: $search-input-left-label-width;

--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -22,6 +22,10 @@
       display: inline-block;
     }
 
+    .info-option-icon[aria-expanded="true"] {
+      fill: $fill-primary;
+    }
+
     .section-info-option .info-option {
       visibility: hidden;
       opacity: 0;
@@ -45,8 +49,8 @@
       line-height: 120%;
       margin-inline-end: -1px;
       offset-inline-end: 0;
+      top: 20px;
       width: 320px;
-      top: 23px;
       padding: 24px;
       -moz-user-select: none;
     }


### PR DESCRIPTION
Followup to Amy's comment in https://github.com/mozilla/activity-stream/issues/2979#issuecomment-325012363

The inherits don't seem totally necessary as it appears that the colors are the same.. But if you set `body {color: red}` to test, you can tell they're not using the right colors.

For info-option-icon, adjusted color to be darker on hover and tweaked the position of the appearing doorhanger as requested.