### PR TITLE
feat(telemetry): #3770 Generate unique ID for impression pings

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -106,8 +106,9 @@ Schema definitions/validations that can be used for tests can be found in `syste
 ```js
 {
   "action": "activity_stream_impression_stats",
-  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
-  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
   "addon_version": "1.0.12",
   "locale": "en-US",
   "source": "pocket",
@@ -122,6 +123,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "action": "activity_stream_impression_stats",
   "client_id": "n/a",
   "session_id": "n/a",
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
   "addon_version": "1.0.12",
   "locale": "en-US",
   "source": "pocket",
@@ -148,6 +150,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `event_id` | [Required] An identifier shared by multiple performance pings that describe ane entire request flow. | :one:
 | `event` | [Required] The type of event. Any user defined string ("click", "share", "delete", "more_items") | :one:
 | `highlight_type` | [Optional] Either ["bookmarks", "recommendation", "history"]. | :one:
+| `impression_id` | [Optional] The unique impression identifier for a specific client. | :one:
 | `ip` | [Auto populated by Onyx] The IP address of the client. | :two:
 | `locale` | [Auto populated by Onyx] The browser chrome's language (eg. en-US). | :two:
 | `load_trigger_ts` | [Optional][Server Counter][Server Alert for too many omissions]  DOMHighResTimeStamp of the action perceived by the user to trigger the load of this page. | :one:
@@ -170,6 +173,7 @@ and losing focus. | :one:
 | `highlights_size` | [Optional] The size of the Highlights set. | :one:
 | `highlights_data_late_by_ms` | [Optional] Time in ms it took for Highlights to become initialized | :one:
 | `topsites_data_late_by_ms` | [Optional] Time in ms it took for TopSites to become initialized | :one:
+| `topstories.domain.affinity.calculation.ms` | [Optional] Time in ms it took for domain affinities to be calculated | :one:
 | `topsites_first_painted_ts` | [Optional][Service Counter][Server Alert for too many omissions] Timestamp of when the Top Sites element finished painting (possibly with only placeholder screenshots) | :one:
 | `topsites_size` | [Optional] The size of the Topsites set. | :one:
 | `topsites_screenshot` | [Optional] The size of the Topsites set with screenshot metadata. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -228,6 +228,24 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 }
 ```
 
+#### Acknowledging a section disclaimer
+
+```js
+{
+  "event": "SECTION_DISCLAIMER_ACKNOWLEDGED",
+  "source": "TOP_STORIES",
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home" | "unknown"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "user_prefs": 7
+}
+```
+
 ## Session end pings
 
 When a session ends, the browser will send a `"activity_stream_session"` ping to our metrics servers. This ping contains the length of the session, a unique reason for why the session ended, and some additional metadata.

--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -76,6 +76,15 @@ section_info_option=Info
 section_info_send_feedback=Send Feedback
 section_info_privacy_notice=Privacy Notice
 
+# LOCALIZATION NOTE (section_disclaimer_topstories): This is shown below
+# the topstories section title to provide additional information about
+# how the stories are selected.
+section_disclaimer_topstories=The most interesting stories on the web, selected based on what you read. From Pocket, now part of Mozilla.
+section_disclaimer_topstories_linktext=Learn how it works.
+# LOCALIZATION NOTE (section_disclaimer_topstories_buttontext): The text of
+# the button used to acknowledge, and hide this disclaimer in the future.
+section_disclaimer_topstories_buttontext=Okay, got it
+
 # LOCALIZATION NOTE (welcome_*): This is shown as a modal dialog, typically on a
 # first-run experience when there's no data to display yet
 welcome_title=Welcome to new tab

--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -83,7 +83,6 @@ class Card extends React.PureComponent {
       this.props.dispatch(ac.ImpressionStats({
         source: this.props.eventSource,
         click: 0,
-        incognito: true,
         tiles: [{id: this.props.link.guid, pos: this.props.index}]
       }));
     }

--- a/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -89,6 +89,40 @@ class Info extends React.PureComponent {
 
 const InfoIntl = injectIntl(Info);
 
+class Disclaimer extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onAcknowledge = this.onAcknowledge.bind(this);
+  }
+
+  onAcknowledge() {
+    this.props.dispatch(ac.SetPref(this.props.disclaimerPref, false));
+    this.props.dispatch(ac.UserEvent({event: "SECTION_DISCLAIMER_ACKNOWLEDGED", source: this.props.eventSource}));
+  }
+
+  render() {
+    const disclaimer = this.props.disclaimer;
+    return (
+      <div className="section-disclaimer">
+          <div className="section-disclaimer-text">
+            {getFormattedMessage(disclaimer.text)}
+            {disclaimer.link &&
+              <a href={disclaimer.link.href} target="_blank" rel="noopener noreferrer">
+                {getFormattedMessage(disclaimer.link.title || disclaimer.link)}
+              </a>
+            }
+          </div>
+
+          <button onClick={this.onAcknowledge}>
+            {getFormattedMessage(disclaimer.button)}
+          </button>
+      </div>
+    );
+  }
+}
+
+const DisclaimerIntl = injectIntl(Disclaimer);
+
 class CollapsibleSection extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -150,7 +184,9 @@ class CollapsibleSection extends React.PureComponent {
   render() {
     const isCollapsed = this.props.Prefs.values[this.props.prefName];
     const {enableAnimation, isAnimating} = this.state;
-    const infoOption = this.props.infoOption;
+    const {id, infoOption, eventSource, disclaimer} = this.props;
+    const disclaimerPref = `section.${id}.showDisclaimer`;
+    const needsDisclaimer = disclaimer && this.props.Prefs.values[disclaimerPref];
 
     return (
       <section className={`collapsible-section ${this.props.className}${enableAnimation ? " animation-enabled" : ""}${isCollapsed ? " collapsed" : ""}`}>
@@ -165,6 +201,7 @@ class CollapsibleSection extends React.PureComponent {
           {infoOption && <InfoIntl infoOption={infoOption} dispatch={this.props.dispatch} />}
         </div>
         <div className={`section-body${isAnimating ? " animating" : ""}`} onTransitionEnd={this.onTransitionEnd}>
+          {needsDisclaimer && <DisclaimerIntl disclaimerPref={disclaimerPref} disclaimer={disclaimer} eventSource={eventSource} dispatch={this.props.dispatch} />}
           {this.props.children}
         </div>
       </section>
@@ -185,3 +222,5 @@ module.exports = injectIntl(CollapsibleSection);
 module.exports._unconnected = CollapsibleSection;
 module.exports.Info = Info;
 module.exports.InfoIntl = InfoIntl;
+module.exports.Disclaimer = Disclaimer;
+module.exports.DisclaimerIntl = DisclaimerIntl;

--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -4,6 +4,7 @@
     .click-target {
       cursor: pointer;
       vertical-align: top;
+      white-space: nowrap;
     }
 
     .icon-arrowhead-down,
@@ -163,10 +164,61 @@
     }
   }
 
+  .section-disclaimer {
+    color: $grey-60;
+    font-size: 13px;
+    margin-bottom: 16px;
+
+    .section-disclaimer-text {
+      display: inline-block;
+
+      @media (min-width: $break-point-small) {
+        width: $card-width;
+      }
+
+      @media (min-width: $break-point-medium) {
+        width: $card-width * 1.5;
+      }
+
+      @media (min-width: $break-point-large) {
+        width: $card-width * 3 - $base-gutter;
+      }
+    }
+
+    a {
+      color: $link-secondary;
+      padding-left: 3px;
+    }
+
+    button {
+      margin-top: 2px;
+      offset-inline-end: 0;
+      height: 26px;
+
+      background: $grey-10;
+      border: 1px solid $grey-40;
+      border-radius: 4px;
+      cursor: pointer;
+
+      &:hover:not(.dismiss) {
+        box-shadow: $shadow-primary;
+        transition: box-shadow 150ms;
+      }
+
+      @media (min-width: $wrapper-default-width) {
+        position: relative;
+      }
+
+      @media (min-width: $break-point-small) {
+        position: absolute;
+      }
+    }
+  }
+
   .section-body {
     // max-height needs to be set to a value larger than it will ever reasonably get.
     // We then transition on max-height, since we can't transition height to/from auto.
-    max-height: 900px;
+    max-height: 1100px;
 
     // This is so the top sites favicon and card dropshadows don't get clipped during animation:
     $horizontal-padding: 7px;
@@ -195,6 +247,10 @@
     .section-body {
       max-height: 0;
       overflow: hidden;
+    }
+
+    .section-disclaimer {
+      position: relative;
     }
 
     .section-info-option {

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -25,8 +25,7 @@ class Section extends React.PureComponent {
     if (this.needsImpressionStats(cards)) {
       props.dispatch(ac.ImpressionStats({
         source: props.eventSource,
-        tiles: cards.map(link => ({id: link.guid})),
-        incognito: props.options && props.options.personalized
+        tiles: cards.map(link => ({id: link.guid}))
       }));
       this.impressionCardGuids = cards.map(link => link.guid);
     }
@@ -124,7 +123,7 @@ class Section extends React.PureComponent {
     const {
       id, eventSource, title, icon, rows,
       infoOption, emptyState, dispatch, maxRows,
-      contextMenuOptions, initialized
+      contextMenuOptions, initialized, disclaimer
     } = this.props;
     const maxCards = CARDS_PER_ROW * maxRows;
 
@@ -143,7 +142,15 @@ class Section extends React.PureComponent {
     // <Section> <-- React component
     // <section> <-- HTML5 element
     return (<ComponentPerfTimer {...this.props}>
-      <CollapsibleSection className="section" icon={icon} title={getFormattedMessage(title)} infoOption={infoOption} prefName={`section.${id}.collapsed`} Prefs={this.props.Prefs} dispatch={this.props.dispatch}>
+      <CollapsibleSection className="section" icon={icon} title={getFormattedMessage(title)}
+        infoOption={infoOption}
+        id={id}
+        eventSource={eventSource}
+        disclaimer={disclaimer}
+        prefName={`section.${id}.collapsed`}
+        Prefs={this.props.Prefs}
+        dispatch={this.props.dispatch}>
+
         {!shouldShowEmptyState && (<ul className="section-list" style={{padding: 0}}>
           {realRows.map((link, index) => link &&
             <Card key={index} index={index} dispatch={dispatch} link={link} contextMenuOptions={contextMenuOptions}

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -53,7 +53,6 @@ module.exports = {
     impression: ac.ImpressionStats({
       source: eventSource,
       block: 0,
-      incognito: true,
       tiles: [{id: site.guid, pos: index}]
     }),
     userEvent: "BLOCK"
@@ -102,7 +101,6 @@ module.exports = {
     impression: ac.ImpressionStats({
       source: eventSource,
       pocket: 0,
-      incognito: true,
       tiles: [{id: site.guid, pos: index}]
     }),
     userEvent: "SAVE_TO_POCKET"

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -64,6 +64,7 @@ const PREFS_CONFIG = new Map([
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "https://getpocket.com/recommendations",
       info_link: "https://www.mozilla.org/privacy/firefox/#pocketstories",
+      disclaimer_link: "https://getpocket.cdn.mozilla.net/firefox/new_tab_learn_more",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       show_spocs: false,
       personalized: false
@@ -109,18 +110,6 @@ const PREFS_CONFIG = new Map([
     title: "Number of Top Sites to display",
     value: 6
   }],
-  ["impressionStats.clicked", {
-    title: "GUIDs of clicked Top stories items",
-    value: "[]"
-  }],
-  ["impressionStats.blocked", {
-    title: "GUIDs of blocked Top stories items",
-    value: "[]"
-  }],
-  ["impressionStats.pocketed", {
-    title: "GUIDs of pocketed Top stories items",
-    value: "[]"
-  }],
   ["telemetry", {
     title: "Enable system error and usage data collection",
     value: true,
@@ -137,6 +126,10 @@ const PREFS_CONFIG = new Map([
   ["section.topstories.collapsed", {
     title: "Collapse the Top Stories section",
     value: false
+  }],
+  ["section.topstories.showDisclaimer", {
+    title: "Boolean flag that decides whether or not to show the topstories disclaimer.",
+    value: true
   }]
 ]);
 

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -32,6 +32,11 @@ const BUILT_IN_SECTIONS = {
     eventSource: "TOP_STORIES",
     icon: options.provider_icon,
     title: {id: "header_recommended_by", values: {provider: options.provider_name}},
+    disclaimer: {
+      text: {id: options.disclaimer_text || "section_disclaimer_topstories"},
+      link: {href: options.disclaimer_link, id: options.disclaimer_linktext || "section_disclaimer_topstories_linktext"},
+      button: {id: options.disclaimer_buttontext || "section_disclaimer_topstories_buttontext"}
+    },
     maxRows: 1,
     availableContextMenuOptions: ["CheckBookmark", "SaveToPocket", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl"],
     infoOption: {

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -34,79 +34,14 @@ const USER_PREFS_ENCODING = {
   "showSponsored": 1 << 5
 };
 
-const IMPRESSION_STATS_RESET_TIME = 60 * 60 * 1000; // 60 minutes
-const PREF_IMPRESSION_STATS_CLICKED = "impressionStats.clicked";
-const PREF_IMPRESSION_STATS_BLOCKED = "impressionStats.blocked";
-const PREF_IMPRESSION_STATS_POCKETED = "impressionStats.pocketed";
+const PREF_IMPRESSION_ID = "impressionId";
 const TELEMETRY_PREF = "telemetry";
-
-/**
- * A pref persistent GUID set
- */
-class PersistentGuidSet extends Set {
-  constructor(prefs, prefName) {
-    let guids = [];
-    try {
-      guids = JSON.parse(prefs.get(prefName));
-      if (typeof guids[Symbol.iterator] !== "function") {
-        guids = [];
-        prefs.set(prefName, "[]");
-      }
-    } catch (e) {
-      Cu.reportError(e);
-      prefs.set(prefName, "[]");
-    }
-
-    super(guids);
-
-    this._prefs = prefs;
-    this._prefName = prefName;
-  }
-
-  /**
-   * Add a GUID and persist
-   *
-   * @param {Integer|String} guid a GUID to save
-   * @returns {Boolean} true if the item has been added
-   */
-  save(guid) {
-    if (!this.has(guid)) {
-      this.add(guid);
-      this._prefs.set(this._prefName, JSON.stringify(this.items()));
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Clear GUID set and persist
-   */
-  clear() {
-    if (this.size !== 0) {
-      this._prefs.set(this._prefName, "[]");
-      super.clear();
-    }
-  }
-
-  /**
-   * Return GUID set as an array ordered by insertion time
-   */
-  items() {
-    return [...this];
-  }
-}
 
 this.TelemetryFeed = class TelemetryFeed {
   constructor(options) {
     this.sessions = new Map();
     this._prefs = new Prefs();
-    this._impressionStatsLastReset = Date.now();
-    this._impressionStats = {
-      clicked: new PersistentGuidSet(this._prefs, PREF_IMPRESSION_STATS_CLICKED),
-      blocked: new PersistentGuidSet(this._prefs, PREF_IMPRESSION_STATS_BLOCKED),
-      pocketed: new PersistentGuidSet(this._prefs, PREF_IMPRESSION_STATS_POCKETED)
-    };
-
+    this._impressionId = this.getOrCreateImpressionId();
     this.telemetryEnabled = this._prefs.get(TELEMETRY_PREF);
     this._aboutHomeSeen = false;
     this._onTelemetryPrefChange = this._onTelemetryPrefChange.bind(this);
@@ -115,6 +50,15 @@ this.TelemetryFeed = class TelemetryFeed {
 
   init() {
     Services.obs.addObserver(this.browserOpenNewtabStart, "browser-open-newtab-start");
+  }
+
+  getOrCreateImpressionId() {
+    let impressionId = this._prefs.get(PREF_IMPRESSION_ID);
+    if (!impressionId) {
+      impressionId = String(gUUIDGenerator.generateUUID());
+      this._prefs.set(PREF_IMPRESSION_ID, impressionId);
+    }
+    return impressionId;
   }
 
   browserOpenNewtabStart() {
@@ -335,25 +279,20 @@ this.TelemetryFeed = class TelemetryFeed {
    * createImpressionStats - Create a ping for an impression stats
    *
    * @param  {ob} action The object with data to be included in the ping.
-   *                     For some user interactions, a boolean "incognito"
-   *                     field of the "data" object could be used to empty
-   *                     all the user specific IDs with "n/a" in the ping.
+   *                     For some user interactions.
    * @return {obj}    A telemetry ping
    */
   createImpressionStats(action) {
-    let ping = Object.assign(
+    return Object.assign(
       this.createPing(au.getPortIdOfSender(action)),
       action.data,
-      {action: "activity_stream_impression_stats"}
+      {
+        action: "activity_stream_impression_stats",
+        impression_id: this._impressionId,
+        client_id: "n/a",
+        session_id: "n/a"
+      }
     );
-
-    if (ping.incognito) {
-      ping.client_id = "n/a";
-      ping.session_id = "n/a";
-      delete ping.incognito;
-    }
-
-    return ping;
   }
 
   createUserEvent(action) {
@@ -402,26 +341,7 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   handleImpressionStats(action) {
-    const payload = action.data;
-    let guidSet;
-    let index;
-
-    if ("click" in payload) {
-      guidSet = this._impressionStats.clicked;
-      index = payload.click;
-    } else if ("block" in payload) {
-      guidSet = this._impressionStats.blocked;
-      index = payload.block;
-    } else if ("pocket" in payload) {
-      guidSet = this._impressionStats.pocketed;
-      index = payload.pocket;
-    }
-
-    // If it is an impression ping, just send it out. For the click, block, and
-    // save to pocket pings, it only sends the first ping for the same article.
-    if (!guidSet || guidSet.save(payload.tiles[index].id)) {
-      this.sendEvent(this.createImpressionStats(action));
-    }
+    this.sendEvent(this.createImpressionStats(action));
   }
 
   handleUserEvent(action) {
@@ -430,13 +350,6 @@ this.TelemetryFeed = class TelemetryFeed {
 
   handleUndesiredEvent(action) {
     this.sendEvent(this.createUndesiredEvent(action));
-  }
-
-  resetImpressionStats() {
-    for (const key of Object.keys(this._impressionStats)) {
-      this._impressionStats[key].clear();
-    }
-    this._impressionStatsLastReset = Date.now();
   }
 
   onAction(action) {
@@ -455,11 +368,6 @@ this.TelemetryFeed = class TelemetryFeed {
         break;
       case at.SAVE_SESSION_PERF_DATA:
         this.saveSessionPerfData(au.getPortIdOfSender(action), action.data);
-        break;
-      case at.SYSTEM_TICK:
-        if (Date.now() - this._impressionStatsLastReset >= IMPRESSION_STATS_RESET_TIME) {
-          this.resetImpressionStats();
-        }
         break;
       case at.TELEMETRY_IMPRESSION_STATS:
         this.handleImpressionStats(action);
@@ -535,11 +443,7 @@ this.TelemetryFeed = class TelemetryFeed {
 
 this.EXPORTED_SYMBOLS = [
   "TelemetryFeed",
-  "PersistentGuidSet",
   "USER_PREFS_ENCODING",
-  "IMPRESSION_STATS_RESET_TIME",
-  "TELEMETRY_PREF",
-  "PREF_IMPRESSION_STATS_CLICKED",
-  "PREF_IMPRESSION_STATS_BLOCKED",
-  "PREF_IMPRESSION_STATS_POCKETED"
+  "PREF_IMPRESSION_ID",
+  "TELEMETRY_PREF"
 ];

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -69,6 +69,9 @@ const TileSchema = Joi.object().keys({
 
 const ImpressionStatsPing = Joi.object().keys(Object.assign({}, baseKeys, {
   source: Joi.string().required(),
+  impression_id: Joi.string().required(),
+  client_id: Joi.valid("n/a").required(),
+  session_id: Joi.valid("n/a").required(),
   action: Joi.valid("activity_stream_impression_stats").required(),
   tiles: Joi.array().items(TileSchema).required(),
   click: Joi.number().integer(),

--- a/system-addon/test/unit/content-src/components/Card.test.jsx
+++ b/system-addon/test/unit/content-src/components/Card.test.jsx
@@ -194,7 +194,6 @@ describe("<Card>", () => {
       assert.calledWith(DEFAULT_PROPS.dispatch.thirdCall, ac.ImpressionStats({
         source: DEFAULT_PROPS.eventSource,
         click: 0,
-        incognito: true,
         tiles: [{id: DEFAULT_PROPS.link.guid, pos: DEFAULT_PROPS.index}]
       }));
     });

--- a/system-addon/test/unit/content-src/components/Sections.test.jsx
+++ b/system-addon/test/unit/content-src/components/Sections.test.jsx
@@ -176,7 +176,6 @@ describe("<Section>", () => {
       const action = dispatch.firstCall.args[0];
       assert.equal(action.type, at.TELEMETRY_IMPRESSION_STATS);
       assert.equal(action.data.source, "TOP_STORIES");
-      assert.isFalse(action.data.incognito);
       assert.deepEqual(action.data.tiles, [{id: 1}, {id: 2}]);
     });
     it("should not send impression stats if not configured", () => {
@@ -190,19 +189,6 @@ describe("<Section>", () => {
       const props = Object.assign({}, FAKE_TOPSTORIES_SECTION_PROPS, {Prefs: {values: {"section.topstories.collapsed": true}}});
       renderSection(props);
       assert.notCalled(dispatch);
-    });
-    it("should not send client id if section is personalized", () => {
-      FAKE_TOPSTORIES_SECTION_PROPS.options.personalized = true;
-      const dispatch = sinon.spy();
-      renderSection({dispatch});
-
-      assert.calledOnce(dispatch);
-
-      const action = dispatch.firstCall.args[0];
-      assert.equal(action.type, at.TELEMETRY_IMPRESSION_STATS);
-      assert.equal(action.data.source, "TOP_STORIES");
-      assert.isTrue(action.data.incognito);
-      assert.deepEqual(action.data.tiles, [{id: 1}, {id: 2}]);
     });
     it("should send 1 impression when the page becomes visibile after loading", () => {
       const props = {

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -36,11 +36,8 @@ describe("TelemetryFeed", () => {
   const {
     TelemetryFeed,
     USER_PREFS_ENCODING,
-    IMPRESSION_STATS_RESET_TIME,
-    TELEMETRY_PREF,
-    PREF_IMPRESSION_STATS_CLICKED,
-    PREF_IMPRESSION_STATS_BLOCKED,
-    PREF_IMPRESSION_STATS_POCKETED
+    PREF_IMPRESSION_ID,
+    TELEMETRY_PREF
   } = injector({"common/PerfService.jsm": {perfService}});
 
   beforeEach(() => {
@@ -70,6 +67,14 @@ describe("TelemetryFeed", () => {
       assert.calledOnce(Services.obs.addObserver);
       assert.calledWithExactly(Services.obs.addObserver,
         instance.browserOpenNewtabStart, "browser-open-newtab-start");
+    });
+    it("should create impression id if none exists", () => {
+      assert.equal(instance._impressionId, FAKE_UUID);
+    });
+    it("should set impression id if it exists", () => {
+      FakePrefs.prototype.prefs = {};
+      FakePrefs.prototype.prefs[PREF_IMPRESSION_ID] = "fakeImpressionId";
+      assert.equal(new TelemetryFeed()._impressionId, "fakeImpressionId");
     });
     describe("telemetry pref changes from false to true", () => {
       beforeEach(() => {
@@ -382,19 +387,6 @@ describe("TelemetryFeed", () => {
       assert.propertyVal(ping, "source", "POCKET");
       assert.propertyVal(ping, "tiles", tiles);
     });
-    it("should empty all the user specific IDs in the ping", async () => {
-      const tiles = [{id: 10001, pos: 2}];
-      const incognito = true;
-      const action = ac.ImpressionStats({source: "POCKET", incognito, tiles, click: 0});
-      const ping = await instance.createImpressionStats(action);
-
-      assert.validate(ping, ImpressionStatsPing);
-      assert.propertyVal(ping, "click", 0);
-      assert.propertyVal(ping, "tiles", tiles);
-      assert.propertyVal(ping, "client_id", "n/a");
-      assert.propertyVal(ping, "session_id", "n/a");
-      assert.isUndefined(ping.incognito);
-    });
     it("should create a valid click ping", async () => {
       const tiles = [{id: 10001, pos: 2}];
       const action = ac.ImpressionStats({source: "POCKET", tiles, click: 0});
@@ -541,32 +533,9 @@ describe("TelemetryFeed", () => {
         instance.browserOpenNewtabStart, "browser-open-newtab-start");
     });
   });
-  describe("#resetImpressionStats", () => {
-    beforeEach(() => {
-      FakePrefs.prototype.prefs = {};
-      FakePrefs.prototype.prefs[PREF_IMPRESSION_STATS_CLICKED] = "[10000]";
-      FakePrefs.prototype.prefs[PREF_IMPRESSION_STATS_BLOCKED] = "[10001]";
-      FakePrefs.prototype.prefs[PREF_IMPRESSION_STATS_POCKETED] = "[10002]";
-    });
-    it("should reset all the GUID sets for impression stats", () => {
-      const lastResetTime = instance._impressionStatsLastReset;
-      // Haven't restored the clock yet, we have to manually tick the clock.
-      clock.tick(IMPRESSION_STATS_RESET_TIME);
-
-      instance.resetImpressionStats();
-
-      for (const key of Object.keys(instance._impressionStats)) {
-        assert.equal(instance._impressionStats[key].size, 0);
-      }
-      assert.isAbove(instance._impressionStatsLastReset, lastResetTime);
-    });
-  });
   describe("#onAction", () => {
     beforeEach(() => {
       FakePrefs.prototype.prefs = {};
-      FakePrefs.prototype.prefs[PREF_IMPRESSION_STATS_CLICKED] = "[]";
-      FakePrefs.prototype.prefs[PREF_IMPRESSION_STATS_BLOCKED] = "[]";
-      FakePrefs.prototype.prefs[PREF_IMPRESSION_STATS_POCKETED] = "[]";
     });
     it("should call .init() on an INIT action", () => {
       const stub = sandbox.stub(instance, "init");
@@ -660,51 +629,6 @@ describe("TelemetryFeed", () => {
       assert.calledWith(eventCreator, action);
       assert.calledWith(sendEvent, eventCreator.returnValue);
     });
-    it("should call .resetImpressionStats on a SYSTEM_TICK action", () => {
-      const resetImpressionStats = sandbox.stub(instance, "resetImpressionStats");
-
-      instance.onAction({type: at.SYSTEM_TICK});
-
-      assert.notCalled(resetImpressionStats);
-
-      clock.tick(IMPRESSION_STATS_RESET_TIME);
-
-      instance.onAction({type: at.SYSTEM_TICK});
-      assert.calledOnce(resetImpressionStats);
-    });
-    it("should not send two click pings for the same article", async () => {
-      const sendEvent = sandbox.stub(instance, "sendEvent");
-      const tiles = [{id: 10001, pos: 2}];
-      const data = {tiles, click: 0};
-      const action = {type: at.TELEMETRY_IMPRESSION_STATS, data};
-
-      instance.onAction(action);
-      instance.onAction(action);
-
-      assert.calledOnce(sendEvent);
-    });
-    it("should not send two block pings for the same article", async () => {
-      const sendEvent = sandbox.stub(instance, "sendEvent");
-      const tiles = [{id: 10001, pos: 2}];
-      const data = {tiles, block: 0};
-      const action = {type: at.TELEMETRY_IMPRESSION_STATS, data};
-
-      instance.onAction(action);
-      instance.onAction(action);
-
-      assert.calledOnce(sendEvent);
-    });
-    it("should not send two save to pocket pings for the same article", async () => {
-      const sendEvent = sandbox.stub(instance, "sendEvent");
-      const tiles = [{id: 10001, pos: 2}];
-      const data = {tiles, pocket: 0};
-      const action = {type: at.TELEMETRY_IMPRESSION_STATS, data};
-
-      instance.onAction(action);
-      instance.onAction(action);
-
-      assert.calledOnce(sendEvent);
-    });
     it("should call .handlePagePrerendered on a PAGE_PRERENDERED action", () => {
       const session = {perf: {}};
       sandbox.stub(instance.sessions, "get").returns(session);
@@ -752,83 +676,6 @@ describe("TelemetryFeed", () => {
       }));
 
       assert.ok(!session.perf.is_preloaded);
-    });
-  });
-});
-
-describe("PersistentGuidSet", () => {
-  const {PersistentGuidSet} = injector({});
-
-  afterEach(() => {
-    FakePrefs.prototype.prefs = {};
-  });
-  describe("#init", () => {
-    it("should initialized empty", () => {
-      let guidSet;
-
-      guidSet = new PersistentGuidSet(new FakePrefs(), "test.guidSet");
-
-      assert.equal(guidSet.size, 0);
-      assert.deepEqual(guidSet.items(), []);
-    });
-    it("should initialized from pref", () => {
-      let guidSet;
-
-      FakePrefs.prototype.prefs = {"test.guidSet": JSON.stringify([10000])};
-      guidSet = new PersistentGuidSet(new FakePrefs(), "test.guidSet");
-
-      assert.equal(guidSet.size, 1);
-      assert.isTrue(guidSet.has(10000));
-      assert.deepEqual(guidSet.items(), [10000]);
-    });
-    it("should initialized empty with invalid pref", () => {
-      let guidSet;
-
-      FakePrefs.prototype.prefs = {"test.guidSet": 10000};
-      guidSet = new PersistentGuidSet(new FakePrefs(), "test.guidSet");
-
-      assert.equal(guidSet.size, 0);
-      assert.deepEqual(guidSet.items(), []);
-    });
-  });
-  describe("#save", () => {
-    it("should save the new GUID", () => {
-      let guidSet;
-      let prefs = new FakePrefs();
-
-      guidSet = new PersistentGuidSet(prefs, "test.guidSet");
-      guidSet.save("10000");
-      guidSet.save("10001");
-
-      assert.equal(guidSet.size, 2);
-      assert.deepEqual(guidSet.items(), ["10000", "10001"]);
-      assert.equal(prefs.get("test.guidSet"), "[\"10000\",\"10001\"]");
-    });
-    it("should not save the same GUID twice", () => {
-      let guidSet;
-      let prefs = new FakePrefs();
-
-      guidSet = new PersistentGuidSet(prefs, "test.guidSet");
-      guidSet.save("10000");
-
-      assert.isFalse(guidSet.save("10000"));
-      assert.equal(guidSet.size, 1);
-      assert.deepEqual(guidSet.items(), ["10000"]);
-      assert.equal(prefs.get("test.guidSet"), "[\"10000\"]");
-    });
-  });
-  describe("#clear", () => {
-    it("should clear the GUID set", () => {
-      let guidSet;
-
-      guidSet = new PersistentGuidSet(new FakePrefs(), "test.guidSet");
-      guidSet.save("10000");
-      guidSet.save("10001");
-
-      assert.equal(guidSet.size, 2);
-      guidSet.clear();
-      assert.equal(guidSet.size, 0);
-      assert.deepEqual(guidSet.items(), []);
     });
   });
 });


### PR DESCRIPTION
Closes #3770 

- Adds new `impression_id` which gets used instead of `client_id` for impression pings

- Adds new `user_event` for acknowledging disclaimers: `SECTION_DISCLAIMER_ACKNOWLEDGED`

- Removes client-side deduping of impressions

- Shows a disclaimer until acknowledged. Includes UI tweaks to make sure disclaimer/section resizes properly.