### PR TITLE
fix(telemetry): Send an undesired event ping if addon fails to init

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -353,8 +353,28 @@ This reports the duration of the domain affinity calculation in milliseconds.
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "addon_version": "1.0.12",
   "locale": "en-US",
-  "user_prefs": 7
+  "user_prefs": 7,
   "event": "topstories.domain.affinity.calculation.ms",
   "value": 43
+}
+```
+
+## Undesired event pings
+
+There pings record the undesired events happen in the addon for further investigation.
+
+### Addon initialization failure
+
+This reports when the addon fails to initialize
+
+```js
+{
+  "action": "activity_stream_undesired_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": "ADDON_INIT_FAILED",
+  "value": -1
 }
 ```

--- a/system-addon/lib/Store.jsm
+++ b/system-addon/lib/Store.jsm
@@ -105,6 +105,9 @@ this.Store = class Store {
   /**
    * init - Initializes the ActivityStreamMessageChannel channel, and adds feeds.
    *
+   * Note that it intentionally initializes the TelemetryFeed first so that the
+   * addon is able to report the init errors from other feeds.
+   *
    * @param  {Map} feedFactories A Map of feeds with the name of the pref for
    *                                the feed as the key and a function that
    *                                constructs an instance of the feed.
@@ -117,8 +120,13 @@ this.Store = class Store {
     this._initAction = initAction;
     this._uninitAction = uninitAction;
 
+    const telemetryKey = "feeds.telemetry";
+    if (feedFactories.has(telemetryKey) && this._prefs.get(telemetryKey)) {
+      this.initFeed(telemetryKey);
+    }
+
     for (const pref of feedFactories.keys()) {
-      if (this._prefs.get(pref)) {
+      if (pref !== telemetryKey && this._prefs.get(pref)) {
         this.initFeed(pref);
       }
     }

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -344,6 +344,14 @@ this.TelemetryFeed = class TelemetryFeed {
     }
   }
 
+  handleUserEvent(action) {
+    this.sendEvent(this.createUserEvent(action));
+  }
+
+  handleUndesiredEvent(action) {
+    this.sendEvent(this.createUndesiredEvent(action));
+  }
+
   resetImpressionStats() {
     for (const key of Object.keys(this._impressionStats)) {
       this._impressionStats[key].clear();
@@ -374,10 +382,10 @@ this.TelemetryFeed = class TelemetryFeed {
         this.handleImpressionStats(action);
         break;
       case at.TELEMETRY_UNDESIRED_EVENT:
-        this.sendEvent(this.createUndesiredEvent(action));
+        this.handleUndesiredEvent(action);
         break;
       case at.TELEMETRY_USER_EVENT:
-        this.sendEvent(this.createUserEvent(action));
+        this.handleUserEvent(action);
         break;
       case at.TELEMETRY_PERFORMANCE_EVENT:
         this.sendEvent(this.createPerformanceEvent(action));

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -232,4 +232,17 @@ describe("ActivityStream", () => {
       assert.isTrue(PREFS_CONFIG.get("feeds.section.topstories").value);
     });
   });
+  describe("telemetry reporting on init failure", () => {
+    it("should send a ping on init error", () => {
+      as = new ActivityStream();
+      const telemetry = {handleUndesiredEvent: sandbox.spy()};
+      sandbox.stub(as.store, "init").throws();
+      sandbox.stub(as.store.feeds, "get").returns(telemetry);
+      try {
+        as.init();
+      } catch (e) {
+      }
+      assert.calledOnce(telemetry.handleUndesiredEvent);
+    });
+  });
 });

--- a/system-addon/test/unit/lib/Store.test.js
+++ b/system-addon/test/unit/lib/Store.test.js
@@ -163,6 +163,17 @@ describe("Store", () => {
       assert.calledOnce(store.dispatch);
       assert.calledWith(store.dispatch, action);
     });
+    it("should initialize the telemtry feed first", () => {
+      store._prefs.set("feeds.foo", true);
+      store._prefs.set("feeds.telemetry", true);
+      const telemetrySpy = sandbox.stub().returns({});
+      const fooSpy = sandbox.stub().returns({});
+      // Intentionally put the telemetry feed as the second item.
+      const feedFactories = new Map([["feeds.foo", fooSpy],
+                                     ["feeds.telemetry", telemetrySpy]]);
+      store.init(feedFactories);
+      assert.ok(telemetrySpy.calledBefore(fooSpy));
+    });
   });
   describe("#uninit", () => {
     it("should emit an uninit event if provided on init", () => {


### PR DESCRIPTION
This closes #3522 

Patch notes:

* The init failure ping was sent from `ActivityStream.init` other than`bootstrap.js` for better test-ability.
* Not sure if we can re-arrange the `ActivityStream.init` function so that it could init the TelemetryFeed as early as possible to be able to report other potential init errors. @k88hudson What do you think about this?