### PR TITLE
fix(prerender): Use prerendered if either pocket or highlights are on

### DIFF
--- a/system-addon/common/PrerenderData.jsm
+++ b/system-addon/common/PrerenderData.jsm
@@ -1,32 +1,73 @@
-const prefConfig = {
-  // Prefs listed with "invalidates: true" will prevent the prerendered version
+class _PrerenderData {
+  constructor(options) {
+    this.initialPrefs = options.initialPrefs;
+    this.initialSections = options.initialSections;
+    this._setValidation(options.validation);
+  }
+
+  get validation() {
+    return this._validation;
+  }
+
+  set validation(value) {
+    this._setValidation(value);
+  }
+
+  get invalidatingPrefs() {
+    return this._invalidatingPrefs;
+  }
+
+    // This is needed so we can use it in the constructor
+  _setValidation(value = []) {
+    this._validation = value;
+    this._invalidatingPrefs = value.reduce((result, next) => {
+      if (typeof next === "string") {
+        result.push(next);
+        return result;
+      } else if (next && next.oneOf) {
+        return result.concat(next.oneOf);
+      }
+      throw new Error("Your validation configuration is not properly configured");
+    }, []);
+  }
+
+  arePrefsValid(getPref) {
+    for (const prefs of this.validation) {
+      // {oneOf: ["foo", "bar"]}
+      if (prefs && prefs.oneOf && !prefs.oneOf.some(name => getPref(name) === this.initialPrefs[name])) {
+        return false;
+
+      // "foo"
+      } else if (getPref(prefs) !== this.initialPrefs[prefs]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+this.PrerenderData = new _PrerenderData({
+  initialPrefs: {
+    "migrationExpired": true,
+    "showTopSites": true,
+    "showSearch": true,
+    "topSitesCount": 6,
+    "feeds.section.topstories": true,
+    "feeds.section.highlights": true
+  },
+  // Prefs listed as invalidating will prevent the prerendered version
   // of AS from being used if their value is something other than what is listed
   // here. This is required because some preferences cause the page layout to be
   // too different for the prerendered version to be used. Unfortunately, this
   // will result in users who have modified some of their preferences not being
   // able to get the benefits of prerendering.
-  "migrationExpired": {value: true},
-  "showTopSites": {
-    value: true,
-    invalidates: true
-  },
-  "showSearch": {
-    value: true,
-    invalidates: true
-  },
-  "topSitesCount": {value: 6},
-  "feeds.section.topstories": {
-    value: true,
-    invalidates: true
-  }
-};
-
-this.PrerenderData = {
-  invalidatingPrefs: Object.keys(prefConfig).filter(key => prefConfig[key].invalidates),
-  initialPrefs: Object.keys(prefConfig).reduce((obj, key) => {
-    obj[key] = prefConfig[key].value;
-    return obj;
-  }, {}), // This creates an object of the form {prefName: value}
+  validation: [
+    "showTopSites",
+    "showSearch",
+    // This means if either of these are set to their default values,
+    // prerendering can be used.
+    {oneOf: ["feeds.section.topstories", "feeds.section.highlights"]}
+  ],
   initialSections: [
     {
       enabled: true,
@@ -35,8 +76,16 @@ this.PrerenderData = {
       order: 1,
       title: {id: "header_recommended_by", values: {provider: "Pocket"}},
       topics: [{}]
+    },
+    {
+      enabled: true,
+      id: "highlights",
+      icon: "highlights",
+      order: 2,
+      title: {id: "header_highlights"}
     }
   ]
-};
+});
 
-this.EXPORTED_SYMBOLS = ["PrerenderData"];
+this._PrerenderData = _PrerenderData;
+this.EXPORTED_SYMBOLS = ["PrerenderData", "_PrerenderData"];

--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -8,6 +8,7 @@ const ManualMigration = require("content-src/components/ManualMigration/ManualMi
 const PreferencesPane = require("content-src/components/PreferencesPane/PreferencesPane");
 const Sections = require("content-src/components/Sections/Sections");
 const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
+const {PrerenderData} = require("common/PrerenderData.jsm");
 
 // Add the locale data for pluralization and relative-time formatting for now,
 // this just uses english locale data. We can make this more sophisticated if
@@ -52,6 +53,10 @@ class Base extends React.Component {
     const {locale, strings, initialized} = props.App;
     const prefs = props.Prefs.values;
 
+    const shouldBeFixedToTop = PrerenderData.arePrefsValid(name => prefs[name]);
+
+    const outerClassName = `outer-wrapper${shouldBeFixedToTop ? " fixed-to-top" : ""}`;
+
     if (!props.isPrerendered && !initialized) {
       return null;
     }
@@ -60,7 +65,7 @@ class Base extends React.Component {
     // all elements on a locale change (such as after preloading).
     // See https://github.com/yahoo/react-intl/issues/695 for more info.
     return (<IntlProvider key="STATIC" locale={locale} messages={strings}>
-        <div className="outer-wrapper">
+        <div className={outerClassName}>
           <main>
             {prefs.showSearch && <Search />}
             {!prefs.migrationExpired && <ManualMigration />}

--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -1,8 +1,12 @@
 .outer-wrapper {
   display: flex;
-  flex-grow: 1;
   padding: $section-spacing $base-gutter $base-gutter;
   height: 100%;
+  flex-grow: 1;
+
+  &.fixed-to-top {
+    height: auto;
+  }
 }
 
 main {

--- a/system-addon/lib/PrefsFeed.jsm
+++ b/system-addon/lib/PrefsFeed.jsm
@@ -17,14 +17,8 @@ this.PrefsFeed = class PrefsFeed {
 
   // If the any prefs are set to something other than what the prerendered version
   // of AS expects, we can't use it.
-  _setPrerenderPref() {
-    for (const prefName of PrerenderData.invalidatingPrefs) {
-      if (this._prefs.get(prefName) !== PrerenderData.initialPrefs[prefName]) {
-        this._prefs.set("prerender", false);
-        return;
-      }
-    }
-    this._prefs.set("prerender", true);
+  _setPrerenderPref(name) {
+    this._prefs.set("prerender", PrerenderData.arePrefsValid(pref => this._prefs.get(pref)));
   }
 
   _checkPrerender(name) {
@@ -37,7 +31,7 @@ this.PrefsFeed = class PrefsFeed {
     if (this._prefMap.has(name)) {
       this.store.dispatch(ac.BroadcastToContent({type: at.PREF_CHANGED, data: {name, value}}));
     }
-    this._checkPrerender(name, value);
+    this._checkPrerender(name);
   }
 
   init() {

--- a/system-addon/test/unit/common/PrerenderData.test.js
+++ b/system-addon/test/unit/common/PrerenderData.test.js
@@ -1,0 +1,98 @@
+const {PrerenderData, _PrerenderData} = require("common/PrerenderData.jsm");
+
+describe("_PrerenderData", () => {
+  describe("properties", () => {
+    it("should set .initialPrefs", () => {
+      const initialPrefs = {foo: true};
+      const instance = new _PrerenderData({initialPrefs});
+
+      assert.equal(instance.initialPrefs, initialPrefs);
+    });
+    it("should set .initialSections", () => {
+      const initialSections = [{id: "foo"}];
+      const instance = new _PrerenderData({initialSections});
+
+      assert.equal(instance.initialSections, initialSections);
+    });
+    it("should set .validation and .invalidatingPrefs in the constructor", () => {
+      const validation = ["foo", "bar", {oneOf: ["baz", "qux"]}];
+      const instance = new _PrerenderData({validation});
+
+      assert.equal(instance.validation, validation);
+      assert.deepEqual(instance.invalidatingPrefs, ["foo", "bar", "baz", "qux"]);
+    });
+    it("should also set .invalidatingPrefs when .validation is set", () => {
+      const validation = ["foo", "bar", {oneOf: ["baz", "qux"]}];
+      const instance = new _PrerenderData({validation});
+
+      const newValidation = ["foo", {oneOf: ["blah", "gloo"]}];
+      instance.validation = newValidation;
+      assert.equal(instance.validation, newValidation);
+      assert.deepEqual(instance.invalidatingPrefs, ["foo", "blah", "gloo"]);
+    });
+    it("should throw if an invalid validation config is set", () => {
+      // {stuff: []} is not a valid configuration type
+      assert.throws(() => new _PrerenderData({validation: ["foo", {stuff: ["bar"]}]}));
+    });
+  });
+  describe("#arePrefsValid", () => {
+    let FAKE_PREFS;
+    const getPrefs = pref => FAKE_PREFS[pref];
+    beforeEach(() => {
+      FAKE_PREFS = {};
+    });
+    it("should return true if all prefs match", () => {
+      FAKE_PREFS = {foo: true, bar: false};
+      const instance = new _PrerenderData({
+        initialPrefs: FAKE_PREFS,
+        validation: ["foo", "bar"]
+      });
+      assert.isTrue(instance.arePrefsValid(getPrefs));
+    });
+    it("should return true if all *invalidating* prefs match", () => {
+      FAKE_PREFS = {foo: true, bar: false};
+      const instance = new _PrerenderData({
+        initialPrefs: {foo: true, bar: true},
+        validation: ["foo"]
+      });
+
+      assert.isTrue(instance.arePrefsValid(getPrefs));
+    });
+    it("should return true if one each oneOf group matches", () => {
+      FAKE_PREFS = {foo: false, floo: true, bar: false, blar: true};
+      const instance = new _PrerenderData({
+        initialPrefs: {foo: true, floo: true, bar: true, blar: true},
+        validation: [{oneOf: ["foo", "floo"]}, {oneOf: ["bar", "blar"]}]
+      });
+
+      assert.isTrue(instance.arePrefsValid(getPrefs));
+    });
+    it("should return false if an invalidating pref is mismatched", () => {
+      FAKE_PREFS = {foo: true, bar: false};
+      const instance = new _PrerenderData({
+        initialPrefs: {foo: true, bar: true},
+        validation: ["foo", "bar"]
+      });
+
+      assert.isFalse(instance.arePrefsValid(getPrefs));
+    });
+    it("should return false if none of the oneOf group matches", () => {
+      FAKE_PREFS = {foo: true, bar: false, baz: false};
+      const instance = new _PrerenderData({
+        initialPrefs: {foo: true, bar: true, baz: true},
+        validation: ["foo", {oneOf: ["bar", "baz"]}]
+      });
+
+      assert.isFalse(instance.arePrefsValid(getPrefs));
+    });
+  });
+});
+
+// This is the instance used by Activity Stream
+describe("PrerenderData", () => {
+  it("should set initial values for all invalidating prefs", () => {
+    PrerenderData.invalidatingPrefs.forEach(pref => {
+      assert.property(PrerenderData.initialPrefs, pref);
+    });
+  });
+});

--- a/system-addon/test/unit/lib/PrefsFeed.test.js
+++ b/system-addon/test/unit/lib/PrefsFeed.test.js
@@ -57,7 +57,7 @@ describe("PrefsFeed", () => {
     });
     it("should set prerender pref to false if a pref does not match its initial value", () => {
       Object.keys(initialPrefs).forEach(name => FAKE_PREFS.set(name, initialPrefs[name]));
-      FAKE_PREFS.set("feeds.section.topstories", false);
+      FAKE_PREFS.set("showSearch", false);
       feed.onAction({type: at.INIT});
       assert.calledWith(feed._prefs.set, PRERENDER_PREF_NAME, false);
     });
@@ -70,16 +70,16 @@ describe("PrefsFeed", () => {
     it("should set the prerender pref to false if a pref in invalidatingPrefs is changed from its original value", () => {
       Object.keys(initialPrefs).forEach(name => FAKE_PREFS.set(name, initialPrefs[name]));
 
-      feed._prefs.set("feeds.section.topstories", false);
-      feed.onPrefChanged("feeds.section.topstories", false);
+      feed._prefs.set("showSearch", false);
+      feed.onPrefChanged("showSearch", false);
       assert.calledWith(feed._prefs.set, PRERENDER_PREF_NAME, false);
     });
     it("should set the prerender pref back to true if the invalidatingPrefs are changed back to their original values", () => {
       Object.keys(initialPrefs).forEach(name => FAKE_PREFS.set(name, initialPrefs[name]));
-      FAKE_PREFS.set("feeds.section.topstories", false);
+      FAKE_PREFS.set("showSearch", false);
 
-      feed._prefs.set("feeds.section.topstories", true);
-      feed.onPrefChanged("feeds.section.topstories", true);
+      feed._prefs.set("showSearch", true);
+      feed.onPrefChanged("showSearch", true);
       assert.calledWith(feed._prefs.set, PRERENDER_PREF_NAME, true);
     });
   });


### PR DESCRIPTION
This patch also:
* Refactors PrerenderData to compute whether prefs are valid, allowing
  it to be used in content.
* Adds highlights to the prerendered initial sections
* Adds some styles that reduce the extent to which elements move around
  on the page: a new fixed-to-top class that gets added to outer-wrapper