### PR TITLE
feature(telemetry): make session.page optional & support about:home (closes #2510)

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -18,7 +18,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "addon_version": "1.0.0",
   "client_id": "374dc4d8-0cb2-4ac5-a3cf-c5a9bc3c602e",
   "locale": "en-US",
-  "page": "about:newtab or about:home",
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "session_duration": 1635,
   "session_id": "{12dasd-213asda-213dkakj}",
   "user_prefs": 7
@@ -41,7 +41,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "client_id": "374dc4d8-0cb2-4ac5-a3cf-c5a9bc3c602e",
   "event": "click or scroll or search or delete",
   "locale": "en-US",
-  "page": "about:newtab or about:home",
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "source": "top sites, or bookmarks, or...",
   "session_id": "{12dasd-213asda-213dkakj}",
   "recommender_type": "pocket-trending",
@@ -66,6 +66,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "event": "previewCacheHit",
   "event_id": "45f1912165ca4dfdb5c1c2337dbdc58f",
   "locale": "en-US",
+  "page": "unknown", // all session-specific perf events should be part of the session perf object
   "receive_at": 1457396660000,
   "source": "TOP_FRECENT_SITES",
   "value": 1,
@@ -88,7 +89,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "event": "MISSING_IMAGE",
   "locale": "en-US",
-  "page": "about:newtab or about:home",
+  "page": ["about:newtab" | "about:home" | "unknown"]
   "source": "HIGHLIGHTS",
   "value": 0,
   "user_prefs": 7,
@@ -110,7 +111,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "addon_version": "1.0.12",
   "locale": "en-US",
   "source": "pocket",
-  "page": "about:newtab",
+  "page": ["about:newtab" | "about:home" | "unknown"]
   "tiles": [{"id": 10000}, {"id": 10001}, {"id": 10002}]
   "user_prefs": 7
 }
@@ -124,7 +125,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "addon_version": "1.0.12",
   "locale": "en-US",
   "source": "pocket",
-  "page": "about:newtab",
+  "page": "unknown",
   "user_prefs": 7,
 
   // "pos" is the 0-based index to record the tile's position in the Pocket section.
@@ -152,7 +153,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `load_trigger_ts` | [Optional][Server Counter][Server Alert for too many omissions]  DOMHighResTimeStamp of the action perceived by the user to trigger the load of this page. | :one:
 | `load_trigger_type` | [Server Counter][Server Alert for too many omissions] Either ["menu_plus_or_keyboard", "unexpected"]. | :one:
 | `metadata_source` | [Optional] The source of which we computed metadata. Either (`MetadataService` or `Local` or `TippyTopProvider`). | :one:
