### PR TITLE
fix(places): Avoid impacting performance when listening to onItemAdded - switch to dateAdded to avoid an extra fetch (#3204)

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -114,8 +114,8 @@ function TopSites(prevState = INITIAL_STATE.TopSites, action) {
       }
       newRows = prevState.rows.map(site => {
         if (site && site.url === action.data.url) {
-          const {bookmarkGuid, bookmarkTitle, lastModified} = action.data;
-          return Object.assign({}, site, {bookmarkGuid, bookmarkTitle, bookmarkDateCreated: lastModified});
+          const {bookmarkGuid, bookmarkTitle, dateAdded} = action.data;
+          return Object.assign({}, site, {bookmarkGuid, bookmarkTitle, bookmarkDateCreated: dateAdded});
         }
         return site;
       });
@@ -231,8 +231,8 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
         rows: section.rows.map(item => {
           // find the item within the rows that is attempted to be bookmarked
           if (item.url === action.data.url) {
-            const {bookmarkGuid, bookmarkTitle, lastModified} = action.data;
-            Object.assign(item, {bookmarkGuid, bookmarkTitle, bookmarkDateCreated: lastModified});
+            const {bookmarkGuid, bookmarkTitle, dateAdded} = action.data;
+            Object.assign(item, {bookmarkGuid, bookmarkTitle, bookmarkDateCreated: dateAdded});
           }
           return item;
         })

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -88,19 +88,24 @@ class BookmarksObserver extends Observer {
    * @param  {int} dateAdded
    * @param  {str} guid      The unique id of the bookmark
    */
-  async onItemAdded(...args) {
+  onItemAdded(...args) {
     const type = args[3];
-    const guid = args[7];
     if (type !== PlacesUtils.bookmarks.TYPE_BOOKMARK) {
       return;
     }
-    try {
-      // bookmark: {bookmarkGuid, bookmarkTitle, lastModified, url}
-      const bookmark = await NewTabUtils.activityStreamProvider.getBookmark(guid);
-      this.dispatch({type: at.PLACES_BOOKMARK_ADDED, data: bookmark});
-    } catch (e) {
-      Cu.reportError(e);
-    }
+    const uri = args[4];
+    const bookmarkTitle = args[5];
+    const dateAdded = args[6];
+    const bookmarkGuid = args[7];
+    this.dispatch({
+      type: at.PLACES_BOOKMARK_ADDED,
+      data: {
+        bookmarkGuid,
+        bookmarkTitle,
+        dateAdded,
+        url: uri.href
+      }
+    });
   }
 
   /**

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -68,7 +68,7 @@ describe("Reducers", () => {
           url: "bar.com",
           bookmarkGuid: "bookmark123",
           bookmarkTitle: "Title for bar.com",
-          lastModified: 1234567
+          dateAdded: 1234567
         }
       };
       const nextState = TopSites(oldState, action);
@@ -77,7 +77,7 @@ describe("Reducers", () => {
       assert.equal(newRow.url, action.data.url);
       assert.equal(newRow.bookmarkGuid, action.data.bookmarkGuid);
       assert.equal(newRow.bookmarkTitle, action.data.bookmarkTitle);
-      assert.equal(newRow.bookmarkDateCreated, action.data.lastModified);
+      assert.equal(newRow.bookmarkDateCreated, action.data.dateAdded);
 
       // old row is unchanged
       assert.equal(nextState.rows[0], oldState.rows[0]);
@@ -92,7 +92,7 @@ describe("Reducers", () => {
           url: "bar.com",
           bookmarkGuid: "bookmark123",
           bookmarkTitle: "Title for bar.com",
-          lastModified: 123456
+          dateAdded: 123456
         }]
       };
       const action = {type: at.PLACES_BOOKMARK_REMOVED, data: {url: "bar.com"}};
@@ -328,7 +328,7 @@ describe("Reducers", () => {
           url: "www.foo.bar",
           bookmarkGuid: "bookmark123",
           bookmarkTitle: "Title for bar.com",
-          lastModified: 1234567
+          dateAdded: 1234567
         }
       };
       const nextState = Sections(oldState, action);
@@ -340,7 +340,7 @@ describe("Reducers", () => {
       assert.equal(newRow.url, action.data.url);
       assert.equal(newRow.bookmarkGuid, action.data.bookmarkGuid);
       assert.equal(newRow.bookmarkTitle, action.data.bookmarkTitle);
-      assert.equal(newRow.bookmarkDateCreated, action.data.lastModified);
+      assert.equal(newRow.bookmarkDateCreated, action.data.dateAdded);
 
       // old row is unchanged
       assert.equal(oldRow, oldState[0].rows[1]);

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -3,7 +3,7 @@ const {HistoryObserver, BookmarksObserver} = PlacesFeed;
 const {GlobalOverrider} = require("test/unit/utils");
 const {actionTypes: at} = require("common/Actions.jsm");
 
-const FAKE_BOOKMARK = {bookmarkGuid: "xi31", bookmarkTitle: "Foo", lastModified: 123214232, url: "foo.com"};
+const FAKE_BOOKMARK = {bookmarkGuid: "xi31", bookmarkTitle: "Foo", dateAdded: 123214232, url: "foo.com"};
 const TYPE_BOOKMARK = 0; // This is fake, for testing
 
 const BLOCKED_EVENT = "newtab-linkBlocked"; // The event dispatched in NewTabUtils when a link is blocked;
@@ -210,27 +210,17 @@ describe("PlacesFeed", () => {
     });
     describe("#onItemAdded", () => {
       beforeEach(() => {
-        // Make sure getBookmark returns our fake bookmark if it is called with the expected guid
-        sandbox.stub(global.NewTabUtils.activityStreamProvider, "getBookmark")
-          .withArgs(FAKE_BOOKMARK.guid).returns(Promise.resolve(FAKE_BOOKMARK));
       });
       it("should dispatch a PLACES_BOOKMARK_ADDED action with the bookmark data", async () => {
         // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK, null, null, null, FAKE_BOOKMARK.guid];
+        const args = [null, null, null, TYPE_BOOKMARK,
+          {href: FAKE_BOOKMARK.url}, FAKE_BOOKMARK.bookmarkTitle,
+          FAKE_BOOKMARK.dateAdded,
+          FAKE_BOOKMARK.bookmarkGuid
+        ];
         await observer.onItemAdded(...args);
 
         assert.calledWith(dispatch, {type: at.PLACES_BOOKMARK_ADDED, data: FAKE_BOOKMARK});
-      });
-      it("should catch errors gracefully", async () => {
-        const e = new Error("test error");
-        global.NewTabUtils.activityStreamProvider.getBookmark.restore();
-        sandbox.stub(global.NewTabUtils.activityStreamProvider, "getBookmark")
-          .returns(Promise.reject(e));
-
-        const args = [null, null, null, TYPE_BOOKMARK, null, null, null, FAKE_BOOKMARK.guid];
-        await observer.onItemAdded(...args);
-
-        assert.calledWith(global.Components.utils.reportError, e);
       });
       it("should ignore events that are not of TYPE_BOOKMARK", async () => {
         const args = [null, null, null, "nottypebookmark"];


### PR DESCRIPTION
Fix #3204. I switched to dateAdded as discussed, and hence we can now avoid the extra fetch.