### PR TITLE
chore(styles): Backport Bug 1399642 - Use photon search icon in awesomebar. r=dao

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -4,7 +4,7 @@
   $search-height: 36px;
   $search-input-left-label-width: 35px;
   $search-button-width: 36px;
-  $search-glyph-image: url('chrome://browser/skin/find.svg');
+  $search-glyph-image: url('chrome://browser/skin/search-glass.svg');
   $glyph-forward: url('chrome://browser/skin/forward.svg');
   $search-glyph-size: 16px;
   $search-glyph-fill: rgba($grey-90, 0.4);


### PR DESCRIPTION
Fix #3612. r=dao