### PR TITLE
chore(vendor): Backport Bug 1399997 - Remove usage of eval and new Function() in JSM scopes. r=Mossop

### DIFF
--- a/system-addon/vendor/Redux.jsm
+++ b/system-addon/vendor/Redux.jsm
@@ -4,6 +4,12 @@
  * This file has been reformatted as a Javascript Core Module
  */
 this.EXPORTED_SYMBOLS = ["redux"];
+
+// Defining these prevents redux from using indirect eval or `new
+// Function()` to get its global object.
+const self = this;
+this.Object = Object;
+
 this.redux =
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache


### PR DESCRIPTION
Fix #3487. r? @k88hudson 