### PR TITLE
feat(topstories): Add functionality for spoc experiment

### DIFF
--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -67,10 +67,12 @@ class Card extends React.Component {
               <h4 className="card-title" dir="auto">{link.title}</h4>
               <p className="card-description" dir="auto">{link.description}</p>
             </div>
-            {icon && <div className="card-context">
-              <span className={`card-context-icon icon icon-${icon}`} />
-              <div className="card-context-label"><FormattedMessage id={intlID} defaultMessage="Visited" /></div>
-            </div>}
+            <div className="card-context">
+              {icon && !link.context && <span className={`card-context-icon icon icon-${icon}`} />}
+              {link.icon && link.context && <span className="card-context-icon icon" style={{backgroundImage: `url('${link.icon}')`}} />}
+              {intlID && !link.context && <div className="card-context-label"><FormattedMessage id={intlID} defaultMessage="Visited" /></div>}
+              {link.context && <div className="card-context-label">{link.context}</div>}
+            </div>
           </div>
         </div>
       </a>

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -62,6 +62,7 @@ const PREFS_CONFIG = new Map([
       stories_referrer: "https://getpocket.com/recommendations",
       info_link: "https://www.mozilla.org/privacy/firefox/#pocketstories",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
+      show_spocs: false,
       personalized: false
     })
   }],

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -9,7 +9,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/NewTabUtils.jsm");
 Cu.importGlobalProperties(["fetch"]);
 
-const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
+const {actionTypes: at, actionCreators: ac} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 
 const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const {shortURL} = Cu.import("resource://activity-stream/lib/ShortURL.jsm", {});
