### PR TITLE
fix(bookmarks): Fixes #3254 Block bookmarked items that were deleted from history

### DIFF
--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -65,7 +65,7 @@ module.exports = {
       type: at.DIALOG_OPEN,
       data: {
         onConfirm: [
-          ac.SendToMain({type: at.DELETE_HISTORY_URL, data: site.url}),
+          ac.SendToMain({type: at.DELETE_HISTORY_URL, data: {url: site.url, forceBlock: site.bookmarkGuid}}),
           ac.UserEvent({event: "DELETE"})
         ],
         body_string_id: ["confirm_history_delete_p1", "confirm_history_delete_notice_p2"],

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -244,9 +244,14 @@ class PlacesFeed {
       case at.DELETE_BOOKMARK_BY_ID:
         NewTabUtils.activityStreamLinks.deleteBookmark(action.data);
         break;
-      case at.DELETE_HISTORY_URL:
-        NewTabUtils.activityStreamLinks.deleteHistoryEntry(action.data);
+      case at.DELETE_HISTORY_URL: {
+        const {url, forceBlock} = action.data;
+        NewTabUtils.activityStreamLinks.deleteHistoryEntry(url);
+        if (forceBlock) {
+          NewTabUtils.activityStreamLinks.blockURL({url});
+        }
         break;
+      }
       case at.OPEN_NEW_WINDOW:
         this.openNewWindow(action);
         break;

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -101,7 +101,7 @@ describe("<LinkMenu>", () => {
       menu_action_open_new_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
       menu_action_open_private_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
       menu_action_dismiss: FAKE_SITE.url,
-      menu_action_delete: FAKE_SITE.url,
+      menu_action_delete: {url: FAKE_SITE.url, forceBlock: FAKE_SITE.bookmarkGuid},
       menu_action_pin: {site: {url: FAKE_SITE.url}, index: FAKE_INDEX},
       menu_action_unpin: {site: {url: FAKE_SITE.url}},
       menu_action_save_to_pocket: {site: {url: FAKE_SITE.url, title: FAKE_SITE.title}}
@@ -125,6 +125,8 @@ describe("<LinkMenu>", () => {
 
         // option.action has correct data
         // (delete is a special case as it dispatches a nested DIALOG_OPEN-type action)
+        // in the case of this FAKE_SITE, we send a bookmarkGuid therefore we also want
+        // to block this if we delete it
         if (option.id === "menu_action_delete") {
           assert.deepEqual(option.action.data.onConfirm[0].data, expectedActionData[option.id]);
         } else {

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -98,8 +98,14 @@ describe("PlacesFeed", () => {
       assert.calledWith(global.NewTabUtils.activityStreamLinks.deleteBookmark, "g123kd");
     });
     it("should delete a history entry on DELETE_HISTORY_URL", () => {
-      feed.onAction({type: at.DELETE_HISTORY_URL, data: "guava.com"});
+      feed.onAction({type: at.DELETE_HISTORY_URL, data: {url: "guava.com", forceBlock: null}});
       assert.calledWith(global.NewTabUtils.activityStreamLinks.deleteHistoryEntry, "guava.com");
+      assert.notCalled(global.NewTabUtils.activityStreamLinks.blockURL);
+    });
+    it("should delete a history entry on DELETE_HISTORY_URL and force a site to be blocked if specified", () => {
+      feed.onAction({type: at.DELETE_HISTORY_URL, data: {url: "guava.com", forceBlock: "g123kd"}});
+      assert.calledWith(global.NewTabUtils.activityStreamLinks.deleteHistoryEntry, "guava.com");
+      assert.calledWith(global.NewTabUtils.activityStreamLinks.blockURL, {url: "guava.com"});
     });
     it("should call openNewWindow with the correct url on OPEN_NEW_WINDOW", () => {
       sinon.stub(feed, "openNewWindow");


### PR DESCRIPTION
Fix #3254. Adds an additional field to data to force a block action for sites that need to no longer be shown once deleted. This was to fix the bug where you can't delete a site that's been bookmarked - so now we force it to block a site that has a bookmark guid