### PR TITLE
Frequency caps support for spoc experiment

### DIFF
--- a/system-addon/lib/UserDomainAffinityProvider.jsm
+++ b/system-addon/lib/UserDomainAffinityProvider.jsm
@@ -271,7 +271,7 @@ this.UserDomainAffinityProvider = class UserDomainAffinityProvider {
   calculateItemRelevanceScore(item) {
     const params = this.parameterSets[item.parameter_set];
     if (!item.domain_affinities || !params) {
-      return 1;
+      return item.item_score;
     }
 
     const scores = Object

--- a/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
+++ b/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
@@ -138,11 +138,10 @@ describe("User Domain Affinity Provider", () => {
       const itemScore = instance.calculateItemRelevanceScore(testItem);
       assert.equal(expectedItemScore, itemScore);
     });
-    it("should calculate relevance score of 1 if item has no domain affinities", () => {
-      const testItem = {};
-      const expectedItemScore = 1;
+    it("should calculate relevance score equal to item_score if item has no domain affinities", () => {
+      const testItem = {item_score: 0.985};
       const itemScore = instance.calculateItemRelevanceScore(testItem);
-      assert.equal(expectedItemScore, itemScore);
+      assert.equal(testItem.item_score, itemScore);
     });
     it("should calculate scores with factor", () => {
       assert.equal(1, instance.calculateScore(2, 1, 0.5));


### PR DESCRIPTION
This PR brings in frequency caps for the sponsored content experiment:

Frequency caps are based on campaigns (not individual spocs). We currently support two types of frequency caps:
  - lifetime: Indicates how many times spocs from a campaign can be shown in total
  - period: Indicates how many times spocs from a campaign can be shown within a period
  
So, for example, the feed configuration below defines that for campaign 1 no more than 5 spocs can be show in total, and no more than 2 per hour.
```
"campaign_id": 1,
  "caps": {
    "lifetime": 5,
    "campaign": {
      "count": 2,
      "period": 3600
    }
  }
```

This is implemented storing a mapping of campaign IDs to timestamps (impressions) in a pref. The pref is cleaned up every time the feed is fetched. Only campaigns part of the last response are considered active, all others can be removed.

The second commit contains a minor refactoring to guard against missing domain affinities in the server response.