### PR TITLE
fix(topsites): Use title instead of label to reuse existing titles of pinned links

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -135,7 +135,8 @@ class TopSite extends React.PureComponent {
     const {props} = this;
     const {link} = props;
     const isContextMenuOpen = this.state.showContextMenu && this.state.activeTile === props.index;
-    const title = link.label || link.hostname;
+    // Use the link's title only if it's pinned, so by default use the hostname
+    const title = (link.isPinned && link.title) || link.hostname;
     return (<TopSiteLink {...props} onClick={this.onLinkClick} className={isContextMenuOpen ? "active" : ""} title={title}>
         {!props.editMode &&
           <div>

--- a/system-addon/content-src/components/TopSites/TopSiteForm.jsx
+++ b/system-addon/content-src/components/TopSites/TopSiteForm.jsx
@@ -8,20 +8,20 @@ class TopSiteForm extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      label: props.label || "",
+      title: props.title || "",
       url: props.url || "",
       validationError: false
     };
-    this.onLabelChange = this.onLabelChange.bind(this);
+    this.onTitleChange = this.onTitleChange.bind(this);
     this.onUrlChange = this.onUrlChange.bind(this);
     this.onCancelButtonClick = this.onCancelButtonClick.bind(this);
     this.onAddButtonClick = this.onAddButtonClick.bind(this);
     this.onSaveButtonClick = this.onSaveButtonClick.bind(this);
     this.onUrlInputMount = this.onUrlInputMount.bind(this);
   }
-  onLabelChange(event) {
+  onTitleChange(event) {
     this.resetValidation();
-    this.setState({"label": event.target.value});
+    this.setState({"title": event.target.value});
   }
   onUrlChange(event) {
     this.resetValidation();
@@ -35,8 +35,8 @@ class TopSiteForm extends React.PureComponent {
     ev.preventDefault();
     if (this.validateForm()) {
       let site = {url: this.cleanUrl()};
-      if (this.state.label !== "") {
-        site.label = this.state.label;
+      if (this.state.title !== "") {
+        site.title = this.state.title;
       }
       this.props.dispatch(ac.SendToMain({
         type: at.TOP_SITES_ADD,
@@ -53,8 +53,8 @@ class TopSiteForm extends React.PureComponent {
     ev.preventDefault();
     if (this.validateForm()) {
       let site = {url: this.cleanUrl()};
-      if (this.state.label !== "") {
-        site.label = this.state.label;
+      if (this.state.title !== "") {
+        site.title = this.state.title;
       }
       this.props.dispatch(ac.SendToMain({
         type: at.TOP_SITES_PIN,
@@ -112,8 +112,8 @@ class TopSiteForm extends React.PureComponent {
             <div className="field title">
               <input
                 type="text"
-                value={this.state.label}
-                onChange={this.onLabelChange}
+                value={this.state.title}
+                onChange={this.onTitleChange}
                 placeholder={this.props.intl.formatMessage({id: "topsites_form_title_placeholder"})} />
             </div>
             <div className={`field url${this.state.validationError ? " invalid" : ""}`}>
@@ -152,7 +152,7 @@ class TopSiteForm extends React.PureComponent {
 }
 
 TopSiteForm.defaultProps = {
-  label: "",
+  title: "",
   url: "",
   index: 0,
   editMode: false // by default we are in "Add New Top Site" mode

--- a/system-addon/content-src/components/TopSites/TopSitesEdit.jsx
+++ b/system-addon/content-src/components/TopSites/TopSitesEdit.jsx
@@ -124,7 +124,7 @@ class TopSitesEdit extends React.PureComponent {
           <div className="modal-overlay" onClick={this.onModalOverlayClick} />
           <div className="modal">
             <TopSiteForm
-              label={this.props.TopSites.rows[this.state.editIndex].label || this.props.TopSites.rows[this.state.editIndex].hostname}
+              title={this.props.TopSites.rows[this.state.editIndex].title || this.props.TopSites.rows[this.state.editIndex].hostname}
               url={this.props.TopSites.rows[this.state.editIndex].url}
               index={this.state.editIndex}
               editMode={true}

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -361,7 +361,14 @@ describe("<TopSite>", () => {
 
     assert.equal(wrapper.find(TopSiteLink).props().title, "foobar");
   });
+  it("should render the title of a pinned link", () => {
+    link.isPinned = true;
+    link.title = "title";
 
+    const wrapper = shallow(<TopSite link={link} />);
+
+    assert.equal(wrapper.find(TopSiteLink).props().title, "title");
+  });
   it("should have .active class, on top-site-outer if context menu is open", () => {
     const wrapper = shallow(<TopSite link={link} index={1} />);
     wrapper.setState({showContextMenu: true, activeTile: 1});
@@ -647,13 +654,13 @@ describe("<TopSiteForm>", () => {
       assert.notCalled(wrapper.instance().props.dispatch);
     });
     it("should call onClose and dispatch with right args if URL is valid", () => {
-      wrapper.setState({"url": "valid.com", "label": "a label"});
+      wrapper.setState({"url": "valid.com", "title": "a title"});
       wrapper.find(".add").simulate("click");
       assert.calledOnce(wrapper.instance().props.onClose);
       assert.calledWith(
         wrapper.instance().props.dispatch,
         {
-          data: {site: {label: "a label", url: "http://valid.com"}},
+          data: {site: {title: "a title", url: "http://valid.com"}},
           meta: {from: "ActivityStream:Content", to: "ActivityStream:Main"},
           type: at.TOP_SITES_ADD
         }
@@ -667,8 +674,8 @@ describe("<TopSiteForm>", () => {
         }
       );
     });
-    it("should not pass empty string label in dispatch data", () => {
-      wrapper.setState({"url": "valid.com", "label": ""});
+    it("should not pass empty string title in dispatch data", () => {
+      wrapper.setState({"url": "valid.com", "title": ""});
       wrapper.find(".add").simulate("click");
       assert.calledWith(
         wrapper.instance().props.dispatch,
@@ -682,7 +689,7 @@ describe("<TopSiteForm>", () => {
   });
 
   describe("#editMode", () => {
-    beforeEach(() => setup({editMode: true, url: "https://foo.bar", label: "baz", index: 7}));
+    beforeEach(() => setup({editMode: true, url: "https://foo.bar", title: "baz", index: 7}));
 
     it("should render the component", () => {
       assert.ok(wrapper.find(TopSiteForm));
@@ -719,7 +726,7 @@ describe("<TopSiteForm>", () => {
       assert.calledWith(
         wrapper.instance().props.dispatch,
         {
-          data: {site: {label: "baz", url: "https://foo.bar"}, index: 7},
+          data: {site: {title: "baz", url: "https://foo.bar"}, index: 7},
           meta: {from: "ActivityStream:Content", to: "ActivityStream:Main"},
           type: at.TOP_SITES_PIN
         }
@@ -733,8 +740,8 @@ describe("<TopSiteForm>", () => {
         }
       );
     });
-    it("should not pass empty string label in dispatch data", () => {
-      wrapper.setState({"label": ""});
+    it("should not pass empty string title in dispatch data", () => {
+      wrapper.setState({"title": ""});
       wrapper.find(".save").simulate("click");
       assert.calledWith(
         wrapper.instance().props.dispatch,

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -513,7 +513,7 @@ describe("Top Sites Feed", () => {
     it("should call pin with correct args on TOP_SITES_ADD", () => {
       const addAction = {
         type: at.TOP_SITES_ADD,
-        data: {site: {url: "foo.bar", label: "foo"}}
+        data: {site: {url: "foo.bar", title: "foo"}}
       };
       feed.onAction(addAction);
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
@@ -522,14 +522,14 @@ describe("Top Sites Feed", () => {
   });
   describe("#add", () => {
     it("should pin site in first slot of empty pinned list", () => {
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.add({data: {site}});
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 0);
     });
     it("should pin site in first slot of pinned list with empty first slot", () => {
       fakeNewTabUtils.pinnedLinks.links = [null, {url: "example.com"}];
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.add({data: {site}});
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 0);
@@ -537,7 +537,7 @@ describe("Top Sites Feed", () => {
     it("should move a pinned site in first slot to the next slot: part 1", () => {
       const site1 = {url: "example.com"};
       fakeNewTabUtils.pinnedLinks.links = [site1];
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.add({data: {site}});
       assert.calledTwice(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 0);
@@ -547,7 +547,7 @@ describe("Top Sites Feed", () => {
       const site1 = {url: "example.com"};
       const site2 = {url: "example.org"};
       fakeNewTabUtils.pinnedLinks.links = [site1, null, site2];
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.add({data: {site}});
       assert.calledTwice(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 0);
@@ -556,21 +556,21 @@ describe("Top Sites Feed", () => {
   });
   describe("#pin", () => {
     it("should pin site in specified slot empty pinned list", () => {
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.pin({data: {index: 2, site}});
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 2);
     });
     it("should pin site in specified slot of pinned list that is free", () => {
       fakeNewTabUtils.pinnedLinks.links = [null, {url: "example.com"}];
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.pin({data: {index: 2, site}});
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 2);
     });
     it("should NOT move a pinned site in specified slot to the next slot", () => {
       fakeNewTabUtils.pinnedLinks.links = [null, null, {url: "example.com"}];
-      const site = {url: "foo.bar", label: "foo"};
+      const site = {url: "foo.bar", title: "foo"};
       feed.pin({data: {index: 2, site}});
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 2);


### PR DESCRIPTION
Fix #3514. r?@rlr Switches from `label` to `title`. Somewhat amusingly, the input box field that the user sees asks for "Enter a title". One behavior change is that when a link gets pinned, it shows its title as opposed to the hostname, but the user can edit it. Maybe with #3490.