### PR TITLE
fix(styles): Truncate card titles to 3 lines if it has a description

### DIFF
--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -67,7 +67,12 @@ class Card extends React.Component {
           </div>}
           <div className={`card-details${hasImage ? "" : " no-image"}`}>
             {link.hostname && <div className="card-host-name">{link.hostname}</div>}
-            <div className={`card-text${hasImage ? "" : " no-image"}${link.hostname ? "" : " no-host-name"}${icon ? "" : " no-context"}`}>
+            <div className={["card-text",
+              icon ? "" : "no-context",
+              link.description ? "" : "no-description",
+              link.hostname ? "" : "no-host-name",
+              hasImage ? "" : "no-image"
+            ].join(" ")}>
               <h4 className="card-title" dir="auto">{link.title}</h4>
               <p className="card-description" dir="auto">{link.description}</p>
             </div>

--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -109,6 +109,10 @@
     &.no-image.no-host-name.no-context {
       max-height: 12*$card-text-line-height + $card-title-margin;
     }
+    &:not(.no-description) .card-title {
+      max-height: 3*$card-text-line-height;
+      overflow: hidden;
+    }
   }
 
   .card-host-name {


### PR DESCRIPTION
Fix #1971. r?@sarracini Adds a "no-description" like the other class names although I suppose it might be a little confusing with the `:not(.no`

Before:
![screen shot 2017-09-14 at 5 17 15 am](https://user-images.githubusercontent.com/438537/30429785-997a1eac-990d-11e7-8c5d-37fc1be6b119.png)

After:
![screen shot 2017-09-14 at 5 16 40 am](https://user-images.githubusercontent.com/438537/30429794-9e6ceac0-990d-11e7-89ee-9b563970c76c.png)

