### PR TITLE
chore(build): Restore version zero pad of minutes to 4 instead of 5

### DIFF
--- a/bin/update-version.js
+++ b/bin/update-version.js
@@ -53,7 +53,7 @@ simpleGit.revparse(["--short", "HEAD"], (err, gitHash) => {
   let versionString = String(time.getUTCFullYear()) +
     "." + zeroPadStart(time.getUTCMonth() + 1, 2) +
     "." + zeroPadStart(time.getUTCDate(), 2) +
-    "." + zeroPadStart(minuteOfDay, 5) +
+    "." + zeroPadStart(minuteOfDay, 4) +
     "-" + gitHash.trim();
 
   cd(process.argv[2]);


### PR DESCRIPTION
Versions slightly changed with #3286. r?@dmose 