### PR TITLE
fix(styles): Use css to calculate rtl offset instead of hardcoded of expected width

### DIFF
--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -85,7 +85,8 @@
       }
 
       label {
-        background-position-x: 35px;
+        $icon-offset-start: 35px;
+        background-position-x: $icon-offset-start;
         background-position-y: 2.5px;
         background-repeat: no-repeat;
         display: inline-block;
@@ -96,7 +97,7 @@
         width: 100%;
 
         &:dir(rtl) {
-          background-position-x: 217px;
+          background-position-x: calc(100% - #{$icon-offset-start});
         }
       }
       [type='checkbox']:not(:checked) + label,


### PR DESCRIPTION
Fix #3699. r?@rlr Couldn't reproduce on mac, so below are screenshots from linux.

Before:
![screen shot 2017-10-12 at 2 09 40 pm](https://user-images.githubusercontent.com/438537/31519397-2d5c8ace-af57-11e7-8e9f-bfafcc5f8676.png)

After:
![screen shot 2017-10-12 at 2 09 25 pm](https://user-images.githubusercontent.com/438537/31519390-28825736-af57-11e7-986e-5a63216934e2.png)