### PR TITLE
feat(topsites): Migrate browser.newtabpage.rows and fetch more topSitesCount

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -56,7 +56,10 @@ this.TopSitesFeed = class TopSitesFeed {
     this.store.dispatch(ac.BroadcastToContent(action));
   }
   async getLinksWithDefaults(action) {
-    let frecent = await NewTabUtils.activityStreamLinks.getTopSites();
+    // Get at least SHOWMORE amount so toggling between 1 and 2 rows has sites
+    const numItems = Math.max(this.store.getState().Prefs.values.topSitesCount,
+      TOP_SITES_SHOWMORE_LENGTH);
+    let frecent = await NewTabUtils.activityStreamLinks.getTopSites({numItems});
     const notBlockedDefaultSites = DEFAULT_TOP_SITES.filter(site => !NewTabUtils.blockedLinks.isBlocked({url: site.url}));
     const defaultUrls = notBlockedDefaultSites.map(site => site.url);
     let pinned = this._getPinnedWithData(frecent);
@@ -86,7 +89,7 @@ this.TopSitesFeed = class TopSitesFeed {
       filterAdult(dedupedUnpinned) : dedupedUnpinned;
 
     // Insert the original pinned sites into the deduped frecent and defaults
-    return insertPinned(checkedAdult, pinned).slice(0, TOP_SITES_SHOWMORE_LENGTH);
+    return insertPinned(checkedAdult, pinned).slice(0, numItems);
   }
   async refresh(target = null) {
     if (!this._tippyTopProvider.initialized) {

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -68,7 +68,7 @@ describe("Top Sites Feed", () => {
       dispatch: sinon.spy(),
       getState() { return this.state; },
       state: {
-        Prefs: {values: {filterAdult: false}},
+        Prefs: {values: {filterAdult: false, topSitesCount: 6}},
         TopSites: {rows: Array(12).fill("site")}
       }
     };
@@ -211,6 +211,13 @@ describe("Top Sites Feed", () => {
       assert.doesNotThrow(() => {
         feed.getLinksWithDefaults(action);
       });
+    });
+    it("should get more if the user has asked for more", async () => {
+      feed.store.state.Prefs.values.topSitesCount = TOP_SITES_SHOWMORE_LENGTH + 1;
+
+      const result = await feed.getLinksWithDefaults();
+
+      assert.propertyVal(result, "length", feed.store.state.Prefs.values.topSitesCount);
     });
     describe("deduping", () => {
       beforeEach(() => {


### PR DESCRIPTION
Fix #2592. r?@rlr Unofficially support a larger `topSitesCount` so the pref pane still juts shows "[x] Show two rows" Also I suppose because it's not super official, some things might be broken. But at least it shows this with 20 pinned sites, 1 history visit after migrating from a `browser.newtabpage.rows` of 4:

![screen shot 2017-09-16 at 1 27 43 pm](https://user-images.githubusercontent.com/438537/30515784-2ba78d74-9ae3-11e7-971c-62407f9722cb.png)

Makes use of the `{numItems}` I snuck into https://hg.mozilla.org/mozilla-central/rev/73c7371abb7f#l1.140 >:)