### PR TITLE
fix(cache): Allow concurrent cache callers to get links with shared state

### DIFF
--- a/system-addon/lib/LinksCache.jsm
+++ b/system-addon/lib/LinksCache.jsm
@@ -19,19 +19,21 @@ this.LinksCache = class LinksCache {
    *
    * @param {object} linkObject Object containing the link property
    * @param {string} linkProperty Name of property on object to access
-   * @param {function} migrator Optional callback receiving the old and new link
-   *                            to allow custom migrating data from old to new.
+   * @param {array} properties Optional properties list to migrate to new links.
    * @param {function} shouldRefresh Optional callback receiving the old and new
    *                                 options to refresh even when not expired.
    */
-  constructor(linkObject, linkProperty, migrator = () => {}, shouldRefresh = () => {}) {
+  constructor(linkObject, linkProperty, properties = [], shouldRefresh = () => {}) {
     this.clear();
+
     // Allow getting links from both methods and array properties
     this.linkGetter = options => {
       const ret = linkObject[linkProperty];
       return typeof ret === "function" ? ret.call(linkObject, options) : ret;
     };
-    this.migrator = migrator;
+
+    // Always migrate the shared cache data in addition to any custom properties
+    this.migrateProperties = ["__sharedCache", ...properties];
     this.shouldRefresh = shouldRefresh;
   }
 
@@ -78,37 +80,38 @@ this.LinksCache = class LinksCache {
           }
         }
 
-        // Make a shallow copy of each resulting link to allow direct edits
-        const copied = (await this.linkGetter(options)).map(link => link &&
-          Object.assign({}, link));
+        // Update the cache with migrated links without modifying source objects
+        resolve((await this.linkGetter(options)).map(link => {
+          // Keep original array hole positions
+          if (!link) {
+            return link;
+          }
 
-        // Migrate data to the new link if we have an old link
-        for (const newLink of copied) {
-          if (newLink) {
-            const oldLink = toMigrate.get(newLink.url);
-            if (oldLink) {
-              this.migrator(oldLink, newLink);
+          // Migrate data to the new link copy if we have an old link
+          const newLink = Object.assign({}, link);
+          const oldLink = toMigrate.get(newLink.url);
+          if (oldLink) {
+            for (const property of this.migrateProperties) {
+              const oldValue = oldLink[property];
+              if (oldValue) {
+                newLink[property] = oldValue;
+              }
             }
-
-            // Add a method that can be copied to cloned links that will update
-            // the original cached link's property with the current one
-            newLink.__updateCache = function(prop) {
-              const val = this[prop];
-              if (val === undefined) {
-                delete newLink[prop];
-              } else {
-                newLink[prop] = val;
+          } else {
+            // Share data among link copies and new links from future requests
+            newLink.__sharedCache = {
+              // Provide a helper to update the cached link
+              updateLink(property, value) {
+                newLink[property] = value;
               }
             };
           }
-        }
-
-        // Update cache with the copied links migrated
-        resolve(copied);
+          return newLink;
+        }));
       });
     }
 
-    // Return the promise of the links array
-    return this.cache;
+    // Provide a shallow copy of the cached link objects for callers to modify
+    return (await this.cache).map(link => link && Object.assign({}, link));
   }
 };

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -33,11 +33,11 @@ this.TopSitesFeed = class TopSitesFeed {
     this._tippyTopProvider = new TippyTopProvider();
     this.dedupe = new Dedupe(this._dedupeKey);
     this.frecentCache = new LinksCache(NewTabUtils.activityStreamLinks,
-      "getTopSites", this.getLinkMigrator(), (oldOptions, newOptions) =>
+      "getTopSites", ["screenshot"], (oldOptions, newOptions) =>
         // Refresh if no old options or requesting more items
         !(oldOptions.numItems >= newOptions.numItems));
-    this.pinnedCache = new LinksCache(NewTabUtils.pinnedLinks,
-      "links", this.getLinkMigrator(["favicon", "faviconSize"]));
+    this.pinnedCache = new LinksCache(NewTabUtils.pinnedLinks, "links",
+      ["favicon", "faviconSize", "screenshot"]);
   }
   _dedupeKey(site) {
     return site && site.hostname;
@@ -59,22 +59,6 @@ this.TopSitesFeed = class TopSitesFeed {
     }
   }
 
