### PR TITLE
chore(system-addon): closes #3861, remove unused react-json-inspector…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "page-metadata-parser": "0.6.0",
     "react": "15.3.2",
     "react-dom": "15.3.2",
-    "react-json-inspector": "7.0.0",
     "react-redux": "4.4.5",
     "redux": "3.6.0",
     "redux-logger": "2.7.4",


### PR DESCRIPTION
… dep.  The version we've got in package.json is not compatible with React 16, but, as it turns out, we're not using it at all.