### PR TITLE
fix(styles): Remove italics from edit placeholder

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -343,10 +343,6 @@
         &:focus {
           border: $input-border-active;
         }
-
-        &::placeholder {
-          font-style: italic;
-        }
       }
     }
 


### PR DESCRIPTION
Fix #3602. r?@rlr Guess what?! Taking away italics makes it not italics. ;)

<img width="381" alt="image" src="https://user-images.githubusercontent.com/438537/30870841-f8621f9c-a2b2-11e7-9503-0e6a3ac547a8.png">
