### PR TITLE
fix (systemaddon): #3377 dont skip refresh if already refreshing

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -81,9 +81,6 @@ this.TopSitesFeed = class TopSitesFeed {
     return pinned.slice(0, TOP_SITES_SHOWMORE_LENGTH);
   }
   async refresh(target = null) {
-    if (this.isRefreshing) { return; }
-    this.isRefreshing = true;
-
     if (!this._tippyTopProvider.initialized) {
       await this._tippyTopProvider.init();
     }
@@ -123,7 +120,6 @@ this.TopSitesFeed = class TopSitesFeed {
       this.store.dispatch(ac.BroadcastToContent(newAction));
     }
     this.lastUpdated = Date.now();
-    this.isRefreshing = false;
   }
   _getPinnedWithData() {
     // Augment the pinned links with any other extra data we have for them already in the store

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -252,14 +252,6 @@ describe("Top Sites Feed", () => {
       await feed.refresh(action);
       assert.ok(feed._tippyTopProvider.initialized);
     });
-    it("should do nothing if another refresh is already in progress", async () => {
-      feed.isRefreshing = true;
-      sinon.spy(feed, "getLinksWithDefaults");
-      sinon.spy(feed, "getScreenshot");
-      await feed.refresh(action);
-      assert.notCalled(feed.getLinksWithDefaults);
-      assert.notCalled(feed.getScreenshot);
-    });
     it("should dispatch an action with the links returned", async () => {
       sandbox.stub(feed, "getScreenshot");
       await feed.refresh(action);


### PR DESCRIPTION
This is one (simple) way to fix #3377 the problem.

The downside is that TippyTop provider can be initialized twice in some cases, but that does no harm other than wasting a few cycles.

Another option is to not call `refresh()` on `INIT` and wait until `NEW_TAB_LOAD`. Downside of that is the first tab load might take more time.

There are more complex solutions. Like we could have some sort of list of targets that need to be refreshed when the current refresh is complete. 

@AdamHillier @Mardak thoughts?