### PR TITLE
feat(prerender): Compute rtl in Reducer for use in Base and prerendered

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -13,7 +13,6 @@ const INITIAL_STATE_JS_FILE_PATH = path.join(BASE_FILE_PATH, "activity-stream-in
 const DEFAULT_OPTIONS = {
   baseUrl: "resource://activity-stream/",
   locale: "", // TODO: pass in options.locale. For now, we're just doing empty strings.
-  direction: "ltr",
   title: "New Tab"
 };
 
@@ -90,13 +89,13 @@ function main() {
     alias: {
       baseUrl: "b",
       title: "t",
-      locale: "l",
-      direction: "d"
+      locale: "l"
     }
   });
 
   const options = Object.assign({}, DEFAULT_OPTIONS, args || {});
   const {html, state} = prerender(options.locale);
+  options.direction = state.App.textDirection;
 
   fs.writeFileSync(HTML_FILE_PATH, templateHTML(options));
   fs.writeFileSync(PRERENDERED_HTML_FILE_PATH, templateHTML(options, html));

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -5,6 +5,9 @@
 
 const {actionTypes: at} = Components.utils.import("resource://activity-stream/common/Actions.jsm", {});
 
+// Locales that should be displayed RTL
+const RTL_LIST = ["ar", "he", "fa", "ur"];
+
 const TOP_SITES_DEFAULT_LENGTH = 6;
 const TOP_SITES_SHOWMORE_LENGTH = 12;
 
@@ -16,6 +19,8 @@ const INITIAL_STATE = {
     locale: "",
     // Localized strings with defaults
     strings: null,
+    // The text direction for the locale
+    textDirection: "",
     // The version of the system-addon
     version: null
   },
@@ -48,7 +53,8 @@ function App(prevState = INITIAL_STATE.App, action) {
       let {locale, strings} = action.data;
       return Object.assign({}, prevState, {
         locale,
-        strings
+        strings,
+        textDirection: RTL_LIST.indexOf(locale.split("-")[0]) >= 0 ? "rtl" : "ltr"
       });
     }
     default:

--- a/system-addon/content-src/activity-stream-prerender.jsx
+++ b/system-addon/content-src/activity-stream-prerender.jsx
@@ -17,7 +17,7 @@ const EMPTY_LOCALE = "en-PRERENDER";
  * @param  {type} strings All the strings for the page
  * @return {obj}         A store
  */
-function prerenderStore(locale, strings) {
+function prerenderStore(locale = "", strings) {
   const store = initStore(reducers, INITIAL_STATE);
   store.dispatch({type: at.LOCALE_UPDATED, data: {locale, strings}});
   store.dispatch({type: at.PREFS_INITIAL_VALUES, data: PrerenderData.initialPrefs});

--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -9,16 +9,13 @@ const PreferencesPane = require("content-src/components/PreferencesPane/Preferen
 const Sections = require("content-src/components/Sections/Sections");
 const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
 
-// Locales that should be displayed RTL
-const RTL_LIST = ["ar", "he", "fa", "ur"];
-
 // Add the locale data for pluralization and relative-time formatting for now,
 // this just uses english locale data. We can make this more sophisticated if
 // more features are needed.
-function addLocaleDataForReactIntl({locale}) {
+function addLocaleDataForReactIntl({locale, textDirection}) {
   addLocaleData([{locale, parentLocale: "en"}]);
   document.documentElement.lang = locale;
-  document.documentElement.dir = RTL_LIST.indexOf(locale.split("-")[0]) >= 0 ? "rtl" : "ltr";
+  document.documentElement.dir = textDirection;
 }
 
 class Base extends React.Component {

--- a/system-addon/test/unit/activity-stream-prerender.test.jsx
+++ b/system-addon/test/unit/activity-stream-prerender.test.jsx
@@ -14,7 +14,7 @@ describe("prerenderStore", () => {
     const state = store.getState();
     assert.equal(state.App.initialized, false);
   });
-  it("should set the right locale and strings", () => {
+  it("should set the right locale, strings, and text direction", () => {
     const strings = {foo: "foo"};
 
     const store = prerenderStore("en-FOO", strings);
@@ -22,6 +22,7 @@ describe("prerenderStore", () => {
     const state = store.getState();
     assert.equal(state.App.locale, "en-FOO");
     assert.equal(state.App.strings, strings);
+    assert.equal(state.App.textDirection, "ltr");
   });
   it("should add the right initial prefs", () => {
     const store = prerenderStore();

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -26,12 +26,20 @@ describe("Reducers", () => {
       const nextState = App(undefined, {type: at.LOCALE_UPDATED});
       assert.equal(nextState, INITIAL_STATE.App);
     });
-    it("should set locale, strings on LOCALE_UPDATE", () => {
+    it("should set locale, strings and text direction on LOCALE_UPDATE", () => {
       const strings = {};
       const action = {type: "LOCALE_UPDATED", data: {locale: "zh-CN", strings}};
       const nextState = App(undefined, action);
       assert.propertyVal(nextState, "locale", "zh-CN");
       assert.propertyVal(nextState, "strings", strings);
+      assert.propertyVal(nextState, "textDirection", "ltr");
+    });
+    it("should set rtl text direction for RTL locales", () => {
+      const action = {type: "LOCALE_UPDATED", data: {locale: "ar"}};
+
+      const nextState = App(undefined, action);
+
+      assert.propertyVal(nextState, "textDirection", "rtl");
     });
   });
   describe("TopSites", () => {


### PR DESCRIPTION
Fix #3371. r?@k88hudson Adds support but doesn't actually generate the prerendered rtl file. (Currently working on doing it for each "mozilla-central locale".)