### PR TITLE
New client-side rotation for personalization mode, and minor fixes for Pocket

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -60,7 +60,7 @@ const PREFS_CONFIG = new Map([
       provider_description: "pocket_description",
       provider_icon: "pocket",
       provider_name: "Pocket",
-      read_more_endpoint: "https://getpocket.cdn.mozilla.net/explore/trending?src=fx_new_tab",
+      read_more_endpoint: "https://getpocket.com/explore/trending?src=fx_new_tab",
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "https://getpocket.com/recommendations",
       info_link: "https://www.mozilla.org/privacy/firefox/#pocketstories",

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -12,6 +12,7 @@ describe("Top Stories Feed", () => {
   let SPOC_IMPRESSION_TRACKING_PREF;
   let REC_IMPRESSION_TRACKING_PREF;
   let MIN_DOMAIN_AFFINITIES_UPDATE_TIME;
+  let DEFAULT_RECS_EXPIRE_TIME;
   let instance;
   let clock;
   let globals;
@@ -66,7 +67,8 @@ describe("Top Stories Feed", () => {
       SECTION_ID,
       SPOC_IMPRESSION_TRACKING_PREF,
       REC_IMPRESSION_TRACKING_PREF,
-      MIN_DOMAIN_AFFINITIES_UPDATE_TIME
+      MIN_DOMAIN_AFFINITIES_UPDATE_TIME,
+      DEFAULT_RECS_EXPIRE_TIME
     } = injector({
       "lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs},
       "lib/ShortURL.jsm": {shortURL: shortURLStub},
@@ -354,13 +356,13 @@ describe("Top Stories Feed", () => {
       assert.deepEqual(items, rotated);
 
       // Impression older than expiration time should rotate items
-      clock.tick(5400 * 60 * 60 * 1000 + 1);
+      clock.tick(DEFAULT_RECS_EXPIRE_TIME + 1);
       rotated = instance.rotate(items);
       assert.deepEqual([{"guid": "g4"}, {"guid": "g5"}, {"guid": "g6"}, {"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}], rotated);
 
       instance._prefs.get = pref => (pref === REC_IMPRESSION_TRACKING_PREF) &&
-        JSON.stringify({"g1": 1, "g2": 1, "g3": 1, "g4": 5400 * 60 * 60 * 1001});
-      clock.tick(5400 * 60 * 60 * 1000);
+        JSON.stringify({"g1": 1, "g2": 1, "g3": 1, "g4": DEFAULT_RECS_EXPIRE_TIME + 1});
+      clock.tick(DEFAULT_RECS_EXPIRE_TIME);
       rotated = instance.rotate(items);
       assert.deepEqual([{"guid": "g5"}, {"guid": "g6"}, {"guid": "g1"}, {"guid": "g2"}, {"guid": "g3"}, {"guid": "g4"}], rotated);
     });
@@ -370,7 +372,7 @@ describe("Top Stories Feed", () => {
       instance.personalized = false;
 
       instance._prefs.get = pref => (pref === REC_IMPRESSION_TRACKING_PREF) && JSON.stringify({"g1": 1, "g2": 1, "g3": 1});
-      clock.tick(5400 * 60 * 60 * 1000 + 1);
+      clock.tick(DEFAULT_RECS_EXPIRE_TIME + 1);
       let rotated = instance.rotate(items);
       assert.deepEqual(items, rotated);
     });


### PR DESCRIPTION
Introduces a new client-side rotation mechanism for personalization mode:

Similar to frequency capping, we record impressions in a pref. Main difference is that for recs (stories) we only record the first impression. After fetching and sorting stories we check that stories don't have an impression older than 90 mins (configurable server-side). If they do we'll sort them to the end. The impression tracking pref is cleaned up after every fetch to remove impressions for stories no longer in the feed.

Other minor fixes included here are:
- Adding a check so domain affinity calculation is never calculated more than twice a day in case of idle-daily firing too often. Really just a safe-guard to avoid unneeded computation in case of a problem.
- Changing the View More Topics link to not use the CDN as requested by Pocket.
