### PR TITLE
feat(topstories): Personalized recs based on user domain affinities

### DIFF
--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -50,7 +50,8 @@ class Section extends React.Component {
     const maxCards = 3 * props.maxRows;
     props.dispatch(ac.ImpressionStats({
       source: props.eventSource,
-      tiles: props.rows.slice(0, maxCards).map(link => ({id: link.guid}))
+      tiles: props.rows.slice(0, maxCards).map(link => ({id: link.guid})),
+      incognito: props.options.personalized
     }));
   }
 

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -59,7 +59,8 @@ const PREFS_CONFIG = new Map([
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "https://getpocket.com/recommendations",
       survey_link: "https://www.surveymonkey.com/r/newtabffx",
-      topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`
+      topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
+      personalized: false
     })
   }],
   ["migrationExpired", {

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -3,19 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/NewTabUtils.jsm");
 Cu.importGlobalProperties(["fetch"]);
 
 const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+
 const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const {shortURL} = Cu.import("resource://activity-stream/lib/ShortURL.jsm", {});
 const {SectionsManager} = Cu.import("resource://activity-stream/lib/SectionsManager.jsm", {});
 
+const {UserDomainAffinityProvider} = Cu.import("resource://activity-stream/lib/UserDomainAffinityProvider.jsm", {});
+
 const STORIES_UPDATE_TIME = 30 * 60 * 1000; // 30 minutes
 const TOPICS_UPDATE_TIME = 3 * 60 * 60 * 1000; // 3 hours
+const DOMAIN_AFFINITY_UPDATE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 const STORIES_NOW_THRESHOLD = 24 * 60 * 60 * 1000; // 24 hours
 const SECTION_ID = "topstories";
 const FEED_PREF = "feeds.section.topstories";
@@ -25,6 +29,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
   init() {
     this.storiesLastUpdated = 0;
     this.topicsLastUpdated = 0;
+    this.affinityLastUpdated = 0;
 
     SectionsManager.onceInitialized(this.parseOptions.bind(this));
   }
@@ -36,9 +41,10 @@ this.TopStoriesFeed = class TopStoriesFeed {
       const apiKey = this._getApiKeyFromPref(options.api_key_pref);
       this.stories_endpoint = this._produceFinalEndpointUrl(options.stories_endpoint, apiKey);
       this.topics_endpoint = this._produceFinalEndpointUrl(options.topics_endpoint, apiKey);
-
       this.read_more_endpoint = options.read_more_endpoint;
       this.stories_referrer = options.stories_referrer;
+      this.personalized = options.personalized;
+      this.maxHistoryQueryResults = options.maxHistoryQueryResults;
 
       this.fetchStories();
       this.fetchTopics();
@@ -61,8 +67,10 @@ this.TopStoriesFeed = class TopStoriesFeed {
           throw new Error(`Stories endpoint returned unexpected status: ${response.status}`);
         })
         .then(body => {
-          let items = JSON.parse(body).recommendations;
-          items = items
+          const response = JSON.parse(body);
+          this.updateDomainAffinities(response.settings);
+
+          const items = response.recommendations
             .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
             .map(s => ({
               "guid": s.id,
@@ -73,9 +81,12 @@ this.TopStoriesFeed = class TopStoriesFeed {
               "image": this._normalizeUrl(s.image_src),
               "referrer": this.stories_referrer,
               "url": s.url,
-              "eTLD": this._addETLD(s.url)
-            }));
-          return items;
+              "eTLD": this._addETLD(s.url),
+              "score": this.personalized ? this.affinityProvider.calculateItemRelevanceScore(s) : 1
+            }))
+            .sort(this.personalized ? this.compareScore : (a, b) => 0);
+
+          return this.rotate(items);
         })
         .catch(error => Cu.reportError(`Failed to fetch content: ${error.message}`));
 
@@ -107,6 +118,42 @@ this.TopStoriesFeed = class TopStoriesFeed {
 
   dispatchUpdateEvent(lastUpdated, data) {
     SectionsManager.updateSection(SECTION_ID, data, lastUpdated === 0);
+  }
+
+  compareScore(a, b) {
+    return b.score - a.score;
+  }
+
+  updateDomainAffinities(settings) {
+    if (!this.personalized) {
+      return;
+    }
+
+    if (!this.affinityProvider || (Date.now() - this.affinityLastUpdated >= DOMAIN_AFFINITY_UPDATE_TIME)) {
+      this.affinityProvider = new UserDomainAffinityProvider(
+        settings.timeSegments,
+        settings.domainAffinityParameterSets,
+        this.maxHistoryQueryResults);
+      this.affinityLastUpdated = Date.now();
+    }
+  }
+
+  // If personalization is turned on we have to rotate stories on the client.
+  // An item can only be on top for two iterations (1hr) before it gets moved
+  // to the end. This will later be improved based on interactions/impressions.
+  rotate(items) {
+    if (!this.personalized || items.length <= 3) {
+      return items;
+    }
+
+    const guid = items[0].guid;
+    if (!this.topItem || !(guid in this.topItem)) {
+      this.topItem = {[guid]: 0};
+    } else if (++this.topItem[guid] === 2) {
+      items.push(items.shift());
+      this.topItem = {[items[0].guid]: 0};
+    }
+    return items;
   }
 
   _getApiKeyFromPref(apiKeyPref) {
@@ -173,4 +220,4 @@ this.STORIES_UPDATE_TIME = STORIES_UPDATE_TIME;
 this.TOPICS_UPDATE_TIME = TOPICS_UPDATE_TIME;
 this.SECTION_ID = SECTION_ID;
 this.FEED_PREF = FEED_PREF;
-this.EXPORTED_SYMBOLS = ["TopStoriesFeed", "STORIES_UPDATE_TIME", "TOPICS_UPDATE_TIME", "SECTION_ID", "FEED_PREF"];
+this.EXPORTED_SYMBOLS = ["TopStoriesFeed", "STORIES_UPDATE_TIME", "TOPICS_UPDATE_TIME", "DOMAIN_AFFINITY_UPDATE_TIME", "SECTION_ID", "FEED_PREF"];

--- a/system-addon/lib/UserDomainAffinityProvider.jsm
+++ b/system-addon/lib/UserDomainAffinityProvider.jsm
@@ -1,0 +1,307 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+Cu.import("resource://gre/modules/Services.jsm");
+
+const history = Cc["@mozilla.org/browser/nav-history-service;1"].getService(Ci.nsINavHistoryService);
+
+const DEFAULT_TIME_SEGMENTS = [
+  {"id": "hour", "startTime": 3600, "endTime": 0, "weightPosition": 1},
+  {"id": "day", "startTime": 86400, "endTime": 3600, "weightPosition": 0.75},
+  {"id": "week", "startTime": 604800, "endTime": 86400, "weightPosition": 0.5},
+  {"id": "weekPlus", "startTime": 0, "endTime": 604800, "weightPosition": 0.25},
+  {"id": "alltime", "startTime": 0, "endTime": 0, "weightPosition": 0.25}
+];
+
+const DEFAULT_PARAMETER_SETS = {
+  "linear-frequency": {
+    "recencyFactor": 0.4,
+    "frequencyFactor": 0.5,
+    "combinedDomainFactor": 0.5,
+    "perfectFrequencyVisits": 10,
+    "perfectCombinedDomainScore": 2,
+    "multiDomainBoost": 0.1,
+    "itemScoreFactor": 0
+  }
+};
+
+const DEFAULT_MAX_HISTORY_QUERY_RESULTS = 1000;
+
+function merge(...args) {
+  return Object.assign.apply(this, args);
+}
+
+/**
+ * Provides functionality to personalize content recommendations by calculating
+ * user domain affinity scores. These scores are used to calculate relevance
+ * scores for items/recs/stories that have domain affinities.
+ *
+ * The algorithm works as follows:
+ *
+ * - The recommendation endpoint returns a settings object containing
+ * timeSegments and parametersets.
+ *
+ * - For every time segment we calculate the corresponding domain visit counts,
+ * yielding result objects of the following structure: {"mozilla.org": 12,
+ * "mozilla.com": 34} (see UserDomainAffinityProvider#queryVisits)
+ *
+ * - These visit counts are transformed to domain affinity scores for all
+ * provided parameter sets: {"mozilla.org": {"paramSet1": 0.8,
+ * "paramSet2": 0.9}, "mozilla.org": {"paramSet1": 1, "paramSet2": 0.9}}
+ * (see UserDomainAffinityProvider#calculateScoresForParameterSets)
+ *
+ * - The parameter sets provide factors for weighting which allows for
+ * flexible targeting. The functionality to calculate final scores can
+ * be seen in UserDomainAffinityProvider#calcuateScores
+ *
+ * - The user domain affinity scores are summed up across all time segments
+ * see UserDomainAffinityProvider#calculateAllUserDomainAffinityScores
+ *
+ * - An item's domain affinities are matched to the user's domain affinity
+ * scores by calculating an item relevance score
+ * (see UserDomainAffinityProvider#calculateItemRelevanceScore)
+ *
+ * - The item relevance scores are used to sort items (see TopStoriesFeed for
+ * more details)
+ *
+ * - The data structure was chosen to allow for fast cache lookups during
+ * relevance score calculation. While user domain affinities are calculated
+ * infrequently (i.e. only once a day), the item relevance score (potentially)
+ * needs to be calculated every time the feed updates. Therefore allowing cache
+ * lookups of scores[domain][parameterSet] is beneficial
+ */
+this.UserDomainAffinityProvider = class UserDomainAffinityProvider {
+  constructor(timeSegments = DEFAULT_TIME_SEGMENTS, parameterSets = DEFAULT_PARAMETER_SETS, maxHistoryQueryResults = DEFAULT_MAX_HISTORY_QUERY_RESULTS) {
+    this.timeSegments = timeSegments;
+    this.maxHistoryQueryResults = maxHistoryQueryResults;
+    this.parameterSets = this.prepareParameterSets(parameterSets);
+    this.scores = this.calculateAllUserDomainAffinityScores();
+  }
+
+  /**
+   * Adds dynamic parameters to the given parameter sets that need to be
+   * computed based on time segments.
+   *
+   * @param ps The parameter sets
+   * @return Updated parameter sets with additional fields (i.e. timeSegmentWeights)
+   */
+  prepareParameterSets(ps) {
+    return Object
+      .keys(ps)
+      // Add timeSegmentWeight fields to param sets e.g. timeSegmentWeights: {"hour": 1, "day": 0.8915, ...}
+      .map(k => ({[k]: merge(ps[k], {timeSegmentWeights: this.calculateTimeSegmentWeights(ps[k].recencyFactor)})}))
+      .reduce((acc, cur) => merge(acc, cur));
+  }
+
+  /**
+   * Calculates a time segment weight based on the provided recencyFactor.
+   *
+   * @param recencyFactor The recency factor indicating how to weigh recency
+   * @return An object containing time segment weights: {"hour": 0.987, "day": 1}
+   */
+  calculateTimeSegmentWeights(recencyFactor) {
+    return this.timeSegments
+      .reduce((acc, cur) => merge(acc, ({[cur.id]: this.calculateScore(cur.weightPosition, 1, recencyFactor)})), {});
+  }
+
+  /**
+   * Calculates user domain affinity scores based on browsing history and the
+   * available times segments and parameter sets.
+   */
+  calculateAllUserDomainAffinityScores() {
+    return this.timeSegments
+      // Calculate parameter set specific domain scores for each time segment
+      // => [{"a.com": {"ps1": 12, "ps2": 34}, "b.com": {"ps1": 56, "ps2": 78}}, ...]
+      .map(ts => this.calculateUserDomainAffinityScores(ts))
+      // Keep format, but reduce to single object, with combined scores across all time segments
+      // => "{a.com":{"ps1":2,"ps2":2}, "b.com":{"ps1":3,"ps2":3}}""
+      .reduce((acc, cur) => this._combineScores(acc, cur));
+  }
+
+  /**
+   * Calculates the user domain affinity scores for the given time segment.
+   *
+   * @param ts The time segment
+   * @return The parameter specific scores for all domains with visits in
+   * this time segment: {"a.com": {"ps1": 12, "ps2": 34}, "b.com" ...}
+   */
+  calculateUserDomainAffinityScores(ts) {
+    // Returns domains and visit counts for this time segment: {"a.com": 1, "b.com": 2}
+    let visits = this.queryVisits(ts);
+
+    return Object
+      .keys(visits)
+      .reduce((acc, d) => merge(acc, {[d]: this.calculateScoresForParameterSets(ts, visits[d])}), {});
+  }
+
+  /**
+   * Calculates the scores for all parameter sets for the given time segment
+   * and domain visit count.
+   *
+   * @param ts The time segment
+   * @param vc The domain visit count in the given time segment
+   * @return The parameter specific scores for the visit count in
+   * this time segment: {"ps1": 12, "ps2": 34}
+   */
+  calculateScoresForParameterSets(ts, vc) {
+    return Object
+      .keys(this.parameterSets)
+      .reduce((acc, ps) => merge(acc, {[ps]: this.calculateScoreForParameterSet(ts, vc, this.parameterSets[ps])}), {});
+  }
+
+  /**
+   * Calculates the final affinity score in the given time segment for the given parameter set
+   *
+   * @param timeSegment The time segment
+   * @param visitCount The domain visit count in the given time segment
+   * @param parameterSet The parameter set to use for scoring
+   * @return The final score
+   */
+  calculateScoreForParameterSet(timeSegment, visitCount, parameterSet) {
+    return this.calculateScore(
+      visitCount * parameterSet.timeSegmentWeights[timeSegment.id],
+      parameterSet.perfectFrequencyVisits,
+      parameterSet.frequencyFactor);
+  }
+
+  /**
+   * Keeps the same format, but reduces the two objects to a single object, with
+   * combined scores across all time segments  => {a.com":{"ps1":2,"ps2":2},
+   * "b.com":{"ps1":3,"ps2":3}}
+   */
+  _combineScores(a, b) {
+    // Merge both score objects so we get a combined object holding all domains.
+    // This is so we can combine them without missing domains that are in a and not in b and vice versa.
+    const c = merge({}, a, b);
+    return Object.keys(c).reduce((acc, d) => merge(acc, this._combine(a, b, c, d)), {});
+  }
+
+  _combine(a, b, c, d) {
+    return Object
+      .keys(c[d])
+      // Summing up the parameter set specific scores of each domain
+      .map(ps => ({[d]: {[ps]: Math.min(1, ((a[d] && a[d][ps]) || 0) + ((b[d] && b[d][ps]) || 0))}}))
+      // Reducing from an array of objects with a single parameter set to a single object
+      // [{"a.com":{"ps1":11}}, {"a.com: {"ps2":12}}] => {"a.com":{"ps1":11,"ps2":12}}
+      .reduce((acc, cur) => ({[d]: merge(acc[d], cur[d])}));
+  }
+
+  /**
+   * Calculates a value on the curve described by the provided parameters. The curve we're using is
+   * (a^(b*x) - 1) / (a^b - 1): https://www.desmos.com/calculator/maqhpttupp
+   *
+   * @param {number} score A value between 0 and maxScore, representing x.
+   * @param {number} maxScore Highest possible score.
+   * @param {number} factor The slope describing the curve to get to maxScore. A low slope value
+   * [0, 0.5] results in a log-shaped curve, a high slope [0.5, 1] results in a exp-shaped curve,
+   * a slope of exactly 0.5 is linear.
+   * @param {number} ease Adjusts how much bend is in the curve i.e. how dramatic the maximum
+   * effect of the slope can be. This represents b in the formula above.
+   * @return {number} the final score
+   */
+  calculateScore(score, maxScore, factor, ease = 2) {
+    let a = 0;
+    let x = Math.max(0, score / maxScore);
+
+    if (x >= 1) {
+      return 1;
+    }
+
+    if (factor === 0.5) {
+      return x;
+    }
+
+    if (factor < 0.5) {
+      // We want a log-shaped curve so we scale "a" between 0 and .99
+      a = (factor / 0.5) * 0.49;
+    } else if (factor > 0.5) {
+      // We want an exp-shaped curve so we scale "a" between 1.01 and 10
+      a = 1 + (factor - 0.5) / 0.5 * 9;
+    }
+
+    return (Math.pow(a, ease * x) - 1) / (Math.pow(a, ease) - 1);
+  }
+
+  /**
+   * Queries the visit counts in the given time segment.
+   *
+   * @param ts the time segment
+   * @return the visit count object: {"a.com": 1, "b.com": 2}
+   */
+  queryVisits(ts) {
+    const visitCounts = {};
+    const query = history.getNewQuery();
+    const wwwRegEx = /^www\./;
+
+    query.beginTimeReference = query.TIME_RELATIVE_NOW;
+    query.beginTime = (ts.startTime && ts.startTime !== 0) ? -(ts.startTime * 1000 * 1000) : -(Date.now() * 1000);
+
+    query.endTimeReference = query.TIME_RELATIVE_NOW;
+    query.endTime = (ts.endTime && ts.endTime !== 0) ? -(ts.endTime * 1000 * 1000) : 0;
+
+    const options = history.getNewQueryOptions();
+    options.sortingMode = options.SORT_BY_VISITCOUNT_DESCENDING;
+    options.maxResults = this.maxHistoryQueryResults;
+
+    const root = history.executeQuery(query, options).root;
+    root.containerOpen = true;
+    for (let i = 0; i < root.childCount; i++) {
+      let node = root.getChild(i);
+      let host = Services.io.newURI(node.uri).host.replace(wwwRegEx, "");
+      if (!visitCounts[host]) {
+        visitCounts[host] = 0;
+      }
+      visitCounts[host] += node.accessCount;
+    }
+    root.containerOpen = false;
+    return visitCounts;
+  }
+
+  /**
+   * Calculates an item's relevance score.
+   *
+   * @param item the item (story), must contain domain affinities, otherwise a
+   * score of 1 is returned.
+   * @return the calculated item's score or 1 if item has no domain_affinities
+   * or references an unknown parameter set.
+   */
+  calculateItemRelevanceScore(item) {
+    const params = this.parameterSets[item.parameter_set];
+    if (!item.domain_affinities || !params) {
+      return 1;
+    }
+
+    const scores = Object
+      .keys(item.domain_affinities)
+      .reduce((acc, d) => {
+        let userDomainAffinityScore = this.scores[d] ? this.scores[d][item.parameter_set] : false;
+        if (userDomainAffinityScore) {
+          acc.combinedDomainScore += userDomainAffinityScore * item.domain_affinities[d];
+          acc.matchingDomainsCount++;
+        }
+        return acc;
+      }, {combinedDomainScore: 0, matchingDomainsCount: 0});
+
+    // Boost the score as configured in the provided parameter set
+    const boostedCombinedDomainScore = scores.combinedDomainScore *
+      Math.pow(params.multiDomainBoost + 1, scores.matchingDomainsCount);
+
+    // Calculate what the score would be if the item score is ignored
+    const normalizedCombinedDomainScore = this.calculateScore(boostedCombinedDomainScore,
+      params.perfectCombinedDomainScore,
+      params.combinedDomainFactor);
+
+    // Calculate the final relevance score using the itemScoreFactor. The itemScoreFactor
+    // allows weighting the item score in relation to the normalizedCombinedDomainScore:
+    // An itemScoreFactor of 1 results in the item score and ignores the combined domain score
+    // An itemScoreFactor of 0.5 results in the the average of item score and combined domain score
+    // An itemScoreFactor of 0 results in the combined domain score and ignores the item score
+    return params.itemScoreFactor * (item.item_score - normalizedCombinedDomainScore) + normalizedCombinedDomainScore;
+  }
+
+};
+
+this.EXPORTED_SYMBOLS = ["UserDomainAffinityProvider"];

--- a/system-addon/test/unit/content-src/components/Sections.test.jsx
+++ b/system-addon/test/unit/content-src/components/Sections.test.jsx
@@ -136,7 +136,8 @@ describe("<Section>", () => {
         addEventListener: sinon.stub(),
         removeEventListener: sinon.stub()
       },
-      eventSource: "TOP_STORIES"
+      eventSource: "TOP_STORIES",
+      options: {personalized: false}
     };
 
     function renderSection(props = {}) {
@@ -154,6 +155,20 @@ describe("<Section>", () => {
       const action = dispatch.firstCall.args[0];
       assert.equal(action.type, at.TELEMETRY_IMPRESSION_STATS);
       assert.equal(action.data.source, "TOP_STORIES");
+      assert.isFalse(action.data.incognito);
+      assert.deepEqual(action.data.tiles, [{id: 1}, {id: 2}]);
+    });
+    it("should not send client id if section is personalized", () => {
+      FAKE_TOPSTORIES_SECTION_PROPS.options.personalized = true;
+      const dispatch = sinon.spy();
+      renderSection({dispatch});
+
+      assert.calledOnce(dispatch);
+
+      const action = dispatch.firstCall.args[0];
+      assert.equal(action.type, at.TELEMETRY_IMPRESSION_STATS);
+      assert.equal(action.data.source, "TOP_STORIES");
+      assert.isTrue(action.data.incognito);
       assert.deepEqual(action.data.tiles, [{id: 1}, {id: 2}]);
     });
     it("should send 1 impression when the page becomes visibile after loading", () => {

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -8,6 +8,7 @@ describe("Top Stories Feed", () => {
   let TopStoriesFeed;
   let STORIES_UPDATE_TIME;
   let TOPICS_UPDATE_TIME;
+  let DOMAIN_AFFINITY_UPDATE_TIME;
   let SECTION_ID;
   let FEED_PREF;
   let instance;
@@ -32,7 +33,9 @@ describe("Top Stories Feed", () => {
 
     globals = new GlobalOverrider();
     globals.set("Services", {locale: {getRequestedLocale: () => "en-CA"}});
-
+    globals.set("PlacesUtils", {history: {}});
+    clock = sinon.useFakeTimers();
+    shortURLStub = sinon.stub().callsFake(site => site.url);
     sectionsManagerStub = {
       onceInitialized: sinon.stub().callsFake(callback => callback()),
       enableSection: sinon.spy(),
@@ -41,19 +44,19 @@ describe("Top Stories Feed", () => {
       sections: new Map([["topstories", {options: FAKE_OPTIONS}]])
     };
 
-    clock = sinon.useFakeTimers();
-
-    shortURLStub = sinon.stub().callsFake(site => site.url);
-
-    ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, SECTION_ID, FEED_PREF} = injector({
+    class FakeUserDomainAffinityProvider {}
+    ({TopStoriesFeed, STORIES_UPDATE_TIME, TOPICS_UPDATE_TIME, DOMAIN_AFFINITY_UPDATE_TIME, SECTION_ID, FEED_PREF} = injector({
       "lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs},
       "lib/ShortURL.jsm": {shortURL: shortURLStub},
+      "lib/UserDomainAffinityProvider.jsm": {UserDomainAffinityProvider: FakeUserDomainAffinityProvider},
       "lib/SectionsManager.jsm": {SectionsManager: sectionsManagerStub}
     }));
+
     instance = new TopStoriesFeed();
     instance.store = {getState() { return {}; }, dispatch: sinon.spy()};
     instance.storiesLastUpdated = 0;
     instance.topicsLastUpdated = 0;
+    instance.affinityProvider = {calculateItemRelevanceScore: s => 1};
   });
   afterEach(() => {
     globals.restore();
@@ -153,7 +156,8 @@ describe("Top Stories Feed", () => {
         "referrer": "referrer",
         "url": "rec-url",
         "eTLD": "",
-        "hostname": "rec-url"
+        "hostname": "rec-url",
+        "score": 1
       }];
 
       instance.stories_endpoint = "stories-endpoint";
@@ -258,6 +262,104 @@ describe("Top Stories Feed", () => {
       assert.notCalled(instance.store.dispatch);
       assert.called(Components.utils.reportError);
     });
+    it("should initialize user domain affinity provider if personalization is preffed on", async () => {
+      const response = `{
+        "recommendations":  [{
+          "id" : "1",
+          "title": "title",
+          "excerpt": "description",
+          "image_src": "image-url",
+          "url": "rec-url",
+          "published_timestamp" : "123"}
+        ],
+        "settings": {"timeSegments": {}, "domainAffinityParameterSets": {}}
+      }`;
+
+      instance.affinityProvider = undefined;
+
+      instance.stories_endpoint = "stories-endpoint";
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      fetchStub.resolves({ok: true, status: 200, text: () => response});
+
+      await instance.fetchStories();
+      assert.isUndefined(instance.affinityProvider);
+
+      instance.personalized = true;
+      await instance.fetchStories();
+      assert.isDefined(instance.affinityProvider);
+    });
+    it("should sort stories if personalization is preffed on", async () => {
+      const response = `{
+        "recommendations":  [{"id" : "1"}, {"id" : "2"}],
+        "settings": {"timeSegments": {}, "domainAffinityParameterSets": {}}
+      }`;
+
+      instance.personalized = true;
+      instance.compareScore = sinon.spy();
+      instance.stories_endpoint = "stories-endpoint";
+
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
+      fetchStub.resolves({ok: true, status: 200, text: () => response});
+
+      await instance.fetchStories();
+      assert.calledOnce(instance.compareScore);
+    });
+    it("should not sort stories if personalization is preffed off", async () => {
+      const response = `{
+        "recommendations":  [{"id" : "1"}, {"id" : "2"}],
+        "settings": {"timeSegments": {}, "domainAffinityParameterSets": {}}
+      }`;
+
+      instance.personalized = false;
+      instance.compareScore = sinon.spy();
+      instance.stories_endpoint = "stories-endpoint";
+
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
+      fetchStub.resolves({ok: true, status: 200, text: () => response});
+
+      await instance.fetchStories();
+      assert.notCalled(instance.compareScore);
+    });
+    it("should sort items based on relevance score", () => {
+      let items = [{"score": 0.1}, {"score": 0.2}];
+      items = items.sort(instance.compareScore);
+      assert.deepEqual(items, [{"score": 0.2}, {"score": 0.1}]);
+    });
+    it("should rotate items if personalization is preffed on", () => {
+      let items = [{"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}];
+
+      instance.personalized = true;
+
+      let rotated = instance.rotate(items);
+      assert.deepEqual({"g1": 0}, instance.topItem);
+      assert.deepEqual(items, rotated);
+
+      rotated = instance.rotate(items);
+      assert.deepEqual({"g1": 1}, instance.topItem);
+      assert.deepEqual(items, rotated);
+
+      rotated = instance.rotate(items);
+      assert.deepEqual({"g2": 0}, instance.topItem);
+      assert.deepEqual([{"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}, {"guid": "g1"}], rotated);
+
+      rotated = instance.rotate(items);
+      assert.deepEqual({"g2": 1}, instance.topItem);
+      assert.deepEqual([{"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}, {"guid": "g1"}], rotated);
+    });
+    it("should note rotate items if personalization is preffed off", () => {
+      let items = [{"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}];
+
+      instance.personalized = false;
+
+      instance.topItem = {"g1": 1};
+      const rotated = instance.rotate(items);
+      assert.deepEqual(items, rotated);
+    });
   });
   describe("#update", () => {
     it("should fetch stories after update interval", () => {
@@ -279,6 +381,19 @@ describe("Top Stories Feed", () => {
       clock.tick(TOPICS_UPDATE_TIME);
       instance.onAction({type: at.SYSTEM_TICK});
       assert.calledOnce(instance.fetchTopics);
+    });
+    it("should update domain affinities after update interval", () => {
+      instance.init();
+      instance.personalized = true;
+      const fakeSettings = {timeSegments: {}, parameterSets: {}};
+      instance.affinityProvider = {status: "not_changed"};
+
+      instance.updateDomainAffinities(fakeSettings);
+      assert.equal("not_changed", instance.affinityProvider.status);
+
+      clock.tick(DOMAIN_AFFINITY_UPDATE_TIME);
+      instance.updateDomainAffinities(fakeSettings);
+      assert.isUndefined(instance.affinityProvider.status);
     });
   });
 });

--- a/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
+++ b/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
@@ -1,0 +1,154 @@
+"use strict";
+const injector = require("inject!lib/UserDomainAffinityProvider.jsm");
+const {GlobalOverrider} = require("test/unit/utils");
+
+const TIME_SEGMENTS = [
+  {"id": "hour", "startTime": 3600, "endTime": 0, "weightPosition": 1},
+  {"id": "day", "startTime": 86400, "endTime": 3600, "weightPosition": 0.75},
+  {"id": "week", "startTime": 604800, "endTime": 86400, "weightPosition": 0.5},
+  {"id": "weekPlus", "startTime": null, "endTime": 604800, "weightPosition": 0.25}
+];
+
+const PARAMETER_SETS = {
+  "paramSet1": {
+    "recencyFactor": 0.5,
+    "frequencyFactor": 0.5,
+    "combinedDomainFactor": 0.5,
+    "perfectFrequencyVisits": 10,
+    "perfectCombinedDomainScore": 2,
+    "multiDomainBoost": 0.1,
+    "itemScoreFactor": 0
+  },
+  "paramSet2": {
+    "recencyFactor": 1,
+    "frequencyFactor": 0.7,
+    "combinedDomainFactor": 0.8,
+    "perfectFrequencyVisits": 10,
+    "perfectCombinedDomainScore": 2,
+    "multiDomainBoost": 0.1,
+    "itemScoreFactor": 0
+  }
+};
+
+describe("User Domain Affinity Provider", () => {
+  let UserDomainAffinityProvider;
+  let instance;
+  let globals;
+
+  beforeEach(() => {
+    globals = new GlobalOverrider();
+    globals.set("Services", {locale: {getRequestedLocale: () => "en-CA"}, io: {newURI: u => ({host: "www.somedomain.org"})}});
+    globals.set("PlacesUtils", {
+      history: {
+        getNewQuery: () => ({"TIME_RELATIVE_NOW": 1}),
+        getNewQueryOptions: () => ({}),
+        executeQuery: () => ({root: {childCount: 1, getChild: index => ({uri: "www.somedomain.org", accessCount: 1})}})
+      }
+    });
+    global.Components.classes["@mozilla.org/browser/nav-history-service;1"] = {
+      getService() {
+        return global.PlacesUtils.history;
+      }
+    };
+
+    ({UserDomainAffinityProvider} = injector());
+    instance = new UserDomainAffinityProvider(TIME_SEGMENTS, PARAMETER_SETS);
+  });
+  afterEach(() => {
+    globals.restore();
+  });
+  describe("#init", () => {
+    function calculateScore(visitCounts, timeSeg, domain, ps) {
+      const vc = visitCounts[timeSeg][domain];
+      const score = instance.calculateScore(vc * Number(ps.timeSegmentWeights[timeSeg]), ps.perfectFrequencyVisits, ps.frequencyFactor);
+      return Math.min(1, score);
+    }
+    it("should create a UserDomainAffinityProvider", () => {
+      assert.instanceOf(instance, UserDomainAffinityProvider);
+    });
+    it("should calculate time segment weights for parameter sets", () => {
+      const expectedParamSets = Object.assign({}, PARAMETER_SETS);
+
+      // Verify that parameter set specific recencyFactor was applied
+      expectedParamSets.paramSet1.timeSegmentWeights = {"hour": 1, "day": 0.75, "week": 0.5, "weekPlus": 0.25};
+      expectedParamSets.paramSet2.timeSegmentWeights = {"hour": 1, "day": 1, "week": 1, "weekPlus": 1};
+      assert.deepEqual(expectedParamSets, instance.parameterSets);
+    });
+    it("should calculate user domain affinity scores", () => {
+      const ps1 = instance.parameterSets.paramSet1;
+      const ps2 = instance.parameterSets.paramSet2;
+
+      const visitCounts = {
+        "hour": {"a.com": 1, "b.com": 2},
+        "day": {"a.com": 4},
+        "week": {"c.com": 1},
+        "weekPlus": {"a.com": 1, "d.com": 3}
+      };
+      instance.queryVisits = ts => visitCounts[ts.id];
+
+      const expScoreAHourPs1 = calculateScore(visitCounts, "hour", "a.com", ps1);
+      const expScoreBHourPs1 = calculateScore(visitCounts, "hour", "b.com", ps1);
+      const expScoreAHourPs2 = calculateScore(visitCounts, "hour", "a.com", ps2);
+      const expScoreBHourPs2 = calculateScore(visitCounts, "hour", "b.com", ps2);
+      const expScoreADayPs1 = calculateScore(visitCounts, "day", "a.com", ps1);
+      const expScoreADayPs2 = calculateScore(visitCounts, "day", "a.com", ps2);
+      const expScoreCWeekPs1 = calculateScore(visitCounts, "week", "c.com", ps1);
+      const expScoreCWeekPs2 = calculateScore(visitCounts, "week", "c.com", ps2);
+      const expScoreAWeekPlusPs1 = calculateScore(visitCounts, "weekPlus", "a.com", ps1);
+      const expScoreAWeekPlusPs2 = calculateScore(visitCounts, "weekPlus", "a.com", ps2);
+      const expScoreDWeekPlusPs1 = calculateScore(visitCounts, "weekPlus", "d.com", ps1);
+      const expScoreDWeekPlusPs2 = calculateScore(visitCounts, "weekPlus", "d.com", ps2);
+      const expectedScores = {
+        "a.com": {
+          "paramSet1": Math.min(1, expScoreAHourPs1 + expScoreADayPs1 + expScoreAWeekPlusPs1),
+          "paramSet2": Math.min(1, expScoreAHourPs2 + expScoreADayPs2 + expScoreAWeekPlusPs2)
+        },
+        "b.com": {"paramSet1": expScoreBHourPs1, "paramSet2": expScoreBHourPs2},
+        "c.com": {"paramSet1": expScoreCWeekPs1, "paramSet2": expScoreCWeekPs2},
+        "d.com": {"paramSet1": expScoreDWeekPlusPs1, "paramSet2": expScoreDWeekPlusPs2}
+      };
+
+      const scores = instance.calculateAllUserDomainAffinityScores();
+      assert.deepEqual(expectedScores, scores);
+    });
+  });
+  describe("#score", () => {
+    it("should calculate item relevance score", () => {
+      const ps = instance.parameterSets.paramSet2;
+
+      const visitCounts = {
+        "hour": {"a.com": 1, "b.com": 2},
+        "day": {"a.com": 4},
+        "week": {"c.com": 1},
+        "weekPlus": {"a.com": 1, "d.com": 3}
+      };
+      instance.queryVisits = ts => visitCounts[ts.id];
+      instance.scores = instance.calculateAllUserDomainAffinityScores();
+
+      const testItem = {
+        "domain_affinities": {"a.com": 1},
+        "item_score": 1,
+        "parameter_set": "paramSet2"
+      };
+      const combinedDomainScore = instance.scores["a.com"].paramSet2 * Math.pow(ps.multiDomainBoost + 1, 1);
+      const expectedItemScore = instance.calculateScore(combinedDomainScore,
+        ps.perfectCombinedDomainScore,
+        ps.combinedDomainFactor);
+
+      const itemScore = instance.calculateItemRelevanceScore(testItem);
+      assert.equal(expectedItemScore, itemScore);
+    });
+    it("should calculate relevance score of 1 if item has no domain affinities", () => {
+      const testItem = {};
+      const expectedItemScore = 1;
+      const itemScore = instance.calculateItemRelevanceScore(testItem);
+      assert.equal(expectedItemScore, itemScore);
+    });
+    it("should calculate scores with factor", () => {
+      assert.equal(1, instance.calculateScore(2, 1, 0.5));
+      assert.equal(0.5, instance.calculateScore(0.5, 1, 0.5));
+      assert.isBelow(instance.calculateScore(0.5, 1, 0.49), 1);
+      assert.isBelow(instance.calculateScore(0.5, 1, 0.51), 1);
+    });
+  });
+});


### PR DESCRIPTION
closes #3259 .

This PR adds support for personalized recs based on domain affinities. 

*This functionality is turned **off** by default.* We want to bring this in so we can run experiments in 57.

The algorithm works as follows:

- Pocket's endpoint (v2) returns a settings object containing *timeSegments* [1] and *parameterSets* [2]
- For every time segment we calculate the corresponding domain visit counts, yielding result objects of the following structure: ```{"mozilla.org": 12, "mozilla.com": 34}```
- These visit counts are transformed to domain affinity scores for all provided parameter sets: ```{"mozilla.org": {"paramSet1": 0.8, "paramSet2": 0.9}, "mozilla.org": {"paramSet1": 1, "paramSet2": 0.9}}```
- The parameter sets provide factors for weighting which allows for flexible targeting. The functionality to calculate final scores can be seen in [3]
- The user domain affinity scores are summed up across all time segments, cached and only updated once a day

---

- Every item in Pocket's feed contains a list of domain affinities which are matched to the user's domain affinity scores by calculating an item relevance score [4]
- The items are sorted using these relevance scores and the top (3) items are displayed [5]
- Client-side rotation (only active if personalization is on) makes sure we don't display the same top 3 items all the time. This will be improved in future iterations to factor in user signals

---

Notes on implementation:
- The data structure was chosen to allow for fast cache lookups during relevance score calculation. While user domain affinities are calculated only once a day, the item relevance score (potentially) needs to be calculated every time we fetch the feed. Therefore allowing cache lookups of ```scores[domain][parameterSet]``` is beneficial
- I decided to use map/reduce where possible so the code very closely matches the description of the algorithm, to avoid mutable state, and to limit the lines of code required to implement this functionality
- Test coverage for all of the above included ;)


[1] [Time segments](https://github.com/csadilek/activity-stream/blob/personalization-poc/system-addon/lib/UserDomainAffinityProvider.jsm#L11)
[2] [Parameter sets](https://github.com/csadilek/activity-stream/blob/personalization-poc/system-addon/lib/UserDomainAffinityProvider.jsm#L19)
[3] [Scoring with weights](https://github.com/csadilek/activity-stream/blob/personalization-poc/system-addon/lib/UserDomainAffinityProvider.jsm#L160)
[4] [Relevance scoring for items](https://github.com/csadilek/activity-stream/blob/personalization-poc/system-addon/lib/UserDomainAffinityProvider.jsm#L226)
[5] [Item sorting](https://github.com/csadilek/activity-stream/blob/personalization-poc/system-addon/lib/TopStoriesFeed.jsm#L86)