### PR TITLE
feat(mc): #3262 Add placeholders for TopSites

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -5,6 +5,41 @@ const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
 
 const {TOP_SITES_SOURCE, TOP_SITES_CONTEXT_MENU_OPTIONS} = require("./TopSitesConstants");
 
+const TopSiteLink = props => {
+  const {link} = props;
+  const topSiteOuterClassName = `top-site-outer${props.className ? ` ${props.className}` : ""}`;
+  const {tippyTopIcon} = link;
+  let imageClassName;
+  let imageStyle;
+  if (tippyTopIcon) {
+    imageClassName = "tippy-top-icon";
+    imageStyle = {
+      backgroundColor: link.backgroundColor,
+      backgroundImage: `url(${tippyTopIcon})`
+    };
+  } else {
+    imageClassName = `screenshot${link.screenshot ? " active" : ""}`;
+    imageStyle = {backgroundImage: link.screenshot ? `url(${link.screenshot})` : "none"};
+  }
+  return (<li className={topSiteOuterClassName} key={link.guid || link.url}>
+   <a href={link.url} onClick={props.onClick}>
+     <div className="tile" aria-hidden={true}>
+         <span className="letter-fallback">{props.title[0]}</span>
+         <div className={imageClassName} style={imageStyle} />
+     </div>
+     <div className={`title ${link.isPinned ? "pinned" : ""}`}>
+       {link.isPinned && <div className="icon icon-pin-small" />}
+       <span dir="auto">{props.title}</span>
+     </div>
+   </a>
+   {props.children}
+  </li>);
+};
+TopSiteLink.defaultProps = {
+  title: "",
+  link: {}
+};
+
 class TopSite extends React.Component {
   constructor(props) {
     super(props);
@@ -78,42 +113,19 @@ class TopSite extends React.Component {
     this.props.onEdit(this.props.index);
   }
   render() {
-    const {link, index, dispatch, editMode} = this.props;
-    const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === index;
+    const {props} = this;
+    const {link} = props;
+    const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === props.index;
     const title = link.label || link.hostname;
-    const topSiteOuterClassName = `top-site-outer${isContextMenuOpen ? " active" : ""}`;
-    const {tippyTopIcon} = link;
-    let imageClassName;
-    let imageStyle;
-    if (tippyTopIcon) {
-      imageClassName = "tippy-top-icon";
-      imageStyle = {
-        backgroundColor: link.backgroundColor,
-        backgroundImage: `url(${tippyTopIcon})`
-      };
-    } else {
-      imageClassName = `screenshot${link.screenshot ? " active" : ""}`;
-      imageStyle = {backgroundImage: link.screenshot ? `url(${link.screenshot})` : "none"};
-    }
-    return (<li className={topSiteOuterClassName} key={link.guid || link.url}>
-        <a href={link.url} onClick={this.onLinkClick}>
-          <div className="tile" aria-hidden={true}>
-              <span className="letter-fallback">{title[0]}</span>
-              <div className={imageClassName} style={imageStyle} />
-          </div>
-          <div className={`title ${link.isPinned ? "pinned" : ""}`}>
-            {link.isPinned && <div className="icon icon-pin-small" />}
-            <span dir="auto">{title}</span>
-          </div>
-        </a>
-        {!editMode &&
+    return (<TopSiteLink {...props} onClick={this.onLinkClick} className={isContextMenuOpen ? "active" : ""} title={title}>
+        {!props.editMode &&
           <div>
             <button className="context-menu-button icon" onClick={this.onMenuButtonClick}>
               <span className="sr-only">{`Open context menu for ${title}`}</span>
             </button>
             <LinkMenu
-              dispatch={dispatch}
-              index={index}
+              dispatch={props.dispatch}
+              index={props.index}
               onUpdate={this.onMenuUpdate}
               options={TOP_SITES_CONTEXT_MENU_OPTIONS}
               site={link}
@@ -121,7 +133,7 @@ class TopSite extends React.Component {
               visible={isContextMenuOpen} />
           </div>
         }
-        {editMode &&
+        {props.editMode &&
           <div className="edit-menu">
             <button
               className={`icon icon-${link.isPinned ? "unpin" : "pin"}`}
@@ -137,13 +149,17 @@ class TopSite extends React.Component {
               onClick={this.onDismissButtonClick} />
           </div>
         }
-    </li>);
+    </TopSiteLink>);
   }
 }
-
 TopSite.defaultProps = {
   editMode: false,
+  link: {},
   onEdit() {}
 };
 
-module.exports = TopSite;
+const TopSitePlaceholder = () => <TopSiteLink className="placeholder" />;
+
+module.exports.TopSite = TopSite;
+module.exports.TopSiteLink = TopSiteLink;
+module.exports.TopSitePlaceholder = TopSitePlaceholder;

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -4,22 +4,27 @@ const {FormattedMessage} = require("react-intl");
 
 const TopSitesPerfTimer = require("./TopSitesPerfTimer");
 const TopSitesEdit = require("./TopSitesEdit");
-const TopSite = require("./TopSite");
+const {TopSite, TopSitePlaceholder} = require("./TopSite");
 
-const TopSites = props => (<TopSitesPerfTimer>
-  <section className="top-sites">
-    <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
-    <ul className="top-sites-list">
-      {props.TopSites.rows.slice(0, props.TopSitesCount).map((link, index) => link && <TopSite
-        key={link.guid || link.url}
-        dispatch={props.dispatch}
-        link={link}
-        index={index}
-        intl={props.intl} />)}
-    </ul>
-    <TopSitesEdit {...props} />
-  </section>
-</TopSitesPerfTimer>);
+const TopSites = props => {
+  const realTopSites = props.TopSites.rows.slice(0, props.TopSitesCount);
+  const placeholderCount = props.TopSitesCount - realTopSites.length;
+  return (<TopSitesPerfTimer>
+    <section className="top-sites">
+      <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
+      <ul className="top-sites-list">
+        {realTopSites.map((link, index) => link && <TopSite
+          key={link.guid || link.url}
+          dispatch={props.dispatch}
+          link={link}
+          index={index}
+          intl={props.intl} />)}
+        {placeholderCount > 0 && [...Array(placeholderCount)].map((_, i) => <TopSitePlaceholder key={i} />)}
+      </ul>
+      {realTopSites.length > 0 && <TopSitesEdit {...props} />}
+    </section>
+  </TopSitesPerfTimer>);
+};
 
 module.exports = connect(state => ({TopSites: state.TopSites, TopSitesCount: state.Prefs.values.topSitesCount}))(TopSites);
 module.exports._unconnected = TopSites;

--- a/system-addon/content-src/components/TopSites/TopSitesEdit.jsx
+++ b/system-addon/content-src/components/TopSites/TopSitesEdit.jsx
@@ -3,7 +3,7 @@ const {FormattedMessage, injectIntl} = require("react-intl");
 const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
 
 const TopSiteForm = require("./TopSiteForm");
-const TopSite = require("./TopSite");
+const {TopSite, TopSitePlaceholder} = require("./TopSite");
 
 const {TOP_SITES_DEFAULT_LENGTH, TOP_SITES_SHOWMORE_LENGTH} = require("common/Reducers.jsm");
 const {TOP_SITES_SOURCE} = require("./TopSitesConstants");
@@ -68,6 +68,8 @@ class TopSitesEdit extends React.Component {
     }));
   }
   render() {
+    const realTopSites = this.props.TopSites.rows.slice(0, this.props.TopSitesCount);
+    const placeholderCount = this.props.TopSitesCount - realTopSites.length;
     return (<div className="edit-topsites-wrapper">
       <div className="edit-topsites-button">
         <button
@@ -84,7 +86,7 @@ class TopSitesEdit extends React.Component {
             <section className="edit-topsites-inner-wrapper">
               <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
               <ul className="top-sites-list">
-                {this.props.TopSites.rows.slice(0, this.props.TopSitesCount).map((link, index) => link && <TopSite
+                {realTopSites.map((link, index) => link && <TopSite
                   key={link.guid || link.url}
                   dispatch={this.props.dispatch}
                   link={link}
@@ -92,6 +94,7 @@ class TopSitesEdit extends React.Component {
                   intl={this.props.intl}
                   onEdit={this.onEdit}
                   editMode={true} />)}
+                  {placeholderCount > 0 && [...Array(placeholderCount)].map((_, i) => <TopSitePlaceholder key={i} />)}
               </ul>
             </section>
             <section className="actions">

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -102,6 +102,15 @@
       justify-content: center;
     }
 
+    &.placeholder {
+      .tile {
+        box-shadow: inset $inner-box-shadow;
+      }
+      .screenshot {
+        display: none;
+      }
+    }
+
     .screenshot {
       position: absolute;
       top: 0;
@@ -135,7 +144,7 @@
 
     .title {
       font: message-box;
-      height: 20px;
+      height: $top-sites-title-height;
       line-height: $top-sites-title-height;
       text-align: center;
       width: $top-sites-size;
@@ -149,6 +158,7 @@
       }
 
       span {
+        height: $top-sites-title-height;
         display: block;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
This adds placeholders for TopSites. Part of the prerendering work.

This is alternative approach that requires fewer changes, which one do you think is better?

https://github.com/mozilla/activity-stream/compare/master...k88hudson:gh3262b?expand=1