### PR TITLE
fix(tippytop): Also disable tippy top service for reftests

### DIFF
--- a/mozilla-central-patches/disable-testing-tippy.diff
+++ b/mozilla-central-patches/disable-testing-tippy.diff
@@ -1,3 +1,14 @@
+diff --git a/layout/tools/reftest/reftest-preferences.js b/layout/tools/reftest/reftest-preferences.js
+--- a/layout/tools/reftest/reftest-preferences.js
++++ b/layout/tools/reftest/reftest-preferences.js
+@@ -150,5 +150,6 @@ user_pref("marionette.prefs.recommended", false);
+ 
+-// Make sure we don't reach out to the network with pocket or snippets
++// Make sure we don't reach out to the network for activity stream services
+ user_pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+ user_pref("browser.newtabpage.activity-stream.feeds.snippets", false);
++user_pref("browser.newtabpage.activity-stream.tippyTop.service.endpoint", "");
+ 
 diff --git a/testing/profiles/prefs_general.js b/testing/profiles/prefs_general.js
 --- a/testing/profiles/prefs_general.js
 +++ b/testing/profiles/prefs_general.js


### PR DESCRIPTION
More followup to #3829 and #3827. r?@rlr Also disable reftests.