### PR TITLE
feat(sections): Add support for nested prefs

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -110,10 +110,20 @@ class PreferencesPane extends React.PureComponent {
               {sections
                 .filter(section => !section.shouldHidePref)
                 .map(({id, title, enabled, pref}) =>
-                  <PreferencesInput key={id} className="showSection" prefName={(pref && pref.feed) || id}
-                    value={enabled} onChange={(pref && pref.feed) ? this.handlePrefChange : this.handleSectionChange}
-                    titleString={(pref && pref.titleString) || title} descString={pref && pref.descString} />)}
+                  <div key={id}>
+                    <PreferencesInput className="showSection" prefName={(pref && pref.feed) || id}
+                      value={enabled} onChange={(pref && pref.feed) ? this.handlePrefChange : this.handleSectionChange}
+                      titleString={(pref && pref.titleString) || title} descString={pref && pref.descString} />
 
+                        {pref.nestedPrefs && pref.nestedPrefs.map(nestedPref =>
+                          <div key={pref.nestedPrefs.name} className={`options${enabled ? "" : " disabled"}`}>
+                            <PreferencesInput prefName={nestedPref.name} disabled={!enabled} value={prefs[nestedPref.name]}
+                              onChange={this.handlePrefChange} titleString={nestedPref.titleString}
+                              labelClassName={`icon ${nestedPref.icon}`} />
+                          </div>
+                        )}
+                  </div>
+                )}
               <hr />
 
               <PreferencesInput className="showSnippets" prefName="feeds.snippets"

--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -16,6 +16,8 @@ const PreferencesInput = props => (
     {props.descString && <p className="prefs-input-description">
       {getFormattedMessage(props.descString)}
     </p>}
+    {React.Children.map(props.children,
+      child => <div className={`options${child.props.disabled ? " disabled" : ""}`}>{child}</div>)}
   </section>
 );
 