-| `page` | [Required] Either ["NEW_TAB", "HOME"]. | :one:
+| `page` | [Required] One of ["about:newtab", "about:home", "unknown" (which either means not-applicable or is a bug)]. | :one:
 | `recommender_type` | [Optional] The type of recommendation that is being shown, if any. | :one:
 | `session_duration` | [Optional][Server Counter][Server Alert for too many omissions] Time in (integer) milliseconds of the difference between the new tab becoming visible
 and losing focus. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -32,7 +32,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 1,
 
   // Basic metadata
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown" ],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -52,7 +52,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -68,10 +68,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "CLICK",
   "source": "TOP_SITES",
   "action_position": 2,
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -87,10 +87,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "DELETE",
   "source": "TOP_SITES",
   "action_position": 2,
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -106,10 +106,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "BLOCK",
   "source": "TOP_SITES",
   "action_position": 2,
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -144,10 +144,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "BOOKMARK_DELETE",
   "source": "TOP_SITES",
   "action_position": 2,
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -163,10 +163,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "OPEN_NEW_WINDOW",
   "source": "TOP_SITES",
   "action_position": 2,
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -182,10 +182,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "event": "OPEN_PRIVATE_WINDOW",
   "source": "TOP_SITES",
   "action_position": 2,
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -199,10 +199,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   "event": "OPEN_NEWTAB_PREFS",
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -216,10 +216,10 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 ```js
 {
   "event": "CLOSE_NEWTAB_PREFS",
-  
+
   // Basic metadata
   "action": "activity_stream_event",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
@@ -243,7 +243,7 @@ All `"activity_stream_session"` pings have the following basic shape. Some field
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
   "addon_version": "1.0.12",
   "locale": "en-US",
-  "page": ["about:newtab" | "about:home"],
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "session_duration": 4199,
   "user_prefs": 7
 }
@@ -308,7 +308,7 @@ This reports all the Pocket recommended articles (a list of `id`s) when the user
   "addon_version": "1.0.12",
   "locale": "en-US",
   "source": "pocket",
-  "page": "about:newtab",
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "user_prefs": 7,
   "tiles": [{"id": 10000}, {"id": 10001}, {"id": 10002}]
 }
@@ -328,7 +328,7 @@ This reports the user's interaction with those Pocket tiles.
   "addon_version": "1.0.12",
   "locale": "en-US",
   "source": "pocket",
-  "page": "about:newtab",
+  "page": ["about:newtab" | "about:home" | "unknown"],
   "user_prefs": 7,
 
   // "pos" is the 0-based index to record the tile's position in the Pocket section.

--- a/system-addon/lib/ActivityStreamMessageChannel.jsm
+++ b/system-addon/lib/ActivityStreamMessageChannel.jsm
@@ -140,10 +140,10 @@ this.ActivityStreamMessageChannel = class ActivityStreamMessageChannel {
     this.channel.addMessageListener(this.incomingMessageName, this.onMessage);
 
     // Some pages might have already loaded, so we won't get the usual message
-    for (const {loaded, portID} of this.channel.messagePorts) {
-      const simulatedMsg = {target: {portID}};
+    for (const target of this.channel.messagePorts) {
+      const simulatedMsg = {target};
       this.onNewTabInit(simulatedMsg);
-      if (loaded) {
+      if (target.loaded) {
         this.onNewTabLoad(simulatedMsg);
       }
     }
@@ -172,7 +172,10 @@ this.ActivityStreamMessageChannel = class ActivityStreamMessageChannel {
  * @param  {obj} msg The messsage from a page that was just initialized
  */
   onNewTabInit(msg) {
-    this.onActionFromContent({type: at.NEW_TAB_INIT}, msg.target.portID);
+    this.onActionFromContent({
+      type: at.NEW_TAB_INIT,
+      data: {url: msg.target.url}
+    }, msg.target.portID);
   }
 
   /**

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -7,7 +7,7 @@ const baseKeys = {
   addon_version: Joi.string().required(),
   locale: Joi.string().required(),
   session_id: Joi.string(),
-  page: Joi.valid(["about:home", "about:newtab"]),
+  page: Joi.valid(["about:home", "about:newtab", "unknown"]),
   user_prefs: Joi.number().integer().required()
 };
 

--- a/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
@@ -82,13 +82,22 @@ describe("ActivityStreamMessageChannel", () => {
       });
       it("should simluate init for existing ports", () => {
         sinon.stub(mm, "onActionFromContent");
-        RPmessagePorts.push({loaded: false, portID: "inited"});
-        RPmessagePorts.push({loaded: true, portID: "loaded"});
+
+        RPmessagePorts.push({
+          url: "about:monkeys",
+          loaded: false,
+          portID: "inited"
+        });
+        RPmessagePorts.push({
+          url: "about:sheep",
+          loaded: true,
+          portID: "loaded"
+        });
 
         mm.createChannel();
 
-        assert.calledWith(mm.onActionFromContent.firstCall, {type: at.NEW_TAB_INIT}, "inited");
-        assert.calledWith(mm.onActionFromContent.secondCall, {type: at.NEW_TAB_INIT}, "loaded");
+        assert.calledWith(mm.onActionFromContent.firstCall, {type: at.NEW_TAB_INIT, data: {url: "about:monkeys"}}, "inited");
+        assert.calledWith(mm.onActionFromContent.secondCall, {type: at.NEW_TAB_INIT, data: {url: "about:sheep"}}, "loaded");
       });
       it("should simluate load for loaded ports", () => {
         sinon.stub(mm, "onActionFromContent");
@@ -146,10 +155,15 @@ describe("ActivityStreamMessageChannel", () => {
     });
     describe("#onNewTabInit", () => {
       it("should dispatch a NEW_TAB_INIT action", () => {
-        const t = {portID: "foo"};
+        const t = {portID: "foo", url: "about:monkeys"};
         sinon.stub(mm, "onActionFromContent");
+
         mm.onNewTabInit({target: t});
-        assert.calledWith(mm.onActionFromContent, {type: at.NEW_TAB_INIT}, "foo");
+
+        assert.calledWith(mm.onActionFromContent, {
+          type: at.NEW_TAB_INIT,
+          data: {url: "about:monkeys"}
+        }, "foo");
       });
     });
     describe("#onNewTabLoad", () => {


### PR DESCRIPTION
Fix #2510. This shouldn't be landed/tested until [bug 1398955](https://bugzilla.mozilla.org/show_bug.cgi?id=1398955) is merged to mozilla-central.

Once that happens, it's only easy to see that it's working with the first PingCentre commit in this PR (which should be removed before this patch is merged to master).

r? @ncloudioj and r? @emtwo, since this makes session.page optional in some cases.