### PR TITLE
React error on key warnings during tests

### DIFF
--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -1,6 +1,17 @@
 const {GlobalOverrider, FakePrefs, FakePerformance, EventEmitter} = require("test/unit/utils");
 const {chaiAssertions} = require("test/schemas/pings");
 
+// Cause React warnings to make tests that trigger them fail
+const origConsoleError = console.error; // eslint-disable-line no-console
+console.error = function(msg, ...args) { // eslint-disable-line no-console
+  if (/(Invalid prop|Failed prop type|Check the render method)/.test(msg)) {
+    throw new Error(msg);
+  }
+
+  // eslint-disable-next-line no-console
+  origConsoleError.apply(console, [msg, ...args]);
+};
+
 const req = require.context(".", true, /\.test\.jsx?$/);
 const files = req.keys();
 

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -4,12 +4,12 @@ const {chaiAssertions} = require("test/schemas/pings");
 // Cause React warnings to make tests that trigger them fail
 const origConsoleError = console.error; // eslint-disable-line no-console
 console.error = function(msg, ...args) { // eslint-disable-line no-console
+  // eslint-disable-next-line no-console
+  origConsoleError.apply(console, [msg, ...args]);
+
   if (/(Invalid prop|Failed prop type|Check the render method)/.test(msg)) {
     throw new Error(msg);
   }
-
-  // eslint-disable-next-line no-console
-  origConsoleError.apply(console, [msg, ...args]);
 };
 
 const req = require.context(".", true, /\.test\.jsx?$/);


### PR DESCRIPTION
The warnings are now all gone; this patch will keep them from returning.

How to test: after applying this patch, edit a test somewhere to be missing a required prop while `npm run tddmc` is going and save the file.  The tests should break.