### PR TITLE
fix(topstories): #3801 Pocket notice text and button overlap on Windows

### DIFF
--- a/locales/de/strings.properties
+++ b/locales/de/strings.properties
@@ -80,7 +80,7 @@ section_info_privacy_notice=Datenschutzhinweis
 # the topstories section title to provide additional information about
 # how the stories are selected.
 section_disclaimer_topstories=Die interessantesten Inhalte aus dem Internet auf Sie abgestimmt. Von Pocket, jetzt Teil von Mozilla.
-section_disclaimer_topstories_linktext=Lernen Sie wie das funktioniert.
+section_disclaimer_topstories_linktext=Lernen Sie, wie das funktioniert.
 # LOCALIZATION NOTE (section_disclaimer_topstories_buttontext): The text of
 # the button used to acknowledge, and hide this disclaimer in the future.
 section_disclaimer_topstories_buttontext=Okay, verstanden

--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -168,6 +168,7 @@
     color: $grey-60;
     font-size: 13px;
     margin-bottom: 16px;
+    position: relative;
 
     .section-disclaimer-text {
       display: inline-block;
@@ -177,11 +178,11 @@
       }
 
       @media (min-width: $break-point-medium) {
-        width: $card-width * 1.5;
+        width: 340px;
       }
 
       @media (min-width: $break-point-large) {
-        width: $card-width * 3 - $base-gutter;
+        width: 610px;
       }
     }
 
@@ -193,7 +194,8 @@
     button {
       margin-top: 2px;
       offset-inline-end: 0;
-      height: 26px;
+      min-height: 26px;
+      max-width: 130px;
 
       background: $grey-10;
       border: 1px solid $grey-40;
@@ -203,10 +205,6 @@
       &:hover:not(.dismiss) {
         box-shadow: $shadow-primary;
         transition: box-shadow 150ms;
-      }
-
-      @media (min-width: $wrapper-default-width) {
-        position: relative;
       }
 
       @media (min-width: $break-point-small) {
@@ -247,10 +245,6 @@
     .section-body {
       max-height: 0;
       overflow: hidden;
-    }
-
-    .section-disclaimer {
-      position: relative;
     }
 
     .section-info-option {


### PR DESCRIPTION
Closes #3801 

- Includes refactoring to remove no longer needed styles
- Adds the missing comma in the temporary German translations