### PR TITLE
fix(highlights): Avoid fetching Highlights on INIT and just wait for NEW_TAB_LOAD

### DIFF
--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -5,9 +5,6 @@
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/NewTabUtils.jsm");
-Cu.importGlobalProperties(["fetch"]);
 
 const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
@@ -39,7 +36,6 @@ this.HighlightsFeed = class HighlightsFeed {
 
   postInit() {
     SectionsManager.enableSection(SECTION_ID);
-    this.fetchHighlights();
   }
 
   uninit() {

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -60,10 +60,12 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(sectionsManagerStub.enableSection);
       assert.calledWith(sectionsManagerStub.enableSection, SECTION_ID);
     });
-    it("should fetch highlights on init", () => {
+    it("should *not* fetch highlights on init to avoid loading Places too early", () => {
       feed.fetchHighlights = sinon.spy();
+
       feed.onAction({type: at.INIT});
-      assert.calledOnce(feed.fetchHighlights);
+
+      assert.notCalled(feed.fetchHighlights);
     });
   });
   describe("#fetchHighlights", () => {
@@ -94,7 +96,7 @@ describe("Top Sites Feed", () => {
   });
   describe("#onAction", () => {
     it("should fetch highlights on NEW_TAB_LOAD after update interval", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.NEW_TAB_LOAD});
       assert.notCalled(feed.fetchHighlights);
@@ -105,62 +107,62 @@ describe("Top Sites Feed", () => {
     });
     it("should fetch highlights on NEW_TAB_LOAD if grid is empty", async () => {
       links = [];
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.NEW_TAB_LOAD});
       assert.calledOnce(feed.fetchHighlights);
     });
     it("should fetch highlights on NEW_TAB_LOAD if grid isn't full", async () => {
       links = new Array(8).fill(null).map((v, i) => ({url: `http://www.site${i}.com`}));
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.NEW_TAB_LOAD});
       assert.calledOnce(feed.fetchHighlights);
     });
     it("should fetch highlights on MIGRATION_COMPLETED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.MIGRATION_COMPLETED});
       assert.calledOnce(feed.fetchHighlights);
       assert.calledWith(feed.fetchHighlights, true);
     });
     it("should fetch highlights on PLACES_HISTORY_CLEARED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.PLACES_HISTORY_CLEARED});
       assert.calledOnce(feed.fetchHighlights);
       assert.calledWith(feed.fetchHighlights, true);
     });
     it("should fetch highlights on PLACES_LINK_DELETED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.PLACES_LINK_DELETED});
       assert.calledOnce(feed.fetchHighlights);
       assert.calledWith(feed.fetchHighlights, true);
     });
     it("should fetch highlights on PLACES_LINK_BLOCKED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.PLACES_LINK_BLOCKED});
       assert.calledOnce(feed.fetchHighlights);
       assert.calledWith(feed.fetchHighlights, true);
     });
     it("should fetch highlights on PLACES_BOOKMARK_ADDED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.PLACES_BOOKMARK_ADDED});
       assert.calledOnce(feed.fetchHighlights);
       assert.calledWith(feed.fetchHighlights, false);
     });
     it("should fetch highlights on PLACES_BOOKMARK_REMOVED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.PLACES_BOOKMARK_REMOVED});
       assert.calledOnce(feed.fetchHighlights);
       assert.calledWith(feed.fetchHighlights, false);
     });
     it("should fetch highlights on TOP_SITES_UPDATED", async () => {
-      await feed.init();
+      await feed.fetchHighlights();
       feed.fetchHighlights = sinon.spy();
       feed.onAction({type: at.TOP_SITES_UPDATED});
       assert.calledOnce(feed.fetchHighlights);


### PR DESCRIPTION
Fix #3382. r?@rlr I see it's the same pattern from `TopSitesFeed` but turns out by waiting for `TippyTopProvider`, it delays accessing `NewTabUtils.activityStreamLinks` long enough to avoid startup load checks. I also removed some unnecessary imports.