### PR TITLE
chore(topstories): Pretend "Now" is "Trending" until we have strings

### DIFF
--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -54,7 +54,8 @@ class Card extends React.Component {
     const {index, link, dispatch, contextMenuOptions, eventSource} = this.props;
     const {props} = this;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeCard === index;
-    const {icon, intlID} = link.type ? cardContextTypes[link.type] : {};
+    // Display "now" as "trending" until we have new strings #3402
+    const {icon, intlID} = cardContextTypes[link.type === "now" ? "trending" : link.type] || {};
 
     return (<li className={`card-outer${isContextMenuOpen ? " active" : ""}${props.placeholder ? " placeholder" : ""}`}>
       <a href={link.url} onClick={!props.placeholder && this.onLinkClick}>


### PR DESCRIPTION
Fix #3391. r?@csadilek Design says to just use "Trending" until we're out of string freeze to use "Popular" #3402