### PR TITLE
fix(styles): Have pref options stretch in height but anchor icon to top line

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -66,17 +66,18 @@
       padding: 10px;
 
       label {
-        background-position: 35px center;
+        background-position-x: 35px;
+        background-position-y: 2.5px;
         background-repeat: no-repeat;
         display: inline-block;
         font-size: 13px;
         font-weight: normal;
-        height: 21px;
+        height: auto;
         line-height: 21px;
         width: 100%;
 
         &:dir(rtl) {
-          background-position: 217px center;
+          background-position-x: 217px;
         }
       }
       [type='checkbox']:not(:checked) + label,


### PR DESCRIPTION
Fix #3313. r?@rlr 

<img width="348" alt="image" src="https://user-images.githubusercontent.com/438537/29944349-1638dae4-8e52-11e7-875b-df3abde432dc.png">
