### PR TITLE
fix(card): Fade from gradient to loaded image only after loading

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -50,15 +50,11 @@
   }
 
   .card-preview-image-outer {
+    background-color: $background-primary;
     position: relative;
-    background: linear-gradient(135deg, $grey-40, $grey-30);
     height: $card-preview-image-height;
     border-radius: $border-radius $border-radius 0 0;
     overflow: hidden;
-
-    &:dir(rtl) {
-      background: linear-gradient(225deg, $grey-40, $grey-30);
-    }
 
     &::after {
       border-bottom: 1px solid rgba(0, 0, 0, 0.05);
@@ -74,8 +70,8 @@
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
-      transition: opacity 1s;
       opacity: 0;
+      transition: opacity 1s $photon-easing;
       &.loaded {
         opacity: 1;
       }

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -11,6 +11,9 @@ $grey-90: #0C0C0D;
 $teal-70: #008EA4;
 $red-60: #D70022;
 
+// Photon transitions from http://design.firefox.com/photon/motion/duration-and-easing.html
+$photon-easing: cubic-bezier(.07, .95, 0, 1);
+
 // Aliases and derived styles based on Photon colors for common usage
 $background-primary: $grey-10;
 $background-secondary: $grey-20;

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -27,6 +27,8 @@ overrider.set({
   ContentSearchUIController: function() {}, // NB: This is a function/constructor
   dump() {},
   fetch() {},
+  // eslint-disable-next-line object-shorthand
+  Image: function() {}, // NB: This is a function/constructor
   Preferences: FakePrefs,
   Services: {
     locale: {


### PR DESCRIPTION
Fix #3605. r?@sarracini Adds an image loader that sets the "loaded" class only after loading instead of when the image is set.

See video with existing on left and with PR on right:
https://ed.agadak.net/as/activity-stream.fade-pocket.webm
This video includes the changes from #3610.