### PR TITLE
fix(collapsing): Fixes #3682 Sections are no longer animated when collapsed if the sections were disabled and re-enabled from customization menu

### DIFF
--- a/system-addon/common/PrerenderData.jsm
+++ b/system-addon/common/PrerenderData.jsm
@@ -52,6 +52,9 @@ this.PrerenderData = new _PrerenderData({
     "showTopSites": true,
     "showSearch": true,
     "topSitesCount": 6,
+    "collapseTopSites": false,
+    "section.highlights.collapsed": false,
+    "section.topstories.collapsed": false,
     "feeds.section.topstories": true,
     "feeds.section.highlights": true
   },
@@ -64,6 +67,9 @@ this.PrerenderData = new _PrerenderData({
   validation: [
     "showTopSites",
     "showSearch",
+    "collapseTopSites",
+    "section.highlights.collapsed",
+    "section.topstories.collapsed",
     // This means if either of these are set to their default values,
     // prerendering can be used.
     {oneOf: ["feeds.section.topstories", "feeds.section.highlights"]}

--- a/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -93,14 +93,9 @@ class CollapsibleSection extends React.PureComponent {
     this.onInfoLeave = this.onInfoLeave.bind(this);
     this.onHeaderClick = this.onHeaderClick.bind(this);
     this.onTransitionEnd = this.onTransitionEnd.bind(this);
-    this.state = {enableAnimation: false, isAnimating: false, infoActive: false};
+    this.state = {isAnimating: false, infoActive: false};
   }
-  componentDidUpdate(prevProps, prevState) {
-    // Enable animations once we get prefs loaded in to avoid animations running during loading.
-    if (prevProps.Prefs.values[this.props.prefName] === undefined && this.props.Prefs.values[this.props.prefName] !== undefined) {
-      setTimeout(() => this.setState({enableAnimation: true}), 0);
-    }
-  }
+
   _setInfoState(nextActive) {
     // Take a truthy value to conditionally change the infoActive state.
     const infoActive = !!nextActive;
@@ -137,7 +132,7 @@ class CollapsibleSection extends React.PureComponent {
   }
   render() {
     const isCollapsed = this.props.Prefs.values[this.props.prefName];
-    const {enableAnimation, isAnimating} = this.state;
+    const {isAnimating} = this.state;
     const infoOption = this.props.infoOption;
 
     return (
@@ -152,7 +147,7 @@ class CollapsibleSection extends React.PureComponent {
           </h3>
           {infoOption && <InfoIntl infoOption={infoOption} dispatch={this.props.dispatch} />}
         </div>
-        <div className={`section-body${enableAnimation ? " animation-enabled" : ""}${isAnimating ? " animating" : ""}`} onTransitionEnd={this.onTransitionEnd}>
+        <div className={`section-body${isAnimating ? " animating" : ""}`} onTransitionEnd={this.onTransitionEnd}>
           {this.props.children}
         </div>
       </section>

--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -173,10 +173,7 @@
     $horizontal-padding: 7px;
     margin: 0 (-$horizontal-padding);
     padding: 0 $horizontal-padding;
-
-    &.animation-enabled {
-      transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);
-    }
+    transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);
 
     &.animating {
       overflow: hidden;


### PR DESCRIPTION
Fix #3682. Don't prerender if we have sections collapsed - also lets us get rid of the animation-enabled class