### PR TITLE
feat(telemetry): add about:home first-window-opened load_trigger_type (#2658)

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -151,7 +151,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `ip` | [Auto populated by Onyx] The IP address of the client. | :two:
 | `locale` | [Auto populated by Onyx] The browser chrome's language (eg. en-US). | :two:
 | `load_trigger_ts` | [Optional][Server Counter][Server Alert for too many omissions]  DOMHighResTimeStamp of the action perceived by the user to trigger the load of this page. | :one:
-| `load_trigger_type` | [Server Counter][Server Alert for too many omissions] Either ["menu_plus_or_keyboard", "unexpected"]. | :one:
+| `load_trigger_type` | [Server Counter][Server Alert for too many omissions] Either ["first_window_opened", "menu_plus_or_keyboard", "unexpected"]. | :one:
 | `metadata_source` | [Optional] The source of which we computed metadata. Either (`MetadataService` or `Local` or `TippyTopProvider`). | :one:
 | `page` | [Required] One of ["about:newtab", "about:home", "unknown" (which either means not-applicable or is a bug)]. | :one:
 | `recommender_type` | [Optional] The type of recommendation that is being shown, if any. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -277,6 +277,7 @@ perf: {
 
   // What was the perceived trigger of the load action:
   "load_trigger_type": [
+    "first_window_opened" | // home only
     "menu_plus_or_keyboard" | // newtab only
     "unexpected" // sessions lacking actual start times
   ],

--- a/system-addon/common/PerfService.jsm
+++ b/system-addon/common/PerfService.jsm
@@ -67,6 +67,14 @@ _PerfService.prototype = {
    * Used to ensure that timestamps from the add-on code and the content code
    * are comparable.
    *
+   * @note If this is called from a context without a window
+   * (eg a JSM in chrome), it will return the timeOrigin of the XUL hidden
+   * window, which appears to be the first created window (and thus
+   * timeOrigin) in the browser.  Note also, however, there is also a private
+   * hidden window, presumably for private browsing, which appears to be
+   * created dynamically later.  Exactly how/when that shows up needs to be
+   * investigated.
+   *
    * @return {Number} A double of milliseconds with a precision of 0.5us.
    */
   get timeOrigin() {
@@ -75,7 +83,8 @@ _PerfService.prototype = {
 
   /**
    * Returns the "absolute" version of performance.now(), i.e. one that
-   * based on the timeOrigin of the XUL hiddenwindow.
+   * should ([bug 1401406](https://bugzilla.mozilla.org/show_bug.cgi?id=1401406)
+   * be comparable across both chrome and content.
    *
    * @return {Number}
    */

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -208,9 +208,7 @@ this.TelemetryFeed = class TelemetryFeed {
       // or someone who has changed their default home page preference to
       // something else and later clicks the toolbar.  It will also be
       // incorrectly unset if someone changes their "Home Page" preference to
-      // about:newtab.  load_trigger_type will be incorrectly set to
-      // "menu_plus_or_keyboard" in the case where someone opens a new tab,
-      // and then clicks the home button.
+      // about:newtab.
       //
       // That said, the ratio of these mistakes to correct cases should
       // be very small, and these issues should follow away as we implement
@@ -461,7 +459,11 @@ this.TelemetryFeed = class TelemetryFeed {
     // browser as those don't get the event until shown. Better fix for more
     // cases forthcoming.
     //
-    if (data.visibility_event_rcvd_ts) {
+    // XXX the about:home check (and the corresponding test) should go away
+    // once the load trigger stuff in add_session is refactored into
+    // setLoadTriggerInfo.
+    //
+    if (data.visibility_event_rcvd_ts && session.page !== "about:home") {
       this.setLoadTriggerInfo(port);
     }
 

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -8,8 +8,6 @@
 const {interfaces: Ci, utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-// XXX removeme and console.log call before landing
-Cu.import("resource://gre/modules/Console.jsm");
 
 const {actionTypes: at, actionUtils: au} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
 const {Prefs} = Cu.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
@@ -363,7 +361,6 @@ this.TelemetryFeed = class TelemetryFeed {
 
   async sendEvent(event_object) {
     if (this.telemetryEnabled) {
-      console.log(`sendEvent: ${JSON.stringify(event_object)}`);
       this.pingCentre.sendPing(event_object);
     }
   }

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -460,7 +460,7 @@ this.TelemetryFeed = class TelemetryFeed {
     // cases forthcoming.
     //
     // XXX the about:home check (and the corresponding test) should go away
-    // once the load trigger stuff in add_session is refactored into
+    // once the load_trigger stuff in addSession is refactored into
     // setLoadTriggerInfo.
     //
     if (data.visibility_event_rcvd_ts && session.page !== "about:home") {

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -194,9 +194,8 @@ this.TelemetryFeed = class TelemetryFeed {
    * @return {obj}    Session object
    */
   addSession(id, url) {
-    // XXX refactor to use saveSessionPerfData?
-    // XXX file bug on newtab -> home button -> close tab not sending
-    //     about:home telemetry (test if this is related to this patch or not)
+    // XXX refactor to use setLoadTriggerInfo or saveSessionPerfData
+
     // "unexpected" will be overwritten when appropriate
     let load_trigger_type = "unexpected";
     let load_trigger_ts;
@@ -209,8 +208,13 @@ this.TelemetryFeed = class TelemetryFeed {
       // or someone who has changed their default home page preference to
       // something else and later clicks the toolbar.  It will also be
       // incorrectly unset if someone changes their "Home Page" preference to
-      // about:newtab.  The ratio of these mistakes to correct cases should
-      // be very small.
+      // about:newtab.  load_trigger_type will be incorrectly set to
+      // "menu_plus_or_keyboard" in the case where someone opens a new tab,
+      // and then clicks the home button.
+      //
+      // That said, the ratio of these mistakes to correct cases should
+      // be very small, and these issues should follow away as we implement
+      // the remaining load_trigger_type values for about:home in issue 3556.
       //
       // XXX file a bug to implement remaining about:home cases so this
       // problem will go away and link to it here.

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -101,7 +101,8 @@ const SessionPing = Joi.object().keys(Object.assign({}, baseKeys, {
     //
     // Not required at least for the error cases where the observer event
     // doesn't fire
-    load_trigger_type: Joi.valid(["menu_plus_or_keyboard", "unexpected"])
+    load_trigger_type: Joi.valid(["first_window_opened",
+      "menu_plus_or_keyboard", "unexpected"])
       .notes(["server counter", "server counter alert"]).required(),
 
     // When did the topsites element finish painting?  Note that, at least for

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -29,6 +29,7 @@ describe("TelemetryFeed", () => {
     getMostRecentAbsMarkStartByName() { return 1234; }
     mark() {}
     absNow() { return 123; }
+    get timeOrigin() { return 123456; }
   }
   const perfService = new PerfService();
   const {
@@ -114,7 +115,38 @@ describe("TelemetryFeed", () => {
 
       assert.propertyVal(session.perf, "load_trigger_type", "unexpected");
     });
+    it("should set load_trigger_type to first_window_opened on the first about:home seen", () => {
+      const session = instance.addSession("foo", "about:home");
+
+      assert.propertyVal(session.perf, "load_trigger_type",
+        "first_window_opened");
+    });
+    it("should not set load_trigger_type to first_window_opened on the second about:home seen", () => {
+      instance.addSession("foo", "about:home");
+
+      const session2 = instance.addSession("foo", "about:home");
+
+      assert.propertyNotVal(session2.perf, "load_trigger_type",
+        "first_window_opened");
+    });
+    it("should set load_trigger_ts to the value of perfService.timeOrigin", () => {
+      const session = instance.addSession("foo", "about:home");
+
+      assert.propertyVal(session.perf, "load_trigger_ts",
+        123456);
+    });
+    it("should a valid session ping on the first about:home seen", () => {
+      // Add a session
+      const portID = "foo";
+      const session = instance.addSession(portID, "about:home");
+
+      // Create a ping referencing the session
+      const ping = instance.createSessionEndEvent(session);
+      console.log("ping: ", JSON.stringify(ping));
+      assert.validate(ping, SessionPing);
+    });
   });
+
   describe("#browserOpenNewtabStart", () => {
     it("should call perfService.mark with browser-open-newtab-start", () => {
       sandbox.stub(perfService, "mark");

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -430,7 +430,7 @@ describe("TelemetryFeed", () => {
       assert.include(instance.sessions.get("port123").perf, data);
     });
 
-    it("should call setLoadTriggerInfo if data has visibility_event_rcvd_ts and ", () => {
+    it("should call setLoadTriggerInfo if data has visibility_event_rcvd_ts", () => {
       sandbox.stub(instance, "setLoadTriggerInfo");
       instance.addSession("port123");
       const data = {visibility_event_rcvd_ts: 444455};

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -430,7 +430,7 @@ describe("TelemetryFeed", () => {
       assert.include(instance.sessions.get("port123").perf, data);
     });
 
-    it("should call setLoadTriggerInfo if data has visibility_event_rcvd_ts", () => {
+    it("should call setLoadTriggerInfo if data has visibility_event_rcvd_ts and ", () => {
       sandbox.stub(instance, "setLoadTriggerInfo");
       instance.addSession("port123");
       const data = {visibility_event_rcvd_ts: 444455};
@@ -447,6 +447,16 @@ describe("TelemetryFeed", () => {
       instance.addSession("port123");
 
       instance.saveSessionPerfData("port123", {monkeys_ts: 444455});
+
+      assert.notCalled(instance.setLoadTriggerInfo);
+    });
+
+    it("should not call setLoadTriggerInfo when url is about:home", () => {
+      sandbox.stub(instance, "setLoadTriggerInfo");
+      instance.addSession("port123", "about:home");
+      const data = {visibility_event_rcvd_ts: 444455};
+
+      instance.saveSessionPerfData("port123", data);
 
       assert.notCalled(instance.setLoadTriggerInfo);
     });


### PR DESCRIPTION
How to test:

1. buildmc & `mach run`
2. ensure that your telemetry and logging prefs are on
3. restart and open the browser console
4. open a new tab
5. close the original tab from the startup
6. in the console, you should see a TELEMETRY PING log with page=about:home, load_trigger_type=first_window_opened,load_trigger_ts=(some number)
7. open a new window and close
8. in the console, you should see a TELEMETRY PING log with page=about:home, load_trigger_type=unexpected

@fmarier fmarier has given this data-review+