### PR TITLE
fix(styles): Avoid horizontal scrollbar on pref page by staying within the size

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -107,8 +107,9 @@
 
   .actions {
     background-color: $background-primary;
+    border-left: $border-secondary;
     bottom: 0;
-    offset-inline-end: -1px;
+    offset-inline-end: 0;
     padding: $prefs-spacing;
     position: fixed;
     width: $prefs-width;


### PR DESCRIPTION
Fix #3357. r?@rlr Looks like the negative right offset was causing the scrollbar.