### PR TITLE
feat(highlights): Always show bookmarks even if duplicate of top sites

### DIFF
--- a/system-addon/common/Dedupe.jsm
+++ b/system-addon/common/Dedupe.jsm
@@ -1,15 +1,10 @@
 this.Dedupe = class Dedupe {
-  constructor(createKey, compare) {
+  constructor(createKey) {
     this.createKey = createKey || this.defaultCreateKey;
-    this.compare = compare || this.defaultCompare;
   }
 
   defaultCreateKey(item) {
     return item;
-  }
-
-  defaultCompare() {
-    return false;
   }
 
   /**
@@ -25,7 +20,7 @@ this.Dedupe = class Dedupe {
       const valueMap = new Map();
       for (const value of values) {
         const key = this.createKey(value);
-        if (!globalKeys.has(key) && (!valueMap.has(key) || this.compare(valueMap.get(key), value))) {
+        if (!globalKeys.has(key) && !valueMap.has(key)) {
           valueMap.set(key, value);
         }
       }

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -37,7 +37,8 @@ this.HighlightsFeed = class HighlightsFeed {
   }
 
   _dedupeKey(site) {
-    return site && site.url;
+    // Treat bookmarks as un-dedupable, otherwise show one of a url
+    return site && (site.type === "bookmark" ? {} : site.url);
   }
 
   init() {

--- a/system-addon/test/unit/common/Dedupe.test.js
+++ b/system-addon/test/unit/common/Dedupe.test.js
@@ -22,21 +22,5 @@ describe("Dedupe", () => {
       const afterItems = [[{id: 1}, {id: 2}], [{id: 3}], [{id: 5}]];
       assert.deepEqual(instance.group(...beforeItems), afterItems);
     });
-    it("should take a custom comparison function", () => {
-      function compare(previous, current) {
-        return current.amount > previous.amount;
-      }
-      instance = new Dedupe(item => item.id, compare);
-      const beforeItems = [
-        [{id: 1, amount: 50}, {id: 1, amount: 100}],
-        [{id: 1, amount: 200}, {id: 2, amount: 0}, {id: 2, amount: 100}]
-      ];
-      const afterItems = [
-        [{id: 1, amount: 100}],
-        [{id: 2, amount: 100}]
-      ];
-
-      assert.deepEqual(instance.group(...beforeItems), afterItems);
-    });
   });
 });

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -161,6 +161,17 @@ describe("Highlights Feed", () => {
       assert.equal(highlights.length, 1);
       assert.equal(highlights[0].url, links[0].url);
     });
+    it("should include bookmark but not history already in Top Sites", async () => {
+      links = [
+        {url: "http://www.topsite0.com", type: "bookmark"},
+        {url: "http://www.topsite1.com", type: "history"}
+      ];
+
+      const highlights = await fetchHighlights();
+
+      assert.equal(highlights.length, 1);
+      assert.equal(highlights[0].url, links[0].url);
+    });
     it("should not include history of same hostname as a bookmark", async () => {
       links = [
         {url: "https://site.com/bookmark", type: "bookmark"},


### PR DESCRIPTION
Fix #3608. r?@piatra Removes `compare` of `Dedupe`. Make bookmark type highlights un-dedupable