### PR TITLE
fix(prerender): #3414 Render English string for prerender search

### DIFF
--- a/system-addon/content-src/activity-stream-prerender.jsx
+++ b/system-addon/content-src/activity-stream-prerender.jsx
@@ -36,7 +36,14 @@ function prerender(_locale) {
     strings = allStrings[locale];
   } else {
     Object.keys(allStrings["en-US"]).forEach(key => {
-      strings[key] = " ";
+      if (key === "search_web_placeholder") {
+        // TODO: This is a special case to allow us to render a placeholder string
+        // for search, which is needed for certain Quantum perf tests. We will
+        // remove this when issue #3370 is resolved.
+        strings[key] = allStrings["en-US"][key];
+      } else {
+        strings[key] = " ";
+      }
     });
   }
 

--- a/system-addon/test/unit/activity-stream-prerender.test.jsx
+++ b/system-addon/test/unit/activity-stream-prerender.test.jsx
@@ -59,4 +59,11 @@ describe("prerender", () => {
     assert.equal(state.App.locale, "en-PRERENDER");
     assert.equal(state.App.strings.newtab_page_title, " ");
   });
+  // # TODO: Remove when #3370 is resolved.
+  it("should render a real English string for search_web_placeholder", () => {
+    const {store} = prerender();
+
+    const state = store.getState();
+    assert.equal(state.App.strings.search_web_placeholder, "Search the Web");
+  });
 });


### PR DESCRIPTION
Fix #3414. 
<img width="543" alt="image" src="https://user-images.githubusercontent.com/438537/30295079-3a9c4308-96f4-11e7-974b-72b2a5cc1025.png">
