### PR TITLE
fix(favicons): Fall back to higher domain's icon if no subdomain match

### DIFF
--- a/system-addon/lib/FaviconFeed.jsm
+++ b/system-addon/lib/FaviconFeed.jsm
@@ -112,10 +112,25 @@ this.FaviconFeed = class FaviconFeed {
     }));
   }
 
+  /**
+   * Get a domain from an available list of domains preferring exact matches.
+   * @param {string} url The url to extract a domain from
+   * @param {array} domains An array of strings of acceptable domains
+   * @returns A domain or empty string if no match
+   */
+  getBestDomain(url, domains) {
+    let domain = getDomain(url);
+    while (domain && !domains.includes(domain)) {
+      // Remove the first subdomain part if there's no exact match
+      domain = domain.split(".").slice(1).join(".");
+    }
+    return domain;
+  }
+
   async fetchIcon(url) {
     const sitesByDomain = await this.getSitesByDomain();
-    const domain = getDomain(url);
-    if (domain in sitesByDomain) {
+    const domain = this.getBestDomain(url, Object.keys(sitesByDomain));
+    if (domain) {
       let iconUri = Services.io.newURI(sitesByDomain[domain].image_url);
       // The #tippytop is to be able to identify them for telemetry.
       iconUri.ref = "tippytop";

--- a/system-addon/test/unit/lib/FaviconFeed.test.js
+++ b/system-addon/test/unit/lib/FaviconFeed.test.js
@@ -195,6 +195,31 @@ describe("FaviconFeed", () => {
     });
   });
 
+  describe("#getBestDomain", () => {
+    const getBest = url => feed.getBestDomain(url, ["mozilla.org", "xyz.mozilla.org"]);
+    it("should return empty if no match", () => {
+      assert.equal(getBest("https://facebook.com/"), "");
+    });
+    it("should return an exact match", () => {
+      assert.equal(getBest("https://mozilla.org/"), "mozilla.org");
+    });
+    it("should not care about protocol", () => {
+      assert.equal(getBest("http://mozilla.org/"), "mozilla.org");
+    });
+    it("should not care about www.", () => {
+      assert.equal(getBest("https://www.mozilla.org/"), "mozilla.org");
+    });
+    it("should fall back to higher domain matches", () => {
+      assert.equal(getBest("https://bugzilla.mozilla.org/"), "mozilla.org");
+    });
+    it("should prefer an exact match over top level match", () => {
+      assert.equal(getBest("https://xyz.mozilla.org/"), "xyz.mozilla.org");
+    });
+    it("should fall back to best match", () => {
+      assert.equal(getBest("https://foo.xyz.mozilla.org/"), "xyz.mozilla.org");
+    });
+  });
+
   describe("#fetchIcon", () => {
     it("should setAndFetchFaviconForPage if the url is in the TippyTop data", async () => {
       let url = "https://mozilla.org";


### PR DESCRIPTION
Fix #3842. r?@rlr Not entirely sure if this is desired… but it would fix the go.twitch.tv vs twitch.tv situation. However, as in the unit test, it would set bugzilla.mozilla.org's icon to mozilla.org. Or similarly mail.google.com would get google.com.