### PR TITLE
fix(styles): Avoid fixed heights to wrap long strings properly

### DIFF
--- a/system-addon/content-src/components/ManualMigration/_ManualMigration.scss
+++ b/system-addon/content-src/components/ManualMigration/_ManualMigration.scss
@@ -1,3 +1,5 @@
+$migration-spacing: 12px;
+
 .manual-migration-container {
   background: $background-secondary;
   border: $border-secondary;
@@ -5,26 +7,18 @@
   font-size: 13px;
   border-radius: 2px;
   margin-bottom: $section-spacing;
-  padding: 20px;
+  padding: $migration-spacing 0;
   text-align: center;
 
   @media (min-width: $break-point-medium) {
     display: flex;
     justify-content: space-between;
-    height: 100px;
-    padding: 0;
     text-align: left;
   }
 
-  @media (min-width: $break-point-large) {
-    height: 50px;
-  }
-
   p {
-    margin: 0;
+    margin: 0 $migration-spacing;
     @media (min-width: $break-point-medium) {
-      margin-inline-end: 4px;
-      margin-inline-start: 12px;
       align-self: center;
       display: flex;
       justify-content: space-between;
@@ -37,7 +31,7 @@
       display: block;
       fill: $fill-secondary;
       margin: 0;
-      margin-inline-end: 12px;
+      margin-inline-end: $migration-spacing;
       align-self: center;
     }
   }
@@ -46,7 +40,7 @@
 .manual-migration-actions {
   border: none;
   display: block;
-  padding: 10px 0 0 0;
+  padding: $migration-spacing 0 0;
   line-height: 34px;
 
   @media (min-width: $break-point-medium) {
@@ -57,11 +51,11 @@
 
   button {
     align-self: center;
-    padding: 0 12px;
     height: 24px;
-    margin-inline-end: 12px;
+    margin-inline-end: $migration-spacing;
     font-size: 13px;
     min-width: 100px;
+    padding: 0 $migration-spacing;
     white-space: nowrap;
   }
 }

--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -40,7 +40,9 @@
       }
 
       label {
+        display: inline-block;
         position: relative;
+        width: 100%;
 
         input {
           offset-inline-start: -30px;


### PR DESCRIPTION
Fix #3244. r?@piatra Refactor Manual Migration spacing styles to use a variable and remove the fixed `height`s. Also makes the pref label/header a block so multi-line wraps to the same position.

![screen shot 2017-08-26 at 10 12 36 pm](https://user-images.githubusercontent.com/438537/29747337-5df1e2c6-8aac-11e7-8822-9eab39ae3b57.png)
