### PR TITLE
fix(topics): Allow showing uninitialized topics to avoid height changes on receiving topics

### DIFF
--- a/system-addon/common/PrerenderData.jsm
+++ b/system-addon/common/PrerenderData.jsm
@@ -74,8 +74,7 @@ this.PrerenderData = new _PrerenderData({
       icon: "pocket",
       id: "topstories",
       order: 1,
-      title: {id: "header_recommended_by", values: {provider: "Pocket"}},
-      topics: [{}]
+      title: {id: "header_recommended_by", values: {provider: "Pocket"}}
     },
     {
       enabled: true,

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -142,9 +142,11 @@ class Section extends React.PureComponent {
       contextMenuOptions, intl, initialized
     } = this.props;
     const maxCards = CARDS_PER_ROW * maxRows;
+
+    // Show topics only for top stories and if it's not initialized yet (so
+    // content doesn't shift when it is loaded) or has loaded with topics
     const shouldShowTopics = (id === "topstories" &&
-      this.props.topics &&
-      this.props.topics.length > 0);
+      (!this.props.topics || this.props.topics.length > 0));
 
     const infoOptionIconA11yAttrs = {
       "aria-haspopup": "true",

--- a/system-addon/content-src/components/Topics/Topics.jsx
+++ b/system-addon/content-src/components/Topics/Topics.jsx
@@ -14,7 +14,7 @@ class Topics extends React.PureComponent {
     return (
       <div className="topic">
         <span><FormattedMessage id="pocket_read_more" /></span>
-        <ul>{topics.map(t => <Topic key={t.name} url={t.url} name={t.name} />)}</ul>
+        <ul>{topics && topics.map(t => <Topic key={t.name} url={t.url} name={t.name} />)}</ul>
 
         {read_more_endpoint && <a className="topic-read-more" href={read_more_endpoint}>
           <FormattedMessage id="pocket_read_even_more" />

--- a/system-addon/test/unit/content-src/components/Sections.test.jsx
+++ b/system-addon/test/unit/content-src/components/Sections.test.jsx
@@ -163,22 +163,38 @@ describe("<Section>", () => {
       assert.lengthOf(wrapper.find('.info-option-icon[aria-expanded="false"]'), 1);
     });
 
-    it("should render topics component for non-empty topics", () => {
-      let TOP_STORIES_SECTION = {
-        id: "topstories",
-        title: "TopStories",
-        rows: [{guid: 1, link: "http://localhost", isDefault: true}],
-        topics: [],
-        read_more_endpoint: "http://localhost/read-more",
-        maxRows: 1,
-        eventSource: "TOP_STORIES"
-      };
-      wrapper = mountWithIntl(<Section {...TOP_STORIES_SECTION} />);
-      assert.lengthOf(wrapper.find(".topic"), 0);
+    describe("should render topics component", () => {
+      let TOP_STORIES_SECTION;
+      beforeEach(() => {
+        TOP_STORIES_SECTION = {
+          id: "topstories",
+          title: "TopStories",
+          rows: [{guid: 1, link: "http://localhost", isDefault: true}],
+          topics: [],
+          read_more_endpoint: "http://localhost/read-more",
+          maxRows: 1,
+          eventSource: "TOP_STORIES"
+        };
+      });
+      it("should not render for empty topics", () => {
+        wrapper = mountWithIntl(<Section {...TOP_STORIES_SECTION} />);
 
-      TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
-      wrapper = mountWithIntl(<Section {...TOP_STORIES_SECTION} />);
-      assert.lengthOf(wrapper.find(".topic"), 1);
+        assert.lengthOf(wrapper.find(".topic"), 0);
+      });
+      it("should render for non-empty topics", () => {
+        TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
+
+        wrapper = mountWithIntl(<Section {...TOP_STORIES_SECTION} />);
+
+        assert.lengthOf(wrapper.find(".topic"), 1);
+      });
+      it("should render for uninitialized topics", () => {
+        delete TOP_STORIES_SECTION.topics;
+
+        wrapper = mountWithIntl(<Section {...TOP_STORIES_SECTION} />);
+
+        assert.lengthOf(wrapper.find(".topic"), 1);
+      });
     });
   });
 


### PR DESCRIPTION
Fix #3604. r?@k88hudson Make topics initial data be like the actual initial data of undefined and render the empty section until actual topics come in.