@@ -93,36 +95,57 @@ class PreferencesPane extends React.PureComponent {
               <h1><FormattedMessage id="settings_pane_header" /></h1>
               <p><FormattedMessage id="settings_pane_body2" /></p>
 
-              <PreferencesInput className="showSearch" prefName="showSearch" value={prefs.showSearch} onChange={this.handlePrefChange}
-                titleString={{id: "settings_pane_search_header"}} descString={{id: "settings_pane_search_body"}} />
+              <PreferencesInput
+                className="showSearch"
+                prefName="showSearch"
+                value={prefs.showSearch}
+                onChange={this.handlePrefChange}
+                titleString={{id: "settings_pane_search_header"}}
+                descString={{id: "settings_pane_search_body"}} />
 
               <hr />
 
-              <PreferencesInput className="showTopSites" prefName="showTopSites" value={prefs.showTopSites} onChange={this.handlePrefChange}
-                titleString={{id: "settings_pane_topsites_header"}} descString={{id: "settings_pane_topsites_body"}} />
+              <PreferencesInput
+                className="showTopSites"
+                prefName="showTopSites"
+                value={prefs.showTopSites}
+                onChange={this.handlePrefChange}
+                titleString={{id: "settings_pane_topsites_header"}}
+                descString={{id: "settings_pane_topsites_body"}}>
 
-              <div className={`options${prefs.showTopSites ? "" : " disabled"}`}>
-                <PreferencesInput className="showMoreTopSites" prefName="topSitesCount" disabled={!prefs.showTopSites}
-                  value={prefs.topSitesCount !== TOP_SITES_DEFAULT_LENGTH} onChange={this.handlePrefChange}
-                  titleString={{id: "settings_pane_topsites_options_showmore"}} labelClassName="icon icon-topsites" />
-              </div>
+                <PreferencesInput
+                  className="showMoreTopSites"
+                  prefName="topSitesCount"
+                  disabled={!prefs.showTopSites}
+                  value={prefs.topSitesCount !== TOP_SITES_DEFAULT_LENGTH}
+                  onChange={this.handlePrefChange}
+                  titleString={{id: "settings_pane_topsites_options_showmore"}}
+                  labelClassName="icon icon-topsites" />
+              </PreferencesInput>
 
               {sections
                 .filter(section => !section.shouldHidePref)
                 .map(({id, title, enabled, pref}) =>
-                  <div key={id}>
-                    <PreferencesInput className="showSection" prefName={(pref && pref.feed) || id}
-                      value={enabled} onChange={(pref && pref.feed) ? this.handlePrefChange : this.handleSectionChange}
-                      titleString={(pref && pref.titleString) || title} descString={pref && pref.descString} />
+                  <PreferencesInput
+                    key={id}
+                    className="showSection"
+                    prefName={(pref && pref.feed) || id}
+                    value={enabled}
+                    onChange={(pref && pref.feed) ? this.handlePrefChange : this.handleSectionChange}
+                    titleString={(pref && pref.titleString) || title}
+                    descString={pref && pref.descString}>
 
-                        {pref.nestedPrefs && pref.nestedPrefs.map(nestedPref =>
-                          <div key={pref.nestedPrefs.name} className={`options${enabled ? "" : " disabled"}`}>
-                            <PreferencesInput prefName={nestedPref.name} disabled={!enabled} value={prefs[nestedPref.name]}
-                              onChange={this.handlePrefChange} titleString={nestedPref.titleString}
-                              labelClassName={`icon ${nestedPref.icon}`} />
-                          </div>
-                        )}
-                  </div>
+                    {pref.nestedPrefs && pref.nestedPrefs.map(nestedPref =>
+                      <PreferencesInput
+                        key={nestedPref.name}
+                        prefName={nestedPref.name}
+                        disabled={!enabled}
+                        value={prefs[nestedPref.name]}
+                        onChange={this.handlePrefChange}
+                        titleString={nestedPref.titleString}
+                        labelClassName={`icon ${nestedPref.icon}`} />
+                    )}
+                   </PreferencesInput>
                 )}
               <hr />
 

--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -50,7 +50,7 @@
       margin: $prefs-spacing 0;
 
       p {
-        margin: 5px 0 5px 30px;
+        margin: 5px 0 20px 30px;
       }
 
       label {

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -23,7 +23,7 @@ const BUILT_IN_SECTIONS = {
       titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
       descString: {id: options.provider_description || "pocket_feedback_body"}
     },
-    shouldHidePref:  options.hidden,
+    shouldHidePref: options.hidden,
     eventSource: "TOP_STORIES",
     icon: options.provider_icon,
     title: {id: "header_recommended_by", values: {provider: options.provider_name}},

--- a/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
+++ b/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
@@ -45,7 +45,26 @@ describe("<PreferencesPane>", () => {
   const fakeSections = [
     {id: "section1", shouldHidePref: false, enabled: true, pref: {titleString: "section1", feed: "section1_feed"}},
     {id: "section2", shouldHidePref: false, enabled: false, pref: {titleString: "section2"}},
-    {id: "section3", shouldHidePref: true, enabled: true, pref: {titleString: {id: "section3"}}}
+    {id: "section3", shouldHidePref: true, enabled: true, pref: {titleString: {id: "section3"}}},
+    {
+      id: "section4",
+      shouldHidePref: false,
+      enabled: true,
+      pref: {
+        titleString: {id: "section4"},
+        nestedPrefs: [
+          {
+            name: "nestedPref1",
+            titleString: {id: "Some nested pref", values: {}},
+            icon: "icon-info"
+          }, {
+            name: "nestedPref2",
+            titleString: {id: "Some other nested pref", values: {}},
+            icon: "icon-info"
+          }
+        ]
+      }
+    }
   ];
   const fakePreferencesPane = {visible: false};
 
@@ -117,10 +136,11 @@ describe("<PreferencesPane>", () => {
   });
   it("should show PreferencesInputs for a section if and only if shouldHidePref is false", () => {
     const sectionsWrapper = wrapper.find(".showSection");
-    assert.equal(sectionsWrapper.length, 2);
+    assert.equal(sectionsWrapper.length, 3);
     assert.ok(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section1_feed" />));
     assert.ok(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section2" />));
     assert.notOk(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section3" />));
+    assert.ok(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section4" />));
   });
   it("should set the value prop of a section PreferencesInput to equal section.enabled", () => {
     const section1 = wrapper.findWhere(prefInput => prefInput.props().prefName === "section1_feed");
@@ -139,5 +159,16 @@ describe("<PreferencesPane>", () => {
     showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesCount", checked: true}});
     assert.calledOnce(dispatch);
     assert.calledWith(dispatch, ac.SetPref("topSitesCount", 12));
+  });
+  it("should render nested PreferencesInput for nested Section pref", () => {
+    const nestedPrefsWrapper = wrapper.find(".options");
+    assert.ok(nestedPrefsWrapper.containsMatchingElement(<PreferencesInput prefName="nestedPref1" />));
+    assert.ok(nestedPrefsWrapper.containsMatchingElement(<PreferencesInput prefName="nestedPref2" />));
+  });
+  it("should dispatch a SetPref action when a nested PreferencesInput is clicked", () => {
+    const section1 = wrapper.findWhere(prefInput => prefInput.props().prefName === "nestedPref1");
+    section1.simulate("change", {target: {name: "nestedPref1", checked: false}});
+    assert.calledOnce(dispatch);
+    assert.calledWith(dispatch, ac.SetPref("nestedPref1", false));
   });
 });

--- a/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
+++ b/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
@@ -137,10 +137,16 @@ describe("<PreferencesPane>", () => {
   it("should show PreferencesInputs for a section if and only if shouldHidePref is false", () => {
     const sectionsWrapper = wrapper.find(".showSection");
     assert.equal(sectionsWrapper.length, 3);
+
     assert.ok(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section1_feed" />));
     assert.ok(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section2" />));
     assert.notOk(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section3" />));
-    assert.ok(sectionsWrapper.containsMatchingElement(<PreferencesInput prefName="section4" />));
+    assert.ok(sectionsWrapper.containsMatchingElement(
+      <PreferencesInput prefName="section4">
+        <PreferencesInput prefName="nestedPref1" />
+        <PreferencesInput prefName="nestedPref2" />
+      </PreferencesInput>)
+    );
   });
   it("should set the value prop of a section PreferencesInput to equal section.enabled", () => {
     const section1 = wrapper.findWhere(prefInput => prefInput.props().prefName === "section1_feed");
@@ -161,7 +167,7 @@ describe("<PreferencesPane>", () => {
     assert.calledWith(dispatch, ac.SetPref("topSitesCount", 12));
   });
   it("should render nested PreferencesInput for nested Section pref", () => {
-    const nestedPrefsWrapper = wrapper.find(".options");
+    const nestedPrefsWrapper = wrapper.find(".showSection");
     assert.ok(nestedPrefsWrapper.containsMatchingElement(<PreferencesInput prefName="nestedPref1" />));
     assert.ok(nestedPrefsWrapper.containsMatchingElement(<PreferencesInput prefName="nestedPref2" />));
   });


### PR DESCRIPTION
Enhancement to support nested prefs in Sections.

This will be needed when
- refactoring TopSites to a Section as it has a nested pref ("Show two rows")
- enhancing the spoc experiment to support opt-out functionality via a nested pref

To declare nested prefs in SectionManager:

```javascript
const BUILT_IN_SECTIONS = {
  "feeds.section.topstories": options => ({
  id: "topstories",
  pref: {
    titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
    descString: {id: options.provider_description || "pocket_feedback_body"},
    nestedPrefs: [{
      name: "foo",
        titleString: {id: "Some nested pref", values: {}},
        icon: "icon-info"
      }, {
        name: "bar",
        titleString: {id: "Some other nested pref", values: {}},
        icon: "icon-info"
    }]
  ...
```

UI:
<img width="351" alt="sectionmanager-screenshot2" src="https://user-images.githubusercontent.com/472523/31151087-02afcb6e-a864-11e7-9b1d-a56d89540151.png">




