### PR TITLE
Use flex-wrap to force a new line for small width.

### DIFF
--- a/system-addon/content-src/components/ManualMigration/_ManualMigration.scss
+++ b/system-addon/content-src/components/ManualMigration/_ManualMigration.scss
@@ -44,6 +44,7 @@
   button {
     align-self: center;
     height: 26px;
+    margin: 0;
     margin-inline-start: 20px;
     padding: 0 12px;
   }

--- a/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
+++ b/system-addon/content-src/components/PreferencesPane/_PreferencesPane.scss
@@ -115,7 +115,6 @@
     border-left: $border-secondary;
     bottom: 0;
     offset-inline-end: 0;
-    padding: $prefs-spacing;
     position: fixed;
     width: $prefs-width;
 

--- a/system-addon/content-src/styles/_activity-stream.scss
+++ b/system-addon/content-src/styles/_activity-stream.scss
@@ -79,8 +79,9 @@ a {
   display: flex;
   flex-direction: row;
   margin: 0;
-  padding: 15px 25px;
+  padding: 15px 25px 0 25px;
   justify-content: flex-start;
+  flex-wrap: wrap;
 
   button {
     background: $input-secondary;
@@ -89,6 +90,7 @@ a {
     color: inherit;
     cursor: pointer;
     padding: 10px 30px;
+    margin-bottom: 15px;
     white-space: nowrap;
 
     &:hover:not(.dismiss) {


### PR DESCRIPTION
Closes #3630 

<img width="301" alt="image" src="https://user-images.githubusercontent.com/810040/32299500-3d509170-bf2c-11e7-876b-6ecb890df58b.png">

Quickest fix. Could use some margins but this seems to obscure to write media queries for. And we've closed quite a few issues recently where we decided this width doesn't make too much sense to support. https://github.com/mozilla/activity-stream/issues/3749#issuecomment-339401334