### PR TITLE
Fix Bug 1422918 - make sourcemaps for unit tests work again

### DIFF
--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -16,10 +16,12 @@ const PATHS = {
   coverageReportingPath: "logs/coverage/system-addon"
 };
 
+// When tweaking here, be sure to review the docs about the execution ordering
+// semantics of the preprocessors array, as they are somewhat odd.
 const preprocessors = {};
 preprocessors[PATHS.testFilesPattern] = [
-  "sourcemap", // require("karma-sourcemap-loader")
-  "webpack" // require("karma-webpack")
+  "webpack", // require("karma-webpack")
+  "sourcemap" // require("karma-sourcemap-loader")
 ];
 
 module.exports = function(config) {


### PR DESCRIPTION
To test: 

* edit a test so that it will always fail
* npm run tddmc
* notice whether the error message contains the name of the test file where the error came from
