### PR TITLE
Register thumbnail expiration filters for topsites and highlights

### DIFF
--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -61,7 +61,17 @@ this.HighlightsFeed = class HighlightsFeed {
       const {initialized, rows} = this.store.getState().Sections[sectionIndex];
 
       if (initialized) {
-        callback(rows.map(site => site.url));
+        const linksToKeep = rows.reduce((acc, site) => {
+          // Screenshots will search for preview_image_url or fallback to URL,
+          // so we prevent both from being expired.
+          // https://github.com/mozilla/activity-stream/blob/95b4c35393b7192d680d1291b6960200be5e7570/system-addon/lib/HighlightsFeed.jsm#L131
+          acc.push(site.url);
+          if (site.preview_image_url) {
+            acc.push(site.preview_image_url);
+          }
+          return acc;
+        }, []);
+        callback(linksToKeep);
       } else {
         callback([]);
       }

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -57,27 +57,18 @@ this.HighlightsFeed = class HighlightsFeed {
 
   filterForThumbnailExpiration(callback) {
     const sectionIndex = SectionsManager.sections.get(SECTION_ID).order;
-    if (this.store.getState().Sections[sectionIndex]) {
-      const {initialized, rows} = this.store.getState().Sections[sectionIndex];
+    const state = this.store.getState().Sections[sectionIndex];
 
-      if (initialized) {
-        const linksToKeep = rows.reduce((acc, site) => {
-          // Screenshots will search for preview_image_url or fallback to URL,
-          // so we prevent both from being expired.
-          // https://github.com/mozilla/activity-stream/blob/95b4c35393b7192d680d1291b6960200be5e7570/system-addon/lib/HighlightsFeed.jsm#L131
-          acc.push(site.url);
-          if (site.preview_image_url) {
-            acc.push(site.preview_image_url);
-          }
-          return acc;
-        }, []);
-        callback(linksToKeep);
-      } else {
-        callback([]);
+    callback(state && state.initialized ? state.rows.reduce((acc, site) => {
+      // Screenshots will search for preview_image_url or fallback to URL,
+      // so we prevent both from being expired.
+      // https://github.com/mozilla/activity-stream/blob/95b4c35393b7192d680d1291b6960200be5e7570/system-addon/lib/HighlightsFeed.jsm#L131
+      acc.push(site.url);
+      if (site.preview_image_url) {
+        acc.push(site.preview_image_url);
       }
-    } else {
-      callback([]);
-    }
+      return acc;
+    }, []) : []);
   }
 
   /**

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -60,9 +60,8 @@ this.HighlightsFeed = class HighlightsFeed {
     const state = this.store.getState().Sections[sectionIndex];
 
     callback(state && state.initialized ? state.rows.reduce((acc, site) => {
-      // Screenshots will search for preview_image_url or fallback to URL,
-      // so we prevent both from being expired.
-      // https://github.com/mozilla/activity-stream/blob/95b4c35393b7192d680d1291b6960200be5e7570/system-addon/lib/HighlightsFeed.jsm#L131
+      // Screenshots call in `fetchImage` will search for preview_image_url or
+      // fallback to URL, so we prevent both from being expired.
       acc.push(site.url);
       if (site.preview_image_url) {
         acc.push(site.preview_image_url);

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -57,10 +57,14 @@ this.HighlightsFeed = class HighlightsFeed {
 
   filterForThumbnailExpiration(callback) {
     const sectionIndex = SectionsManager.sections.get(SECTION_ID).order;
-    const {initialized, rows} = this.store.getState().Sections[sectionIndex];
+    if (this.store.getState().Sections[sectionIndex]) {
+      const {initialized, rows} = this.store.getState().Sections[sectionIndex];
 
-    if (initialized) {
-      callback(rows.map(site => site.url));
+      if (initialized) {
+        callback(rows.map(site => site.url));
+      } else {
+        callback([]);
+      }
     } else {
       callback([]);
     }

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -66,13 +66,8 @@ this.TopSitesFeed = class TopSitesFeed {
   }
 
   filterForThumbnailExpiration(callback) {
-    const {initialized, rows} = this.store.getState().TopSites;
-
-    if (initialized) {
-      callback(rows.map(site => site.url));
-    } else {
-      callback([]);
-    }
+    const {rows} = this.store.getState().TopSites;
+    callback(rows.map(site => site.url));
   }
 
   async getLinksWithDefaults(action) {

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -20,6 +20,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Screenshots",
   "resource://activity-stream/lib/Screenshots.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PageThumbs",
+  "resource://gre/modules/PageThumbs.jsm");
 
 const DEFAULT_SITES_PREF = "default.sites";
 const DEFAULT_TOP_SITES = [];
@@ -36,7 +38,13 @@ this.TopSitesFeed = class TopSitesFeed {
         !(oldOptions.numItems >= newOptions.numItems));
     this.pinnedCache = new LinksCache(NewTabUtils.pinnedLinks, "links",
       ["favicon", "faviconSize", "screenshot"]);
+    PageThumbs.addExpirationFilter(this);
   }
+
+  uninit() {
+    PageThumbs.removeExpirationFilter(this);
+  }
+
   _dedupeKey(site) {
     return site && site.hostname;
   }
@@ -54,6 +62,16 @@ this.TopSitesFeed = class TopSitesFeed {
         site.hostname = shortURL(site);
         DEFAULT_TOP_SITES.push(site);
       }
+    }
+  }
+
+  filterForThumbnailExpiration(callback) {
+    const {initialized, rows} = this.store.getState().TopSites;
+
+    if (initialized) {
+      callback(rows.map(site => site.url));
+    } else {
+      callback([]);
     }
   }
 
@@ -260,6 +278,9 @@ this.TopSitesFeed = class TopSitesFeed {
         break;
       case at.TOP_SITES_ADD:
         this.add(action);
+        break;
+      case at.UNINIT:
+        this.uninit();
         break;
     }
   }

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -107,6 +107,16 @@ describe("Highlights Feed", () => {
       assert.calledOnce(stub);
       assert.calledWithExactly(stub, rows.map(r => r.url));
     });
+    it("should include preview_image_url (if present) in the callback results", () => {
+      const rows = [{url: "foo.com"}, {"url": "bar.com", "preview_image_url": "bar.jpg"}];
+      feed.store.state.Sections = [{rows, initialized: true}];
+      const stub = sinon.stub();
+
+      feed.filterForThumbnailExpiration(stub);
+
+      assert.calledOnce(stub);
+      assert.calledWithExactly(stub, ["foo.com", "bar.com", "bar.jpg"]);
+    });
     it("should pass an empty array if not initialized", () => {
       const rows = [{url: "foo.com"}, {"url": "bar.com"}];
       feed.store.state.Sections = [{rows, initialized: false}];

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -20,6 +20,7 @@ describe("Highlights Feed", () => {
   let filterAdultStub;
   let sectionsManagerStub;
   let shortURLStub;
+  let fakePageThumbs;
 
   beforeEach(() => {
     globals = new GlobalOverrider();
@@ -39,8 +40,13 @@ describe("Highlights Feed", () => {
     };
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url.match(/\/([^/]+)/)[1]);
+    fakePageThumbs = {
+      addExpirationFilter: sinon.stub(),
+      removeExpirationFilter: sinon.stub()
+    };
 
     globals.set("NewTabUtils", fakeNewTabUtils);
+    globals.set("PageThumbs", fakePageThumbs);
     ({HighlightsFeed, SECTION_ID} = injector({
       "lib/FilterAdult.jsm": {filterAdult: filterAdultStub},
       "lib/ShortURL.jsm": {shortURL: shortURLStub},
@@ -72,6 +78,9 @@ describe("Highlights Feed", () => {
     it("should create a HighlightsFeed", () => {
       assert.instanceOf(feed, HighlightsFeed);
     });
+    it("should register a expiration filter", () => {
+      assert.calledOnce(fakePageThumbs.addExpirationFilter);
+    });
     it("should call SectionsManager.onceInitialized on INIT", () => {
       feed.onAction({type: at.INIT});
       assert.calledOnce(sectionsManagerStub.onceInitialized);
@@ -85,6 +94,28 @@ describe("Highlights Feed", () => {
       feed.fetchHighlights = sinon.spy();
       feed.postInit();
       assert.calledOnce(feed.fetchHighlights);
+    });
+  });
+  describe("#filterForThumbnailExpiration", () => {
+    it("should pass rows.urls to the callback provided", () => {
+      const rows = [{url: "foo.com"}, {"url": "bar.com"}];
+      feed.store.state.Sections = [{rows, initialized: true}];
+      const stub = sinon.stub();
+
+      feed.filterForThumbnailExpiration(stub);
+
+      assert.calledOnce(stub);
+      assert.calledWithExactly(stub, rows.map(r => r.url));
+    });
+    it("should pass an empty array if not initialized", () => {
+      const rows = [{url: "foo.com"}, {"url": "bar.com"}];
+      feed.store.state.Sections = [{rows, initialized: false}];
+      const stub = sinon.stub();
+
+      feed.filterForThumbnailExpiration(stub);
+
+      assert.calledOnce(stub);
+      assert.calledWithExactly(stub, []);
     });
   });
   describe("#fetchHighlights", () => {
@@ -287,6 +318,10 @@ describe("Highlights Feed", () => {
       feed.onAction({type: at.UNINIT});
       assert.calledOnce(sectionsManagerStub.disableSection);
       assert.calledWith(sectionsManagerStub.disableSection, SECTION_ID);
+    });
+    it("should remove the expiration filter", () => {
+      feed.onAction({type: at.UNINIT});
+      assert.calledOnce(fakePageThumbs.removeExpirationFilter);
     });
   });
   describe("#onAction", () => {

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -31,6 +31,7 @@ describe("Top Sites Feed", () => {
   let fakeScreenshot;
   let filterAdultStub;
   let shortURLStub;
+  let fakePageThumbs;
 
   beforeEach(() => {
     globals = new GlobalOverrider();
@@ -63,6 +64,11 @@ describe("Top Sites Feed", () => {
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url);
     const fakeDedupe = function() {};
+    fakePageThumbs = {
+      addExpirationFilter: sinon.stub(),
+      removeExpirationFilter: sinon.stub()
+    };
+    globals.set("PageThumbs", fakePageThumbs);
     globals.set("NewTabUtils", fakeNewTabUtils);
     FakePrefs.prototype.prefs["default.sites"] = "https://foo.com/";
     ({TopSitesFeed, DEFAULT_TOP_SITES} = injector({
@@ -126,6 +132,28 @@ describe("Top Sites Feed", () => {
       feed.refreshDefaults("");
 
       assert.equal(DEFAULT_TOP_SITES.length, 0);
+    });
+  });
+  describe("#filterForThumbnailExpiration", () => {
+    it("should pass rows.urls to the callback provided", () => {
+      const rows = [{url: "foo.com"}, {"url": "bar.com"}];
+      feed.store.state.TopSites = {rows, initialized: true};
+      const stub = sinon.stub();
+
+      feed.filterForThumbnailExpiration(stub);
+
+      assert.calledOnce(stub);
+      assert.calledWithExactly(stub, rows.map(r => r.url));
+    });
+    it("should pass an empty array if not initialized", () => {
+      const rows = [{url: "foo.com"}, {"url": "bar.com"}];
+      feed.store.state.TopSites = {rows, initialized: false};
+      const stub = sinon.stub();
+
+      feed.filterForThumbnailExpiration(stub);
+
+      assert.calledOnce(stub);
+      assert.calledWithExactly(stub, []);
     });
   });
   describe("#getLinksWithDefaults", () => {
@@ -561,6 +589,11 @@ describe("Top Sites Feed", () => {
       feed.onAction(addAction);
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, addAction.data.site, 0);
+    });
+    it("should remove the expiration filter on UNINIT", () => {
+      feed.onAction({type: "UNINIT"});
+
+      assert.calledOnce(fakePageThumbs.removeExpirationFilter);
     });
   });
   describe("#add", () => {

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -137,23 +137,13 @@ describe("Top Sites Feed", () => {
   describe("#filterForThumbnailExpiration", () => {
     it("should pass rows.urls to the callback provided", () => {
       const rows = [{url: "foo.com"}, {"url": "bar.com"}];
-      feed.store.state.TopSites = {rows, initialized: true};
+      feed.store.state.TopSites = {rows};
       const stub = sinon.stub();
 
       feed.filterForThumbnailExpiration(stub);
 
       assert.calledOnce(stub);
       assert.calledWithExactly(stub, rows.map(r => r.url));
-    });
-    it("should pass an empty array if not initialized", () => {
-      const rows = [{url: "foo.com"}, {"url": "bar.com"}];
-      feed.store.state.TopSites = {rows, initialized: false};
-      const stub = sinon.stub();
-
-      feed.filterForThumbnailExpiration(stub);
-
-      assert.calledOnce(stub);
-      assert.calledWithExactly(stub, []);
     });
   });
   describe("#getLinksWithDefaults", () => {


### PR DESCRIPTION
Closes #3646. 

Needs a follow up bug in m-c to remove the current TopSites expiration https://github.com/mozilla/activity-stream/issues/3646#issuecomment-337616103. Should be fine to land this independently right?