### PR TITLE
fix(sections): Rename context_menu_options to contextMenuOptions for consistency

### DIFF
--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -81,7 +81,7 @@ class Card extends React.Component {
         index={index}
         source={eventSource}
         onUpdate={this.onMenuUpdate}
-        options={link.context_menu_options || contextMenuOptions}
+        options={link.contextMenuOptions || contextMenuOptions}
         site={link}
         visible={isContextMenuOpen} />
    </li>);

--- a/system-addon/test/unit/content-src/components/Card.test.jsx
+++ b/system-addon/test/unit/content-src/components/Card.test.jsx
@@ -62,10 +62,10 @@ describe("<Card>", () => {
     assert.equal(index, DEFAULT_PROPS.index);
   });
   it("should pass through the correct menu options to LinkMenu if overridden by individual card", () => {
-    DEFAULT_PROPS.link.context_menu_options = ["CheckBookmark"];
+    DEFAULT_PROPS.link.contextMenuOptions = ["CheckBookmark"];
     wrapper = mountWithIntl(<Card {...DEFAULT_PROPS} />);
     const {options} = wrapper.find(LinkMenu).props();
-    assert.equal(options, DEFAULT_PROPS.link.context_menu_options);
+    assert.equal(options, DEFAULT_PROPS.link.contextMenuOptions);
   });
   it("should have a context based on type", () => {
     wrapper = shallow(<Card {...DEFAULT_PROPS} />);


### PR DESCRIPTION
Setting the menu items at a section level is through `contextMenuOptions`. At a card level it's through `context_menu_options`. They should be the same, and camel case is also consistent with other card properties.