### PR TITLE
Dedupe sections in the reducer

### DIFF
--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -21,16 +21,11 @@ XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Screenshots",
   "resource://activity-stream/lib/Screenshots.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "ProfileAge",
-  "resource://gre/modules/ProfileAge.jsm");
 
 const HIGHLIGHTS_MAX_LENGTH = 9;
 const HIGHLIGHTS_UPDATE_TIME = 15 * 60 * 1000; // 15 minutes
 const MANY_EXTRA_LENGTH = HIGHLIGHTS_MAX_LENGTH * 5 + TOP_SITES_SHOWMORE_LENGTH;
 const SECTION_ID = "highlights";
-const BOOKMARKS_THRESHOLD = 4000; // 3 seconds to milliseconds.
-// Some default seconds ago for Activity Stream recent requests
-const ACTIVITY_STREAM_DEFAULT_RECENT = 5 * 24 * 60 * 60;
 
 this.HighlightsFeed = class HighlightsFeed {
   constructor() {
@@ -58,20 +53,6 @@ this.HighlightsFeed = class HighlightsFeed {
     SectionsManager.disableSection(SECTION_ID);
   }
 
-  /**
-   * Timeframe used to select recent bookmarks, in seconds.
-   * Looks back 5 days while also taking into account new profiles
-   * not to include default bookmarks.
-   */
-  async _getBookmarksThreshold() {
-    if (this._profileAge === 0) {
-      // Value in milliseconds.
-      this._profileAge = await (new ProfileAge()).created;
-    }
-    const defaultsThreshold = Date.now() - this._profileAge - BOOKMARKS_THRESHOLD;
-    return Math.min(ACTIVITY_STREAM_DEFAULT_RECENT, defaultsThreshold / 1000);
-  }
-
   async fetchHighlights(broadcast = false) {
     // We broadcast when we want to force an update, so get fresh links
     if (broadcast) {
@@ -92,10 +73,7 @@ this.HighlightsFeed = class HighlightsFeed {
 
     // Request more than the expected length to allow for items being removed by
     // deduping against Top Sites or multiple history from the same domain, etc.
-    const manyPages = await this.linksCache.request({
-      numItems: MANY_EXTRA_LENGTH,
-      bookmarkSecondsAgo: await this._getBookmarksThreshold()
-    });
+    const manyPages = await this.linksCache.request({numItems: MANY_EXTRA_LENGTH});
 
     // Remove adult highlights if we need to
     const checkedAdult = this.store.getState().Prefs.values.filterAdult ?

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -6,8 +6,10 @@
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/EventEmitter.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 const {actionCreators: ac, actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.jsm", {});
-const {Dedupe} = Cu.import("resource://activity-stream/common/Dedupe.jsm", {});
+
+XPCOMUtils.defineLazyModuleGetter(this, "PlacesUtils", "resource://gre/modules/PlacesUtils.jsm");
 
 /*
  * Generators for built in sections, keyed by the pref name for their feed.
@@ -79,12 +81,20 @@ const SectionsManager = {
     for (const feedPrefName of Object.keys(BUILT_IN_SECTIONS)) {
       const optionsPrefName = `${feedPrefName}.options`;
       this.addBuiltInSection(feedPrefName, prefs[optionsPrefName]);
+
+      this._dedupeConfiguration = [];
+      this.sections.forEach(section => {
+        if (section.dedupeFrom) {
+          this._dedupeConfiguration.push({
+            id: section.id,
+            dedupeFrom: section.dedupeFrom
+          });
+        }
+      });
     }
 
     Object.keys(this.CONTEXT_MENU_PREFS).forEach(k =>
       Services.prefs.addObserver(this.CONTEXT_MENU_PREFS[k], this));
-
-    this.dedupe = new Dedupe(site => site && site.url);
 
     this.initialized = true;
     this.emit(this.INIT);
@@ -134,33 +144,28 @@ const SectionsManager = {
   },
   updateSection(id, options, shouldBroadcast) {
     this.updateSectionContextMenuOptions(options);
-
     if (this.sections.has(id)) {
-      const dedupedOptions = this.dedupeRows(id, options);
-      this.sections.set(id, Object.assign(this.sections.get(id), dedupedOptions));
-      this.emit(this.UPDATE_SECTION, id, dedupedOptions, shouldBroadcast);
-
-      // Update any sections that dedupe from the updated section
-      this.sections.forEach(section => {
-        if (section.dedupeFrom && section.dedupeFrom.includes(id)) {
-          this.updateSection(section.id, section, shouldBroadcast);
-        }
-      });
+      const optionsWithDedupe = Object.assign({}, options, {dedupeConfigurations: this._dedupeConfiguration});
+      this.sections.set(id, Object.assign(this.sections.get(id), options));
+      this.emit(this.UPDATE_SECTION, id, optionsWithDedupe, shouldBroadcast);
     }
   },
-  dedupeRows(id, options) {
-    const newOptions = Object.assign({}, options);
-    const dedupeFrom = this.sections.get(id).dedupeFrom;
-    if (dedupeFrom && dedupeFrom.length > 0 && options.rows) {
-      for (const sectionId of dedupeFrom) {
-        const section = this.sections.get(sectionId);
-        if (section && section.rows) {
-          const [, newRows] = this.dedupe.group(section.rows, options.rows);
-          newOptions.rows = newRows;
-        }
+
+  updateBookmarkMetadata({url}) {
+    this.sections.forEach(section => {
+      if (section.rows) {
+        section.rows.forEach(card => {
+          if (card.url === url && card.description && card.title && card.image) {
+            PlacesUtils.history.update({
+              url: card.url,
+              title: card.title,
+              description: card.description,
+              previewImageURL: card.image
+            });
+          }
+        });
       }
-    }
-    return newOptions;
+    });
   },
 
   /**
@@ -297,6 +302,9 @@ class SectionsFeed {
         }
         break;
       }
+      case at.PLACES_BOOKMARK_ADDED:
+        SectionsManager.updateBookmarkMetadata(action.data);
+        break;
       case at.SECTION_DISABLE:
         SectionsManager.disableSection(action.data);
         break;

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -232,7 +232,8 @@ this.TopStoriesFeed = class TopStoriesFeed {
 
         // Create a new array with a spoc inserted at index 2
         // For now we're using the top scored spoc until we can support viewability based rotation
-        let rows = this.stories.slice(0, this.stories.length);
+        const position = SectionsManager.sections.get(SECTION_ID).order;
+        let rows = this.store.getState().Sections[position].rows.slice(0, this.stories.length);
         rows.splice(2, 0, this.spocs[0]);
 
         // Send a content update to the target tab
@@ -281,14 +282,6 @@ this.TopStoriesFeed = class TopStoriesFeed {
       case at.PLACES_LINK_BLOCKED:
         if (this.spocs) {
           this.spocs = this.spocs.filter(s => s.url !== action.data.url);
-        }
-
-        if (this.stories) {
-          const prevStoriesLength = this.stories.length;
-          this.stories = this.stories.filter(s => s.url !== action.data.url);
-          if (prevStoriesLength !== this.stories.length) {
-            SectionsManager.updateSection(SECTION_ID, {rows: this.stories}, true);
-          }
         }
         break;
     }

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -356,6 +356,19 @@ describe("Reducers", () => {
       const updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.propertyVal(updatedSection, "initialized", false);
     });
+    it("should dedupe based on dedupeConfigurations", () => {
+      const site = {url: "foo.com"};
+      const highlights = {rows: [site], id: "highlights"};
+      const topstories = {rows: [site], id: "topstories"};
+      const dedupeConfigurations = [{id: "topstories", dedupeFrom: ["highlights"]}];
+      const action = {data: {dedupeConfigurations}, type: "SECTION_UPDATE"};
+      const state = [highlights, topstories];
+
+      const nextState = Sections(state, action);
+
+      assert.equal(nextState.find(s => s.id === "highlights").rows.length, 1);
+      assert.equal(nextState.find(s => s.id === "topstories").rows.length, 0);
+    });
     it("should remove blocked and deleted urls from all rows in all sections", () => {
       const blockAction = {type: at.PLACES_LINK_BLOCKED, data: {url: "www.foo.bar"}};
       const deleteAction = {type: at.PLACES_LINKS_DELETED, data: ["www.foo.bar"]};

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -22,7 +22,6 @@ describe("Highlights Feed", () => {
   let filterAdultStub;
   let sectionsManagerStub;
   let shortURLStub;
-  let profileAgeCreatedStub;
 
   const fetchHighlights = async() => {
     await feed.fetchHighlights();
@@ -48,13 +47,7 @@ describe("Highlights Feed", () => {
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url.match(/\/([^/]+)/)[1]);
 
-    const fakeProfileAgePromise = {};
-    const fakeProfileAge = function() { return fakeProfileAgePromise; };
-    profileAgeCreatedStub = sinon.stub().callsFake(() => Promise.resolve(42));
-    sinon.stub(fakeProfileAgePromise, "created").get(profileAgeCreatedStub);
-
     globals.set("NewTabUtils", fakeNewTabUtils);
-    globals.set("ProfileAge", fakeProfileAge);
     ({HighlightsFeed, HIGHLIGHTS_UPDATE_TIME, SECTION_ID} = injector({
       "lib/FilterAdult.jsm": {filterAdult: filterAdultStub},
       "lib/ShortURL.jsm": {shortURL: shortURLStub},
@@ -117,7 +110,6 @@ describe("Highlights Feed", () => {
       const subscribeCallback = feed.store.subscribe.firstCall.args[0];
       await subscribeCallback();
       await firstFetch;
-      await feed._getBookmarksThreshold();
       assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
 
       // If TopSites is initialised in the first place it shouldn't wait
@@ -126,7 +118,6 @@ describe("Highlights Feed", () => {
       fakeNewTabUtils.activityStreamLinks.getHighlights.reset();
       await feed.fetchHighlights();
       assert.notCalled(feed.store.subscribe);
-      await feed._getBookmarksThreshold();
       assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
     });
     it("should add hostname and hasImage to each link", async () => {
@@ -262,28 +253,6 @@ describe("Highlights Feed", () => {
       await feed.fetchImage(card);
 
       assert.notProperty(card, "image");
-    });
-  });
-  describe("#_getBookmarksThreshold", () => {
-    it("should have the correct default", () => {
-      assert.equal(feed._profileAge, 0);
-    });
-    it("should not call ProfileAge if _profileAge is set", async () => {
-      feed._profileAge = 10;
-
-      await feed._getBookmarksThreshold();
-
-      assert.notCalled(profileAgeCreatedStub);
-    });
-    it("should call ProfileAge if _profileAge is not set", async () => {
-      await feed._getBookmarksThreshold();
-
-      assert.calledOnce(profileAgeCreatedStub);
-    });
-    it("should set _profileAge", async () => {
-      await feed._getBookmarksThreshold();
-
-      assert.notEqual(feed._profileAge, 0);
     });
   });
   describe("#uninit", () => {

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -22,6 +22,7 @@ describe("Highlights Feed", () => {
   let filterAdultStub;
   let sectionsManagerStub;
   let shortURLStub;
+  let profileAgeCreatedStub;
 
   const fetchHighlights = async() => {
     await feed.fetchHighlights();
@@ -46,7 +47,14 @@ describe("Highlights Feed", () => {
     };
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url.match(/\/([^/]+)/)[1]);
+
+    const fakeProfileAgePromise = {};
+    const fakeProfileAge = function() { return fakeProfileAgePromise; };
+    profileAgeCreatedStub = sinon.stub().callsFake(() => Promise.resolve(42));
+    sinon.stub(fakeProfileAgePromise, "created").get(profileAgeCreatedStub);
+
     globals.set("NewTabUtils", fakeNewTabUtils);
+    globals.set("ProfileAge", fakeProfileAge);
     ({HighlightsFeed, HIGHLIGHTS_UPDATE_TIME, SECTION_ID} = injector({
       "lib/FilterAdult.jsm": {filterAdult: filterAdultStub},
       "lib/ShortURL.jsm": {shortURL: shortURLStub},
@@ -109,6 +117,7 @@ describe("Highlights Feed", () => {
       const subscribeCallback = feed.store.subscribe.firstCall.args[0];
       await subscribeCallback();
       await firstFetch;
+      await feed._getBookmarksThreshold();
       assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
 
       // If TopSites is initialised in the first place it shouldn't wait
@@ -117,6 +126,7 @@ describe("Highlights Feed", () => {
       fakeNewTabUtils.activityStreamLinks.getHighlights.reset();
       await feed.fetchHighlights();
       assert.notCalled(feed.store.subscribe);
+      await feed._getBookmarksThreshold();
       assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
     });
     it("should add hostname and hasImage to each link", async () => {
@@ -252,6 +262,28 @@ describe("Highlights Feed", () => {
       await feed.fetchImage(card);
 
       assert.notProperty(card, "image");
+    });
+  });
+  describe("#_getBookmarksThreshold", () => {
+    it("should have the correct default", () => {
+      assert.equal(feed._profileAge, 0);
+    });
+    it("should not call ProfileAge if _profileAge is set", async () => {
+      feed._profileAge = 10;
+
+      await feed._getBookmarksThreshold();
+
+      assert.notCalled(profileAgeCreatedStub);
+    });
+    it("should call ProfileAge if _profileAge is not set", async () => {
+      await feed._getBookmarksThreshold();
+
+      assert.calledOnce(profileAgeCreatedStub);
+    });
+    it("should set _profileAge", async () => {
+      await feed._getBookmarksThreshold();
+
+      assert.notEqual(feed._profileAge, 0);
     });
   });
   describe("#uninit", () => {

--- a/system-addon/test/unit/lib/SectionsManager.test.js
+++ b/system-addon/test/unit/lib/SectionsManager.test.js
@@ -12,11 +12,14 @@ const FAKE_CARD_OPTIONS = {title: "Some fake title"};
 describe("SectionsManager", () => {
   let globals;
   let fakeServices;
+  let fakePlacesUtils;
 
   beforeEach(() => {
     globals = new GlobalOverrider();
     fakeServices = {prefs: {getBoolPref: sinon.spy(), addObserver: sinon.spy(), removeObserver: sinon.spy()}};
+    fakePlacesUtils = {history: {update: sinon.stub()}};
     globals.set("Services", fakeServices);
+    globals.set("PlacesUtils", fakePlacesUtils);
   });
 
   afterEach(() => {
@@ -132,10 +135,11 @@ describe("SectionsManager", () => {
     it("should emit an UPDATE_SECTION event with correct arguments", () => {
       SectionsManager.addSection(FAKE_ID, FAKE_OPTIONS);
       const spy = sinon.spy();
+      const dedupeConfigurations = [{id: "topstories", dedupeFrom: ["highlights"]}];
       SectionsManager.on(SectionsManager.UPDATE_SECTION, spy);
       SectionsManager.updateSection(FAKE_ID, {rows: FAKE_ROWS}, true);
       assert.calledOnce(spy);
-      assert.calledWith(spy, SectionsManager.UPDATE_SECTION, FAKE_ID, {rows: FAKE_ROWS}, true);
+      assert.calledWith(spy, SectionsManager.UPDATE_SECTION, FAKE_ID, {rows: FAKE_ROWS, dedupeConfigurations}, true);
     });
     it("should do nothing if the section doesn't exist", () => {
       SectionsManager.removeSection(FAKE_ID);
@@ -205,25 +209,33 @@ describe("SectionsManager", () => {
       assert.notCalled(spy);
     });
   });
-  describe("#dedupe", () => {
-    it("should dedupe stories from highlights", () => {
-      SectionsManager.init();
-      // Add some rows to highlights
-      SectionsManager.updateSection("highlights", {rows: [{url: "https://highlight.com/abc"}, {url: "https://shared.com/def"}]});
-      // Add some rows to top stories
-      SectionsManager.updateSection("topstories", {rows: [{url: "https://topstory.com/ghi"}, {url: "https://shared.com/def"}]});
-      // Verify deduping
-      assert.deepEqual(SectionsManager.sections.get("topstories").rows, [{url: "https://topstory.com/ghi"}]);
+  describe("#updateBookmarkMetadata", () => {
+    let rows;
+    beforeEach(() => {
+      rows = [{
+        url: "bar",
+        title: "title",
+        description: "description",
+        image: "image"
+      }];
+      SectionsManager.addSection(FAKE_ID, {rows});
     });
-    it("should dedupe stories from highlights when updating highlights", () => {
-      SectionsManager.init();
-      // Add some rows to top stories
-      SectionsManager.updateSection("topstories", {rows: [{url: "https://topstory.com/ghi"}, {url: "https://shared.com/def"}]});
-      assert.deepEqual(SectionsManager.sections.get("topstories").rows, [{url: "https://topstory.com/ghi"}, {url: "https://shared.com/def"}]);
-      // Add some rows to highlights
-      SectionsManager.updateSection("highlights", {rows: [{url: "https://highlight.com/abc"}, {url: "https://shared.com/def"}]});
-      // Verify deduping
-      assert.deepEqual(SectionsManager.sections.get("topstories").rows, [{url: "https://topstory.com/ghi"}]);
+    it("shouldn't call PlacesUtils if no story", () => {
+      SectionsManager.updateBookmarkMetadata({url: "foo"});
+
+      assert.notCalled(fakePlacesUtils.history.update);
+    });
+
+    it("should call PlacesUtils", () => {
+      SectionsManager.updateBookmarkMetadata({url: "bar"});
+
+      assert.calledOnce(fakePlacesUtils.history.update);
+      assert.calledWithExactly(fakePlacesUtils.history.update, {
+        url: "bar",
+        title: "title",
+        description: "description",
+        previewImageURL: "image"
+      });
     });
   });
 });
@@ -425,6 +437,13 @@ describe("SectionsFeed", () => {
       for (const action of disallowedActions) {
         assert.neverCalledWith(spy, "ACTION_DISPATCHED", action);
       }
+    });
+    it("should call updateBookmarkMetadata on PLACES_BOOKMARK_ADDED", () => {
+      const stub = sinon.stub(SectionsManager, "updateBookmarkMetadata");
+
+      feed.onAction({type: "PLACES_BOOKMARK_ADDED", data: {}});
+
+      assert.calledOnce(stub);
     });
   });
 });

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -40,7 +40,7 @@ describe("Top Stories Feed", () => {
       enableSection: sinon.spy(),
       disableSection: sinon.spy(),
       updateSection: sinon.spy(),
-      sections: new Map([["topstories", {options: FAKE_OPTIONS}]])
+      sections: new Map([["topstories", {order: 0, options: FAKE_OPTIONS}]])
     };
 
     class FakeUserDomainAffinityProvider {}
@@ -377,7 +377,7 @@ describe("Top Stories Feed", () => {
 
       const response = {
         "settings": {"spocsPerNewTabs": 2},
-        "recommendations": [{"id": "rec1"}, {"id": "rec2"}, {"id": "rec3"}],
+        "recommendations": [{"guid": "rec1"}, {"guid": "rec2"}, {"guid": "rec3"}],
         "spocs": [{"id": "spoc1"}, {"id": "spoc2"}]
       };
 
@@ -387,11 +387,12 @@ describe("Top Stories Feed", () => {
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
       await instance.fetchStories();
 
-      instance.store.getState = () => ({Sections: [{rows: response.recommendations}], Prefs: {values: {showSponsored: true}}});
+      instance.store.getState = () => ({Sections: [{rows: response.recommendations}]});
 
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
       assert.calledOnce(instance.store.dispatch);
       let action = instance.store.dispatch.firstCall.args[0];
+
       assert.equal(at.SECTION_UPDATE, action.type);
       assert.equal(true, action.meta.skipMain);
       assert.equal(action.data.rows[0].guid, "rec1");
@@ -431,6 +432,8 @@ describe("Top Stories Feed", () => {
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
       assert.notCalled(instance.store.dispatch);
       assert.equal(instance.contentUpdateQueue.length, 1);
+
+      instance.store.getState = () => ({Sections: [{rows: response.recommendations}]});
 
       await instance.fetchStories();
       assert.equal(instance.contentUpdateQueue.length, 0);
@@ -563,15 +566,11 @@ describe("Top Stories Feed", () => {
       assert.equal(instance.topicsLastUpdated, 0);
       assert.equal(instance.affinityLastUpdated, 0);
     });
-    it("should filter recs and spocs when link is blocked", () => {
-      instance.stories = [{"url": "not_blocked"}, {"url": "blocked"}];
+    it("should filter spocs when link is blocked", () => {
       instance.spocs = [{"url": "not_blocked"}, {"url": "blocked"}];
       instance.onAction({type: at.PLACES_LINK_BLOCKED, data: {url: "blocked"}});
 
-      assert.deepEqual(instance.stories, [{"url": "not_blocked"}]);
       assert.deepEqual(instance.spocs, [{"url": "not_blocked"}]);
-      assert.calledOnce(sectionsManagerStub.updateSection);
-      assert.calledWith(sectionsManagerStub.updateSection, SECTION_ID, {rows: instance.stories});
     });
   });
 });

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -387,7 +387,7 @@ describe("Top Stories Feed", () => {
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
       await instance.fetchStories();
 
-      instance.store.getState = () => ({Sections: [{rows: response.recommendations}]});
+      instance.store.getState = () => ({Sections: [{rows: response.recommendations}], Prefs: {values: {showSponsored: true}}});
 
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
       assert.calledOnce(instance.store.dispatch);


### PR DESCRIPTION
fix #3573 and fix #3629 and fix #3587. Re submitting https://github.com/mozilla/activity-stream/pull/3623 without highlights date filtering that was based on `ProfileAge` module.

I did a bigger try push https://treeherder.mozilla.org/#/jobs?repo=try&revision=ceb8c64e3ee8035a463a778bb3561ebfa5cb101a 
Some recurrent failures:
 * devtools/shared/webconsole/test/test_console_serviceworker.html -- consistently failing but also on latest master so disregarding.
 * Unused file whitelist item. file: chrome://global/skin/arrow/panelarrow-vertical@2x.png -- referenced files?
* `SpecialPowers.getDOMWindowUtils(...).addToStyloBlocklist is not a function` -- but I don't see how we could cause this
