### PR TITLE
fix(search): Close Bug 1417943 - in-page search box gets focus after entering input in location bar (only on initial tab at browser startup)

### DIFF
--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -47,11 +47,6 @@ class Search extends React.PureComponent {
       window.gContentSearchController = new ContentSearchUIController(input, input.parentNode,
         healthReportKey, searchSource);
       addEventListener("ContentSearchClient", this);
-
-      // Focus the search box if we are on about:home
-      if (!IS_NEWTAB) {
-        input.focus();
-      }
     } else {
       window.gContentSearchController = null;
       removeEventListener("ContentSearchClient", this);

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -41,10 +41,6 @@ const REASON_ADDON_UNINSTALL = 6;
 // Configure default Activity Stream prefs with a plain `value` or a `getValue`
 // that computes a value. A `value_local_dev` is used for development defaults.
 const PREFS_CONFIG = new Map([
-  ["aboutHome.autoFocus", {
-    title: "Focus the about:home search box on load",
-    value: false
-  }],
   ["default.sites", {
     title: "Comma-separated list of default top sites to fill in behind visited sites",
     getValue: ({geo}) => DEFAULT_SITES.get(DEFAULT_SITES.has(geo) ? geo : "")

--- a/system-addon/lib/NewTabInit.jsm
+++ b/system-addon/lib/NewTabInit.jsm
@@ -40,13 +40,6 @@ this.NewTabInit = class NewTabInit {
         if (action.data.simulated) {
           this._repliedEarlyTabs.set(action.data.portID, false);
         }
-
-        if (action.data.url === "about:home") {
-          const prefs = this.store.getState().Prefs.values;
-          if (prefs["aboutHome.autoFocus"] && prefs.showSearch) {
-            action.data.browser.focus();
-          }
-        }
         break;
       case at.NEW_TAB_UNLOAD:
         // Clean up for any tab (no-op if not an early tab)

--- a/system-addon/test/unit/lib/NewTabInit.test.js
+++ b/system-addon/test/unit/lib/NewTabInit.test.js
@@ -19,50 +19,6 @@ describe("NewTabInit", () => {
     const resp = ac.SendToContent({type: at.NEW_TAB_INITIAL_STATE, data: STATE}, 123);
     assert.calledWith(store.dispatch, resp);
   });
-  describe("about:home search auto focus", () => {
-    let action;
-    beforeEach(() => {
-      STATE.Prefs = {
-        values: {
-          "aboutHome.autoFocus": true,
-          "showSearch": true
-        }
-      };
-      action = {
-        type: at.NEW_TAB_INIT,
-        data: {
-          url: "about:home",
-          browser: {focus: sinon.spy()}
-        }
-      };
-    });
-    it("should focus the content browser when NEW_TAB_INIT", () => {
-      instance.onAction(action);
-
-      assert.calledOnce(action.data.browser.focus);
-    });
-    it("should NOT focus the content browser when NEW_TAB_INIT for about:newtab", () => {
-      action.data.url = "about:newtab";
-
-      instance.onAction(action);
-
-      assert.notCalled(action.data.browser.focus);
-    });
-    it("should NOT focus the content browser when NEW_TAB_INIT when autoFocus pref is off", () => {
-      STATE.Prefs.values["aboutHome.autoFocus"] = false;
-
-      instance.onAction(action);
-
-      assert.notCalled(action.data.browser.focus);
-    });
-    it("should NOT focus the content browser when NEW_TAB_INIT when there's no search", () => {
-      STATE.Prefs.values.showSearch = false;
-
-      instance.onAction(action);
-
-      assert.notCalled(action.data.browser.focus);
-    });
-  });
   describe("early / simulated new tabs", () => {
     const simulateTabInit = portID => instance.onAction({
       type: at.NEW_TAB_INIT,


### PR DESCRIPTION
Also fix Bug 1400585 - With activity-stream.aboutHome.autoFocus set, initil focus is in the address bar then moves to content search
Also fix Bug 1421417 - Focus moves to about:home search box when turning on the search preference

r?@sarracini Basically reverts #3452