### PR TITLE
fix(systemaddon): Fix #3203 Avoid impacting performance when listening to onItemChanged for bookmarks - avoid the fetch by disabling the unused code for now.

### DIFF
--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -127,21 +127,29 @@ class BookmarksObserver extends Observer {
    * @param  {str} guid         The unique id of the bookmark
    */
   async onItemChanged(...args) {
-    const property = args[1];
-    const type = args[5];
-    const guid = args[7];
+    // Disabled due to performance cost, see Issue 3203 /
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1392267.
+    //
+    // If this is used, please consider avoiding the call to
+    // NewTabUtils.activityStreamProvider.getBookmark which performs an additional
+    // fetch to the database.
+    // If you need more fields, please talk to the places team.
 
-    // Only process this event if it is a TYPE_BOOKMARK, and uri or title was the property changed.
-    if (type !== PlacesUtils.bookmarks.TYPE_BOOKMARK || !["uri", "title"].includes(property)) {
-      return;
-    }
-    try {
-      // bookmark: {bookmarkGuid, bookmarkTitle, lastModified, url}
-      const bookmark = await NewTabUtils.activityStreamProvider.getBookmark(guid);
-      this.dispatch({type: at.PLACES_BOOKMARK_CHANGED, data: bookmark});
-    } catch (e) {
-      Cu.reportError(e);
-    }
+    // const property = args[1];
+    // const type = args[5];
+    // const guid = args[7];
+    //
+    // // Only process this event if it is a TYPE_BOOKMARK, and uri or title was the property changed.
+    // if (type !== PlacesUtils.bookmarks.TYPE_BOOKMARK || !["uri", "title"].includes(property)) {
+    //   return;
+    // }
+    // try {
+    //   // bookmark: {bookmarkGuid, bookmarkTitle, lastModified, url}
+    //   const bookmark = await NewTabUtils.activityStreamProvider.getBookmark(guid);
+    //   this.dispatch({type: at.PLACES_BOOKMARK_CHANGED, data: bookmark});
+    // } catch (e) {
+    //   Cu.reportError(e);
+    // }
   }
 }
 

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -241,13 +241,17 @@ describe("PlacesFeed", () => {
         sandbox.stub(global.NewTabUtils.activityStreamProvider, "getBookmark")
           .withArgs(FAKE_BOOKMARK.guid).returns(Promise.resolve(FAKE_BOOKMARK));
       });
-      it("should dispatch a PLACES_BOOKMARK_CHANGED action with the bookmark data", async () => {
+      it("has an empty function to keep xpconnect happy", async () => {
+        await observer.onItemChanged();
+      });
+      // Disabled in Issue 3203, see observer.onItemChanged for more information.
+      it.skip("should dispatch a PLACES_BOOKMARK_CHANGED action with the bookmark data", async () => {
         const args = [null, "title", null, null, null, TYPE_BOOKMARK, null, FAKE_BOOKMARK.guid];
         await observer.onItemChanged(...args);
 
         assert.calledWith(dispatch, {type: at.PLACES_BOOKMARK_CHANGED, data: FAKE_BOOKMARK});
       });
-      it("should catch errors gracefully", async () => {
+      it.skip("should catch errors gracefully", async () => {
         const e = new Error("test error");
         global.NewTabUtils.activityStreamProvider.getBookmark.restore();
         sandbox.stub(global.NewTabUtils.activityStreamProvider, "getBookmark")
@@ -258,11 +262,11 @@ describe("PlacesFeed", () => {
 
         assert.calledWith(global.Components.utils.reportError, e);
       });
-      it("should ignore events that are not of TYPE_BOOKMARK", async () => {
+      it.skip("should ignore events that are not of TYPE_BOOKMARK", async () => {
         await observer.onItemChanged(null, "title", null, null, null, "nottypebookmark");
         assert.notCalled(dispatch);
       });
-      it("should ignore events that are not changes to uri/title", async () => {
+      it.skip("should ignore events that are not changes to uri/title", async () => {
         await observer.onItemChanged(null, "tags", null, null, null, TYPE_BOOKMARK);
         assert.notCalled(dispatch);
       });


### PR DESCRIPTION
As this isn't used yet, I'm suggesting that we disable the code for now - we're starting to look at bookmarks performance with respect to recent changes, so I'd like to get this cleaned up.

I've also added a comment that we're happy to talk about adding more fields if we need to in future.