@@ -24,32 +24,36 @@ const STORIES_NOW_THRESHOLD = 24 * 60 * 60 * 1000; // 24 hours
 const SECTION_ID = "topstories";
 
 this.TopStoriesFeed = class TopStoriesFeed {
-
-  init() {
+  constructor() {
     this.storiesLastUpdated = 0;
     this.topicsLastUpdated = 0;
     this.affinityLastUpdated = 0;
-
-    SectionsManager.onceInitialized(this.parseOptions.bind(this));
+    this.spocsPerNewTabs = 0;
+    this.newTabsSinceSpoc = 0;
+    this.contentUpdateQueue = [];
   }
 
-  parseOptions() {
-    SectionsManager.enableSection(SECTION_ID);
-    const options = SectionsManager.sections.get(SECTION_ID).options;
-    try {
-      const apiKey = this._getApiKeyFromPref(options.api_key_pref);
-      this.stories_endpoint = this._produceFinalEndpointUrl(options.stories_endpoint, apiKey);
-      this.topics_endpoint = this._produceFinalEndpointUrl(options.topics_endpoint, apiKey);
-      this.read_more_endpoint = options.read_more_endpoint;
-      this.stories_referrer = options.stories_referrer;
-      this.personalized = options.personalized;
-      this.maxHistoryQueryResults = options.maxHistoryQueryResults;
+  init() {
+    const initFeed = () => {
+      SectionsManager.enableSection(SECTION_ID);
+      try {
+        const options = SectionsManager.sections.get(SECTION_ID).options;
+        const apiKey = this.getApiKeyFromPref(options.api_key_pref);
+        this.stories_endpoint = this.produceFinalEndpointUrl(options.stories_endpoint, apiKey);
+        this.topics_endpoint = this.produceFinalEndpointUrl(options.topics_endpoint, apiKey);
+        this.read_more_endpoint = options.read_more_endpoint;
+        this.stories_referrer = options.stories_referrer;
+        this.personalized = options.personalized;
+        this.show_spocs = options.show_spocs;
+        this.maxHistoryQueryResults = options.maxHistoryQueryResults;
 
-      this.fetchStories();
-      this.fetchTopics();
-    } catch (e) {
-      Cu.reportError(`Problem initializing top stories feed: ${e.message}`);
-    }
+        this.fetchStories();
+        this.fetchTopics();
+      } catch (e) {
+        Cu.reportError(`Problem initializing top stories feed: ${e.message}`);
+      }
+    };
+    SectionsManager.onceInitialized(initFeed);
   }
 
   uninit() {
@@ -62,36 +66,46 @@ this.TopStoriesFeed = class TopStoriesFeed {
     }
     try {
       const response = await fetch(this.stories_endpoint);
-
       if (!response.ok) {
         throw new Error(`Stories endpoint returned unexpected status: ${response.status}`);
       }
 
       const body = await response.json();
-      this.updateDomainAffinities(body.settings);
+      this.updateSettings(body.settings);
+      this.stories = this.rotate(this.transform(body.recommendations));
+      this.spocs = this.show_spocs && this.transform(body.spocs).filter(s => s.score >= s.min_score);
 
-      const recommendations = body.recommendations
-        .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
-        .map(s => ({
-          "guid": s.id,
-          "hostname": shortURL(Object.assign({}, s, {url: s.url})),
-          "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
-          "title": s.title,
-          "description": s.excerpt,
-          "image": this._normalizeUrl(s.image_src),
-          "referrer": this.stories_referrer,
-          "url": s.url,
-          "score": this.personalized ? this.affinityProvider.calculateItemRelevanceScore(s) : 1
-        }))
-        .sort(this.personalized ? this.compareScore : (a, b) => 0);
-
-      const rows = this.rotate(recommendations);
-
-      this.dispatchUpdateEvent(this.storiesLastUpdated, {rows});
+      this.dispatchUpdateEvent(this.storiesLastUpdated, {rows: this.stories});
       this.storiesLastUpdated = Date.now();
+      // This is filtered so an update function can return true to retry on the next run
+      this.contentUpdateQueue = this.contentUpdateQueue.filter(update => update());
     } catch (error) {
       Cu.reportError(`Failed to fetch content: ${error.message}`);
     }
+  }
+
+  transform(items) {
+    if (!items) {
+      return [];
+    }
+
+    return items
+      .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
+      .map(s => ({
+        "guid": s.id,
+        "hostname": shortURL(Object.assign({}, s, {url: s.url})),
+        "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
+        "context": s.context,
+        "icon": s.icon,
+        "title": s.title,
+        "description": s.excerpt,
+        "image": this.normalizeUrl(s.image_src),
+        "referrer": this.stories_referrer,
+        "url": s.url,
+        "min_score": s.min_score || 0,
+        "score": this.personalized ? this.affinityProvider.calculateItemRelevanceScore(s) : 1
+      }))
+      .sort(this.personalized ? this.compareScore : (a, b) => 0);
   }
 
   async fetchTopics() {
@@ -121,10 +135,12 @@ this.TopStoriesFeed = class TopStoriesFeed {
     return b.score - a.score;
   }
 
-  updateDomainAffinities(settings) {
+  updateSettings(settings) {
     if (!this.personalized) {
       return;
     }
+
+    this.spocsPerNewTabs = settings.spocsPerNewTabs;
 
     if (!this.affinityProvider || (Date.now() - this.affinityLastUpdated >= DOMAIN_AFFINITY_UPDATE_TIME)) {
       this.affinityProvider = new UserDomainAffinityProvider(
@@ -153,7 +169,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
     return items;
   }
 
-  _getApiKeyFromPref(apiKeyPref) {
+  getApiKeyFromPref(apiKeyPref) {
     if (!apiKeyPref) {
       return apiKeyPref;
     }
@@ -161,7 +177,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
     return new Prefs().get(apiKeyPref) || Services.prefs.getCharPref(apiKeyPref);
   }
 
-  _produceFinalEndpointUrl(url, apiKey) {
+  produceFinalEndpointUrl(url, apiKey) {
     if (!url) {
       return url;
     }
@@ -173,11 +189,47 @@ this.TopStoriesFeed = class TopStoriesFeed {
 
   // Need to remove parenthesis from image URLs as React will otherwise
   // fail to render them properly as part of the card template.
-  _normalizeUrl(url) {
+  normalizeUrl(url) {
     if (url) {
       return url.replace(/\(/g, "%28").replace(/\)/g, "%29");
     }
     return url;
+  }
+
+  maybeAddSpoc(target) {
+    if (!this.show_spocs) {
+      return;
+    }
+
+    if (this.newTabsSinceSpoc === 0 || this.newTabsSinceSpoc === this.spocsPerNewTabs) {
+      const updateContent = () => {
+        if (!this.spocs || !this.spocs.length) {
+          // We have stories but no spocs so there's nothing to do and this update can be
+          // removed from the queue.
+          return false;
+        }
+
+        // Create a new array with a spoc inserted at index 2
+        // For now we're using the top scored spoc until we can support viewability based rotation
+        let rows = this.stories.slice(0, this.stories.length);
+        rows.splice(2, 0, this.spocs[0]);
+
+        // Send a content update to the target tab
+        const action = {type: at.SECTION_UPDATE, meta: {skipMain: true}, data: Object.assign({rows}, {id: SECTION_ID})};
+        this.store.dispatch(ac.SendToContent(action, target));
+        return false;
+      };
+
+      if (this.stories) {
+        updateContent();
+      } else {
+        // Delay updating tab content until initial data has been fetched
+        this.contentUpdateQueue.push(updateContent);
+      }
+
+      this.newTabsSinceSpoc = 0;
+    }
+    this.newTabsSinceSpoc++;
   }
 
   onAction(action) {
@@ -195,6 +247,9 @@ this.TopStoriesFeed = class TopStoriesFeed {
         break;
       case at.UNINIT:
         this.uninit();
+        break;
+      case at.NEW_TAB_REHYDRATED:
+        this.maybeAddSpoc(action.meta.fromTarget);
         break;
     }
   }

--- a/system-addon/test/unit/content-src/components/Card.test.jsx
+++ b/system-addon/test/unit/content-src/components/Card.test.jsx
@@ -76,6 +76,22 @@ describe("<Card>", () => {
     assert.isTrue(context.childAt(1).hasClass("card-context-label"));
     assert.equal(context.childAt(1).props().children.props.id, intlID);
   });
+  it("should support setting custom context", () => {
+    const linkWithCustomContext = {
+      type: "history",
+      context: "Custom",
+      icon: "icon-url"
+    };
+
+    wrapper = shallow(<Card {...Object.assign({}, DEFAULT_PROPS, {link: linkWithCustomContext})} />);
+    const context = wrapper.find(".card-context");
+    const {icon} = cardContextTypes[DEFAULT_PROPS.link.type];
+    assert.isFalse(context.childAt(0).hasClass(`icon-${icon}`));
+    assert.equal(context.childAt(0).props().style.backgroundImage, "url('icon-url')");
+
+    assert.isTrue(context.childAt(1).hasClass("card-context-label"));
+    assert.equal(context.childAt(1).text(), linkWithCustomContext.context);
+  });
   it("should have .active class, on card-outer if context menu is open", () => {
     const button = wrapper.find(".context-menu-button");
     assert.isFalse(wrapper.find(".card-outer").hasClass("active"));

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -141,18 +141,23 @@ describe("Top Stories Feed", () => {
           "excerpt": "description",
           "image_src": "image-url",
           "url": "rec-url",
-          "published_timestamp": "123"
+          "published_timestamp": "123",
+          "context": "trending",
+          "icon": "icon"
         }]
       };
       const stories = [{
         "guid": "1",
         "type": "now",
         "title": "title",
+        "context": "trending",
+        "icon": "icon",
         "description": "description",
         "image": "image-url",
         "referrer": "referrer",
         "url": "rec-url",
         "hostname": "rec-url",
+        "min_score": 0,
         "score": 1
       }];
 
@@ -356,6 +361,108 @@ describe("Top Stories Feed", () => {
       const rotated = instance.rotate(items);
       assert.deepEqual(items, rotated);
     });
+    it("should insert spoc at provided interval", async () => {
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
+
+      const response = {
+        "settings": {"spocsPerNewTabs": 2},
+        "recommendations": [{"id": "rec1"}, {"id": "rec2"}, {"id": "rec3"}],
+        "spocs": [{"id": "spoc1"}, {"id": "spoc2"}]
+      };
+
+      instance.personalized = true;
+      instance.show_spocs = true;
+      instance.stories_endpoint = "stories-endpoint";
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
+      await instance.fetchStories();
+
+      instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.calledOnce(instance.store.dispatch);
+      let action = instance.store.dispatch.firstCall.args[0];
+      assert.equal(at.SECTION_UPDATE, action.type);
+      assert.equal(true, action.meta.skipMain);
+      assert.equal(action.data.rows[0].guid, "rec1");
+      assert.equal(action.data.rows[1].guid, "rec2");
+      assert.equal(action.data.rows[2].guid, "spoc1");
+
+      // Second new tab shouldn't trigger a section update event (spocsPerNewTab === 2)
+      instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.calledOnce(instance.store.dispatch);
+
+      instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.calledTwice(instance.store.dispatch);
+      action = instance.store.dispatch.secondCall.args[0];
+      assert.equal(at.SECTION_UPDATE, action.type);
+      assert.equal(true, action.meta.skipMain);
+      assert.equal(action.data.rows[0].guid, "rec1");
+      assert.equal(action.data.rows[1].guid, "rec2");
+      assert.equal(action.data.rows[2].guid, "spoc1");
+    });
+    it("should delay inserting spoc if stories haven't been fetched", async () => {
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
+
+      const response = {
+        "settings": {"spocsPerNewTabs": 2},
+        "recommendations": [{"id": "rec1"}, {"id": "rec2"}, {"id": "rec3"}],
+        "spocs": [{"id": "spoc1"}, {"id": "spoc2"}]
+      };
+
+      instance.personalized = true;
+      instance.show_spocs = true;
+      instance.stories_endpoint = "stories-endpoint";
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
+
+      instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.notCalled(instance.store.dispatch);
+      assert.equal(instance.contentUpdateQueue.length, 1);
+
+      await instance.fetchStories();
+      assert.equal(instance.contentUpdateQueue.length, 0);
+      assert.calledOnce(instance.store.dispatch);
+      let action = instance.store.dispatch.firstCall.args[0];
+      assert.equal(action.type, at.SECTION_UPDATE);
+    });
+    it("should not insert spoc if preffed off", async () => {
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
+
+      const response = {
+        "settings": {"spocsPerNewTabs": 2},
+        "recommendations": [{"id": "rec1"}, {"id": "rec2"}, {"id": "rec3"}],
+        "spocs": [{"id": "spoc1"}, {"id": "spoc2"}]
+      };
+
+      instance.show_spocs = false;
+      instance.stories_endpoint = "stories-endpoint";
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
+      await instance.fetchStories();
+
+      instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.notCalled(instance.store.dispatch);
+    });
+    it("should not fail if there is no spoc", async () => {
+      let fetchStub = globals.sandbox.stub();
+      globals.set("fetch", fetchStub);
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
+
+      const response = {
+        "settings": {"spocsPerNewTabs": 2},
+        "recommendations": [{"id": "rec1"}, {"id": "rec2"}, {"id": "rec3"}]
+      };
+
+      instance.show_spocs = true;
+      instance.stories_endpoint = "stories-endpoint";
+      fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
+      await instance.fetchStories();
+
+      instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.notCalled(instance.store.dispatch);
+    });
   });
   describe("#update", () => {
     it("should fetch stories after update interval", () => {
@@ -384,11 +491,11 @@ describe("Top Stories Feed", () => {
       const fakeSettings = {timeSegments: {}, parameterSets: {}};
       instance.affinityProvider = {status: "not_changed"};
 
-      instance.updateDomainAffinities(fakeSettings);
+      instance.updateSettings(fakeSettings);
       assert.equal("not_changed", instance.affinityProvider.status);
 
       clock.tick(DOMAIN_AFFINITY_UPDATE_TIME);
-      instance.updateDomainAffinities(fakeSettings);
+      instance.updateSettings(fakeSettings);
       assert.isUndefined(instance.affinityProvider.status);
     });
   });


### PR DESCRIPTION
This brings in the functionality we need for the spoc experiment. In this experiment, we swap out the third story/card at a frequency defined in the API response (```spocsPerNewTab```). So, every Nth new tab would render the top scored spoc. Scoring is based on our personalization algorithm.

The only other change in this PR is for the Card UI to allow setting a custom context and icon and some refactorings.

This is preffed off by default. To turn it on, the following changes to ```feeds.section.topstories.options``` are required [1]:
```
show_spocs: true,
personalized: true,
stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}&feed_variant=spocs`,
```
[1] This will currently only display test spocs