### PR TITLE
feat(topstories): Turn on personalized recommendations by default

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -67,7 +67,7 @@ const PREFS_CONFIG = new Map([
       disclaimer_link: "https://getpocket.cdn.mozilla.net/firefox/new_tab_learn_more",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       show_spocs: false,
-      personalized: false
+      personalized: true
     })
   }],
   ["showSponsored", {


### PR DESCRIPTION
This is turning on personalization by default as requested for 59 and 58 (by Nate, Maria). 

I will double-check today and mark this as blocked in the meantime.