### PR TITLE
Placeholders for sections

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -199,7 +199,7 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
       // the section has an order, insert it at the correct place in the array.
       // Otherwise, prepend it and set the order to be minimal.
       if (!hasMatch) {
-        const initialized = action.data.rows && action.data.rows.length > 0;
+        const initialized = !!(action.data.rows && action.data.rows.length > 0);
         let order;
         let index;
         if (prevState.length > 0) {
@@ -209,14 +209,17 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
           order = action.data.order || 1;
           index = 0;
         }
-        const section = Object.assign({title: "", initialized, rows: [], order, enabled: false}, action.data);
+        const section = Object.assign({title: "", rows: [], order, enabled: false}, action.data, {initialized});
         newState.splice(index, 0, section);
       }
       return newState;
     case at.SECTION_UPDATE:
       return prevState.map(section => {
         if (section && section.id === action.data.id) {
-          return Object.assign({}, section, action.data);
+          // If the action is updating rows, we should consider initialized to be true.
+          // This can be overridden if initialized is defined in the action.data
+          const initialized = action.data.rows ? {initialized: true} : {};
+          return Object.assign({}, section, initialized, action.data);
         }
         return section;
       });

--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -52,11 +52,12 @@ class Card extends React.Component {
   }
   render() {
     const {index, link, dispatch, contextMenuOptions, eventSource} = this.props;
+    const {props} = this;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeCard === index;
     const {icon, intlID} = link.type ? cardContextTypes[link.type] : {};
 
-    return (<li className={`card-outer${isContextMenuOpen ? " active" : ""}`}>
-      <a href={link.url} onClick={this.onLinkClick}>
+    return (<li className={`card-outer${isContextMenuOpen ? " active" : ""}${props.placeholder ? " placeholder" : ""}`}>
+      <a href={link.url} onClick={!props.placeholder && this.onLinkClick}>
         <div className="card">
           {link.image && <div className="card-preview-image" style={{backgroundImage: `url(${link.image})`}} />}
           <div className={`card-details${link.image ? "" : " no-image"}`}>
@@ -72,19 +73,24 @@ class Card extends React.Component {
           </div>
         </div>
       </a>
-      <button className="context-menu-button icon"
+      {!props.placeholder && <button className="context-menu-button icon"
         onClick={this.onMenuButtonClick}>
         <span className="sr-only">{`Open context menu for ${link.title}`}</span>
-      </button>
-      <LinkMenu
+      </button>}
+      {!props.placeholder && <LinkMenu
         dispatch={dispatch}
         index={index}
         source={eventSource}
         onUpdate={this.onMenuUpdate}
         options={link.contextMenuOptions || contextMenuOptions}
         site={link}
-        visible={isContextMenuOpen} />
+        visible={isContextMenuOpen} />}
    </li>);
   }
 }
+Card.defaultProps = {link: {}};
+
+const PlaceholderCard = () => <Card placeholder={true} />;
+
 module.exports = Card;
+module.exports.PlaceholderCard = PlaceholderCard;

--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -8,6 +8,13 @@
   position: relative;
   @include context-menu-button;
 
+  &.placeholder {
+    background: transparent;
+    .card {
+      box-shadow:  inset $inner-box-shadow;
+    }
+  }
+
   .card {
     height: 100%;
     border-radius: $border-radius;

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -117,7 +117,11 @@ class Section extends React.Component {
   }
 
   render() {
-    const {id, eventSource, title, icon, rows, infoOption, emptyState, dispatch, maxRows, contextMenuOptions, intl, initialized} = this.props;
+    const {
+      id, eventSource, title, icon, rows,
+      infoOption, emptyState, dispatch, maxRows,
+      contextMenuOptions, intl, initialized
+    } = this.props;
     const maxCards = CARDS_PER_ROW * maxRows;
     const shouldShowTopics = (id === "topstories" &&
       this.props.topics &&

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -92,7 +92,7 @@ const SectionsManager = {
     this.emit(this.ENABLE_SECTION, id);
   },
   disableSection(id) {
-    this.updateSection(id, {enabled: false, rows: []}, true);
+    this.updateSection(id, {enabled: false, rows: [], initialized: false}, true);
     this.emit(this.DISABLE_SECTION, id);
   },
   updateSections() {

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -58,60 +58,59 @@ this.TopStoriesFeed = class TopStoriesFeed {
   }
 
   async fetchStories() {
-    if (this.stories_endpoint) {
-      const stories = await fetch(this.stories_endpoint)
-        .then(response => {
-          if (response.ok) {
-            return response.text();
-          }
-          throw new Error(`Stories endpoint returned unexpected status: ${response.status}`);
-        })
-        .then(body => {
-          const response = JSON.parse(body);
-          this.updateDomainAffinities(response.settings);
+    if (!this.stories_endpoint) {
+      return;
+    }
+    try {
+      const response = await fetch(this.stories_endpoint);
 
-          const items = response.recommendations
-            .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
-            .map(s => ({
-              "guid": s.id,
-              "hostname": shortURL(Object.assign({}, s, {url: s.url})),
-              "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
-              "title": s.title,
-              "description": s.excerpt,
-              "image": this._normalizeUrl(s.image_src),
-              "referrer": this.stories_referrer,
-              "url": s.url,
-              "score": this.personalized ? this.affinityProvider.calculateItemRelevanceScore(s) : 1
-            }))
-            .sort(this.personalized ? this.compareScore : (a, b) => 0);
-
-          return this.rotate(items);
-        })
-        .catch(error => Cu.reportError(`Failed to fetch content: ${error.message}`));
-
-      if (stories) {
-        this.dispatchUpdateEvent(this.storiesLastUpdated, {rows: stories});
-        this.storiesLastUpdated = Date.now();
+      if (!response.ok) {
+        throw new Error(`Stories endpoint returned unexpected status: ${response.status}`);
       }
+
+      const body = await response.json();
+      this.updateDomainAffinities(body.settings);
+
+      const recommendations = body.recommendations
+        .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
+        .map(s => ({
+          "guid": s.id,
+          "hostname": shortURL(Object.assign({}, s, {url: s.url})),
+          "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
+          "title": s.title,
+          "description": s.excerpt,
+          "image": this._normalizeUrl(s.image_src),
+          "referrer": this.stories_referrer,
+          "url": s.url,
+          "score": this.personalized ? this.affinityProvider.calculateItemRelevanceScore(s) : 1
+        }))
+        .sort(this.personalized ? this.compareScore : (a, b) => 0);
+
+      const rows = this.rotate(recommendations);
+
+      this.dispatchUpdateEvent(this.storiesLastUpdated, {rows});
+      this.storiesLastUpdated = Date.now();
+    } catch (error) {
+      Cu.reportError(`Failed to fetch content: ${error.message}`);
     }
   }
 
   async fetchTopics() {
-    if (this.topics_endpoint) {
-      const topics = await fetch(this.topics_endpoint)
-        .then(response => {
-          if (response.ok) {
-            return response.text();
-          }
-          throw new Error(`Topics endpoint returned unexpected status: ${response.status}`);
-        })
-        .then(body => JSON.parse(body).topics)
-        .catch(error => Cu.reportError(`Failed to fetch topics: ${error.message}`));
-
+    if (!this.topics_endpoint) {
+      return;
+    }
+    try {
+      const response = await fetch(this.topics_endpoint);
+      if (!response.ok) {
+        throw new Error(`Topics endpoint returned unexpected status: ${response.status}`);
+      }
+      const {topics} = await response.json();
       if (topics) {
         this.dispatchUpdateEvent(this.topicsLastUpdated, {topics, read_more_endpoint: this.read_more_endpoint});
         this.topicsLastUpdated = Date.now();
       }
+    } catch (error) {
+      Cu.reportError(`Failed to fetch topics: ${error.message}`);
     }
   }
 

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -268,6 +268,20 @@ describe("Reducers", () => {
       const updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.ok(updatedSection && updatedSection.title === NEW_TITLE);
     });
+    it("should set initialized to false on SECTION_REGISTER if there are no rows", () => {
+      const NEW_TITLE = "New Title";
+      const action = {type: at.SECTION_REGISTER, data: {id: "bloop", title: NEW_TITLE}};
+      const newState = Sections(oldState, action);
+      const updatedSection = newState.find(section => section.id === "bloop");
+      assert.propertyVal(updatedSection, "initialized", false);
+    });
+    it("should set initialized to true on SECTION_REGISTER if there are rows", () => {
+      const NEW_TITLE = "New Title";
+      const action = {type: at.SECTION_REGISTER, data: {id: "bloop", title: NEW_TITLE, rows: [{}, {}]}};
+      const newState = Sections(oldState, action);
+      const updatedSection = newState.find(section => section.id === "bloop");
+      assert.propertyVal(updatedSection, "initialized", true);
+    });
     it("should have no effect on SECTION_UPDATE if the id doesn't exist", () => {
       const action = {type: at.SECTION_UPDATE, data: {id: "fake_id", data: "fake_data"}};
       const newState = Sections(oldState, action);
@@ -279,6 +293,20 @@ describe("Reducers", () => {
       const newState = Sections(oldState, action);
       const updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.include(updatedSection, FAKE_DATA);
+    });
+    it("should set initialized to true on SECTION_UPDATE if rows is defined on action.data", () => {
+      const data = {rows: [], id: "foo_bar_2"};
+      const action = {type: at.SECTION_UPDATE, data};
+      const newState = Sections(oldState, action);
+      const updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.propertyVal(updatedSection, "initialized", true);
+    });
+    it("should allow action.data to set .initialized", () => {
+      const data = {rows: [], initialized: false, id: "foo_bar_2"};
+      const action = {type: at.SECTION_UPDATE, data};
+      const newState = Sections(oldState, action);
+      const updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.propertyVal(updatedSection, "initialized", false);
     });
     it("should remove blocked and deleted urls from all rows in all sections", () => {
       const blockAction = {type: at.PLACES_LINK_BLOCKED, data: {url: "www.foo.bar"}};

--- a/system-addon/test/unit/content-src/components/Card.test.jsx
+++ b/system-addon/test/unit/content-src/components/Card.test.jsx
@@ -2,6 +2,7 @@ const React = require("react");
 const {shallow} = require("enzyme");
 const {mountWithIntl} = require("test/unit/utils");
 const Card = require("content-src/components/Card/Card");
+const {PlaceholderCard} = Card;
 const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
 const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
 const cardContextTypes = require("content-src/components/Card/types");
@@ -82,6 +83,28 @@ describe("<Card>", () => {
     assert.isTrue(wrapper.find(".card-outer").hasClass("active"));
   });
 
+  describe("placeholder=true", () => {
+    beforeEach(() => {
+      wrapper = mountWithIntl(<Card placeholder={true} />);
+    });
+    it("should render when placeholder=true", () => {
+      assert.ok(wrapper.exists());
+    });
+    it("should add a placeholder class to the outer element", () => {
+      assert.isTrue(wrapper.find(".card-outer").hasClass("placeholder"));
+    });
+    it("should not have a context menu button or LinkMenu", () => {
+      assert.isFalse(wrapper.find(".context-menu-button").exists(), "context menu button");
+      assert.isFalse(wrapper.find(LinkMenu).exists(), "LinkMenu");
+    });
+    it("should not call onLinkClick when the link is clicked", () => {
+      const spy = sinon.spy(wrapper.instance(), "onLinkClick");
+      const card = wrapper.find(".card");
+      card.simulate("click");
+      assert.notCalled(spy);
+    });
+  });
+
   describe("#trackClick", () => {
     it("should call dispatch when the link is clicked with the right data", () => {
       const card = wrapper.find(".card");
@@ -109,5 +132,12 @@ describe("<Card>", () => {
         tiles: [{id: DEFAULT_PROPS.link.guid, pos: DEFAULT_PROPS.index}]
       }));
     });
+  });
+});
+
+describe("<PlaceholderCard />", () => {
+  it("should render a Card with placeholder=true", () => {
+    const wrapper = shallow(<PlaceholderCard />);
+    assert.isTrue(wrapper.find(Card).props().placeholder);
   });
 });

--- a/system-addon/test/unit/lib/SectionsManager.test.js
+++ b/system-addon/test/unit/lib/SectionsManager.test.js
@@ -109,12 +109,12 @@ describe("SectionsManager", () => {
     });
   });
   describe("#disableSection", () => {
-    it("should call updateSection with {enabled: false, rows: []}", () => {
+    it("should call updateSection with {enabled: false, rows: [], initialized: false}", () => {
       sinon.spy(SectionsManager, "updateSection");
       SectionsManager.addSection(FAKE_ID, FAKE_OPTIONS);
       SectionsManager.disableSection(FAKE_ID);
       assert.calledOnce(SectionsManager.updateSection);
-      assert.calledWith(SectionsManager.updateSection, FAKE_ID, {enabled: false, rows: []}, true);
+      assert.calledWith(SectionsManager.updateSection, FAKE_ID, {enabled: false, rows: [], initialized: false}, true);
       SectionsManager.updateSection.restore();
     });
     it("should emit a DISABLE_SECTION event", () => {

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -140,13 +140,16 @@ describe("Top Stories Feed", () => {
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
-      const response = `{"recommendations": [{"id" : "1",
-        "title": "title",
-        "excerpt": "description",
-        "image_src": "image-url",
-        "url": "rec-url",
-        "published_timestamp" : "123"
-      }]}`;
+      const response = {
+        "recommendations": [{
+          "id": "1",
+          "title": "title",
+          "excerpt": "description",
+          "image_src": "image-url",
+          "url": "rec-url",
+          "published_timestamp": "123"
+        }]
+      };
       const stories = [{
         "guid": "1",
         "type": "now",
@@ -161,7 +164,7 @@ describe("Top Stories Feed", () => {
 
       instance.stories_endpoint = "stories-endpoint";
       instance.stories_referrer = "referrer";
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
       await instance.fetchStories();
 
       assert.calledOnce(fetchStub);
@@ -193,9 +196,9 @@ describe("Top Stories Feed", () => {
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: site => site.url === "blocked"}});
 
-      const response = `{"recommendations": [{"url" : "blocked"}, {"url" : "not_blocked"}]}`;
+      const response = {"recommendations": [{"url": "blocked"}, {"url": "not_blocked"}]};
       instance.stories_endpoint = "stories-endpoint";
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
       await instance.fetchStories();
 
       assert.calledOnce(sectionsManagerStub.updateSection);
@@ -207,16 +210,16 @@ describe("Top Stories Feed", () => {
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
       clock.restore();
-      const response = JSON.stringify({
+      const response = {
         "recommendations": [
           {"published_timestamp": Date.now() / 1000},
           {"published_timestamp": "0"},
           {"published_timestamp": (Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000}
         ]
-      });
+      };
 
       instance.stories_endpoint = "stories-endpoint";
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
 
       await instance.fetchStories();
       assert.calledOnce(sectionsManagerStub.updateSection);
@@ -229,7 +232,7 @@ describe("Top Stories Feed", () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
 
-      const response = `{"topics": [{"name" : "topic1", "url" : "url-topic1"}, {"name" : "topic2", "url" : "url-topic2"}]}`;
+      const response = {"topics": [{"name": "topic1", "url": "url-topic1"}, {"name": "topic2", "url": "url-topic2"}]};
       const topics = [{
         "name": "topic1",
         "url": "url-topic1"
@@ -239,7 +242,7 @@ describe("Top Stories Feed", () => {
       }];
 
       instance.topics_endpoint = "topics-endpoint";
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
       await instance.fetchTopics();
 
       assert.calledOnce(fetchStub);
@@ -262,24 +265,24 @@ describe("Top Stories Feed", () => {
       assert.called(Components.utils.reportError);
     });
     it("should initialize user domain affinity provider if personalization is preffed on", async () => {
-      const response = `{
+      const response = {
         "recommendations":  [{
-          "id" : "1",
+          "id": "1",
           "title": "title",
           "excerpt": "description",
           "image_src": "image-url",
           "url": "rec-url",
-          "published_timestamp" : "123"}
-        ],
+          "published_timestamp": "123"
+        }],
         "settings": {"timeSegments": {}, "domainAffinityParameterSets": {}}
-      }`;
+      };
 
       instance.affinityProvider = undefined;
 
       instance.stories_endpoint = "stories-endpoint";
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
 
       await instance.fetchStories();
       assert.isUndefined(instance.affinityProvider);
@@ -289,10 +292,10 @@ describe("Top Stories Feed", () => {
       assert.isDefined(instance.affinityProvider);
     });
     it("should sort stories if personalization is preffed on", async () => {
-      const response = `{
-        "recommendations":  [{"id" : "1"}, {"id" : "2"}],
+      const response = {
+        "recommendations":  [{"id": "1"}, {"id": "2"}],
         "settings": {"timeSegments": {}, "domainAffinityParameterSets": {}}
-      }`;
+      };
 
       instance.personalized = true;
       instance.compareScore = sinon.spy();
@@ -301,7 +304,7 @@ describe("Top Stories Feed", () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
 
       await instance.fetchStories();
       assert.calledOnce(instance.compareScore);
@@ -319,7 +322,7 @@ describe("Top Stories Feed", () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
-      fetchStub.resolves({ok: true, status: 200, text: () => response});
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
 
       await instance.fetchStories();
       assert.notCalled(instance.compareScore);


### PR DESCRIPTION
This also changes the behaviour of sections relative to `initialized` somewhat.

- When sections are first registered, `initialized` is  `false` unless the register action contains non-empty `rows` (in that case, `initialized` will be `true`). 
- When a section is *updated* with an action that includes the `rows` property, `initialized` is set to `true` whether or not rows are empty.

The result of this is that when the section first starts, it will show placeholders; it will only show the empty state if it receives an empty response and there is no data to show.