### PR TITLE
chore(performance): Cache affinity scores and calculate on idle-daily

### DIFF
--- a/system-addon/lib/UserDomainAffinityProvider.jsm
+++ b/system-addon/lib/UserDomainAffinityProvider.jsm
@@ -55,7 +55,7 @@ function merge(...args) {
  *
  * - The parameter sets provide factors for weighting which allows for
  * flexible targeting. The functionality to calculate final scores can
- * be seen in UserDomainAffinityProvider#calcuateScores
+ * be seen in UserDomainAffinityProvider#calculateScores
  *
  * - The user domain affinity scores are summed up across all time segments
  * see UserDomainAffinityProvider#calculateAllUserDomainAffinityScores
@@ -74,11 +74,22 @@ function merge(...args) {
  * lookups of scores[domain][parameterSet] is beneficial
  */
 this.UserDomainAffinityProvider = class UserDomainAffinityProvider {
-  constructor(timeSegments = DEFAULT_TIME_SEGMENTS, parameterSets = DEFAULT_PARAMETER_SETS, maxHistoryQueryResults = DEFAULT_MAX_HISTORY_QUERY_RESULTS) {
+  constructor(
+    timeSegments = DEFAULT_TIME_SEGMENTS,
+    parameterSets = DEFAULT_PARAMETER_SETS,
+    maxHistoryQueryResults = DEFAULT_MAX_HISTORY_QUERY_RESULTS,
+    version,
+    scores) {
     this.timeSegments = timeSegments;
     this.maxHistoryQueryResults = maxHistoryQueryResults;
-    this.parameterSets = this.prepareParameterSets(parameterSets);
-    this.scores = this.calculateAllUserDomainAffinityScores();
+    this.version = version;
+    if (scores) {
+      this.parameterSets = parameterSets;
+      this.scores = scores;
+    } else {
+      this.parameterSets = this.prepareParameterSets(parameterSets);
+      this.scores = this.calculateAllUserDomainAffinityScores();
+    }
   }
 
   /**
@@ -300,6 +311,19 @@ this.UserDomainAffinityProvider = class UserDomainAffinityProvider {
     // An itemScoreFactor of 0.5 results in the the average of item score and combined domain score
     // An itemScoreFactor of 0 results in the combined domain score and ignores the item score
     return params.itemScoreFactor * (item.item_score - normalizedCombinedDomainScore) + normalizedCombinedDomainScore;
+  }
+
+  /**
+   * Returns an object holding the settings and affinity scores of this provider instance.
+   */
+  getAffinities() {
+    return {
+      timeSegments: this.timeSegments,
+      parameterSets: this.parameterSets,
+      maxHistoryQueryResults: this.maxHistoryQueryResults,
+      version: this.version,
+      scores: this.scores
+    };
   }
 };
 

--- a/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
+++ b/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
@@ -111,6 +111,24 @@ describe("User Domain Affinity Provider", () => {
       const scores = instance.calculateAllUserDomainAffinityScores();
       assert.deepEqual(expectedScores, scores);
     });
+    it("should return domain affinities", () => {
+      const scores = {
+        "a.com": {
+          "paramSet1": 1,
+          "paramSet2": 0.9
+        }
+      };
+      instance = new UserDomainAffinityProvider(TIME_SEGMENTS, PARAMETER_SETS, 100, "v1", scores);
+
+      const expectedAffinities = {
+        "timeSegments": TIME_SEGMENTS,
+        "parameterSets": PARAMETER_SETS,
+        "maxHistoryQueryResults": 100,
+        "scores": scores,
+        "version": "v1"
+      };
+      assert.deepEqual(instance.getAffinities(), expectedAffinities);
+    });
   });
   describe("#score", () => {
     it("should calculate item relevance score", () => {


### PR DESCRIPTION
This is a refactoring to no longer trigger domain affinity calculation on the first fetch, but on idle-daily, and cache the result so it's available on next startup.

This is a performance trade-off. So, in case idle-daily hasn't run yet, there will be no sorting, and the result is the same as the un-personalized, global feed.