### PR TITLE
fix(styles): Size edit input boxes based on available width

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -315,10 +315,11 @@
 
 .topsite-form {
   .form-wrapper {
+    margin: auto;
+    max-width: 350px;
     padding: 15px 0;
 
     .field {
-      margin-inline-start: 205px;
       position: relative;
     }
 
@@ -329,7 +330,6 @@
 
     .section-title {
       margin-bottom: 5px;
-      margin-inline-start: 205px;
     }
 
     input {
@@ -338,7 +338,7 @@
         border-radius: 2px;
         margin: 5px 0;
         padding: 7px;
-        width: 350px;
+        width: 100%;
 
         &:focus {
           border: $input-border-active;


### PR DESCRIPTION
Fix #3598. r?@rlr Were the `205px` picked for a specific reason?

![screen shot 2017-09-26 at 11 28 09 am](https://user-images.githubusercontent.com/438537/30869047-3c90ac56-a2ae-11e7-9319-ae727a817c85.png)
![screen shot 2017-09-26 at 11 24 37 am](https://user-images.githubusercontent.com/438537/30869053-3f51af08-a2ae-11e7-9333-ff8beb1a3922.png)
![screen shot 2017-09-26 at 11 24 59 am](https://user-images.githubusercontent.com/438537/30869060-4326116e-a2ae-11e7-9cda-81c290cb2efa.png)
![screen shot 2017-09-26 at 11 25 14 am](https://user-images.githubusercontent.com/438537/30869061-4467f772-a2ae-11e7-8f97-470d3bb502a5.png)
![screen shot 2017-09-26 at 11 25 29 am](https://user-images.githubusercontent.com/438537/30869063-45e451d6-a2ae-11e7-8f98-4e58f71c006b.png)
