### PR TITLE
fix(prefs): Default about:home search autoFocus to false

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -41,6 +41,10 @@ const REASON_ADDON_UNINSTALL = 6;
 // Configure default Activity Stream prefs with a plain `value` or a `getValue`
 // that computes a value. A `value_local_dev` is used for development defaults.
 const PREFS_CONFIG = new Map([
+  ["aboutHome.autoFocus", {
+    title: "Focus the about:home search box on load",
+    value: false
+  }],
   ["default.sites", {
     title: "Comma-separated list of default top sites to fill in behind visited sites",
     getValue: ({geo}) => DEFAULT_SITES.get(DEFAULT_SITES.has(geo) ? geo : "")
@@ -117,10 +121,6 @@ const PREFS_CONFIG = new Map([
   ["telemetry.ping.endpoint", {
     title: "Telemetry server endpoint",
     value: "https://tiles.services.mozilla.com/v4/links/activity-stream"
-  }],
-  ["aboutHome.autoFocus", {
-    title: "Focus the about:home search box on load",
-    value: true
   }]
 ]);
 


### PR DESCRIPTION
Fix #3544. r?@rlr I suppose the dream of a clean revert are long gone. ;)