### PR TITLE
fix(mc): #3284 Backport Bug 863246

### DIFF
--- a/system-addon/jar.mn
+++ b/system-addon/jar.mn
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 [features/activity-stream@mozilla.org] chrome.jar:
-% resource activity-stream %content/
+% resource activity-stream %content/ contentaccessible=yes
   content/lib/ (./lib/*)
   content/common/ (./common/*)
   content/vendor/Redux.jsm (./vendor/Redux.jsm)


### PR DESCRIPTION
This bug added contentacessible=yes to jar.mn. Here is the diff: https://hg.mozilla.org/mozilla-central/diff/a676a1188572/browser/extensions/activity-stream/jar.mn

Not including this causes major failures (no scripts can load)