### PR TITLE
chore(l10n): Add remaining strings for Firefox 57 (highlights, Pocket, prefs)

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -3,6 +3,7 @@ default_label_loading=Loading…
 
 header_top_sites=Top Sites
 header_stories=Top Stories
+header_highlights=Highlights
 header_visit_again=Visit Again
 header_bookmarks=Recent Bookmarks
 # LOCALIZATION NOTE(header_recommended_by): This is followed by the name
@@ -72,6 +73,7 @@ search_settings=Change Search Settings
 # LOCALIZATION NOTE (section_info_option): This is the screenreader text for the
 # (?) icon that would show a section's description with optional feedback link.
 section_info_option=Info
+section_info_send_feedback=Send Feedback
 section_info_privacy_notice=Privacy Notice
 
 # LOCALIZATION NOTE (welcome_*): This is shown as a modal dialog, typically on a
@@ -90,7 +92,7 @@ time_label_day={number}d
 # LOCALIZATION NOTE (settings_pane_*): This is shown in the Settings Pane sidebar.
 settings_pane_button_label=Customize your New Tab page
 settings_pane_header=New Tab Preferences
-settings_pane_body=Choose what you see when you open a new tab.
+settings_pane_body2=Choose what you see on this page.
 settings_pane_search_header=Search
 settings_pane_search_body=Search the Web from your new tab.
 settings_pane_topsites_header=Top Sites
@@ -100,8 +102,16 @@ settings_pane_bookmarks_header=Recent Bookmarks
 settings_pane_bookmarks_body=Your newly created bookmarks in one handy location.
 settings_pane_visit_again_header=Visit Again
 settings_pane_visit_again_body=Firefox will show you parts of your browsing history that you might want to remember or get back to.
-settings_pane_pocketstories_header=Top Stories
-settings_pane_pocketstories_body=Pocket, a part of the Mozilla family, will help connect you to high-quality content that you may not have found otherwise.
+settings_pane_highlights_header=Highlights
+settings_pane_highlights_body2=Find your way back to interesting things you’ve recently visited or bookmarked.
+settings_pane_highlights_options_bookmarks=Bookmarks
+settings_pane_highlights_options_visited=Visited Sites
+# LOCALIZATION NOTE(settings_pane_snippets_header): For the "Snippets" feature
+# traditionally on about:home. Alternative translation options: "Small Note" or
+# something that expresses the idea of "a small message, shortened from
+# something else, and non-essential but also not entirely trivial and useless."
+settings_pane_snippets_header=Snippets
+settings_pane_snippets_body=Read short and sweet updates from Mozilla about Firefox, internet culture, and the occasional random meme.
 settings_pane_done_button=Done
 
 # LOCALIZATION NOTE (edit_topsites_*): This is shown in the Edit Top Sites modal
@@ -136,19 +146,19 @@ pocket_read_even_more=View More Stories
 # LOCALIZATION NOTE (pocket_feedback_header): This is shown as an introduction
 # to Pocket as part of the feedback form.
 pocket_feedback_header=The best of the web, curated by over 25 million people.
-# LOCALIZATION NOTE (pocket_feedback_body): This is shown below
-# (pocket_feedback_header) to provide more information about Pocket.
-pocket_feedback_body=Pocket, a part of the Mozilla family, will help connect you to high-quality content that you may not have found otherwise.
-pocket_send_feedback=Send Feedback
+# LOCALIZATION NOTE (pocket_description): This is shown in the settings pane and
+# below (pocket_feedback_header) to provide more information about Pocket.
+pocket_description=Discover high-quality content you might otherwise miss, with help from Pocket, now part of Mozilla.
 
+highlights_empty_state=Start browsing, and we’ll show some of the great articles, videos, and other pages you’ve recently visited or bookmarked here.
 # LOCALIZATION NOTE (topstories_empty_state): When there are no recommendations,
 # in the space that would have shown a few stories, this is shown instead.
 # {provider} is replaced by the name of the content provider for this section.
 topstories_empty_state=You’ve caught up. Check back later for more top stories from {provider}. Can’t wait? Select a popular topic to find more great stories from around the web.
 
-# LOCALIZATION NOTE (manual_migration_explanation): This message is shown to encourage users to
+# LOCALIZATION NOTE (manual_migration_explanation2): This message is shown to encourage users to
 # import their browser profile from another browser they might be using.
