### PR TITLE
feat(style): Hide top sites and sections before we've initialized

### DIFF
--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -85,9 +85,11 @@ class Base extends React.PureComponent {
         <div className={outerClassName}>
           <main>
             {prefs.showSearch && <Search />}
-            {!prefs.migrationExpired && <ManualMigration />}
-            {prefs.showTopSites && <TopSites />}
-            <Sections />
+            <div className={`body-wrapper${(initialized ? " on" : "")}`}>
+              {!prefs.migrationExpired && <ManualMigration />}
+              {prefs.showTopSites && <TopSites />}
+              <Sections />
+            </div>
             <ConfirmDialog />
           </main>
           {initialized && <PreferencesPane />}

--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -46,3 +46,11 @@ main {
     vertical-align: middle;
   }
 }
+
+.body-wrapper {
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+  &.on {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
This hides top sites and sections until we've initialized, but leaves the search box visible from the start. Let's see if this looks better?