### PR TITLE
fix(styles): Remove sharp corner of search when suggestions are shown to not need extended border

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -41,10 +41,6 @@
       fill: $white;
       -moz-context-properties: fill;
     }
-
-    &[aria-expanded="true"] {
-      border-radius: $search-border-radius $search-border-radius 0 0;
-    }
   }
 
   .search-label {
@@ -85,7 +81,6 @@
   // Adjust the style of the contentSearchUI-generated table
   .contentSearchSuggestionTable {
     border: 0;
-    box-shadow: $search-shadow-outline;
     transform: translateY(2px);
   }
 }


### PR DESCRIPTION
Fix #3374. r?@sarracini 

![screen shot 2017-09-07 at 2 03 16 pm](https://user-images.githubusercontent.com/438537/30185408-1d01fd68-93d6-11e7-99f3-efee50a7c4b4.png)

"muuuuuuch better, thank you!"