### PR TITLE
fix(init): Remember when rehydrating early tabs to only do it once

### DIFF
--- a/system-addon/lib/ActivityStreamMessageChannel.jsm
+++ b/system-addon/lib/ActivityStreamMessageChannel.jsm
@@ -142,7 +142,7 @@ this.ActivityStreamMessageChannel = class ActivityStreamMessageChannel {
   simulateMessagesForExistingTabs() {
     // Some pages might have already loaded, so we won't get the usual message
     for (const target of this.channel.messagePorts) {
-      const simulatedMsg = {target};
+      const simulatedMsg = {target: Object.assign({simulated: true}, target)};
       this.onNewTabInit(simulatedMsg);
       if (target.loaded) {
         this.onNewTabLoad(simulatedMsg);

--- a/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
@@ -90,12 +90,14 @@ describe("ActivityStreamMessageChannel", () => {
         RPmessagePorts.push({
           url: "about:monkeys",
           loaded: false,
-          portID: "inited"
+          portID: "inited",
+          simulated: true
         });
         RPmessagePorts.push({
           url: "about:sheep",
           loaded: true,
-          portID: "loaded"
+          portID: "loaded",
+          simulated: true
         });
 
         mm.simulateMessagesForExistingTabs();


### PR DESCRIPTION
Fix #3747. r?@k88hudson Special case early tabs by marking them as `simulated` and only `reply`ing once.