### PR TITLE
chore(react): Remove unused and unnecessary defaultProps from ConfirmDialog

### DIFF
--- a/system-addon/content-src/components/ConfirmDialog/ConfirmDialog.jsx
+++ b/system-addon/content-src/components/ConfirmDialog/ConfirmDialog.jsx
@@ -29,13 +29,6 @@ class ConfirmDialog extends React.PureComponent {
     this._handleConfirmBtn = this._handleConfirmBtn.bind(this);
   }
 
-  getDefaultProps() {
-    return {
-      visible: false,
-      data: {}
-    };
-  }
-
   _handleCancelBtn() {
     this.props.dispatch({type: actionTypes.DIALOG_CANCEL});
     this.props.dispatch(ac.UserEvent({event: actionTypes.DIALOG_CANCEL}));


### PR DESCRIPTION
This was in the console when prerendering:
`Warning: getDefaultProps was defined on ConfirmDialog, a plain JavaScript class. This is only supported for classes created using React.createClass. Use a static property to define defaultProps instead.`

Followup from #3713. r?@rlr We get the props through `connect` state.
https://github.com/mozilla/activity-stream/blob/d6b67193c571c697105d1ee04f595f4f7f4477b3/system-addon/common/Reducers.jsm#L47-L49