### PR TITLE
Fix Bug 1421844 - Add implementation to Activity Stream mochitests/head.js

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -50,7 +50,7 @@ this.TopSitesFeed = class TopSitesFeed {
   _dedupeKey(site) {
     return site && site.hostname;
   }
-  refreshDefaults(sites, options = {}) {
+  refreshDefaults(sites) {
     // Clear out the array of any previous defaults
     DEFAULT_TOP_SITES.length = 0;
 
@@ -63,11 +63,6 @@ this.TopSitesFeed = class TopSitesFeed {
         };
         site.hostname = shortURL(site);
         DEFAULT_TOP_SITES.push(site);
-      }
-
-      // Update Top Sites if the pref for default sites changes
-      if (options.broadcast) {
-        this.refresh({broadcast: true});
       }
     }
   }
@@ -286,7 +281,7 @@ this.TopSitesFeed = class TopSitesFeed {
         break;
       case at.PREF_CHANGED:
         if (action.data.name === DEFAULT_SITES_PREF) {
-          this.refreshDefaults(action.data.value, {broadcast: true});
+          this.refreshDefaults(action.data.value);
         }
         break;
       case at.PREFS_INITIAL_VALUES:

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -50,7 +50,7 @@ this.TopSitesFeed = class TopSitesFeed {
   _dedupeKey(site) {
     return site && site.hostname;
   }
-  refreshDefaults(sites) {
+  refreshDefaults(sites, options = {}) {
     // Clear out the array of any previous defaults
     DEFAULT_TOP_SITES.length = 0;
 
@@ -63,6 +63,11 @@ this.TopSitesFeed = class TopSitesFeed {
         };
         site.hostname = shortURL(site);
         DEFAULT_TOP_SITES.push(site);
+      }
+
+      // Update Top Sites if the pref for default sites changes
+      if (options.broadcast) {
+        this.refresh({broadcast: true});
       }
     }
   }
@@ -281,7 +286,7 @@ this.TopSitesFeed = class TopSitesFeed {
         break;
       case at.PREF_CHANGED:
         if (action.data.name === DEFAULT_SITES_PREF) {
-          this.refreshDefaults(action.data.value);
+          this.refreshDefaults(action.data.value, {broadcast: true});
         }
         break;
       case at.PREFS_INITIAL_VALUES:

--- a/system-addon/test/functional/mochitest/browser.ini
+++ b/system-addon/test/functional/mochitest/browser.ini
@@ -6,3 +6,5 @@ support-files =
 [browser_as_load_location.js]
 [browser_as_render.js]
 [browser_getScreenshots.js]
+[browser_highlights_section.js]
+[browser_topsites_section.js]

--- a/system-addon/test/functional/mochitest/browser_highlights_section.js
+++ b/system-addon/test/functional/mochitest/browser_highlights_section.js
@@ -1,0 +1,50 @@
+"use strict";
+
+/**
+ * Helper for setup and cleanup of Highlights section tests.
+ * @param bookmarkCount Number of bookmark higlights to add
+ * @param test The test case
+ */
+function test_highlights(bookmarkCount, test) {
+  test_newtab({
+    async before({tab}) {
+      if (bookmarkCount) {
+        await addHighlightsBookmarks(bookmarkCount);
+        // Wait for HighlightsFeed to update and display the items.
+        await ContentTask.spawn(tab.linkedBrowser, null, async () => {
+          await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".card-outer:not(.placeholder)"),
+            "No highlights cards found.");
+        });
+      }
+    },
+    test,
+    async after() {
+      await clearHistoryAndBookmarks();
+    }
+  });
+}
+
+test_highlights(
+  2, // Number of highlights cards
+  function check_highlights_cards() {
+    let found = content.document.querySelectorAll(".card-outer:not(.placeholder)").length;
+    is(found, 2, "there should be 2 highlights cards");
+
+    found = content.document.querySelectorAll(".section-list .placeholder").length;
+    is(found, 1, "there should be 1 highlights placeholder");
+
+    found = content.document.querySelectorAll(".card-context-icon.icon-bookmark-added").length;
+    is(found, 2, "there should be 2 bookmark icons");
+  }
+);
+
+test_highlights(
+  1, // Number of highlights cards
+  function check_highlights_context_menu() {
+    const menuButton = content.document.querySelector(".section-list .context-menu-button");
+    // Open the menu.
+    menuButton.click();
+    const found = content.document.querySelector(".context-menu");
+    ok(found && !found.hidden, "Should find a visible context menu");
+  }
+);

