### PR TITLE
fix(topsites): Fixes #3428 When pinning a site the corner icon disappears

### DIFF
--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -385,6 +385,17 @@ describe("Top Sites Feed", () => {
         data: [Object.assign({}, site1, {hostname: "foo.com"})]
       }));
     });
+    it("should compare against links if available, instead of getting from store", () => {
+      const frecentSite = {url: "foo.com", faviconSize: 32, favicon: "favicon.png"};
+      const pinnedSite1 = {url: "bar.com"};
+      const pinnedSite2 = {url: "foo.com"};
+      fakeNewTabUtils.pinnedLinks.links = [pinnedSite1, pinnedSite2];
+      feed.store = {getState() { return {TopSites: {rows: sinon.spy()}}; }};
+      let result = feed._getPinnedWithData([frecentSite]);
+      assert.deepEqual(result[0], pinnedSite1);
+      assert.deepEqual(result[1], Object.assign({}, frecentSite, pinnedSite2));
+      assert.notCalled(feed.store.getState().TopSites.rows);
+    });
     it("should call unpin with correct parameters on TOP_SITES_UNPIN", () => {
       fakeNewTabUtils.pinnedLinks.links = [null, null, {url: "foo.com"}, null, null, null, null, null, FAKE_LINKS[0]];
       const unpinAction = {


### PR DESCRIPTION
This generalizes the ```_getPinnedWithData``` function so that we can augment with the data that comes from either some links that we give, or from the store if we don't give links. It wasn't enough to just change the Object.assign to smoosh onto the pinnedLink, because when we restart firefox and it gets it from the store, the favicons don't exist yet - we have to get them out of places. So to fix that we need to also augment the pinnedLinks on the refresh with the links that come out of places. 