### PR TITLE
fix(prefs): Use MOZILLA_OFFICIAL instead of checking channel for dev-ness

### DIFF
--- a/system-addon/lib/ActivityStreamPrefs.jsm
+++ b/system-addon/lib/ActivityStreamPrefs.jsm
@@ -4,6 +4,7 @@
 "use strict";
 
 const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/AppConstants.jsm");
 Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
@@ -75,9 +76,8 @@ this.DefaultPrefs = class DefaultPrefs {
    * init - Set default prefs for all prefs in the config
    */
   init() {
-    // If Firefox is a locally built version or a testing build on try, etc.
-    // the value of the app.update.channel pref should be "default"
-    const IS_UNOFFICIAL_BUILD = Services.prefs.getStringPref("app.update.channel") === "default";
+    // Local developer builds (with the default mozconfig) aren't OFFICIAL
+    const IS_UNOFFICIAL_BUILD = !AppConstants.MOZILLA_OFFICIAL;
 
     for (const pref of this._config.keys()) {
       const prefConfig = this._config.get(pref);

--- a/system-addon/test/unit/lib/ActivityStreamPrefs.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamPrefs.test.js
@@ -101,8 +101,12 @@ describe("ActivityStreamPrefs", () => {
         defaultPrefs.init();
         assert.calledWith(defaultPrefs.branch.setIntPref, "baz", 1);
       });
+      it("should initialize a pref with value if Firefox is not a local build", () => {
+        defaultPrefs.init();
+        assert.calledWith(defaultPrefs.branch.setStringPref, "qux", "foo");
+      });
       it("should initialize a pref with value_local_dev if Firefox is a local build", () => {
-        sandbox.stub(global.Services.prefs, "getStringPref").returns("default");
+        sandbox.stub(global.AppConstants, "MOZILLA_OFFICIAL").value(false);
         defaultPrefs.init();
         assert.calledWith(defaultPrefs.branch.setStringPref, "qux", "foofoo");
       });

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -23,6 +23,7 @@ chai.use(chaiAssertions);
 let overrider = new GlobalOverrider();
 
 overrider.set({
+  AppConstants: {MOZILLA_OFFICIAL: true},
   Components: {
     classes: {},
     interfaces: {},


### PR DESCRIPTION
Fix #3769. r?@k88hudson Also adds test that we don't use `value_local_dev` when not dev.