-manual_migration_explanation=Try Firefox with your favorite sites and bookmarks from another browser.
+manual_migration_explanation2=Try Firefox with the bookmarks, history and passwords from another browser.
 # LOCALIZATION NOTE (manual_migration_cancel_button): This message is shown on a button that cancels the
 # process of importing another browser’s profile into Firefox.
 manual_migration_cancel_button=No Thanks

--- a/system-addon/content-src/components/ManualMigration/ManualMigration.jsx
+++ b/system-addon/content-src/components/ManualMigration/ManualMigration.jsx
@@ -31,7 +31,7 @@ class ManualMigration extends React.Component {
     return (<div className="manual-migration-container">
         <p>
           <span className="icon icon-import" />
-          <FormattedMessage id="manual_migration_explanation" />
+          <FormattedMessage id="manual_migration_explanation2" />
         </p>
         <div className="manual-migration-actions actions">
           <button className="dismiss" onClick={this.onCancelTour}>

--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -81,7 +81,7 @@ class PreferencesPane extends React.Component {
           <div className={`sidebar ${isVisible ? "" : "hidden"}`}>
             <div className="prefs-modal-inner-wrapper">
               <h1><FormattedMessage id="settings_pane_header" /></h1>
-              <p><FormattedMessage id="settings_pane_body" /></p>
+              <p><FormattedMessage id="settings_pane_body2" /></p>
 
               <PreferencesInput className="showSearch" prefName="showSearch" value={prefs.showSearch} onChange={this.handlePrefChange}
                 titleString={{id: "settings_pane_search_header"}} descString={{id: "settings_pane_search_body"}} />

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -53,7 +53,7 @@ const PREFS_CONFIG = new Map([
       hidden: !PREFS_CONFIG.get("feeds.section.topstories").getValue(args),
       learn_more_endpoint: "https://getpocket.cdn.mozilla.net/firefox_learnmore?src=ff_newtab",
       provider_header: "pocket_feedback_header",
-      provider_description: "pocket_feedback_body",
+      provider_description: "pocket_description",
       provider_icon: "pocket",
       provider_name: "Pocket",
       read_more_endpoint: "https://getpocket.cdn.mozilla.net/explore/trending?src=ff_new_tab",

--- a/system-addon/test/unit/content-src/components/ManualMigration.test.jsx
+++ b/system-addon/test/unit/content-src/components/ManualMigration.test.jsx
@@ -18,7 +18,7 @@ describe("<ManualMigration>", () => {
     const fm = wrapper.find("p").find(FormattedMessage);
 
     assert.isNotNull(fm.getNode());
-    assert.equal(fm.props().id, "manual_migration_explanation");
+    assert.equal(fm.props().id, "manual_migration_explanation2");
   });
   describe("actions", () => {
     it("should render two buttons", () => {


### PR DESCRIPTION
Fix #3267 by adding strings for #3146, #3147 and #3155. Also fix #3271. r?@sarracini 

<img width="1269" alt="screen shot 2017-08-31 at 4 33 13 pm" src="https://user-images.githubusercontent.com/438537/29949571-8d770348-8e6a-11e7-88ef-182c263fece1.png">

---

old stuff

@flodolo this isn't the final set of strings yet as we have some "Design feedback needed" issues (`settings_pane_snippets_header=Snippets` -> "Tips from Mozilla" ? and #3265), but we're trying to be string frozen by end of this week, so I'll update this PR by then. A couple questions for you:

1. We previously removed Highlights in #2740 and split it to a Recently Visited section and a Bookmarks section, but it was decided to combine them for the initial 57 release and potentially split again later. `header_highlights=Highlights` is actually exactly the same from before but `settings_pane_highlights_body` is a previously used and currently removed identifier with a new string. Is it okay to reuse that string identifier as Pontoon has removed it automatically?

2. In #3216 @AdamHillier made it so that (the section header + description) are both used in the (section top line + info-option/feedback area) as well as in the preferences pane (line with checkbox + body). Is that okay to reuse the strings or should they stay duplicated? E.g., I've renamed to `pocket_description` for the double-use of the string.

3. There's a number of currently unused strings (that were used in Test Pilot) but haven't been ported to the system-addon version as well as a few strings that seem like they won't be used at all. Should we try to clean some of that up potentially running into the highlights-removed-and-now-back issue? -> #3314