### PR TITLE
Skip failed Screenshot requests.

### DIFF
--- a/system-addon/lib/LinksCache.jsm
+++ b/system-addon/lib/LinksCache.jsm
@@ -98,7 +98,7 @@ this.LinksCache = class LinksCache {
           if (oldLink) {
             for (const property of this.migrateProperties) {
               const oldValue = oldLink[property];
-              if (oldValue) {
+              if (oldValue !== undefined) {
                 newLink[property] = oldValue;
               }
             }

--- a/system-addon/lib/Screenshots.jsm
+++ b/system-addon/lib/Screenshots.jsm
@@ -73,9 +73,10 @@ this.Screenshots = {
    @ @param onScreenshot {function} Callback for when the screenshot loads
    */
   async maybeCacheScreenshot(link, url, property, onScreenshot) {
-    // Nothing to do if we already have a pending screenshot
+    // Nothing to do if we already have a pending screenshot or
+    // if a previous request failed and returned null.
     const cache = link.__sharedCache;
-    if (cache.fetchingScreenshot) {
+    if (cache.fetchingScreenshot || link[property] !== undefined) {
       return;
     }
 
@@ -87,9 +88,7 @@ this.Screenshots = {
     delete cache.fetchingScreenshot;
 
     // Update the cache for future links and call back for existing content
-    if (screenshot) {
-      cache.updateLink(property, screenshot);
-      onScreenshot(screenshot);
-    }
+    cache.updateLink(property, screenshot);
+    onScreenshot(screenshot);
   }
 };

--- a/system-addon/test/unit/lib/Screenshots.test.js
+++ b/system-addon/test/unit/lib/Screenshots.test.js
@@ -52,7 +52,7 @@ describe("Screenshots", () => {
   describe("#maybeCacheScreenshot", () => {
     let link;
     beforeEach(() => {
-      link = {__sharedCache: {updateLink: sinon.stub()}};
+      link = {__sharedCache: {updateLink: (prop, val) => { link[prop] = val; }}};
     });
     it("should call getScreenshotForURL", () => {
       sandbox.stub(Screenshots, "getScreenshotForURL");
@@ -62,20 +62,20 @@ describe("Screenshots", () => {
       assert.calledWithExactly(Screenshots.getScreenshotForURL, "mozilla.com");
     });
     it("should not call getScreenshotForURL twice if a fetch is in progress", () => {
-      sandbox.stub(Screenshots, "getScreenshotForURL").callsFake(() => new Promise(resolve => setTimeout(resolve, 0)));
+      sandbox.stub(Screenshots, "getScreenshotForURL").callsFake(() => new Promise(() => {}));
       Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
       Screenshots.maybeCacheScreenshot(link, "mozilla.org", "image", sinon.stub());
 
       assert.calledOnce(Screenshots.getScreenshotForURL);
       assert.calledWithExactly(Screenshots.getScreenshotForURL, "mozilla.com");
     });
-    it("should not call getScreenshotsForURL if property !== undefined", () => {
-      sandbox.stub(Screenshots, "getScreenshotForURL");
-      link.image = null;
+    it("should not call getScreenshotsForURL if property !== undefined", async () => {
+      sandbox.stub(Screenshots, "getScreenshotForURL").returns(Promise.resolve(null));
+      await Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
+      await Screenshots.maybeCacheScreenshot(link, "mozilla.org", "image", sinon.stub());
 
-      Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
-
-      assert.notCalled(Screenshots.getScreenshotForURL);
+      assert.calledOnce(Screenshots.getScreenshotForURL);
+      assert.calledWithExactly(Screenshots.getScreenshotForURL, "mozilla.com");
     });
   });
 

--- a/system-addon/test/unit/lib/Screenshots.test.js
+++ b/system-addon/test/unit/lib/Screenshots.test.js
@@ -49,6 +49,36 @@ describe("Screenshots", () => {
     });
   });
 
+  describe("#maybeCacheScreenshot", () => {
+    let link;
+    beforeEach(() => {
+      link = {__sharedCache: {updateLink: sinon.stub()}};
+    });
+    it("should call getScreenshotForURL", () => {
+      sandbox.stub(Screenshots, "getScreenshotForURL");
+      Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
+
+      assert.calledOnce(Screenshots.getScreenshotForURL);
+      assert.calledWithExactly(Screenshots.getScreenshotForURL, "mozilla.com");
+    });
+    it("should not call getScreenshotForURL twice if a fetch is in progress", () => {
+      sandbox.stub(Screenshots, "getScreenshotForURL").callsFake(() => new Promise(resolve => setTimeout(resolve, 0)));
+      Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
+      Screenshots.maybeCacheScreenshot(link, "mozilla.org", "image", sinon.stub());
+
+      assert.calledOnce(Screenshots.getScreenshotForURL);
+      assert.calledWithExactly(Screenshots.getScreenshotForURL, "mozilla.com");
+    });
+    it("should not call getScreenshotsForURL if property !== undefined", () => {
+      sandbox.stub(Screenshots, "getScreenshotForURL");
+      link.image = null;
+
+      Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
+
+      assert.notCalled(Screenshots.getScreenshotForURL);
+    });
+  });
+
   describe("#_bytesToString", () => {
     it("should convert no bytes to empty string", () => {
       assert.equal(Screenshots._bytesToString([]), "");

--- a/system-addon/test/unit/lib/Screenshots.test.js
+++ b/system-addon/test/unit/lib/Screenshots.test.js
@@ -62,7 +62,7 @@ describe("Screenshots", () => {
       assert.calledWithExactly(Screenshots.getScreenshotForURL, "mozilla.com");
     });
     it("should not call getScreenshotForURL twice if a fetch is in progress", () => {
-      sandbox.stub(Screenshots, "getScreenshotForURL").callsFake(() => new Promise(() => {}));
+      sandbox.stub(Screenshots, "getScreenshotForURL").returns(new Promise(() => {}));
       Screenshots.maybeCacheScreenshot(link, "mozilla.com", "image", sinon.stub());
       Screenshots.maybeCacheScreenshot(link, "mozilla.org", "image", sinon.stub());
 


### PR DESCRIPTION
Closes #3763.

@Mardak would this be a good enough fix? Would prevent per browser session repeated requests while still allow to make the request on restart for websites that might have legitimate issues.

I've looked into the Screenshots/BackgroundPageThumbs code but it doesn't give more information in case of error to make this more precise. `page-thumbnail:error` is a generic fail.
> fails (eg, times out, remote process crashes.)