### PR TITLE
fix(snippets): do not redirect to about:accounts

### DIFF
--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -13,6 +13,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "ShellService",
   "resource:///modules/ShellService.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "ProfileAge",
   "resource://gre/modules/ProfileAge.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "fxAccounts",
+  "resource://gre/modules/FxAccounts.jsm");
 
 // Url to fetch snippets, in the urlFormatter service format.
 const SNIPPETS_URL_PREF = "browser.aboutHomeSnippets.updateUrl";
@@ -124,9 +126,10 @@ this.SnippetsFeed = class SnippetsFeed {
     this.store.dispatch(ac.BroadcastToContent({type: at.SNIPPETS_RESET}));
   }
 
-  showFirefoxAccounts(browser) {
+  async showFirefoxAccounts(browser) {
+    const url = await fxAccounts.promiseAccountsSignUpURI("snippets");
     // We want to replace the current tab.
-    browser.loadURI("about:accounts?action=signup&entrypoint=snippets");
+    browser.loadURI(url);
   }
 
   onAction(action) {


### PR DESCRIPTION
This supports [Bugzilla #1395460](https://bugzilla.mozilla.org/show_bug.cgi?id=1395460).
TLDR: we are going to get rid of about:accounts, and clients should link to the FxA URLs directly.

Note: Do not merge until the Firefox changes are merged onto mozilla-central.