### PR TITLE
fix(topstories): #3796 Pocket disclaimer not clickable for some users

### DIFF
--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -34,7 +34,11 @@ const BUILT_IN_SECTIONS = {
     title: {id: "header_recommended_by", values: {provider: options.provider_name}},
     disclaimer: {
       text: {id: options.disclaimer_text || "section_disclaimer_topstories"},
-      link: {href: options.disclaimer_link, id: options.disclaimer_linktext || "section_disclaimer_topstories_linktext"},
+      link: {
+        // The href fallback is temporary so users in existing Shield studies get this configuration as well
+        href: options.disclaimer_link || "https://getpocket.cdn.mozilla.net/firefox/new_tab_learn_more",
+        id: options.disclaimer_linktext || "section_disclaimer_topstories_linktext"
+      },
       button: {id: options.disclaimer_buttontext || "section_disclaimer_topstories_buttontext"}
     },
     maxRows: 1,


### PR DESCRIPTION
Closes #3796 

This is adding a fallback in case the disclaimer link is not configured and the defaults can't be overridden i.e. due to an active shield study.