### PR TITLE
fix(styles): Fix Topics and others with inline-start/end instead of left/right

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -160,7 +160,7 @@
     cursor: pointer;
     padding: 15px;
     position: fixed;
-    right: 15px;
+    offset-inline-end: 15px;
     top: 15px;
     z-index: 12001;
 
@@ -170,11 +170,6 @@
 
     &:active {
       background-color: $background-primary;
-    }
-
-    &:dir(rtl) {
-      left: 5px;
-      right: auto;
     }
   }
 }

--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -43,10 +43,10 @@
       border-radius: $border-radius;
       font-size: 13px;
       line-height: 120%;
+      margin-inline-end: -1px;
+      offset-inline-end: 0;
       width: 320px;
-      right: 0;
       top: 23px;
-      margin-right: -1px;
       padding: 24px;
       -moz-user-select: none;
     }

--- a/system-addon/content-src/components/Topics/Topics.jsx
+++ b/system-addon/content-src/components/Topics/Topics.jsx
@@ -18,7 +18,6 @@ class Topics extends React.Component {
 
         <a className="topic-read-more" href={read_more_endpoint}>
           <FormattedMessage id="pocket_read_even_more" />
-          <span className="topic-read-more-logo" />
         </a>
       </div>
     );

--- a/system-addon/content-src/components/Topics/_Topics.scss
+++ b/system-addon/content-src/components/Topics/_Topics.scss
@@ -6,7 +6,6 @@
 
   @media (min-width: $break-point-large) {
     line-height: 16px;
-    min-width: 780px;
   }
 
   ul {
@@ -14,21 +13,19 @@
     padding: 0;
     @media (min-width: $break-point-large) {
       display: inline;
-      padding-left: 12px;
+      padding-inline-start: 12px;
     }
   }
 
 
   ul li {
     display: inline-block;
-    @media (min-width: $break-point-large) {
-      display: inline;
-    }
+
     &::after {
       content: '•';
-      padding-left: 8px;
-      padding-right: 8px;
+      padding: 8px;
     }
+
     &:last-child::after {
       content: none;
     }
@@ -39,21 +36,31 @@
   }
 
   .topic-read-more {
-    @media (min-width: $break-point-large) {
-      margin-right: 40px;
-      float: right;
-    }
     color: $link-primary;
-  }
 
-  .topic-read-more-logo {
-    padding-right: 10px;
-    margin-left: 5px;
-    background-image: url('#{$image-path}topic-show-more-12.svg');
-    background-repeat: no-repeat;
-    fill: $link-primary;
-    -moz-context-properties: fill;
-    vertical-align: middle;
-  }
+    @media (min-width: $break-point-large) {
+      float: right;
 
+      &:dir(rtl) {
+        float: left;
+      }
+    }
+
+    &::after {
+      background-image: url('#{$image-path}topic-show-more-12.svg');
+      background-repeat: no-repeat;
+      content: '';
+      -moz-context-properties: fill;
+      display: inline-block;
+      fill: $link-primary;
+      height: 16px;
+      margin-inline-start: 5px;
+      vertical-align: middle;
+      width: 12px;
+    }
+
+    &:dir(rtl)::after  {
+      transform: scaleX(-1);
+    }
+  }
 }


### PR DESCRIPTION
Fix #3238. r?@csadilek Topics and/or r?@AdamHillier Info Section or for both. Also removed the width on topics section (not sure why it was there and not the right width to begin with…?) and moved the logo to `::after` as `inline-block` so it can be `transform`ed.

<img width="763" alt="image" src="https://user-images.githubusercontent.com/438537/29751452-653800be-8b02-11e7-9fc8-2294998c5d61.png">

RTL:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/438537/29751457-70c95f9a-8b02-11e7-8779-6eb2e6a48c0c.png">

and RTL info dropdown:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/438537/29751565-0c2c34f2-8b04-11e7-96e1-fef69b56deba.png">