### PR TITLE
feat(topsites): Set Top Site card image source to high-res icon when available

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -3,19 +3,19 @@ const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
 
 const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
 
-const {TOP_SITES_SOURCE, TOP_SITES_CONTEXT_MENU_OPTIONS} = require("./TopSitesConstants");
+const {TOP_SITES_SOURCE, TOP_SITES_CONTEXT_MENU_OPTIONS, MIN_FAVICON_SIZE} = require("./TopSitesConstants");
 
 const TopSiteLink = props => {
   const {link} = props;
   const topSiteOuterClassName = `top-site-outer${props.className ? ` ${props.className}` : ""}`;
-  const {tippyTopIcon} = link;
+  const {tippyTopIcon, faviconSize} = link;
   let imageClassName;
   let imageStyle;
-  if (tippyTopIcon) {
-    imageClassName = "tippy-top-icon";
+  if (tippyTopIcon || faviconSize >= MIN_FAVICON_SIZE) {
+    imageClassName = "rich-icon";
     imageStyle = {
       backgroundColor: link.backgroundColor,
-      backgroundImage: `url(${tippyTopIcon})`
+      backgroundImage: `url(${tippyTopIcon || link.favicon})`
     };
   } else {
     imageClassName = `screenshot${link.screenshot ? " active" : ""}`;

--- a/system-addon/content-src/components/TopSites/TopSitesConstants.js
+++ b/system-addon/content-src/components/TopSites/TopSitesConstants.js
@@ -1,5 +1,7 @@
 module.exports = {
   TOP_SITES_SOURCE: "TOP_SITES",
   TOP_SITES_CONTEXT_MENU_OPTIONS: ["CheckPinTopSite", "Separator", "OpenInNewWindow",
-    "OpenInPrivateWindow", "Separator", "BlockUrl", "DeleteUrl"]
+    "OpenInPrivateWindow", "Separator", "BlockUrl", "DeleteUrl"],
+  // minimum size necessary to show a rich icon instead of a screenshot
+  MIN_FAVICON_SIZE: 96
 };

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -4,7 +4,7 @@
   $top-sites-title-height: 30px;
   $top-sites-vertical-space: 18px;
   $screenshot-size: cover;
-  $tippy-top-size: 96px;
+  $rich-icon-size: 96px;
   $edit-menu-button-size: 25px;
 
   list-style: none;
@@ -129,7 +129,7 @@
       }
     }
 
-    .tippy-top-icon {
+    .rich-icon {
       position: absolute;
       top: 0;
       left: 0;
@@ -138,7 +138,8 @@
       border-radius: $top-sites-border-radius;
       box-shadow: inset $inner-box-shadow;
       background-position: center center;
-      background-size: $tippy-top-size;
+      background-size: $rich-icon-size;
+      background-color: $background-primary;
       background-repeat: no-repeat;
     }
 

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -21,6 +21,7 @@ const UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
 const DEFAULT_SITES_PREF = "default.sites";
 const DEFAULT_TOP_SITES = [];
 const FRECENCY_THRESHOLD = 100; // 1 visit (skip first-run/one-time pages)
+const MIN_FAVICON_SIZE = 96;
 
 this.TopSitesFeed = class TopSitesFeed {
   constructor() {
@@ -95,13 +96,13 @@ this.TopSitesFeed = class TopSitesFeed {
       }
     }
 
-    // Now, get a tippy top icon or screenshot for every item
+    // Now, get a tippy top icon, a rich icon, or screenshot for every item
     for (let link of links) {
       if (!link) { continue; }
 
-      // Check for tippy top icon.
+      // Check for tippy top icon or a rich icon.
       link = this._tippyTopProvider.processSite(link);
-      if (link.tippyTopIcon) { continue; }
+      if (link.tippyTopIcon || link.faviconSize >= MIN_FAVICON_SIZE) { continue; }
 
       // If no tippy top, then we get a screenshot.
       if (currentScreenshots[link.url]) {

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -274,9 +274,27 @@ describe("<TopSiteLink>", () => {
     link.backgroundColor = "#FFFFFF";
     const wrapper = shallow(<TopSiteLink link={link} />);
     assert.equal(wrapper.find(".screenshot").length, 0);
-    const tippyTop = wrapper.find(".tippy-top-icon");
+    const tippyTop = wrapper.find(".rich-icon");
     assert.propertyVal(tippyTop.props().style, "backgroundImage", "url(foo.png)");
     assert.propertyVal(tippyTop.props().style, "backgroundColor", "#FFFFFF");
+  });
+  it("should render a rich icon if provided", () => {
+    link.favicon = "foo.png";
+    link.faviconSize = 196;
+    link.backgroundColor = "#FFFFFF";
+    const wrapper = shallow(<TopSiteLink link={link} />);
+    assert.equal(wrapper.find(".screenshot").length, 0);
+    const richIcon = wrapper.find(".rich-icon");
+    assert.propertyVal(richIcon.props().style, "backgroundImage", "url(foo.png)");
+    assert.propertyVal(richIcon.props().style, "backgroundColor", "#FFFFFF");
+  });
+  it("should not render a rich icon if it is smaller than 96x96", () => {
+    link.favicon = "foo.png";
+    link.faviconSize = 48;
+    link.backgroundColor = "#FFFFFF";
+    const wrapper = shallow(<TopSiteLink link={link} />);
+    assert.equal(wrapper.find(".screenshot").length, 1);
+    assert.equal(wrapper.find(".rich-icon").length, 0);
   });
   it("should apply just the default class name to the outer link if props.className is falsey", () => {
     const wrapper = shallow(<TopSiteLink className={false} />);

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -295,6 +295,22 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(feed.store.dispatch);
       assert.notCalled(feed.getScreenshot);
     });
+    it("should skip getting screenshot if there is an icon of size greater than 96x96 and no tippy top", async () => {
+      sandbox.stub(feed, "getScreenshot");
+      feed.getLinksWithDefaults = () => [{
+        url: "foo.com",
+        favicon: "data:foo",
+        faviconSize: 196
+      }];
+      feed._tippyTopProvider.processSite = site => {
+        site.tippyTopIcon = null;
+        site.backgroundColor = null;
+        return site;
+      };
+      await feed.refresh(action);
+      assert.calledOnce(feed.store.dispatch);
+      assert.notCalled(feed.getScreenshot);
+    });
   });
   describe("getScreenshot", () => {
     it("should call Screenshots.getScreenshotForURL with the right url", async () => {


### PR DESCRIPTION
Fix #3327. Generalize the icons so that it's just a rich icon instead of a screenshot