### PR TITLE
fix(topsites): Closes #3296 Deleting from history should update the top sites

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -135,8 +135,11 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
         return site;
       });
       return Object.assign({}, prevState, {rows: newRows});
-    case at.PLACES_LINK_DELETED:
-    case at.PLACES_LINK_BLOCKED:
+    case at.BLOCK_URL:
+    case at.DELETE_HISTORY_URL:
+      // Optimistically update the UI by responding to the context menu action
+      // events and removing the site that was blocked/deleted with an empty slot.
+      // Once refresh() finishes, we update the UI again with a new site
       newRows = prevState.rows.filter(val => val && val.url !== action.data.url);
       return Object.assign({}, prevState, {rows: newRows});
     case at.PINNED_SITES_UPDATED:

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -177,10 +177,9 @@ this.TopSitesFeed = class TopSitesFeed {
           this.refresh(action.meta.fromTarget);
         }
         break;
-      case at.PLACES_HISTORY_CLEARED:
-        this.refresh();
-        break;
-      case at.BLOCK_URL: // Topsite blocked, we want to get a new one in.
+      case at.PLACES_HISTORY_CLEARED: // All these actions mean we need new top sites
+      case at.PLACES_LINK_DELETED:
+      case at.PLACES_LINK_BLOCKED:
         this.refresh();
         break;
       case at.PREF_CHANGED:

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -111,8 +111,8 @@ describe("Reducers", () => {
       const nextState = TopSites(undefined, {type: at.PLACES_BOOKMARK_REMOVED});
       assert.equal(nextState, INITIAL_STATE.TopSites);
     });
-    it("should remove a link on PLACES_LINK_BLOCKED and PLACES_LINK_DELETED", () => {
-      const events = [at.PLACES_LINK_BLOCKED, at.PLACES_LINK_DELETED];
+    it("should remove a link on BLOCK_URL and DELETE_HISTORY_URL", () => {
+      const events = [at.BLOCK_URL, at.DELETE_HISTORY_URL];
       events.forEach(event => {
         const oldState = {rows: [{url: "foo.com"}, {url: "bar.com"}]};
         const action = {type: event, data: {url: "bar.com"}};

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -380,10 +380,17 @@ describe("Top Sites Feed", () => {
       await feed.onAction({type: at.INIT});
       assert.calledOnce(feed.refresh);
     });
-    it("should call refresh on BLOCK_URL action", async () => {
+    it("should call refresh without a target on PLACES_LINK_BLOCKED action", async () => {
       sinon.stub(feed, "refresh");
-      await feed.onAction({type: at.BLOCK_URL});
+      await feed.onAction({type: at.PLACES_LINK_BLOCKED});
       assert.calledOnce(feed.refresh);
+      assert.equal(feed.refresh.firstCall.args[0], null);
+    });
+    it("should call refresh without a target on PLACES_LINK_DELETED action", async () => {
+      sinon.stub(feed, "refresh");
+      await feed.onAction({type: at.PLACES_LINK_DELETED});
+      assert.calledOnce(feed.refresh);
+      assert.equal(feed.refresh.firstCall.args[0], null);
     });
     it("should call pin with correct args on TOP_SITES_ADD", () => {
       const addAction = {


### PR DESCRIPTION
Fix #3296. Instead of the Reducer listening for a ```BLOCK_URL``` and also a ```TOP_SITES_UPDATED``` event that comes from TopSitesFeed.jsm when you block -> refresh, we should just send a ```TOP_SITES_UPDATED``` event when we received the OK from PlacesFeed that the link has been blocked/deleted/history cleared. That way we save ourselves a bounce of a message. 