### PR TITLE
fix (tippytop): handle fetch fail in FaviconFeed

### DIFF
--- a/system-addon/lib/FaviconFeed.jsm
+++ b/system-addon/lib/FaviconFeed.jsm
@@ -96,6 +96,10 @@ this.FaviconFeed = class FaviconFeed {
     return this._sitesByDomain || (this._sitesByDomain = new Promise(async resolve => {
       await this.loadCachedData();
       await this.maybeRefresh();
+      if (this._sitesByDomain instanceof Promise) {
+        // If _sitesByDomain is still a Promise, no data was loaded from cache or fetch.
+        this._sitesByDomain = {};
+      }
       resolve(this._sitesByDomain);
     }));
   }

--- a/system-addon/test/unit/lib/FaviconFeed.test.js
+++ b/system-addon/test/unit/lib/FaviconFeed.test.js
@@ -73,6 +73,12 @@ describe("FaviconFeed", () => {
       assert.notCalled(feed.loadCachedData);
       assert.notCalled(feed.maybeRefresh);
     });
+    it("should resolve to empty object if there is no cache and fetch fails", async () => {
+      feed.loadCachedData = sinon.spy(() => ([]));
+      feed.maybeRefresh = sinon.spy(() => ([]));
+      await feed.getSitesByDomain();
+      assert.deepEqual(feed._sitesByDomain, {});
+    });
   });
 
   describe("#loadCachedData", () => {


### PR DESCRIPTION
r? @Mardak 

With this patch I'm able to set the endpoint to localhost and run tests

```
...
Browser Chrome Test Summary
	Passed: 30
	Failed: 0
	Todo: 0
	Mode: e10s
*** End BrowserChrome Test Results ***
```