### PR TITLE
fix(systemaddon): Fix #3201 Add missing history/bookmark observer methods to avoid warnings from xpconnect.

### DIFF
--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -55,6 +55,16 @@ class HistoryObserver extends Observer {
   onClearHistory() {
     this.dispatch({type: at.PLACES_HISTORY_CLEARED});
   }
+
+  // Empty functions to make xpconnect happy
+  onBeginUpdateBatch() {}
+  onEndUpdateBatch() {}
+  onVisit() {}
+  onTitleChanged() {}
+  onFrecencyChanged() {}
+  onManyFrecenciesChanged() {}
+  onPageChanged() {}
+  onDeleteVisits() {}
 }
 
 /**
@@ -143,6 +153,12 @@ class BookmarksObserver extends Observer {
       Cu.reportError(e);
     }
   }
+
+  // Empty functions to make xpconnect happy
+  onBeginUpdateBatch() {}
+  onEndUpdateBatch() {}
+  onItemVisited() {}
+  onItemMoved() {}
 }
 
 class PlacesFeed {

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -184,6 +184,18 @@ describe("PlacesFeed", () => {
         assert.calledWith(dispatch, {type: at.PLACES_HISTORY_CLEARED});
       });
     });
+    describe("Other empty methods (to keep code coverage happy)", () => {
+      it("should have a various empty functions for xpconnect happiness", () => {
+        observer.onBeginUpdateBatch();
+        observer.onEndUpdateBatch();
+        observer.onVisit();
+        observer.onTitleChanged();
+        observer.onFrecencyChanged();
+        observer.onManyFrecenciesChanged();
+        observer.onPageChanged();
+        observer.onDeleteVisits();
+      });
+    });
   });
 
   describe("BookmarksObserver", () => {
@@ -265,6 +277,14 @@ describe("PlacesFeed", () => {
       it("should ignore events that are not changes to uri/title", async () => {
         await observer.onItemChanged(null, "tags", null, null, null, TYPE_BOOKMARK);
         assert.notCalled(dispatch);
+      });
+    });
+    describe("Other empty methods (to keep code coverage happy)", () => {
+      it("should have a various empty functions for xpconnect happiness", () => {
+        observer.onBeginUpdateBatch();
+        observer.onEndUpdateBatch();
+        observer.onItemVisited();
+        observer.onItemMoved();
       });
     });
   });


### PR DESCRIPTION
Fix #3201. This fixes the warnings and makes everything happy again.