-  /**
-   * Make a cached link data migrator by copying over screenshots and others.
-   *
-   * @param others {array} Optional extra properties to copy
-   */
-  getLinkMigrator(others = []) {
-    const properties = ["__fetchingScreenshot", "screenshot", ...others];
-    return (oldLink, newLink) => {
-      for (const property of properties) {
-        const oldValue = oldLink[property];
-        if (oldValue) {
-          newLink[property] = oldValue;
-        }
-      }
-    };
-  }
   async getLinksWithDefaults(action) {
     // Get at least SHOWMORE amount so toggling between 1 and 2 rows has sites
     const numItems = Math.max(this.store.getState().Prefs.values.topSitesCount,
@@ -107,8 +91,8 @@ this.TopSitesFeed = class TopSitesFeed {
         try {
           NewTabUtils.activityStreamProvider._faviconBytesToDataURI(await
             NewTabUtils.activityStreamProvider._addFavicons([copy]));
-          copy.__updateCache("favicon");
-          copy.__updateCache("faviconSize");
+          copy.__sharedCache.updateLink("favicon", copy.favicon);
+          copy.__sharedCache.updateLink("faviconSize", copy.faviconSize);
         } catch (e) {
           // Some issue with favicon, so just continue without one
         }
@@ -134,9 +118,8 @@ this.TopSitesFeed = class TopSitesFeed {
       if (link) {
         this._fetchIcon(link);
 
-        // Remove any internal properties
-        delete link.__fetchingScreenshot;
-        delete link.__updateCache;
+        // Remove internal properties that might be updated after dispatch
+        delete link.__sharedCache;
       }
     }
 
@@ -176,12 +159,11 @@ this.TopSitesFeed = class TopSitesFeed {
         (!link.favicon || link.faviconSize < MIN_FAVICON_SIZE) &&
         !link.screenshot) {
       const {url} = link;
-      Screenshots.maybeGetAndSetScreenshot(link, url, "screenshot", screenshot => {
-        this.store.dispatch(ac.BroadcastToContent({
+      await Screenshots.maybeCacheScreenshot(link, url, "screenshot",
+        screenshot => this.store.dispatch(ac.BroadcastToContent({
           data: {screenshot, url},
           type: at.SCREENSHOT_UPDATED
-        }));
-      });
+        })));
     }
   }
 

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -43,7 +43,7 @@ describe("Highlights Feed", () => {
     };
     fakeScreenshot = {
       getScreenshotForURL: sandbox.spy(() => Promise.resolve(FAKE_IMAGE)),
-      maybeGetAndSetScreenshot: Screenshots.maybeGetAndSetScreenshot
+      maybeCacheScreenshot: Screenshots.maybeCacheScreenshot
     };
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url.match(/\/([^/]+)/)[1]);
@@ -225,8 +225,12 @@ describe("Highlights Feed", () => {
   describe("#fetchImage", () => {
     const FAKE_URL = "https://mozilla.org";
     const FAKE_IMAGE_URL = "https://mozilla.org/preview.jpg";
+    function fetchImage(page) {
+      return feed.fetchImage(Object.assign({__sharedCache: {updateLink() {}}},
+        page));
+    }
     it("should capture the image, if available", async () => {
-      await feed.fetchImage({
+      await fetchImage({
         preview_image_url: FAKE_IMAGE_URL,
         url: FAKE_URL
       });
@@ -235,13 +239,13 @@ describe("Highlights Feed", () => {
       assert.calledWith(fakeScreenshot.getScreenshotForURL, FAKE_IMAGE_URL);
     });
     it("should fall back to capturing a screenshot", async () => {
-      await feed.fetchImage({url: FAKE_URL});
+      await fetchImage({url: FAKE_URL});
 
       assert.calledOnce(fakeScreenshot.getScreenshotForURL);
       assert.calledWith(fakeScreenshot.getScreenshotForURL, FAKE_URL);
     });
     it("should call SectionsManager.updateSectionCard with the right arguments", async () => {
-      await feed.fetchImage({
+      await fetchImage({
         preview_image_url: FAKE_IMAGE_URL,
         url: FAKE_URL
       });
@@ -249,7 +253,7 @@ describe("Highlights Feed", () => {
       assert.calledOnce(sectionsManagerStub.updateSectionCard);
       assert.calledWith(sectionsManagerStub.updateSectionCard, "highlights", FAKE_URL, {image: FAKE_IMAGE}, true);
     });
-    it("should update the card with the image", async () => {
+    it("should not update the card with the image", async () => {
       const card = {
         preview_image_url: FAKE_IMAGE_URL,
         url: FAKE_URL
@@ -257,7 +261,7 @@ describe("Highlights Feed", () => {
 
       await feed.fetchImage(card);
 
-      assert.propertyVal(card, "image", FAKE_IMAGE);
+      assert.notProperty(card, "image");
     });
   });
   describe("#_getBookmarksThreshold", () => {


### PR DESCRIPTION
Fix #3564. r?@k88hudson The main change is adding a `__sharedCache` that copies of a given link will share via shallow copying. I also stashed the `updateLink` helper on that object so only one thing needs to be `delete`d before dispatch. I also made it so that `Screenshots` doesn't modify the link as generally it'll be too late anyway and would need a `dispatch`, so this fixes #3561.

Added concurrency tests where the first one (backing data called once) was already passing, but the two additional ones are specifically testing for #3564's issues. Other tests were updated for the various naming changes.