### PR TITLE
fix: Stop TopSites refreshing before TippyTop init. Closes #3352.

### DIFF
--- a/system-addon/lib/TippyTopProvider.jsm
+++ b/system-addon/lib/TippyTopProvider.jsm
@@ -24,6 +24,7 @@ function getPath(url) {
 this.TippyTopProvider = class TippyTopProvider {
   constructor() {
     this._sitesByDomain = new Map();
+    this.initialized = false;
   }
   async init() {
     // Load the Tippy Top sites from the json manifest.
@@ -35,6 +36,7 @@ this.TippyTopProvider = class TippyTopProvider {
           this._sitesByDomain.set(getDomain(url), site);
         }
       }
+      this.initialized = true;
     } catch (error) {
       Cu.reportError("Failed to load tippy top manifest.");
     }

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -81,6 +81,13 @@ this.TopSitesFeed = class TopSitesFeed {
     return pinned.slice(0, TOP_SITES_SHOWMORE_LENGTH);
   }
   async refresh(target = null) {
+    if (this.isRefreshing) { return; }
+    this.isRefreshing = true;
+
+    if (!this._tippyTopProvider.initialized) {
+      await this._tippyTopProvider.init();
+    }
+
     const links = await this.getLinksWithDefaults();
 
     // First, cache existing screenshots in case we need to reuse them
@@ -116,6 +123,7 @@ this.TopSitesFeed = class TopSitesFeed {
       this.store.dispatch(ac.BroadcastToContent(newAction));
     }
     this.lastUpdated = Date.now();
+    this.isRefreshing = false;
   }
   _getPinnedWithData() {
     // Augment the pinned links with any other extra data we have for them already in the store
@@ -165,7 +173,6 @@ this.TopSitesFeed = class TopSitesFeed {
   async onAction(action) {
     switch (action.type) {
       case at.INIT:
-        await this._tippyTopProvider.init();
         this.refresh();
         break;
       case at.NEW_TAB_LOAD:

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -15,7 +15,7 @@ const FAKE_SCREENSHOT = "data123";
 
 function FakeTippyTopProvider() {}
 FakeTippyTopProvider.prototype = {
-  async init() {},
+  async init() { this.initialized = true; },
   processSite(site) { return site; }
 };
 
@@ -247,6 +247,19 @@ describe("Top Sites Feed", () => {
     });
   });
   describe("#refresh", () => {
+    it("should initialise _tippyTopProvider if it's not already initialised", async () => {
+      feed._tippyTopProvider.initialized = false;
+      await feed.refresh(action);
+      assert.ok(feed._tippyTopProvider.initialized);
+    });
+    it("should do nothing if another refresh is already in progress", async () => {
+      feed.isRefreshing = true;
+      sinon.spy(feed, "getLinksWithDefaults");
+      sinon.spy(feed, "getScreenshot");
+      await feed.refresh(action);
+      assert.notCalled(feed.getLinksWithDefaults);
+      assert.notCalled(feed.getScreenshot);
+    });
     it("should dispatch an action with the links returned", async () => {
       sandbox.stub(feed, "getScreenshot");
       await feed.refresh(action);


### PR DESCRIPTION
Fix #3352.