### PR TITLE
chore(styles): Reduce bottom spacing of content and site titles to avoid scrollbars

### DIFF
--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -13,9 +13,9 @@ main {
   margin: auto;
   width: $wrapper-default-width;
 
-  // This is needed to offset the snippets container so things
-  // at the bottom of the page are still visible when snippets are visible
-  padding-bottom: $snippets-container-height;
+  // Offset the snippets container so things at the bottom of the page are still
+  // visible when snippets / onboarding are visible. Adjust for other spacing.
+  padding-bottom: $snippets-container-height - $section-spacing - $base-gutter;
 
   @media (min-width: $break-point-small) {
     width: $wrapper-max-width-small;

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -2,7 +2,7 @@
   $top-sites-size: $grid-unit;
   $top-sites-border-radius: 6px;
   $top-sites-title-height: 30px;
-  $top-sites-vertical-space: 18px;
+  $top-sites-vertical-space: 8px;
   $screenshot-size: cover;
   $rich-icon-size: 96px;
   $edit-menu-button-size: 25px;
@@ -12,9 +12,11 @@
 
   list-style: none;
   margin: 0;
+  // Take back the margin from the bottom row of vertical spacing as well as the
+  // extra whitespace below the title text as it's vertically centered.
+  margin-bottom: -($top-sites-vertical-space + $top-sites-title-height/3);
   padding: 0;
   margin-inline-end: -$base-gutter;
-  margin-bottom: -$top-sites-vertical-space;
 
   // Two columns
   @media (max-width: $break-point-small) {


### PR DESCRIPTION
Fix #2963. r?@k88hudson Tested as if on maximized reference machine (753px `innerHeight`). Onboarding is actually 100px, but in the screenshots below, I pretended they were 120px of snippets. This also fixes the increase in spacing below top sites to be decreased to 40px to the next section.

Before with scrollbar:
<img width="1087" alt="screen shot 2017-09-14 at 1 06 34 am" src="https://user-images.githubusercontent.com/438537/30419996-23e8f660-98ed-11e7-8e38-e854eb697f71.png">

After without scrollbar:
<img width="1087" alt="screen shot 2017-09-14 at 1 04 40 am" src="https://user-images.githubusercontent.com/438537/30420015-2c7d5afa-98ed-11e7-9cfa-694023bf24b3.png">
