### PR TITLE
fix(styles): Shift context label down to be centered with icon

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -123,13 +123,12 @@
 
   .card-context-icon {
     fill: $fill-secondary;
-    font-size: 13px;
     margin-inline-end: 6px;
-    display: block;
   }
 
   .card-context-label {
     flex-grow: 1;
+    line-height: $icon-size;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -75,6 +75,7 @@
 
   &.icon-trending {
     background-image: url('#{$image-path}glyph-trending-16.svg');
+    transform: translateY(2px); /* trending bolt is visually top heavy */
   }
 
   &.icon-now {


### PR DESCRIPTION
Fix #3399. r?@sarracini This keeps #3195 by adjusting the Trending icon positioning. The only change necessary was `line-height`. The other removals were because they weren't necessary -> confusing.

After:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/438537/30241871-c1bb8caa-9540-11e7-8d7b-ebdeb971b4ed.png"> without trending 2px adjustment
<img width="220" alt="image" src="https://user-images.githubusercontent.com/438537/30242943-4b2cf370-9555-11e7-97dd-9ed43a86db7a.png"> with trending 2px adjustment

Before:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/438537/30241925-612e2c8e-9541-11e7-92b1-97f8f7b390cd.png">