--- a/system-addon/test/functional/mochitest/browser_topsites_section.js
+++ b/system-addon/test/functional/mochitest/browser_topsites_section.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// Check TopSites edit modal and overlay show up.
+test_newtab(
+  // it should be able to click the topsites edit button to reveal the edit topsites modal and overlay.
+  function topsites_edit() {
+    const topsitesEditBtn = content.document.querySelector(".edit-topsites-button button");
+    topsitesEditBtn.click();
+
+    let found = content.document.querySelector(".edit-topsites");
+    ok(found && !found.hidden, "Should find a visible topsites edit menu");
+
+    found = content.document.querySelector(".modal-overlay");
+    ok(found && !found.hidden, "Should find a visible overlay");
+  }
+);
+
+// Test pin/unpin context menu options.
+test_newtab({
+  async before({pushPrefs}) {
+    // The pref for TopSites is empty by default.
+    await pushPrefs(["browser.newtabpage.activity-stream.default.sites", "https://www.youtube.com/,https://www.facebook.com/,https://www.amazon.com/,https://www.reddit.com/,https://www.wikipedia.org/,https://twitter.com/"]);
+    // Forces TopsitesFeed to refresh with the new default sites pref.
+    await clearHistoryAndBookmarks();
+  },
+  // it should pin the website when we click the first option of the topsite context menu.
+  test: async function topsites_pin_unpin() {
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".context-menu-button"),
+      "Topsite context menu not found");
+    // There are only topsites on the page, the selector with find the first topsite menu button.
+    const topsiteContextBtn = content.document.querySelector(".context-menu-button");
+    topsiteContextBtn.click();
+
+    const contextMenu = content.document.querySelector(".context-menu");
+    ok(contextMenu && !contextMenu.hidden, "Should find a visible topsite context menu");
+
+    const pinUnpinTopsiteBtn = contextMenu.querySelector(".context-menu-item a");
+    // Pin the topsite.
+    pinUnpinTopsiteBtn.click();
+
+    // Need to wait for pin action.
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".icon-pin-small"),
+      "No pinned icon found");
+
+    let pinnedIcon = content.document.querySelectorAll(".icon-pin-small").length;
+    is(pinnedIcon, 1, "should find 1 pinned topsite");
+
+    // Unpin the topsite.
+    pinUnpinTopsiteBtn.click();
+
+    // Need to wait for unpin action.
+    await ContentTaskUtils.waitForCondition(() => !content.document.querySelector(".icon-pin-small"),
+      "Topsite should be unpinned");
+  }
+});

--- a/system-addon/test/functional/mochitest/browser_topsites_section.js
+++ b/system-addon/test/functional/mochitest/browser_topsites_section.js
@@ -20,6 +20,8 @@ test_newtab({
   async before({pushPrefs}) {
     // The pref for TopSites is empty by default.
     await pushPrefs(["browser.newtabpage.activity-stream.default.sites", "https://www.youtube.com/,https://www.facebook.com/,https://www.amazon.com/,https://www.reddit.com/,https://www.wikipedia.org/,https://twitter.com/"]);
+    await pushPrefs(["browser.newtabpage.activity-stream.enabled", false]);
+    await pushPrefs(["browser.newtabpage.activity-stream.enabled", true]);
   },
   // it should pin the website when we click the first option of the topsite context menu.
   test: async function topsites_pin_unpin() {

--- a/system-addon/test/functional/mochitest/browser_topsites_section.js
+++ b/system-addon/test/functional/mochitest/browser_topsites_section.js
@@ -20,8 +20,6 @@ test_newtab({
   async before({pushPrefs}) {
     // The pref for TopSites is empty by default.
     await pushPrefs(["browser.newtabpage.activity-stream.default.sites", "https://www.youtube.com/,https://www.facebook.com/,https://www.amazon.com/,https://www.reddit.com/,https://www.wikipedia.org/,https://twitter.com/"]);
-    // Forces TopsitesFeed to refresh with the new default sites pref.
-    await clearHistoryAndBookmarks();
   },
   // it should pin the website when we click the first option of the topsite context menu.
   test: async function topsites_pin_unpin() {

--- a/system-addon/test/functional/mochitest/browser_topsites_section.js
+++ b/system-addon/test/functional/mochitest/browser_topsites_section.js
@@ -20,8 +20,9 @@ test_newtab({
   async before({pushPrefs}) {
     // The pref for TopSites is empty by default.
     await pushPrefs(["browser.newtabpage.activity-stream.default.sites", "https://www.youtube.com/,https://www.facebook.com/,https://www.amazon.com/,https://www.reddit.com/,https://www.wikipedia.org/,https://twitter.com/"]);
-    await pushPrefs(["browser.newtabpage.activity-stream.enabled", false]);
-    await pushPrefs(["browser.newtabpage.activity-stream.enabled", true]);
+    // Toggle the feed off and on as a workaround to read the new prefs.
+    await pushPrefs(["browser.newtabpage.activity-stream.feeds.topsites", false]);
+    await pushPrefs(["browser.newtabpage.activity-stream.feeds.topsites", true]);
   },
   // it should pin the website when we click the first option of the topsite context menu.
   test: async function topsites_pin_unpin() {


### PR DESCRIPTION
I removed the failing assert and tests seem fine.
https://treeherder.mozilla.org/#/jobs?repo=try&revision=f56ac6ac3f2f94a7a75308f10fb1cd86df6d4b2e&selectedJob=143776229
I did a re-trigger on bc4 previously failing.
Test still checks for the correct number of highlights bookmarks.

Closes #3820