### PR TITLE
fix(cards): Fixes #3805 Very long domain names overflow in cards

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -116,6 +116,8 @@
     font-size: 10px;
     padding-bottom: 4px;
     text-transform: uppercase;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .card-title {


### PR DESCRIPTION
Spoke with Bryan IRL and he said ellipses are good
Before: 
<img width="412" alt="screen shot 2017-11-13 at 3 42 28 pm" src="https://user-images.githubusercontent.com/7219526/32748154-634ef0e0-c889-11e7-9f31-85a748be7f5d.png">

After:
<img width="400" alt="screen shot 2017-11-13 at 3 42 48 pm" src="https://user-images.githubusercontent.com/7219526/32748160-68a03d24-c889-11e7-99bf-2201b72c524f.png">

