### PR TITLE
fix(collapsing): Set max-height via javascript to transition for any size section

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -8,6 +8,9 @@ const VISIBILITY_CHANGE_EVENT = "visibilitychange";
 function getFormattedMessage(message) {
   return typeof message === "string" ? <span>{message}</span> : <FormattedMessage {...message} />;
 }
+function getCollapsed(props) {
+  return props.Prefs.values[props.prefName];
+}
 
 class Info extends React.PureComponent {
   constructor(props) {
@@ -126,6 +129,7 @@ const DisclaimerIntl = injectIntl(Disclaimer);
 class CollapsibleSection extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.onBodyMount = this.onBodyMount.bind(this);
     this.onInfoEnter = this.onInfoEnter.bind(this);
     this.onInfoLeave = this.onInfoLeave.bind(this);
     this.onHeaderClick = this.onHeaderClick.bind(this);
@@ -136,6 +140,16 @@ class CollapsibleSection extends React.PureComponent {
 
   componentWillMount() {
     this.props.document.addEventListener(VISIBILITY_CHANGE_EVENT, this.enableOrDisableAnimation);
+  }
+  componentWillUpdate(nextProps) {
+    // Check if we're about to go from expanded to collapsed
+    if (!getCollapsed(this.props) && getCollapsed(nextProps)) {
+      // This next line forces a layout flush of the section body, which has a
+      // max-height style set, so that the upcoming collapse animation can
+      // animate from that height to the collapsed height. Without this, the
+      // update is coalesced and there's no animation from no-max-height to 0.
+      this.sectionBody.scrollHeight; // eslint-disable-line no-unused-expressions
+    }
   }
   componentWillUnmount() {
     this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this.enableOrDisableAnimation);
@@ -154,6 +168,9 @@ class CollapsibleSection extends React.PureComponent {
       this.setState({infoActive});
     }
   }
+  onBodyMount(node) {
+    this.sectionBody = node;
+  }
   onInfoEnter() {
     // We're getting focus or hover, so info state should be true if not yet.
     this._setInfoState(true);
@@ -168,11 +185,18 @@ class CollapsibleSection extends React.PureComponent {
         Node.DOCUMENT_POSITION_CONTAINS)));
   }
   onHeaderClick() {
-    this.setState({isAnimating: true});
-    this.props.dispatch(ac.SetPref(this.props.prefName, !this.props.Prefs.values[this.props.prefName]));
+    // Get the current height of the body so max-height transitions can work
+    this.setState({
+      isAnimating: true,
+      maxHeight: `${this.sectionBody.scrollHeight}px`
+    });
+    this.props.dispatch(ac.SetPref(this.props.prefName, !getCollapsed(this.props)));
   }
-  onTransitionEnd() {
-    this.setState({isAnimating: false});
+  onTransitionEnd(event) {
+    // Only update the animating state for our own transition (not a child's)
+    if (event.target === event.currentTarget) {
+      this.setState({isAnimating: false});
+    }
   }
   renderIcon() {
     const icon = this.props.icon;
@@ -182,8 +206,8 @@ class CollapsibleSection extends React.PureComponent {
     return <span className={`icon icon-small-spacer icon-${icon || "webextension"}`} />;
   }
   render() {
-    const isCollapsed = this.props.Prefs.values[this.props.prefName];
-    const {enableAnimation, isAnimating} = this.state;
+    const isCollapsed = getCollapsed(this.props);
+    const {enableAnimation, isAnimating, maxHeight} = this.state;
     const {id, infoOption, eventSource, disclaimer} = this.props;
     const disclaimerPref = `section.${id}.showDisclaimer`;
     const needsDisclaimer = disclaimer && this.props.Prefs.values[disclaimerPref];
@@ -200,7 +224,11 @@ class CollapsibleSection extends React.PureComponent {
           </h3>
           {infoOption && <InfoIntl infoOption={infoOption} dispatch={this.props.dispatch} />}
         </div>
-        <div className={`section-body${isAnimating ? " animating" : ""}`} onTransitionEnd={this.onTransitionEnd}>
+        <div
+          className={`section-body${isAnimating ? " animating" : ""}`}
+          onTransitionEnd={this.onTransitionEnd}
+          ref={this.onBodyMount}
+          style={isAnimating && !isCollapsed ? {maxHeight} : null}>
           {needsDisclaimer && <DisclaimerIntl disclaimerPref={disclaimerPref} disclaimer={disclaimer} eventSource={eventSource} dispatch={this.props.dispatch} />}
           {this.props.children}
         </div>

--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -214,10 +214,6 @@
   }
 
   .section-body {
-    // max-height needs to be set to a value larger than it will ever reasonably get.
-    // We then transition on max-height, since we can't transition height to/from auto.
-    max-height: 1100px;
-
     // This is so the top sites favicon and card dropshadows don't get clipped during animation:
     $horizontal-padding: 7px;
     margin: 0 (-$horizontal-padding);
@@ -225,6 +221,7 @@
 
     &.animating {
       overflow: hidden;
+      pointer-events: none;
     }
   }
 

--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -28,7 +28,6 @@
     display: flex;
     border: $border-secondary;
     border-radius: $border-radius;
-    margin-bottom: 16px;
 
     .empty-state {
       margin: auto;

--- a/system-addon/test/unit/content-src/components/CollapsibleSection.test.jsx
+++ b/system-addon/test/unit/content-src/components/CollapsibleSection.test.jsx
@@ -88,6 +88,34 @@ describe("CollapsibleSection", () => {
       assert.ok(wrapper.find(".icon").first().hasClass("icon-webextension"));
     });
   });
+
+  describe("maxHeight", () => {
+    const maxHeight = "123px";
+    const setState = state => wrapper.setState(Object.assign({maxHeight}, state || {}));
+    const checkHeight = val => assert.equal(wrapper.find(".section-body").node.style.maxHeight, val);
+
+    it("should have no max-height normally to avoid unexpected cropping", () => {
+      setState();
+
+      checkHeight("");
+    });
+    it("should have a max-height when animating open to a target height", () => {
+      setState({isAnimating: true});
+
+      checkHeight(maxHeight);
+    });
+    it("should not have a max-height when already collapsed", () => {
+      setup({Prefs: {values: {collapseSection: true}}});
+
+      checkHeight("");
+    });
+    it("should not have a max-height when animating closed to a css-set 0", () => {
+      setup({Prefs: {values: {collapseSection: true}}});
+      setState({isAnimating: true});
+
+      checkHeight("");
+    });
+  });
 });
 
 describe("<Info>", () => {


### PR DESCRIPTION
Fix #3677, fix #3806, fix #3807, fix #3809. r?@rlr See https://ed.agadak.net/as/activity-stream.collapsible.maxHeight.webm

There's some magic forced flushing to get things to work…

I'll add some tests to at least make sure the style is set at the appropriate times.