### PR TITLE
fix (animations): #3707 only animate when page is visible

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -10,7 +10,6 @@
     .icon-arrowhead-forward {
       margin-top: -1px;
       margin-inline-start: 8px;
-      transition: transform 0.5s $photon-easing;
     }
   }
 
@@ -173,10 +172,22 @@
     $horizontal-padding: 7px;
     margin: 0 (-$horizontal-padding);
     padding: 0 $horizontal-padding;
-    transition: max-height 0.5s cubic-bezier(0.07, 0.95, 0, 1);
 
     &.animating {
       overflow: hidden;
+    }
+  }
+
+  &.animation-enabled {
+    .section-title {
+      .icon-arrowhead-down,
+      .icon-arrowhead-forward {
+        transition: transform 0.5s $photon-easing;
+      }
+    }
+
+    .section-body {
+      transition: max-height 0.5s $photon-easing;
     }
   }
 

--- a/system-addon/test/unit/content-src/components/CollapsibleSection.test.jsx
+++ b/system-addon/test/unit/content-src/components/CollapsibleSection.test.jsx
@@ -8,6 +8,11 @@ const DEFAULT_PROPS = {
   prefName: "collapseSection",
   Prefs: {values: {collapseSection: false}},
   infoOption: {},
+  document: {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    visibilityState: "visible"
+  },
   dispatch: () => {}
 };
 
@@ -41,6 +46,18 @@ describe("CollapsibleSection", () => {
     }
     setup({dispatch});
     wrapper.find(".click-target").simulate("click");
+  });
+
+  it("should enable animations if the tab is visible", () => {
+    wrapper.instance().enableOrDisableAnimation();
+    assert.ok(wrapper.instance().state.enableAnimation);
+  });
+
+  it("should disable animations if the tab is in the background", () => {
+    const doc = Object.assign({}, DEFAULT_PROPS.document, {visibilityState: "hidden"});
+    setup({document: doc});
+    wrapper.instance().enableOrDisableAnimation();
+    assert.isFalse(wrapper.instance().state.enableAnimation);
   });
 
   describe("icon", () => {


### PR DESCRIPTION
The issue was that animations/transitions in background tabs are aggressively throttled or paused. So once the tab is brought into view, the rest of the animation happens. To fix, I just disabled the transitions for non visible tabs.

Fixes #3707