### PR TITLE
fix(topsites): Use ::before to show letter fallback to avoid extra link text

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -6,9 +6,10 @@ const LinkMenu = require("content-src/components/LinkMenu/LinkMenu");
 const {TOP_SITES_SOURCE, TOP_SITES_CONTEXT_MENU_OPTIONS, MIN_RICH_FAVICON_SIZE, MIN_CORNER_FAVICON_SIZE} = require("./TopSitesConstants");
 
 const TopSiteLink = props => {
-  const {link} = props;
+  const {link, title} = props;
   const topSiteOuterClassName = `top-site-outer${props.className ? ` ${props.className}` : ""}`;
   const {tippyTopIcon, faviconSize} = link;
+  const letterFallback = title[0];
   let imageClassName;
   let imageStyle;
   let showSmallFavicon = false;
@@ -39,16 +40,16 @@ const TopSiteLink = props => {
   }
   return (<li className={topSiteOuterClassName} key={link.guid || link.url}>
    <a href={link.url} onClick={props.onClick}>
-     <div className="tile" aria-hidden={true}>
-        <span className="letter-fallback">{props.title[0]}</span>
+      <div className="tile" aria-hidden={true} data-fallback={letterFallback}>
         <div className={imageClassName} style={imageStyle} />
-          {showSmallFavicon && <div className="top-site-icon default-icon" style={smallFaviconStyle}>
-          {smallFaviconFallback && props.title[0]}
-        </div>}
+        {showSmallFavicon && <div
+          className="top-site-icon default-icon"
+          data-fallback={smallFaviconFallback && letterFallback}
+          style={smallFaviconStyle} />}
      </div>
      <div className={`title ${link.isPinned ? "pinned" : ""}`}>
        {link.isPinned && <div className="icon icon-pin-small" />}
-       <span dir="auto">{props.title}</span>
+        <span dir="auto">{title}</span>
      </div>
    </a>
    {props.children}

--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -105,6 +105,10 @@
       display: flex;
       align-items: center;
       justify-content: center;
+
+      &::before {
+        content: attr(data-fallback);
+      }
     }
 
     &.placeholder {
@@ -164,6 +168,10 @@
       align-items: center;
       justify-content: center;
       font-size: 20px;
+
+      &[data-fallback]::before {
+        content: attr(data-fallback);
+      }
     }
 
     .title {

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -236,6 +236,11 @@ describe("<TopSiteLink>", () => {
 
     assert.equal(titleEl.text(), "foobar");
   });
+  it("should have only the title as the text of the link", () => {
+    const wrapper = shallow(<TopSiteLink link={link} title="foobar" />);
+
+    assert.equal(wrapper.find("a").text(), "foobar");
+  });
   it("should render the pin icon for pinned links", () => {
     link.isPinned = true;
     link.pinnedIndex = 7;
@@ -249,7 +254,7 @@ describe("<TopSiteLink>", () => {
   });
   it("should render the first letter of the title as a fallback for missing screenshots", () => {
     const wrapper = shallow(<TopSiteLink link={link} title={"foo"} />);
-    assert.equal(wrapper.find(".letter-fallback").text(), "f");
+    assert.equal(wrapper.find(".tile").prop("data-fallback"), "f");
   });
   it("should render a screenshot with the .active class, if it is provided", () => {
     const wrapper = shallow(<TopSiteLink link={link} />);
@@ -268,7 +273,7 @@ describe("<TopSiteLink>", () => {
     assert.propertyVal(screenshotEl.props().style, "backgroundImage", "url(foo.jpg)");
     assert.isTrue(screenshotEl.hasClass("active"));
     assert.lengthOf(defaultIconEl, 1);
-    assert.equal(defaultIconEl.text(), "f");
+    assert.equal(defaultIconEl.prop("data-fallback"), "f");
   });
   it("should render a small icon with fallback letter with the screenshot if the icon is missing", () => {
     const wrapper = shallow(<TopSiteLink link={link} title="foo" />);
@@ -278,7 +283,7 @@ describe("<TopSiteLink>", () => {
     assert.propertyVal(screenshotEl.props().style, "backgroundImage", "url(foo.jpg)");
     assert.isTrue(screenshotEl.hasClass("active"));
     assert.lengthOf(defaultIconEl, 1);
-    assert.equal(defaultIconEl.text(), "f");
+    assert.equal(defaultIconEl.prop("data-fallback"), "f");
   });
   it("should render a small icon with the screenshot if the icon is bigger than 32x32", () => {
     link.favicon = "small-icon.png";


### PR DESCRIPTION
Fix #3765. r?@sarracini 

Before:
![screen shot 2017-11-09 at 1 38 51 am](https://user-images.githubusercontent.com/438537/32598635-1b27651a-c4ef-11e7-8608-5dacbcf6e1f9.png)
![screen shot 2017-11-09 at 1 38 30 am](https://user-images.githubusercontent.com/438537/32598643-2098a3c4-c4ef-11e7-9937-3eadda92be21.png)
![screen shot 2017-11-09 at 1 38 19 am](https://user-images.githubusercontent.com/438537/32598652-275f23fe-c4ef-11e7-9683-7b11aeed6cd4.png)


After:
![screen shot 2017-11-09 at 1 39 13 am](https://user-images.githubusercontent.com/438537/32598618-104b7276-c4ef-11e7-8549-5270e3ef6ce2.png)
![screen shot 2017-11-09 at 1 37 40 am](https://user-images.githubusercontent.com/438537/32598663-2af5b136-c4ef-11e7-83e7-b3af7aa22b5c.png)
![screen shot 2017-11-09 at 1 37 16 am](https://user-images.githubusercontent.com/438537/32598668-2cb4197c-c4ef-11e7-80ad-7a69f668c41e.png)
