### PR TITLE
fix(tippytop): Disable service endpoint for testing

### DIFF
--- a/mozilla-central-patches/disable-testing-tippy.diff
+++ b/mozilla-central-patches/disable-testing-tippy.diff
@@ -1,0 +1,14 @@
+diff --git a/testing/profiles/prefs_general.js b/testing/profiles/prefs_general.js
+--- a/testing/profiles/prefs_general.js
++++ b/testing/profiles/prefs_general.js
+@@ -309,2 +309,3 @@ user_pref("browser.newtabpage.activity-stream.default.sites", "");
+ user_pref("browser.newtabpage.activity-stream.telemetry", false);
++user_pref("browser.newtabpage.activity-stream.tippyTop.service.endpoint", "");
+ user_pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+diff --git a/testing/talos/talos/config.py b/testing/talos/talos/config.py
+--- a/testing/talos/talos/config.py
++++ b/testing/talos/talos/config.py
+@@ -105,2 +105,3 @@ DEFAULTS = dict(
+         'browser.newtabpage.activity-stream.telemetry': False,
++        'browser.newtabpage.activity-stream.tippyTop.service.endpoint': '',
+         'browser.newtabpage.activity-stream.feeds.section.topstories': False,


### PR DESCRIPTION
Followup to #3827. r?@rlr Sets the pref to ""