### PR TITLE
fix(styles): Specify background-color to avoid setting other background-{size,*} values

### DIFF
--- a/system-addon/content-src/styles/_activity-stream.scss
+++ b/system-addon/content-src/styles/_activity-stream.scss
@@ -84,7 +84,7 @@ a {
   flex-wrap: wrap;
 
   button {
-    background: $input-secondary;
+    background-color: $input-secondary;
     border: $border-primary;
     border-radius: 4px;
     color: inherit;


### PR DESCRIPTION
Fix #3818. r?@sarracini 

Before:
<img width="142" alt="image" src="https://user-images.githubusercontent.com/438537/32631990-cb6e4224-c556-11e7-857b-66475c11afb2.png">

After:
<img width="144" alt="image" src="https://user-images.githubusercontent.com/438537/32632336-1c3b55c4-c558-11e7-86a3-42eaa6522bad.png">
