### PR TITLE
fix(styles): Use right aligned ltr for url input

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -323,6 +323,11 @@
       position: relative;
     }
 
+    .url input:not(:placeholder-shown):dir(rtl) {
+      direction: ltr;
+      text-align: right;
+    }
+
     .section-title {
       margin-bottom: 5px;
       margin-inline-start: 205px;


### PR DESCRIPTION
Fix #3549. r?@rlr 

Before top, after bottom:
![screen shot 2017-09-19 at 4 51 20 pm](https://user-images.githubusercontent.com/438537/30620664-75a61f56-9d5b-11e7-8fc6-8f8519ab427d.png)

title I put as "youtube..."