### PR TITLE
fix (systemaddon): use `new URL()` instead of regex for validation

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -467,7 +467,7 @@ class TopSiteForm extends React.Component {
   cleanUrl() {
     let url = this.state.url;
     // If we are missing a protocol, prepend http://
-    if (!url.startsWith("http")) {
+    if (!url.startsWith("http:") && !url.startsWith("https:")) {
       url = `http://${url}`;
     }
     return url;
@@ -478,16 +478,11 @@ class TopSiteForm extends React.Component {
     }
   }
   validateUrl() {
-    let url = this.state.url;
-    if (url && !url.startsWith("http")) {
-      url = `http://${url}`;
-    }
     try {
-      url = new URL(url);
+      return !!new URL(this.cleanUrl());
     } catch (e) {
       return false;
     }
-    return true;
   }
   validateForm() {
     this.resetValidation();

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -478,13 +478,16 @@ class TopSiteForm extends React.Component {
     }
   }
   validateUrl() {
-    const pattern = new RegExp("^(https?:\\/\\/)?" + // protocol
-      "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name
-      "((\\d{1,3}\\.){3}\\d{1,3}))" + // OR ip (v4) address
-      "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // port and path
-      "(\\?[;&a-z\\d%_.~+=-]*)?" + // query string
-      "(\\#[\\/-a-z\\d_]*)?$", "i"); // fragment locater
-    return pattern.test(this.state.url);
+    let url = this.state.url;
+    if (url && !url.startsWith("http")) {
+      url = `http://${url}`;
+    }
+    try {
+      url = new URL(url);
+    } catch (e) {
+      return false;
+    }
+    return true;
   }
   validateForm() {
     this.resetValidation();

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -535,7 +535,7 @@ describe("<TopSiteForm>", () => {
       assert.notCalled(wrapper.instance().props.dispatch);
     });
     it("should show error and not call onClose or dispatch if URL is invalid", () => {
-      wrapper.setState({"url": "invalid"});
+      wrapper.setState({"url": ""});
       assert.equal(0, wrapper.find(".error-tooltip").length);
       wrapper.find(".add").simulate("click");
       assert.equal(1, wrapper.find(".error-tooltip").length);
@@ -601,7 +601,7 @@ describe("<TopSiteForm>", () => {
       assert.notCalled(wrapper.instance().props.dispatch);
     });
     it("should show error and not call onClose or dispatch if URL is invalid", () => {
-      wrapper.setState({"url": "invalid"});
+      wrapper.setState({"url": ""});
       assert.equal(0, wrapper.find(".error-tooltip").length);
       wrapper.find(".save").simulate("click");
       assert.equal(1, wrapper.find(".error-tooltip").length);
@@ -651,8 +651,6 @@ describe("<TopSiteForm>", () => {
     assert.ok(wrapper.instance().validateUrl());
     wrapper.setState({"url": "http://mozilla.org"});
     assert.ok(wrapper.instance().validateUrl());
-    wrapper.setState({"url": "mozillaorg"});
-    assert.isFalse(wrapper.instance().validateUrl());
     wrapper.setState({"url": "https://mozilla.invisionapp.com/d/main/#/projects/prototypes"});
     assert.ok(wrapper.instance().validateUrl());
   });

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -535,7 +535,7 @@ describe("<TopSiteForm>", () => {
       assert.notCalled(wrapper.instance().props.dispatch);
     });
     it("should show error and not call onClose or dispatch if URL is invalid", () => {
-      wrapper.setState({"url": ""});
+      wrapper.setState({"url": "not valid"});
       assert.equal(0, wrapper.find(".error-tooltip").length);
       wrapper.find(".add").simulate("click");
       assert.equal(1, wrapper.find(".error-tooltip").length);
@@ -601,7 +601,7 @@ describe("<TopSiteForm>", () => {
       assert.notCalled(wrapper.instance().props.dispatch);
     });
     it("should show error and not call onClose or dispatch if URL is invalid", () => {
-      wrapper.setState({"url": ""});
+      wrapper.setState({"url": "not valid"});
       assert.equal(0, wrapper.find(".error-tooltip").length);
       wrapper.find(".save").simulate("click");
       assert.equal(1, wrapper.find(".error-tooltip").length);
@@ -643,15 +643,41 @@ describe("<TopSiteForm>", () => {
     });
   });
 
-  it("should properly validate URLs", () => {
-    setup();
-    wrapper.setState({"url": "mozilla.org"});
-    assert.ok(wrapper.instance().validateUrl());
-    wrapper.setState({"url": "https://mozilla.org"});
-    assert.ok(wrapper.instance().validateUrl());
-    wrapper.setState({"url": "http://mozilla.org"});
-    assert.ok(wrapper.instance().validateUrl());
-    wrapper.setState({"url": "https://mozilla.invisionapp.com/d/main/#/projects/prototypes"});
-    assert.ok(wrapper.instance().validateUrl());
+  describe("#validateUrl", () => {
+    it("should properly validate URLs", () => {
+      setup();
+      wrapper.setState({"url": "mozilla.org"});
+      assert.ok(wrapper.instance().validateUrl());
+      wrapper.setState({"url": "https://mozilla.org"});
+      assert.ok(wrapper.instance().validateUrl());
+      wrapper.setState({"url": "http://mozilla.org"});
+      assert.ok(wrapper.instance().validateUrl());
+      wrapper.setState({"url": "https://mozilla.invisionapp.com/d/main/#/projects/prototypes"});
+      assert.ok(wrapper.instance().validateUrl());
+      wrapper.setState({"url": "httpfoobar"});
+      assert.ok(wrapper.instance().validateUrl());
+      wrapper.setState({"url": "httpsfoo.bar"});
+      assert.ok(wrapper.instance().validateUrl());
+      wrapper.setState({"url": "mozilla org"});
+      assert.isFalse(wrapper.instance().validateUrl());
+      wrapper.setState({"url": ""});
+      assert.isFalse(wrapper.instance().validateUrl());
+    });
+  });
+
+  describe("#cleanUrl", () => {
+    it("should properly prepend http:// to URLs when required", () => {
+      setup();
+      wrapper.setState({"url": "mozilla.org"});
+      assert.equal("http://mozilla.org", wrapper.instance().cleanUrl());
+      wrapper.setState({"url": "https.org"});
+      assert.equal("http://https.org", wrapper.instance().cleanUrl());
+      wrapper.setState({"url": "httpcom"});
+      assert.equal("http://httpcom", wrapper.instance().cleanUrl());
+      wrapper.setState({"url": "http://mozilla.org"});
+      assert.equal("http://mozilla.org", wrapper.instance().cleanUrl());
+      wrapper.setState({"url": "https://firefox.com"});
+      assert.equal("https://firefox.com", wrapper.instance().cleanUrl());
+    });
   });
 });


### PR DESCRIPTION
@Mardak thoughts on this approach?

One difference is that `new URL("http://whatever")` is valid. That's weird, but I guess it is technically correct?