### PR TITLE
chore(build): Backport and fix bug 1355088 to use correct bug component

### DIFF
--- a/system-addon/moz.build
+++ b/system-addon/moz.build
@@ -4,6 +4,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+with Files("**"):
+    BUG_COMPONENT = ("Firefox", "Activity Streams: Newtab")
+
 DEFINES['MOZ_APP_VERSION'] = CONFIG['MOZ_APP_VERSION']
 DEFINES['MOZ_APP_MAXVERSION'] = CONFIG['MOZ_APP_MAXVERSION']
 


### PR DESCRIPTION
Fix #3243. r?@dmose Mostly from https://hg.mozilla.org/mozilla-central/rev/f3455c101b7a#l5.1