### PR TITLE
feat(topsites): Fixes #3150 Show low-res icon in corner of screenshot

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -3,7 +3,7 @@ const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
 
 const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
 
-const {TOP_SITES_SOURCE, TOP_SITES_CONTEXT_MENU_OPTIONS, MIN_FAVICON_SIZE} = require("./TopSitesConstants");
+const {TOP_SITES_SOURCE, TOP_SITES_CONTEXT_MENU_OPTIONS, MIN_RICH_FAVICON_SIZE, MIN_CORNER_FAVICON_SIZE} = require("./TopSitesConstants");
 
 const TopSiteLink = props => {
   const {link} = props;
@@ -11,21 +11,32 @@ const TopSiteLink = props => {
   const {tippyTopIcon, faviconSize} = link;
   let imageClassName;
   let imageStyle;
-  if (tippyTopIcon || faviconSize >= MIN_FAVICON_SIZE) {
-    imageClassName = "rich-icon";
+  let showSmallFavicon = false;
+  let smallFaviconStyle;
+  if (tippyTopIcon || faviconSize >= MIN_RICH_FAVICON_SIZE) {
+    // styles and class names for top sites with rich icons
+    imageClassName = "top-site-icon rich-icon";
     imageStyle = {
       backgroundColor: link.backgroundColor,
       backgroundImage: `url(${tippyTopIcon || link.favicon})`
     };
   } else {
+    // styles and class names for top sites with screenshot + small icon in top left corner
     imageClassName = `screenshot${link.screenshot ? " active" : ""}`;
     imageStyle = {backgroundImage: link.screenshot ? `url(${link.screenshot})` : "none"};
+
+    // only show a favicon in top left if it's greater than 32x32
+    if (faviconSize >= MIN_CORNER_FAVICON_SIZE) {
+      showSmallFavicon = true;
+      smallFaviconStyle = {backgroundImage:  `url(${link.favicon})`};
+    }
   }
   return (<li className={topSiteOuterClassName} key={link.guid || link.url}>
    <a href={link.url} onClick={props.onClick}>
      <div className="tile" aria-hidden={true}>
          <span className="letter-fallback">{props.title[0]}</span>
          <div className={imageClassName} style={imageStyle} />
+         {showSmallFavicon && <div className="top-site-icon default-icon" style={smallFaviconStyle} /> }
      </div>
      <div className={`title ${link.isPinned ? "pinned" : ""}`}>
        {link.isPinned && <div className="icon icon-pin-small" />}

--- a/system-addon/content-src/components/TopSites/TopSitesConstants.js
+++ b/system-addon/content-src/components/TopSites/TopSitesConstants.js
@@ -3,5 +3,7 @@ module.exports = {
   TOP_SITES_CONTEXT_MENU_OPTIONS: ["CheckPinTopSite", "Separator", "OpenInNewWindow",
     "OpenInPrivateWindow", "Separator", "BlockUrl", "DeleteUrl"],
   // minimum size necessary to show a rich icon instead of a screenshot
-  MIN_FAVICON_SIZE: 96
+  MIN_RICH_FAVICON_SIZE: 96,
+  // minimum size necessary to show any icon in the top left corner with a screenshot
+  MIN_CORNER_FAVICON_SIZE: 32
 };

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -6,6 +6,9 @@
   $screenshot-size: cover;
   $rich-icon-size: 96px;
   $edit-menu-button-size: 25px;
+  $default-icon-wrapper-size: 42px;
+  $default-icon-size: 32px;
+  $default-icon-offset: 6px;
 
   list-style: none;
   margin: 0;
@@ -129,18 +132,31 @@
       }
     }
 
-    .rich-icon {
+    // Some common styles for all icons (rich and default) in top sites
+    .top-site-icon {
       position: absolute;
-      top: 0;
-      left: 0;
-      height: 100%;
-      width: 100%;
       border-radius: $top-sites-border-radius;
       box-shadow: inset $inner-box-shadow;
       background-position: center center;
-      background-size: $rich-icon-size;
-      background-color: $background-primary;
       background-repeat: no-repeat;
+      background-color: $background-primary;
+    }
+
+    .rich-icon {
+      top: 0;
+      offset-inline-start: 0;
+      height: 100%;
+      width: 100%;
+      background-size: $rich-icon-size;
+    }
+
+    .default-icon {
+      z-index: 1;
+      top: -$default-icon-offset;
+      offset-inline-start: -$default-icon-offset;
+      height: $default-icon-wrapper-size;
+      width: $default-icon-wrapper-size;
+      background-size: $default-icon-size;
     }
 
     .title {

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -264,26 +264,53 @@ describe("<TopSiteLink>", () => {
     assert.propertyVal(screenshotEl.props().style, "backgroundImage", "url(foo.jpg)");
     assert.isTrue(screenshotEl.hasClass("active"));
   });
+  it("should not render a small icon with the screenshot if the icon is smaller than 32x32", () => {
+    link.favicon = "too-small-icon.png";
+    link.faviconSize = 16;
+    const wrapper = shallow(<TopSiteLink link={link} />);
+    const screenshotEl = wrapper.find(".screenshot");
+    const defaultIconEl = wrapper.find(".default-icon");
+
+    assert.propertyVal(screenshotEl.props().style, "backgroundImage", "url(foo.jpg)");
+    assert.isTrue(screenshotEl.hasClass("active"));
+    assert.lengthOf(defaultIconEl, 0);
+    assert.lengthOf(wrapper.find(".rich-icon"), 0);
+  });
+  it("should render a small icon with the screenshot if the icon is bigger than 32x32", () => {
+    link.favicon = "small-icon.png";
+    link.faviconSize = 32;
+
+    const wrapper = shallow(<TopSiteLink link={link} />);
+    const screenshotEl = wrapper.find(".screenshot");
+    const defaultIconEl = wrapper.find(".default-icon");
+
+    assert.propertyVal(screenshotEl.props().style, "backgroundImage", "url(foo.jpg)");
+    assert.isTrue(screenshotEl.hasClass("active"));
+    assert.propertyVal(defaultIconEl.props().style, "backgroundImage", `url(${link.favicon})`);
+    assert.lengthOf(wrapper.find(".rich-icon"), 0);
+  });
   it("should not add the .active class to the screenshot element if no screenshot prop is provided", () => {
     link.screenshot = null;
     const wrapper = shallow(<TopSiteLink link={link} />);
     assert.isFalse(wrapper.find(".screenshot").hasClass("active"));
   });
-  it("should render the tippy top icon if provided", () => {
+  it("should render the tippy top icon if provided and not a small icon", () => {
     link.tippyTopIcon = "foo.png";
     link.backgroundColor = "#FFFFFF";
     const wrapper = shallow(<TopSiteLink link={link} />);
-    assert.equal(wrapper.find(".screenshot").length, 0);
+    assert.lengthOf(wrapper.find(".screenshot"), 0);
+    assert.lengthOf(wrapper.find(".default-icon"), 0);
     const tippyTop = wrapper.find(".rich-icon");
     assert.propertyVal(tippyTop.props().style, "backgroundImage", "url(foo.png)");
     assert.propertyVal(tippyTop.props().style, "backgroundColor", "#FFFFFF");
   });
-  it("should render a rich icon if provided", () => {
+  it("should render a rich icon if provided and not a small icon", () => {
     link.favicon = "foo.png";
     link.faviconSize = 196;
     link.backgroundColor = "#FFFFFF";
     const wrapper = shallow(<TopSiteLink link={link} />);
-    assert.equal(wrapper.find(".screenshot").length, 0);
+    assert.lengthOf(wrapper.find(".screenshot"), 0);
+    assert.lengthOf(wrapper.find(".default-icon"), 0);
     const richIcon = wrapper.find(".rich-icon");
     assert.propertyVal(richIcon.props().style, "backgroundImage", "url(foo.png)");
     assert.propertyVal(richIcon.props().style, "backgroundColor", "#FFFFFF");


### PR DESCRIPTION
A variety of top sites:
<img width="812" alt="screen shot 2017-09-11 at 4 37 28 pm" src="https://user-images.githubusercontent.com/7219526/30295763-c0845120-970f-11e7-9028-4006cdf779d8.png">
