### PR TITLE
feat(topstories): Add perf telemetry for domain affinity calculation

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -2,7 +2,7 @@
 
 By default, the about:newtab and about:home pages in Firefox (the pages you see when you open a new tab and when you start the browser), will send data back to Mozilla servers about usage of these pages.  The intent is to collect data in order to improve the user's experience while using Activity Stream.  Data about your specific browsing behaior or the sites you visit is **never transmitted to any Mozilla server**.  At any time, it is easy to **turn off** this data collection by [opting out of Firefox telemetry](https://support.mozilla.org/kb/share-telemetry-data-mozilla-help-improve-firefox).
 
-Data is sent to our servers in the form of discreet HTTPS 'pings' or messages whenever you do some action on the Activity Stream about:home or about:newtab pages.  We try to minimize the amount and frequency of pings by batching them together.  Pings are sent in [JSON serialized format](http://www.json.org/).  
+Data is sent to our servers in the form of discreet HTTPS 'pings' or messages whenever you do some action on the Activity Stream about:home or about:newtab pages.  We try to minimize the amount and frequency of pings by batching them together.  Pings are sent in [JSON serialized format](http://www.json.org/).
 
 At Mozilla, [we take your privacy very seriously](https://www.mozilla.org/privacy/).  The Activity Stream page will never send any data that could personally identify you.  We do not transmit what you are browsing, searches you perform or any private settings.  Activity Stream does not set or send cookies, and uses [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) to securely transmit data to Mozilla servers.
 
@@ -336,5 +336,25 @@ This reports the user's interaction with those Pocket tiles.
 
   // A 0-based index to record which tile in the "tiles" list that the user just interacted with.
   "click|block|pocket": 0
+}
+```
+
+## Performance pings
+
+These pings are captured to record performance related events i.e. how long certain operations take to execute.
+
+### Domain affinity calculation
+
+This reports the duration of the domain affinity calculation in milliseconds.
+
+```js
+{
+  "action": "activity_stream_performance_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "user_prefs": 7
+  "event": "topstories.domain.affinity.calculation.ms",
+  "value": 43
 }
 ```

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -498,5 +498,17 @@ describe("Top Stories Feed", () => {
       instance.updateSettings(fakeSettings);
       assert.isUndefined(instance.affinityProvider.status);
     });
+    it("should send performance telemetry when updating domain affinities", () => {
+      instance.init();
+      instance.personalized = true;
+      const fakeSettings = {timeSegments: {}, parameterSets: {}};
+
+      clock.tick(DOMAIN_AFFINITY_UPDATE_TIME);
+      instance.updateSettings(fakeSettings);
+      assert.calledOnce(instance.store.dispatch);
+      let action = instance.store.dispatch.firstCall.args[0];
+      assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
+      assert.equal(action.data.event, "topstories.domain.affinity.calculation.ms");
+    });
   });
 });


### PR DESCRIPTION
Measuring the time it takes to calculate domain affinities (once a day, when preffed on) and sending a ping.