### PR TITLE
Log TopSites icons stats in session object.

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -171,9 +171,11 @@ and losing focus. | :one:
 | `highlights_data_late_by_ms` | [Optional] Time in ms it took for Highlights to become initialized | :one:
 | `topsites_data_late_by_ms` | [Optional] Time in ms it took for TopSites to become initialized | :one:
 | `topsites_first_painted_ts` | [Optional][Service Counter][Server Alert for too many omissions] Timestamp of when the Top Sites element finished painting (possibly with only placeholder screenshots) | :one:
-| `topsites_size` | [Optional] The size of the Topsites set. | :one:
-| `topsites_screenshot` | [Optional] The size of the Topsites set with screenshot metadata. | :one:
-| `topsites_tippytop` | [Optional] The size of the Topsites set with TippyTop metadata. | :one:
+| `screenshot_with_icon` | [Optional] Number of topsites that display a screenshot and a favicon. | :one:
+| `screenshot` | [Optional] Number of topsites that display only a screenshot. | :one:
+| `tippytop` | [Optional] Number of topsites that display a tippytop icon. | :one:
+| `rich_icon` | [Optional] Number of topsites that display a high quality favicon. | :one:
+| `no_image` | [Optional] Number of topsites that have no screenshot. | :one:
 | `visibility_event_rcvd_ts` | [Optional][Server Counter][Server Alert for too many omissions] DOMHighResTimeStamp of when the page itself receives an event that document.visibilityState == visible. | :one:
 | `tiles` | [Required] A list of tile objects for the Pocket articles. Each tile object mush have a ID, and optionally a "pos" property to indicate the tile position | :one:
 | `click` | [Optional] An integer to record the 0-based index when user clicks on a Pocket tile. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -291,6 +291,16 @@ perf: {
   // and is therefore just showing placeholder screenshots.
   "topsites_first_painted_ts": 5,
 
+  // The 5 different types of TopSites icons and how many of each kind did the
+  // user see.
+  "topsites_icon_stats": {
+    "screenshot_with_icon": 2,
+    "screenshot": 1,
+    "tippytop": 2,
+    "rich_icon": 1,
+    "no_image": 0
+  }
+
   // How much longer the data took, in milliseconds, to be ready for display
   // than it would have been in the ideal case. The user currently sees placeholder
   // cards instead of real cards for approximately this length of time. This is

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -6,29 +6,88 @@ const TopSitesEdit = require("./TopSitesEdit");
 const {TopSite, TopSitePlaceholder} = require("./TopSite");
 const CollapsibleSection = require("content-src/components/CollapsibleSection/CollapsibleSection");
 const ComponentPerfTimer = require("content-src/components/ComponentPerfTimer/ComponentPerfTimer");
+const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
+const {MIN_RICH_FAVICON_SIZE, MIN_CORNER_FAVICON_SIZE} = require("./TopSitesConstants");
 
-const TopSites = props => {
-  const realTopSites = props.TopSites.rows.slice(0, props.TopSitesCount);
-  const placeholderCount = props.TopSitesCount - realTopSites.length;
-  const infoOption = {
-    header: {id: "settings_pane_topsites_header"},
-    body: {id: "settings_pane_topsites_body"}
+/**
+ * Iterates through TopSites and counts types of images.
+ * @param acc Accumulator for reducer.
+ * @param topsite Entry in TopSites.
+ */
+function countTopSitesIconsTypes(topSites) {
+  const countTopSitesTypes = (acc, link) => {
+    if (link.tippyTopIcon) {
+      acc.tippytop++;
+    } else if (link.faviconSize >= MIN_RICH_FAVICON_SIZE) {
+      acc.rich_icon++;
+    } else if (link.screenshot && link.faviconSize >= MIN_CORNER_FAVICON_SIZE) {
+      acc.screenshot_with_icon++;
+    } else if (link.screenshot) {
+      acc.screenshot++;
+    } else {
+      acc.no_image++;
+    }
+
+    return acc;
   };
-  return (<ComponentPerfTimer id="topsites" initialized={props.TopSites.initialized} dispatch={props.dispatch}>
-    <CollapsibleSection className="top-sites" icon="topsites" title={<FormattedMessage id="header_top_sites" />} infoOption={infoOption} prefName="collapseTopSites" Prefs={props.Prefs} dispatch={props.dispatch}>
-      <ul className="top-sites-list">
-        {realTopSites.map((link, index) => link && <TopSite
-          key={link.guid || link.url}
-          dispatch={props.dispatch}
-          link={link}
-          index={index}
-          intl={props.intl} />)}
-        {placeholderCount > 0 && [...Array(placeholderCount)].map((_, i) => <TopSitePlaceholder key={i} />)}
-      </ul>
-      <TopSitesEdit {...props} />
-    </CollapsibleSection>
-  </ComponentPerfTimer>);
-};
+
+  return topSites.reduce(countTopSitesTypes, {
+    "screenshot_with_icon": 0,
+    "screenshot": 0,
+    "tippytop": 0,
+    "rich_icon": 0,
+    "no_image": 0
+  });
+}
+
+class TopSites extends React.PureComponent {
+  componentDidUpdate() {
+    const realTopSites = this.props.TopSites.rows.slice(0, this.props.TopSitesCount);
+
+    const topSitesIconsStats = countTopSitesIconsTypes(realTopSites);
+    // Dispatch telemetry event with the count of TopSites images types.
+    this.props.dispatch(ac.SendToMain({
+      type: at.SAVE_SESSION_PERF_DATA,
+      data: {topsites_icon_stats: topSitesIconsStats}
+    }));
+  }
+
+  componentDidMount() {
+    const realTopSites = this.props.TopSites.rows.slice(0, this.props.TopSitesCount);
+
+    const topSitesIconsStats = countTopSitesIconsTypes(realTopSites);
+    // Dispatch telemetry event with the count of TopSites images types.
+    this.props.dispatch(ac.SendToMain({
+      type: at.SAVE_SESSION_PERF_DATA,
+      data: {topsites_icon_stats: topSitesIconsStats}
+    }));
+  }
+
+  render() {
+    const props = this.props;
+    const realTopSites = props.TopSites.rows.slice(0, props.TopSitesCount);
+
+    const placeholderCount = props.TopSitesCount - realTopSites.length;
+    const infoOption = {
+      header: {id: "settings_pane_topsites_header"},
+      body: {id: "settings_pane_topsites_body"}
+    };
+    return (<ComponentPerfTimer id="topsites" initialized={props.TopSites.initialized} dispatch={props.dispatch}>
+      <CollapsibleSection className="top-sites" icon="topsites" title={<FormattedMessage id="header_top_sites" />} infoOption={infoOption} prefName="collapseTopSites" Prefs={props.Prefs} dispatch={props.dispatch}>
+        <ul className="top-sites-list">
+          {realTopSites.map((link, index) => link && <TopSite
+            key={link.guid || link.url}
+            dispatch={props.dispatch}
+            link={link}
+            index={index}
+            intl={props.intl} />)}
+          {placeholderCount > 0 && [...Array(placeholderCount)].map((_, i) => <TopSitePlaceholder key={i} />)}
+        </ul>
+        <TopSitesEdit {...props} />
+      </CollapsibleSection>
+    </ComponentPerfTimer>);
+  }
+}
 
 module.exports = connect(state => ({TopSites: state.TopSites, Prefs: state.Prefs, TopSitesCount: state.Prefs.values.topSitesCount}))(TopSites);
 module.exports._unconnected = TopSites;

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -118,6 +118,15 @@ const SessionPing = Joi.object().keys(Object.assign({}, baseKeys, {
     topsites_first_painted_ts: Joi.number().positive()
       .notes(["server counter", "server counter alert"]),
 
+    // Information about the quality of TopSites images and icons.
+    topsites_icon_stats: Joi.object().keys({
+      rich_icon: Joi.number(),
+      screenshot: Joi.number(),
+      screenshot_with_icon: Joi.number(),
+      tippytop: Joi.number(),
+      no_image: Joi.number()
+    }),
+
     // When the page itself receives an event that document.visibilityState
     // == visible.
     //

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -160,6 +160,26 @@ describe("TelemetryFeed", () => {
       assert.propertyVal(instance.sessions.get("foo").perf,
                          "topsites_data_late_by_ms", 10);
     });
+    it("should be a valid ping with the topsites_icon_stats perf", () => {
+      // Add a session
+      const portID = "foo";
+      const session = instance.addSession(portID, "about:home");
+      instance.saveSessionPerfData("foo", {
+        topsites_icon_stats: {
+          "screenshot_with_icon": 2,
+          "screenshot": 1,
+          "tippytop": 2,
+          "rich_icon": 1,
+          "no_image": 0
+        }
+      });
+
+      // Create a ping referencing the session
+      const ping = instance.createSessionEndEvent(session);
+      assert.validate(ping, SessionPing);
+      assert.propertyVal(instance.sessions.get("foo").perf.topsites_icon_stats,
+        "screenshot_with_icon", 2);
+    });
   });
 
   describe("#browserOpenNewtabStart", () => {


### PR DESCRIPTION
Closes #3449.
I've moved the decision logic for topsite image and favicon from `TopSiteLink.render` to TopSites into it's own fn `selectTopSiteIcon`. This way on render `<TopSites>` knows the image quality of all its children. I also think it makes it easier to test.
The information about the 3 types of TopSite images: `tippytop`, `screenshot + favicon`, `screenshot + fallback letter` are added to the user session and updated every time TopSites updates. They are only sent once when the session ends.

@emtwo we currently handle tippytop and rich icons as one (because visually it's the same thing when we render). Are we interested in splitting the telemetry information?