### PR TITLE
fix(topstories): Fix story rotation in personalization experiment

### DIFF
--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -165,12 +165,27 @@ this.TopStoriesFeed = class TopStoriesFeed {
       return items;
     }
 
+    if (!this.topItems) {
+      this.topItems = new Map();
+    }
+
+    // This avoids an infinite recursion if for some reason the feed stops
+    // changing. Otherwise, there's a chance we'd be rotating forever to
+    // find an item we haven't displayed on top yet.
+    if (this.topItems.size >= items.length) {
+      this.topItems.clear();
+    }
+
     const guid = items[0].guid;
-    if (!this.topItem || !(guid in this.topItem)) {
-      this.topItem = {[guid]: 0};
-    } else if (++this.topItem[guid] === 2) {
-      items.push(items.shift());
-      this.topItem = {[items[0].guid]: 0};
+    if (!this.topItems.has(guid)) {
+      this.topItems.set(guid, 0);
+    } else {
+      const val = this.topItems.get(guid) + 1;
+      this.topItems.set(guid, val);
+      if (val >= 2) {
+        items.push(items.shift());
+        this.rotate(items);
+      }
     }
     return items;
   }

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -337,27 +337,36 @@ describe("Top Stories Feed", () => {
       instance.personalized = true;
 
       let rotated = instance.rotate(items);
-      assert.deepEqual({"g1": 0}, instance.topItem);
+      assert.deepEqual(new Map([["g1", 0]]), instance.topItems);
       assert.deepEqual(items, rotated);
 
       rotated = instance.rotate(items);
-      assert.deepEqual({"g1": 1}, instance.topItem);
+      assert.deepEqual(new Map([["g1", 1]]), instance.topItems);
       assert.deepEqual(items, rotated);
 
       rotated = instance.rotate(items);
-      assert.deepEqual({"g2": 0}, instance.topItem);
+      assert.deepEqual(new Map([["g1", 2], ["g2", 0]]), instance.topItems);
       assert.deepEqual([{"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}, {"guid": "g1"}], rotated);
 
-      rotated = instance.rotate(items);
-      assert.deepEqual({"g2": 1}, instance.topItem);
+      // Simulate g1 on top again which should again be rotated to the end
+      rotated = instance.rotate([{"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}]);
+      assert.deepEqual(new Map([["g1", 3], ["g2", 1]]), instance.topItems);
       assert.deepEqual([{"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}, {"guid": "g1"}], rotated);
     });
-    it("should note rotate items if personalization is preffed off", () => {
+    it("should not rotate items if personalization is preffed off", () => {
       let items = [{"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}];
 
       instance.personalized = false;
 
-      instance.topItem = {"g1": 1};
+      instance.topItems = new Map([["g1", 1]]);
+      const rotated = instance.rotate(items);
+      assert.deepEqual(items, rotated);
+    });
+    it("should stop rotating if all items have been on top", () => {
+      let items = [{"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}];
+      instance.topItems = new Map([["g1", 2], ["g2", 2], ["g3", 2], ["g4", 2]]);
+      instance.personalized = true;
+
       const rotated = instance.rotate(items);
       assert.deepEqual(items, rotated);
     });


### PR DESCRIPTION
Previous solution didn't take into account that:

- after re-fetching the feed, a top item that was previously
rotated could be top scored again and therefore needs to be
rotated again to not appear on top.

- a single rotation might not be good enough as the subsequent
item could have also been on top for too long.