### PR TITLE
fix(topsites): Compute hostname once for defaults and only require url for shortURL

### DIFF
--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -13,13 +13,12 @@ this.Dedupe = class Dedupe {
   }
 
   /**
-   * Dedupe an array containing groups of elements.
-   * Duplicate removal favors earlier groups.
+   * Dedupe any number of grouped elements favoring those from earlier groups.
    *
    * @param {Array} groups Contains an arbitrary number of arrays of elements.
-   * @returns {Array}
+   * @returns {Array} A matching array of each provided group deduped.
    */
-  group(groups) {
+  group(...groups) {
     const globalKeys = new Set();
     const result = [];
     for (const values of groups) {

--- a/system-addon/lib/ShortURL.jsm
+++ b/system-addon/lib/ShortURL.jsm
@@ -37,31 +37,26 @@ this.getETLD = getETLD;
 
   /**
  * shortURL - Creates a short version of a link's url, used for display purposes
- *            e.g. {url: http://www.foosite.com, eTLD: "com"}  =>  "foosite"
+ *            e.g. {url: http://www.foosite.com}  =>  "foosite"
  *
  * @param  {obj} link A link object
  *         {str} link.url (required)- The url of the link
- *         {str} link.eTLD (required) - The tld of the link
- *               e.g. for https://foo.org, the tld would be "org"
- *               Note that this property is added in various queries for ActivityStream
- *               via Services.eTLD.getPublicSuffix
- *         {str} link.hostname (optional) - The hostname of the url
- *               e.g. for http://www.hello.com/foo/bar, the hostname would be "www.hello.com"
  *         {str} link.title (optional) - The title of the link
  * @return {str}   A short url
  */
 this.shortURL = function shortURL(link) {
-  if (!link.url && !link.hostname) {
+  if (!link.url) {
     return "";
   }
-  const eTLD = link.eTLD || getETLD(link.url);
-  const hostname = (link.hostname || new URL(link.url).hostname).replace(/^www\./i, "");
 
   // Remove the eTLD (e.g., com, net) and the preceding period from the hostname
-  const eTLDLength = (eTLD || "").length;
-  const eTLDExtra = eTLDLength > 0 ? -(eTLDLength + 1) : Infinity;
-  // If URL and hostname are not present fallback to page title.
-  return handleIDNHost(hostname.slice(0, eTLDExtra).toLowerCase() || hostname) || link.title || link.url;
+  const eTLD = getETLD(link.url);
+  const eTLDExtra = eTLD.length > 0 ? -(eTLD.length + 1) : Infinity;
+
+  // Clean up the url and fallback to page title or url if necessary
+  const hostname = (new URL(link.url).hostname).replace(/^www\./i, "");
+  return handleIDNHost(hostname.slice(0, eTLDExtra).toLowerCase()) ||
+    link.title || link.url;
 };
 
 this.EXPORTED_SYMBOLS = ["shortURL", "getETLD"];

--- a/system-addon/test/unit/common/Dedupe.test.js
+++ b/system-addon/test/unit/common/Dedupe.test.js
@@ -9,18 +9,18 @@ describe("Dedupe", () => {
     it("should remove duplicates inside the groups", () => {
       const beforeItems = [[1, 1, 1], [2, 2, 2], [3, 3, 3]];
       const afterItems = [[1], [2], [3]];
-      assert.deepEqual(instance.group(beforeItems), afterItems);
+      assert.deepEqual(instance.group(...beforeItems), afterItems);
     });
     it("should remove duplicates between groups, favouring earlier groups", () => {
       const beforeItems = [[1, 2, 3], [2, 3, 4], [3, 4, 5]];
       const afterItems = [[1, 2, 3], [4], [5]];
-      assert.deepEqual(instance.group(beforeItems), afterItems);
+      assert.deepEqual(instance.group(...beforeItems), afterItems);
     });
     it("should remove duplicates from groups of objects", () => {
       instance = new Dedupe(item => item.id);
       const beforeItems = [[{id: 1}, {id: 1}, {id: 2}], [{id: 1}, {id: 3}, {id: 2}], [{id: 1}, {id: 2}, {id: 5}]];
       const afterItems = [[{id: 1}, {id: 2}], [{id: 3}], [{id: 5}]];
-      assert.deepEqual(instance.group(beforeItems), afterItems);
+      assert.deepEqual(instance.group(...beforeItems), afterItems);
     });
     it("should take a custom comparison function", () => {
       function compare(previous, current) {
@@ -36,7 +36,7 @@ describe("Dedupe", () => {
         [{id: 2, amount: 100}]
       ];
 
-      assert.deepEqual(instance.group(beforeItems), afterItems);
+      assert.deepEqual(instance.group(...beforeItems), afterItems);
     });
   });
 });

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -62,7 +62,7 @@ describe("Top Sites Feed", () => {
     }));
     feed = new TopSitesFeed();
     feed.store = {dispatch: sinon.spy(), getState() { return {TopSites: {rows: Array(12).fill("site")}}; }};
-    feed.dedupe.group = sites => sites;
+    feed.dedupe.group = (...sites) => sites;
     links = FAKE_LINKS;
     clock = sinon.useFakeTimers();
   });
@@ -86,6 +86,12 @@ describe("Top Sites Feed", () => {
       feed.refreshDefaults("https://foo.com");
 
       DEFAULT_TOP_SITES.forEach(link => assert.propertyVal(link, "isDefault", true));
+    });
+    it("should have default sites with appropriate hostname", () => {
+      feed.refreshDefaults("https://foo.com");
+
+      DEFAULT_TOP_SITES.forEach(link => assert.propertyVal(link, "hostname",
+        shortURLStub(link)));
     });
     it("should add no defaults on empty pref", () => {
       feed.refreshDefaults("");
@@ -143,7 +149,7 @@ describe("Top Sites Feed", () => {
       assert.notInclude(result, blockedDefaultSite);
     });
     it("should call dedupe on the links", async () => {
-      const stub = sinon.stub(feed.dedupe, "group").callsFake(id => id);
+      const stub = sinon.stub(feed.dedupe, "group").callsFake((...id) => id);
 
       await feed.getLinksWithDefaults();
 
@@ -187,6 +193,7 @@ describe("Top Sites Feed", () => {
           "common/Reducers.jsm": {insertPinned, TOP_SITES_SHOWMORE_LENGTH},
           "lib/Screenshots.jsm": {Screenshots: fakeScreenshot}
         }));
+        sandbox.stub(global.Services.eTLD, "getPublicSuffix").returns("com");
         feed = new TopSitesFeed();
       });
       it("should not dedupe pinned sites", async () => {
@@ -202,21 +209,25 @@ describe("Top Sites Feed", () => {
         assert.equal(sites[1].url, fakeNewTabUtils.pinnedLinks.links[1].url);
         assert.equal(sites[0].hostname, sites[1].hostname);
       });
-      it("should not dedupe pinned sites", async () => {
+      it("should prefer pinned sites over links", async () => {
         fakeNewTabUtils.pinnedLinks.links = [
           {url: "https://developer.mozilla.org/en-US/docs/Web"},
           {url: "https://developer.mozilla.org/en-US/docs/Learn"}
         ];
         // These will be the frecent results.
         links = [
-          {url: "https://developer.mozilla.org/en-US/docs/Web"},
-          {url: "https://developer.mozilla.org/en-US/docs/Learn"}
+          {frecency: FAKE_FRECENCY, url: "https://developer.mozilla.org/"},
+          {frecency: FAKE_FRECENCY, url: "https://www.mozilla.org/"}
         ];
 
         const sites = await feed.getLinksWithDefaults();
 
-        // Frecent results are removed and only pinned are kept.
-        assert.lengthOf(sites, 2);
+        // Expecting 3 links where there's 2 pinned and 1 www.mozilla.org, so
+        // the frecent with matching hostname as pinned is removed.
+        assert.lengthOf(sites, 3);
+        assert.equal(sites[0].url, fakeNewTabUtils.pinnedLinks.links[0].url);
+        assert.equal(sites[1].url, fakeNewTabUtils.pinnedLinks.links[1].url);
+        assert.equal(sites[2].url, links[1].url);
       });
       it("should return sites that have a title", async () => {
         // Simulate a pinned link with no title.

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -63,7 +63,7 @@ overrider.set({
     },
     tm: {dispatchToMainThread: cb => cb()},
     eTLD: {getPublicSuffix() {}},
-    io: {NewURI() {}},
+    io: {newURI() {}},
     search: {
       init(cb) { cb(); },
       getVisibleEngines: () => [{identifier: "google"}, {identifier: "bing"}],


### PR DESCRIPTION
r?@piatra This has a few behavior changes. `Dedupe.group` now takes each array as individual parameters instead of an array of arrays. `shortURL` no longer takes a `link` with `eTLD` nor `hostname` as those are unnecessarily provided (or worse -- could be wrong) when `url` includes them. `TopSitesFeed` no longer unnecessarily calls `shortURL`.

Either of the latter 2 changes would fix #3310. Either by not incorrectly slicing hostname or not incorrectly passing a pinned link with a `hostname` to `shortURL`. This fixes both as doing things unnecessarily has led to this issue.

Screenshot of fix where pinned amazon.com and visited bbc.com dedupe GB's default amazon.co.uk and bbc.co.uk:
![screen shot 2017-08-30 at 4 23 19 pm](https://user-images.githubusercontent.com/438537/29899548-ed9c5f04-8da0-11e7-9c01-5eee62b5f851.png)

Also, might be useful to note that `TopSitesFeed.test.js` did **not** catch this because there's a fake shortURL being used.