### PR TITLE
Fix font issue caused by font-weight prop.

### DIFF
--- a/system-addon/content-src/components/Sections/_Sections.scss
+++ b/system-addon/content-src/components/Sections/_Sections.scss
@@ -48,7 +48,6 @@
       .empty-state-message {
         margin-bottom: 0;
         font-size: 13px;
-        font-weight: 300;
         color: $text-secondary;
         text-align: center;
       }


### PR DESCRIPTION
Closes #3772.

I got the 👍 to remove the property [in the issue](https://github.com/mozilla/activity-stream/issues/3772#issuecomment-343250007).

Windows 7
With `font-weight: 300` (as it is now)
<img width="389" alt="screen shot 2017-11-09 at 17 00 17838" src="https://user-images.githubusercontent.com/810040/32615242-90df36c2-c56f-11e7-8c39-2905c28130b4.png">
Without the `font-weight` property
<img width="478" alt="screen shot 2017-11-09 at 17 00 31033" src="https://user-images.githubusercontent.com/810040/32615245-9370d972-c56f-11e7-85e2-08c52eb964e6.png">

OSX without font-weight property
<img width="398" alt="image" src="https://user-images.githubusercontent.com/810040/32623393-48d1c5f4-c586-11e7-9ca0-89c2b76e2a7d.png">
