### PR TITLE
fix(topsites): Refresh pinned links when one is blocked

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -246,9 +246,13 @@ this.TopSitesFeed = class TopSitesFeed {
       // All these actions mean we need new top sites
       case at.MIGRATION_COMPLETED:
       case at.PLACES_HISTORY_CLEARED:
-      case at.PLACES_LINK_BLOCKED:
       case at.PLACES_LINKS_DELETED:
         this.frecentCache.expire();
+        this.refresh();
+        break;
+      case at.PLACES_LINK_BLOCKED:
+        this.frecentCache.expire();
+        this.pinnedCache.expire();
         this.refresh();
         break;
       case at.PREF_CHANGED:


### PR DESCRIPTION
Fix #3609. r?@sarracini In the first commit, I just cleaned up a top level `action` variable to avoid shadowing it and test the `target` behavior. The second commit adds an integration test for pinning then unpinning.