### PR TITLE
fix(addons): #3803 CollapsibleSection icons from add-ons appear to fail

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -177,7 +177,7 @@ class CollapsibleSection extends React.PureComponent {
   renderIcon() {
     const icon = this.props.icon;
     if (icon && icon.startsWith("moz-extension://")) {
-      return <span className="icon icon-small-spacer" style={{"background-image": `url('${icon}')`}} />;
+      return <span className="icon icon-small-spacer" style={{backgroundImage: `url('${icon}')`}} />;
     }
     return <span className={`icon icon-small-spacer icon-${icon || "webextension"}`} />;
   }

--- a/system-addon/test/unit/content-src/components/CollapsibleSection.test.jsx
+++ b/system-addon/test/unit/content-src/components/CollapsibleSection.test.jsx
@@ -77,7 +77,7 @@ describe("CollapsibleSection", () => {
       const icon = "moz-extension://some/extension/path";
       setup({icon});
       const props = wrapper.find(".icon").first().props();
-      assert.equal(props.style["background-image"], `url('${icon}')`);
+      assert.equal(props.style.backgroundImage, `url('${icon}')`);
     });
     it("should use set the icon-* class if a string that doesn't start with `moz-extension://` is provided", () => {
       setup({icon: "cool"});


### PR DESCRIPTION
How to test: need to actually write a webextension that does tries to do this to see if this is the consequence of the test warning that was fixed.  That said, it looks pretty straightforward...

r? @rlr