### PR TITLE
feat(topsites): Add caching of links with image migration for top sites and highlights

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -84,7 +84,7 @@ function insertPinned(links, pinned) {
   // Then insert them in their specified location
   pinned.forEach((val, index) => {
     if (!val) { return; }
-    let link = Object.assign(val, {isPinned: true, pinIndex: index});
+    let link = Object.assign({}, val, {isPinned: true, pinIndex: index});
     if (index > newLinks.length) {
       newLinks[index] = link;
     } else {

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -84,7 +84,7 @@ function insertPinned(links, pinned) {
   // Then insert them in their specified location
   pinned.forEach((val, index) => {
     if (!val) { return; }
-    let link = Object.assign({}, val, {isPinned: true, pinIndex: index});
+    let link = Object.assign(val, {isPinned: true, pinIndex: index});
     if (index > newLinks.length) {
       newLinks[index] = link;
     } else {

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -15,6 +15,8 @@ const {Dedupe} = Cu.import("resource://activity-stream/common/Dedupe.jsm", {});
 
 XPCOMUtils.defineLazyModuleGetter(this, "filterAdult",
   "resource://activity-stream/lib/FilterAdult.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "LinksCache",
+  "resource://activity-stream/lib/LinksCache.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Screenshots",
@@ -28,8 +30,18 @@ const SECTION_ID = "highlights";
 this.HighlightsFeed = class HighlightsFeed {
   constructor() {
     this.highlightsLastUpdated = 0;
-    this.highlights = [];
+    this.highlightsLength = 0;
     this.dedupe = new Dedupe(this._dedupeKey);
+    this.linksCache = new LinksCache(NewTabUtils.activityStreamLinks,
+      "getHighlights", (oldLink, newLink) => {
+        // Migrate any pending images or images to the new link
+        for (const property of ["fetchingImage", "image"]) {
+          const oldValue = oldLink[property];
+          if (oldValue) {
+            newLink[property] = oldValue;
+          }
+        }
+      });
   }
 
   _dedupeKey(site) {
@@ -50,6 +62,11 @@ this.HighlightsFeed = class HighlightsFeed {
   }
 
   async fetchHighlights(broadcast = false) {
+    // We broadcast when we want to force an update, so get fresh links
+    if (broadcast) {
+      this.linksCache.expire();
+    }
+
     // We need TopSites to have been initialised for deduping
     if (!this.store.getState().TopSites.initialized) {
       await new Promise(resolve => {
@@ -64,7 +81,7 @@ this.HighlightsFeed = class HighlightsFeed {
 
     // Request more than the expected length to allow for items being removed by
     // deduping against Top Sites or multiple history from the same domain, etc.
-    const manyPages = await NewTabUtils.activityStreamLinks.getHighlights({numItems: MANY_EXTRA_LENGTH});
+    const manyPages = await this.linksCache.request({numItems: MANY_EXTRA_LENGTH});
 
     // Remove adult highlights if we need to
     const checkedAdult = this.store.getState().Prefs.values.filterAdult ?
@@ -73,16 +90,8 @@ this.HighlightsFeed = class HighlightsFeed {
     // Remove any Highlights that are in Top Sites already
     const [, deduped] = this.dedupe.group(this.store.getState().TopSites.rows, checkedAdult);
 
-    // Store existing images in case we need to reuse them
-    const currentImages = {};
-    for (const site of this.highlights) {
-      if (site && site.image) {
-        currentImages[site.url] = site.image;
-      }
-    }
-
     // Keep all "bookmark"s and at most one (most recent) "history" per host
-    this.highlights = [];
+    const highlights = [];
     const hosts = new Set();
     for (const page of deduped) {
       const hostname = shortURL(page);
@@ -93,46 +102,51 @@ this.HighlightsFeed = class HighlightsFeed {
 
       // If we already have the image for the card, use that immediately. Else
       // asynchronously fetch the image.
-      const image = currentImages[page.url];
-      if (!image) {
-        this.fetchImage(page.url, page.preview_image_url);
+      if (!page.image) {
+        this.fetchImage(page);
       }
 
       // We want the page, so update various fields for UI
       Object.assign(page, {
-        image,
         hasImage: true, // We always have an image - fall back to a screenshot
         hostname,
         type: page.bookmarkGuid ? "bookmark" : page.type
       });
 
       // Add the "bookmark" or not-skipped "history"
-      this.highlights.push(page);
+      highlights.push(page);
       hosts.add(hostname);
 
       // Skip the rest if we have enough items
-      if (this.highlights.length === HIGHLIGHTS_MAX_LENGTH) {
+      if (highlights.length === HIGHLIGHTS_MAX_LENGTH) {
         break;
       }
     }
 
-    SectionsManager.updateSection(SECTION_ID, {rows: this.highlights}, this.highlightsLastUpdated === 0 || broadcast);
+    SectionsManager.updateSection(SECTION_ID, {rows: highlights}, broadcast);
     this.highlightsLastUpdated = Date.now();
+    this.highlightsLength = highlights.length;
   }
 
   /**
    * Fetch an image for a given highlight and update the card with it. If no
-   * image is available then fallback to fetching a screenshot. Update the card
-   * in `this.highlights` so that the image is cached for the next refresh.
+   * image is available then fallback to fetching a screenshot.
    */
-  async fetchImage(url, imageUrl) {
-    const image = await Screenshots.getScreenshotForURL(imageUrl || url);
-    SectionsManager.updateSectionCard(SECTION_ID, url, {image}, true);
+  async fetchImage(page) {
+    // Request a screenshot if we don't already have one pending
+    const {preview_image_url: imageUrl, url} = page;
+    if (!page.fetchingImage) {
+      page.fetchingImage = new Promise(async resolve => {
+        const image = await Screenshots.getScreenshotForURL(imageUrl || url);
+        SectionsManager.updateSectionCard(SECTION_ID, url, {image}, true);
+        resolve(image);
+      });
+    }
+
+    // Update the page so the image is in the cache
+    const image = await page.fetchingImage;
     if (image) {
-      const highlight = this.highlights.find(site => site.url === url);
-      if (highlight) {
-        highlight.image = image;
-      }
+      page.image = image;
     }
   }
 
@@ -142,7 +156,7 @@ this.HighlightsFeed = class HighlightsFeed {
         this.init();
         break;
       case at.NEW_TAB_LOAD:
-        if (this.highlights.length < HIGHLIGHTS_MAX_LENGTH) {
+        if (this.highlightsLength < HIGHLIGHTS_MAX_LENGTH) {
           // If we haven't filled the highlights grid yet, fetch again.
           this.fetchHighlights(true);
         } else if (Date.now() - this.highlightsLastUpdated >= HIGHLIGHTS_UPDATE_TIME) {

--- a/system-addon/lib/LinksCache.jsm
+++ b/system-addon/lib/LinksCache.jsm
@@ -92,12 +92,12 @@ this.LinksCache = class LinksCache {
 
             // Add a method that can be copied to cloned links that will update
             // the original cached link's property with the current one
-            newLink.updateCache = function(prop) {
-              if (prop) {
-                newLink[prop] = this[prop];
+            newLink.__updateCache = function(prop) {
+              const val = this[prop];
+              if (val === undefined) {
+                delete newLink[prop];
               } else {
-                // Provide a way for a link to clean itself up
-                delete this.updateCache;
+                newLink[prop] = val;
               }
             };
           }

--- a/system-addon/lib/LinksCache.jsm
+++ b/system-addon/lib/LinksCache.jsm
@@ -87,8 +87,19 @@ this.LinksCache = class LinksCache {
           if (newLink) {
             const oldLink = toMigrate.get(newLink.url);
             if (oldLink) {
-              this.migrator(toMigrate.get(newLink.url), newLink);
+              this.migrator(oldLink, newLink);
             }
+
+            // Add a method that can be copied to cloned links that will update
+            // the original cached link's property with the current one
+            newLink.updateCache = function(prop) {
+              if (prop) {
+                newLink[prop] = this[prop];
+              } else {
+                // Provide a way for a link to clean itself up
+                delete this.updateCache;
+              }
+            };
           }
         }
 

--- a/system-addon/lib/LinksCache.jsm
+++ b/system-addon/lib/LinksCache.jsm
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+this.EXPORTED_SYMBOLS = ["LinksCache"];
+
+const EXPIRATION_TIME = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Cache link results from a provided object property and refresh after some
+ * amount of time has passed. Allows for migrating data from previously cached
+ * links to the new links with the same url.
+ */
+this.LinksCache = class LinksCache {
+
+  /**
+   * Create a links cache for a given object property.
+   *
+   * @param {object} linkObject Object containing the link property
+   * @param {string} linkProperty Name on object to access
+   * @param {function} migrator Optional callback receiving the old and new link
+   * @param {function} shouldRefresh Optional callback receiving the old and new options
+   */
+  constructor(linkObject, linkProperty, migrator = () => {}, shouldRefresh = () => {}) {
+    this.clear();
+    this.expire();
+    // Allow getting links from both methods and array properties
+    this.linkGetter = options => {
+      const ret = linkObject[linkProperty];
+      return typeof ret === "function" ? ret.call(linkObject, options) : ret;
+    };
+    this.migrator = migrator;
+    this.shouldRefresh = shouldRefresh;
+  }
+
+  /**
+   * Clear the cached data.
+   */
+  clear() {
+    this.cache = Promise.resolve([]);
+    this.lastOptions = {};
+  }
+
+  /**
+   * Force the next request to update the cache.
+   */
+  expire() {
+    // Pretend the we expired at some negative time (tests start at T=0)
+    this.lastUpdate = 0 - EXPIRATION_TIME - 1;
+  }
+
+  /**
+   * Request data and update the cache if necessary.
+   *
+   * @param {object} options Optional data to pass to the underlying method.
+   * @returns {promise(array)} Links array with objects that can be modified.
+   */
+  async request(options = {}) {
+    // Update the cache if the data has been expired
+    const now = Date.now();
+    if (now > this.lastUpdate + EXPIRATION_TIME ||
+        // Allow custom rules around refreshing based on options
+        this.shouldRefresh(this.lastOptions, options)) {
+      // Update request state early so concurrent requests can refer to it
+      this.lastOptions = options;
+      this.lastUpdate = now;
+
+      // Save a promise before awaits, so other requests wait for correct data
+      this.cache = new Promise(async resolve => {
+        // Allow fast lookup of old links by url that might need to migrate
+        const toMigrate = new Map();
+        for (const oldLink of await this.cache) {
+          if (oldLink) {
+            toMigrate.set(oldLink.url, oldLink);
+          }
+        }
+
+        // Make a shallow copy of each resulting link to allow direct edits
+        const copied = (await this.linkGetter(options)).map(link => link &&
+          Object.assign({}, link));
+
+        // Migrate data to the new link if we have an old link
+        for (const newLink of copied) {
+          if (newLink) {
+            const oldLink = toMigrate.get(newLink.url);
+            if (oldLink) {
+              this.migrator(toMigrate.get(newLink.url), newLink);
+            }
+          }
+        }
+
+        // Update cache with the copied links migrated
+        resolve(copied);
+      });
+    }
+
+    // Return the promise of the links array
+    return this.cache;
+  }
+};

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -83,7 +83,7 @@ this.TopSitesFeed = class TopSitesFeed {
     const frecent = (await this.frecentCache.request({
       numItems,
       topsiteFrecency: FRECENCY_THRESHOLD
-    })).map(link => Object.assign(link, {hostname: shortURL(link)}));
+    })).map(link => Object.assign({}, link, {hostname: shortURL(link)}));
 
     // Remove any defaults that have been blocked
     const notBlockedDefaultSites = DEFAULT_TOP_SITES.filter(link =>
@@ -91,15 +91,16 @@ this.TopSitesFeed = class TopSitesFeed {
 
     // Get pinned links augmented with desired properties
     const pinned = (await this.pinnedCache.request()).map(link => {
-      const finder = other => other.url === link.url;
-      if (link) {
-        // Copy over all properties from a frecent link and add more
-        Object.assign(link, frecent.find(finder) || {}, {
-          hostname: shortURL(link),
-          isDefault: !!notBlockedDefaultSites.find(finder)
-        });
+      if (!link) {
+        return link;
       }
-      return link;
+
+      // Copy all properties from a frecent link and add more
+      const finder = other => other.url === link.url;
+      return Object.assign({}, frecent.find(finder) || {}, link, {
+        hostname: shortURL(link),
+        isDefault: !!notBlockedDefaultSites.find(finder)
+      });
     });
 
     // Remove any duplicates from frecent and default sites
@@ -112,21 +113,35 @@ this.TopSitesFeed = class TopSitesFeed {
       filterAdult(dedupedUnpinned) : dedupedUnpinned;
 
     // Insert the original pinned sites into the deduped frecent and defaults
-    return insertPinned(checkedAdult, pinned).slice(0, numItems);
+    const withPinned = insertPinned(checkedAdult, pinned).slice(0, numItems);
+
+    // Now, get a tippy top icon, a rich icon, or screenshot for every item
+    for (const link of withPinned) {
+      if (link) {
+        this._fetchIcon(link);
+
+        // At this point, there's no need to expose the cache details to others
+        if (link.updateCache) {
+          link.updateCache();
+        }
+      }
+    }
+
+    return withPinned;
   }
+
+  /**
+   * Refresh the top sites data for content
+   *
+   * @param target Optional port/channel to receive the update. If not provided,
+   *               the update will be broadcasted.
+   */
   async refresh(target = null) {
     if (!this._tippyTopProvider.initialized) {
       await this._tippyTopProvider.init();
     }
 
     const links = await this.getLinksWithDefaults();
-
-    // Now, get a tippy top icon, a rich icon, or screenshot for every item
-    for (let link of links) {
-      if (!link) { continue; }
-      this._fetchIcon(link);
-    }
-
     const newAction = {type: at.TOP_SITES_UPDATED, data: links};
     if (target) {
       // Send an update to content so the preloaded tab can get the updated content
@@ -142,6 +157,9 @@ this.TopSitesFeed = class TopSitesFeed {
    * Get an image for the link preferring tippy top, rich favicon, screenshots.
    */
   async _fetchIcon(link) {
+    // Update the link's cache if it can be updated
+    const updateCache = prop => link.updateCache && link.updateCache(prop);
+
     // Check for tippy top icon or a rich icon.
     this._tippyTopProvider.processSite(link);
     if (!link.tippyTopIcon &&
@@ -149,13 +167,20 @@ this.TopSitesFeed = class TopSitesFeed {
         !link.screenshot) {
       // Request a screenshot if we don't already have one pending
       if (!link.fetchingScreenshot) {
-        link.fetchingScreenshot = this.getScreenshot(link.url);
+        try {
+          link.fetchingScreenshot = this.getScreenshot(link.url);
+          updateCache("fetchingScreenshot");
+        } catch (e) {
+          // Failed to get the screenshot promise, so nothing else to do
+          return;
+        }
       }
 
       // Update the link so the screenshot is in the cache
       const screenshot = await link.fetchingScreenshot;
       if (screenshot) {
         link.screenshot = screenshot;
+        updateCache("screenshot");
       }
     }
   }

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -475,6 +475,13 @@ describe("Reducers", () => {
       const result = insertPinned(links, pinned);
       assert.equal(links.length, result.length);
     });
+    it("should not modify the original data", () => {
+      const pinned = [{url: "http://example.com"}];
+
+      insertPinned(links, pinned);
+
+      assert.equal(typeof pinned[0].isPinned, "undefined");
+    });
   });
   describe("Snippets", () => {
     it("should return INITIAL_STATE by default", () => {

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -1,5 +1,6 @@
 "use strict";
 const injector = require("inject!lib/HighlightsFeed.jsm");
+const {Screenshots} = require("lib/Screenshots.jsm");
 const {GlobalOverrider} = require("test/unit/utils");
 const {actionTypes: at} = require("common/Actions.jsm");
 const {Dedupe} = require("common/Dedupe.jsm");
@@ -39,7 +40,10 @@ describe("Highlights Feed", () => {
       updateSectionCard: sinon.spy(),
       sections: new Map([["highlights", {}]])
     };
-    fakeScreenshot = {getScreenshotForURL: sandbox.spy(() => Promise.resolve(FAKE_IMAGE))};
+    fakeScreenshot = {
+      getScreenshotForURL: sandbox.spy(() => Promise.resolve(FAKE_IMAGE)),
+      maybeGetAndSetScreenshot: Screenshots.maybeGetAndSetScreenshot
+    };
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url.match(/\/([^/]+)/)[1]);
     globals.set("NewTabUtils", fakeNewTabUtils);
@@ -200,6 +204,12 @@ describe("Highlights Feed", () => {
       // The stub filters out everything
       assert.calledOnce(filterAdultStub);
       assert.equal(highlights.length, 0);
+    });
+    it("should not expose internal link properties", async() => {
+      const highlights = await fetchHighlights();
+
+      const internal = Object.keys(highlights[0]).filter(key => key.startsWith("__"));
+      assert.equal(internal.join(""), "");
     });
   });
   describe("#fetchImage", () => {

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -22,6 +22,11 @@ describe("Highlights Feed", () => {
   let sectionsManagerStub;
   let shortURLStub;
 
+  const fetchHighlights = async() => {
+    await feed.fetchHighlights();
+    return sectionsManagerStub.updateSection.firstCall.args[1].rows;
+  };
+
   beforeEach(() => {
     globals = new GlobalOverrider();
     sandbox = globals.sandbox;
@@ -87,47 +92,56 @@ describe("Highlights Feed", () => {
   });
   describe("#fetchHighlights", () => {
     it("should wait for TopSites to be initialised", async () => {
-      feed.store.getState = () => ({TopSites: {initialized: false}});
+      feed.store.state.TopSites.initialized = false;
       // Initially TopSites is uninitialised and fetchHighlights should wait
-      feed.fetchHighlights();
+      const firstFetch = feed.fetchHighlights();
+
       assert.calledOnce(feed.store.subscribe);
       assert.notCalled(fakeNewTabUtils.activityStreamLinks.getHighlights);
 
       // Initialisation causes the subscribe callback to be called and
       // fetchHighlights should continue
-      feed.store.getState = () => ({TopSites: {initialized: true}});
+      feed.store.state.TopSites.initialized = true;
       const subscribeCallback = feed.store.subscribe.firstCall.args[0];
       await subscribeCallback();
+      await firstFetch;
       assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
 
       // If TopSites is initialised in the first place it shouldn't wait
+      feed.linksCache.expire();
       feed.store.subscribe.reset();
       fakeNewTabUtils.activityStreamLinks.getHighlights.reset();
-      feed.fetchHighlights();
+      await feed.fetchHighlights();
       assert.notCalled(feed.store.subscribe);
       assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
     });
     it("should add hostname and hasImage to each link", async () => {
       links = [{url: "https://mozilla.org"}];
-      await feed.fetchHighlights();
-      assert.equal(feed.highlights[0].hostname, "mozilla.org");
-      assert.equal(feed.highlights[0].hasImage, true);
+
+      const highlights = await fetchHighlights();
+
+      assert.equal(highlights[0].hostname, "mozilla.org");
+      assert.equal(highlights[0].hasImage, true);
     });
     it("should add an existing image if it exists to the link without calling fetchImage", async () => {
       links = [{url: "https://mozilla.org", image: FAKE_IMAGE}];
-      feed.highlights = links;
       sinon.spy(feed, "fetchImage");
-      await feed.fetchHighlights();
-      assert.equal(feed.highlights[0].image, FAKE_IMAGE);
+
+      const highlights = await fetchHighlights();
+
+      assert.equal(highlights[0].image, FAKE_IMAGE);
       assert.notCalled(feed.fetchImage);
     });
     it("should call fetchImage with the correct arguments for new links", async () => {
       links = [{url: "https://mozilla.org", preview_image_url: "https://mozilla.org/preview.jog"}];
-      feed.highlights = [];
       sinon.spy(feed, "fetchImage");
+
       await feed.fetchHighlights();
+
       assert.calledOnce(feed.fetchImage);
-      assert.calledWith(feed.fetchImage, links[0].url, links[0].preview_image_url);
+      const arg = feed.fetchImage.firstCall.args[0];
+      assert.propertyVal(arg, "url", links[0].url);
+      assert.propertyVal(arg, "preview_image_url", links[0].preview_image_url);
     });
     it("should not include any links already in Top Sites", async () => {
       links = [
@@ -136,9 +150,11 @@ describe("Highlights Feed", () => {
         {url: "http://www.topsite1.com"},
         {url: "http://www.topsite2.com"}
       ];
-      await feed.fetchHighlights();
-      assert.equal(feed.highlights.length, 1);
-      assert.deepEqual(feed.highlights[0], links[0]);
+
+      const highlights = await fetchHighlights();
+
+      assert.equal(highlights.length, 1);
+      assert.equal(highlights[0].url, links[0].url);
     });
     it("should not include history of same hostname as a bookmark", async () => {
       links = [
@@ -146,10 +162,10 @@ describe("Highlights Feed", () => {
         {url: "https://site.com/history", type: "history"}
       ];
 
-      await feed.fetchHighlights();
+      const highlights = await fetchHighlights();
 
-      assert.equal(feed.highlights.length, 1);
-      assert.deepEqual(feed.highlights[0], links[0]);
+      assert.equal(highlights.length, 1);
+      assert.equal(highlights[0].url, links[0].url);
     });
     it("should take the first history of a hostname", async () => {
       links = [
@@ -158,16 +174,18 @@ describe("Highlights Feed", () => {
         {url: "https://other", type: "history"}
       ];
 
-      await feed.fetchHighlights();
+      const highlights = await fetchHighlights();
 
-      assert.equal(feed.highlights.length, 2);
-      assert.deepEqual(feed.highlights[0], links[0]);
-      assert.deepEqual(feed.highlights[1], links[2]);
+      assert.equal(highlights.length, 2);
+      assert.equal(highlights[0].url, links[0].url);
+      assert.equal(highlights[1].url, links[2].url);
     });
     it("should set type to bookmark if there is a bookmarkGuid", async () => {
       links = [{url: "https://mozilla.org", type: "history", bookmarkGuid: "1234567890"}];
-      await feed.fetchHighlights();
-      assert.equal(feed.highlights[0].type, "bookmark");
+
+      const highlights = await fetchHighlights();
+
+      assert.equal(highlights[0].type, "bookmark");
     });
     it("should not filter out adult pages when pref is false", async() => {
       await feed.fetchHighlights();
@@ -177,36 +195,49 @@ describe("Highlights Feed", () => {
     it("should filter out adult pages when pref is true", async() => {
       feed.store.state.Prefs.values.filterAdult = true;
 
-      await feed.fetchHighlights();
+      const highlights = await fetchHighlights();
 
       // The stub filters out everything
       assert.calledOnce(filterAdultStub);
-      assert.equal(feed.highlights.length, 0);
+      assert.equal(highlights.length, 0);
     });
   });
   describe("#fetchImage", () => {
     const FAKE_URL = "https://mozilla.org";
     const FAKE_IMAGE_URL = "https://mozilla.org/preview.jpg";
     it("should capture the image, if available", async () => {
-      await feed.fetchImage(FAKE_URL, FAKE_IMAGE_URL);
+      await feed.fetchImage({
+        preview_image_url: FAKE_IMAGE_URL,
+        url: FAKE_URL
+      });
+
       assert.calledOnce(fakeScreenshot.getScreenshotForURL);
       assert.calledWith(fakeScreenshot.getScreenshotForURL, FAKE_IMAGE_URL);
     });
     it("should fall back to capturing a screenshot", async () => {
-      await feed.fetchImage(FAKE_URL, undefined);
+      await feed.fetchImage({url: FAKE_URL});
+
       assert.calledOnce(fakeScreenshot.getScreenshotForURL);
       assert.calledWith(fakeScreenshot.getScreenshotForURL, FAKE_URL);
     });
     it("should call SectionsManager.updateSectionCard with the right arguments", async () => {
-      await feed.fetchImage(FAKE_URL, FAKE_IMAGE_URL);
+      await feed.fetchImage({
+        preview_image_url: FAKE_IMAGE_URL,
+        url: FAKE_URL
+      });
+
       assert.calledOnce(sectionsManagerStub.updateSectionCard);
       assert.calledWith(sectionsManagerStub.updateSectionCard, "highlights", FAKE_URL, {image: FAKE_IMAGE}, true);
     });
-    it("should update the card in feed.highlights with the image", async () => {
-      feed.highlights = [{url: FAKE_URL}];
-      await feed.fetchImage(FAKE_URL, FAKE_IMAGE_URL);
-      const highlight = feed.highlights.find(({url}) => url === FAKE_URL);
-      assert.propertyVal(highlight, "image", FAKE_IMAGE);
+    it("should update the card with the image", async () => {
+      const card = {
+        preview_image_url: FAKE_IMAGE_URL,
+        url: FAKE_URL
+      };
+
+      await feed.fetchImage(card);
+
+      assert.propertyVal(card, "image", FAKE_IMAGE);
     });
   });
   describe("#uninit", () => {


### PR DESCRIPTION
Fix #3447 and fix #3513 . r?@k88hudson Various changes:
- self contained link cache module (no imports!)
  - topsites caches places frecent query and pinned links
  - highlights caches places highlights query
- link objects should be directly modified to save to cache
- custom image caching is removed and instead images are updated on the link
  - screenshot fetching promise is stashed on link to avoid repeat requests
  - also make sure there's only one "update" notification sent out on getting screenshot
- cached links are copies of source data (in particular avoid pinned links #3513)
- use `topsiteFrecency` (`>=` check) to filter out frecency instead of locally (was `>` check)
- get rid of `getPinnedWithData` and have pinned links inherit frecent data
- changes HighlightsFeed "api" to not expose result cache `.highlights` that was used for testing

One thing in particular that did **not** change is the update timing, `onAction` handling of the feeds. Originally I took out the timing checks, but after some more thought, we might still want to be smarter than just "refreshing" on each `NEW_TAB_LOAD` even if it's really fast because we're already sending over that data on rehydrating. I briefly had it set to just update in the background on `SYSTEM_TICK` but figured this change was already big enough.