### PR TITLE
fix(styles): Avoid reshowing info option when moving pointer away and back quickly

### DIFF
--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -55,6 +55,10 @@
     transition: visibility 0.2s, opacity 0.2s $photon-easing;
   }
 
+  .info-option-icon:not([aria-expanded="true"]) + .info-option {
+    pointer-events: none;
+  }
+
   .info-option {
     z-index: 9999;
     position: absolute;


### PR DESCRIPTION
Fix #3635. r?@sarracini 