### PR TITLE
fix(styles): Move favicon from top left to bottom right

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -154,9 +154,9 @@
 
     .default-icon {
       z-index: 1;
-      top: -$default-icon-offset;
-      offset-inline-start: -$default-icon-offset;
+      bottom: -$default-icon-offset;
       height: $default-icon-wrapper-size;
+      offset-inline-end: -$default-icon-offset;
       width: $default-icon-wrapper-size;
       background-size: $default-icon-size;
 


### PR DESCRIPTION
Fix #3492. r?@k88hudson 

Before:
<img width="128" alt="image" src="https://user-images.githubusercontent.com/438537/30494779-533c23f8-99fe-11e7-9c6f-41d2eabaf625.png">

After:
<img width="137" alt="image" src="https://user-images.githubusercontent.com/438537/30494761-43a7839c-99fe-11e7-87a7-5ba32641a649.png">