### PR TITLE
fix (styles): #3681 dont clip dropshadows during section collapse/expand animation

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -169,8 +169,10 @@
     // We then transition on max-height, since we can't transition height to/from auto.
     max-height: 900px;
 
-    // This is so the top sites favicon doesn't get clipped during animation:
-    margin-inline-end: -7px;
+    // This is so the top sites favicon and card dropshadows don't get clipped during animation:
+    $horizontal-padding: 7px;
+    margin: 0 (-$horizontal-padding);
+    padding: 0 $horizontal-padding;
 
     &.animation-enabled {
       transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);


### PR DESCRIPTION
@Mardak this fixes it.

<img src="https://d26dzxoao6i3hh.cloudfront.net/items/3j1J1p1i1y1U291A3Q3S/Screen%20Recording%202017-10-10%20at%2001.33%20PM.gif" />

Fixes #3681