### PR TITLE
chore(search): Closes #3321 Change contentSearchUIController to better match existing tests

### DIFF
--- a/system-addon/content-src/lib/constants.js
+++ b/system-addon/content-src/lib/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // constant to know if the page is about:newtab or about:home
+  IS_NEWTAB: document.documentURI === "about:newtab"
+};

--- a/system-addon/test/unit/content-src/components/Search.test.jsx
+++ b/system-addon/test/unit/content-src/components/Search.test.jsx
@@ -45,12 +45,19 @@ describe("<Search>", () => {
     assert.equal(spy.firstCall.args[0], "ContentSearchClient");
     assert.equal(spy.firstCall.args[1], wrapper.node);
   });
+  it("should add gContentSearchController as a global", () => {
+    // current about:home tests need gContentSearchController to exist as a global
+    // so let's test it here too to ensure we don't break this behaviour
+    mountWithIntl(<Search {...DEFAULT_PROPS} />);
+    assert.property(window, "gContentSearchController");
+    assert.ok(window.gContentSearchController);
+  });
   it("should pass along search when clicking the search button", () => {
     const wrapper = mountWithIntl(<Search {...DEFAULT_PROPS} />);
 
     wrapper.find(".search-button").simulate("click");
 
-    const {search} = wrapper.node.controller;
+    const {search} = window.gContentSearchController;
     assert.calledOnce(search);
     assert.propertyVal(search.firstCall.args[0], "type", "click");
   });


### PR DESCRIPTION
Fix #3321.
1. Exposes  gContentSearchcontroller to window so that various tests in browser_aboutHome.js can find it (and removes it on unmount)
2. Adds a healthReportKey and a source depending on the document uri. see -> http://searchfox.org/mozilla-central/source/browser/base/content/abouthome/aboutHome.js#235-236