### PR TITLE
fix(styles): Only set a fade transition delay for about:newtab

### DIFF
--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -59,7 +59,11 @@ main {
   // currently have a 100ms width transition that competes with this transition.
   // When webrender/Quantum turns on, overlapping transitions are no problem.
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1401682#c4
-  transition: opacity 75ms ease-in-out 125ms;
+  transition: opacity 75ms ease-in-out;
+  @-moz-document url(about:newtab) {
+    transition-delay: 125ms;
+  }
+
   &.on {
     opacity: 1;
   }


### PR DESCRIPTION
Fix #3657. r?@k88hudson 