### PR TITLE
fix(styles): Use the same 12px margin between section title and content

### DIFF
--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -35,6 +35,11 @@ main {
   }
 }
 
+.section-top-bar {
+  height: 16px;
+  margin-bottom: 12px;
+}
+
 .section-title {
   font-size: $section-title-font-size;
   font-weight: bold;

--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -1,8 +1,6 @@
 .sections-list {
   .section-top-bar {
     position: relative;
-    height: 16px;
-    margin-bottom: 18px;
 
     .section-info-option {
       offset-inline-end: 0;

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -11,7 +11,9 @@ const TopSites = props => {
   const placeholderCount = props.TopSitesCount - realTopSites.length;
   return (<TopSitesPerfTimer>
     <section className="top-sites">
-      <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
+      <div className="section-top-bar">
+        <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
+      </div>
       <ul className="top-sites-list">
         {realTopSites.map((link, index) => link && <TopSite
           key={link.guid || link.url}


### PR DESCRIPTION
Fix #3562. r?@sarracini 

Before left, after right:
![screen shot 2017-09-20 at 7 26 49 pm](https://user-images.githubusercontent.com/438537/30676270-0cf0b75c-9e3a-11e7-9423-8b1e6f689686.png)
