### PR TITLE
fix (topsites): dont collapse holes in Top Sites

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -180,6 +180,30 @@ TopSite.defaultProps = {
 
 const TopSitePlaceholder = () => <TopSiteLink className="placeholder" />;
 
+const TopSiteList = props => {
+  const topSites = props.TopSites.rows.slice(0, props.TopSitesCount);
+  const topSitesUI = [];
+  for (let i = 0, l = props.TopSitesCount; i < l; i++) {
+    const link = topSites[i];
+    topSitesUI.push(!link ? <TopSitePlaceholder key={i} /> : <TopSite
+      key={link.guid || link.url}
+      dispatch={props.dispatch}
+      link={link}
+      index={i}
+      intl={props.intl}
+      onEdit={props.onEdit}
+      editMode={props.editMode} />);
+  }
+  return (<ul className="top-sites-list">
+    {topSitesUI}
+  </ul>);
+};
+TopSiteList.defaultProps = {
+  editMode: false,
+  onEdit() {}
+};
+
 module.exports.TopSite = TopSite;
 module.exports.TopSiteLink = TopSiteLink;
 module.exports.TopSitePlaceholder = TopSitePlaceholder;
+module.exports.TopSiteList = TopSiteList;

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -3,7 +3,7 @@ const {connect} = require("react-redux");
 const {FormattedMessage} = require("react-intl");
 
 const TopSitesEdit = require("./TopSitesEdit");
-const {TopSite, TopSitePlaceholder} = require("./TopSite");
+const {TopSiteList} = require("./TopSite");
 const CollapsibleSection = require("content-src/components/CollapsibleSection/CollapsibleSection");
 const ComponentPerfTimer = require("content-src/components/ComponentPerfTimer/ComponentPerfTimer");
 const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
@@ -70,24 +70,13 @@ class TopSites extends React.PureComponent {
 
   render() {
     const props = this.props;
-    const topSites = this._getTopSites();
-
-    const placeholderCount = props.TopSitesCount - topSites.length;
     const infoOption = {
       header: {id: "settings_pane_topsites_header"},
       body: {id: "settings_pane_topsites_body"}
     };
     return (<ComponentPerfTimer id="topsites" initialized={props.TopSites.initialized} dispatch={props.dispatch}>
       <CollapsibleSection className="top-sites" icon="topsites" title={<FormattedMessage id="header_top_sites" />} infoOption={infoOption} prefName="collapseTopSites" Prefs={props.Prefs} dispatch={props.dispatch}>
-        <ul className="top-sites-list">
-          {topSites.map((link, index) => link && <TopSite
-            key={link.guid || link.url}
-            dispatch={props.dispatch}
-            link={link}
-            index={index}
-            intl={props.intl} />)}
-          {placeholderCount > 0 && [...Array(placeholderCount)].map((_, i) => <TopSitePlaceholder key={i} />)}
-        </ul>
+        <TopSiteList TopSites={props.TopSites} TopSitesCount={props.TopSitesCount} dispatch={props.dispatch} intl={props.intl} />
         <TopSitesEdit {...props} />
       </CollapsibleSection>
     </ComponentPerfTimer>);

--- a/system-addon/content-src/components/TopSites/TopSitesEdit.jsx
+++ b/system-addon/content-src/components/TopSites/TopSitesEdit.jsx
@@ -3,7 +3,7 @@ const {FormattedMessage, injectIntl} = require("react-intl");
 const {actionCreators: ac, actionTypes: at} = require("common/Actions.jsm");
 
 const TopSiteForm = require("./TopSiteForm");
-const {TopSite, TopSitePlaceholder} = require("./TopSite");
+const {TopSiteList} = require("./TopSite");
 
 const {TOP_SITES_DEFAULT_LENGTH, TOP_SITES_SHOWMORE_LENGTH} = require("common/Reducers.jsm");
 const {TOP_SITES_SOURCE} = require("./TopSitesConstants");
@@ -70,8 +70,6 @@ class TopSitesEdit extends React.PureComponent {
     }));
   }
   render() {
-    const realTopSites = this.props.TopSites.rows.slice(0, this.props.TopSitesCount);
-    const placeholderCount = this.props.TopSitesCount - realTopSites.length;
     const showEditForm = (this.props.TopSites.editForm && this.props.TopSites.editForm.visible) ||
                          (this.state.showEditModal && this.state.showEditForm);
     let editIndex = this.state.editIndex;
@@ -96,17 +94,7 @@ class TopSitesEdit extends React.PureComponent {
               <div className="section-top-bar">
                 <h3 className="section-title"><span className={`icon icon-small-spacer icon-topsites`} /><FormattedMessage id="header_top_sites" /></h3>
               </div>
-              <ul className="top-sites-list">
-                {realTopSites.map((link, index) => link && <TopSite
-                  key={link.guid || link.url}
-                  dispatch={this.props.dispatch}
-                  link={link}
-                  index={index}
-                  intl={this.props.intl}
-                  onEdit={this.onEdit}
-                  editMode={true} />)}
-                  {placeholderCount > 0 && [...Array(placeholderCount)].map((_, i) => <TopSitePlaceholder key={i} />)}
-              </ul>
+              <TopSiteList TopSites={this.props.TopSites} TopSitesCount={this.props.TopSitesCount} editMode={true} onEdit={this.onEdit} dispatch={this.props.dispatch} intl={this.props.intl} />
             </section>
             <section className="actions">
               <button className="add" onClick={this.onAddButtonClick}>

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -5,7 +5,7 @@ const {mountWithIntl} = require("test/unit/utils");
 const TopSiteForm = require("content-src/components/TopSites/TopSiteForm");
 const TopSitesEditConnected = require("content-src/components/TopSites/TopSitesEdit");
 const {_unconnected: TopSitesEdit} = TopSitesEditConnected;
-const {TopSite, TopSiteLink, TopSitePlaceholder} = require("content-src/components/TopSites/TopSite");
+const {TopSite, TopSiteLink, TopSitePlaceholder, TopSiteList} = require("content-src/components/TopSites/TopSite");
 const {_unconnected: TopSites} = require("content-src/components/TopSites/TopSites");
 
 const {actionTypes: at, actionCreators: ac} = require("common/Actions.jsm");
@@ -40,32 +40,6 @@ describe("<TopSites>", () => {
   it("should render a TopSites element", () => {
     const wrapper = shallow(<TopSites {...DEFAULT_PROPS} />);
     assert.ok(wrapper.exists());
-  });
-  it("should render a TopSite for each link with the right url", () => {
-    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
-
-    const wrapper = shallow(<TopSites {...DEFAULT_PROPS} TopSites={{rows}} />);
-
-    const links = wrapper.find(TopSite);
-
-    rows.forEach((row, i) => assert.equal(links.get(i).props.link.url, row.url));
-  });
-  it("should slice the TopSite rows to the TopSitesCount pref", () => {
-    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}, {url: "https://baz.com"}, {url: "https://bam.com"}, {url: "https://zoom.com"}, {url: "https://woo.com"}, {url: "https://eh.com"}];
-
-    const wrapper = shallow(<TopSites {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={TOP_SITES_DEFAULT_LENGTH} />);
-
-    const links = wrapper.find(TopSite);
-    assert.lengthOf(links, TOP_SITES_DEFAULT_LENGTH);
-  });
-  it("should fill with placeholders if TopSites rows is less than TopSitesCount", () => {
-    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
-    const topSitesCount = 5;
-
-    const wrapper = shallow(<TopSites {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={topSitesCount} />);
-
-    assert.lengthOf(wrapper.find(TopSite), 2, "topSites");
-    assert.lengthOf(wrapper.find(TopSitePlaceholder), 3, "placeholders");
   });
   it("should always render TopSitesEdit", () => {
     let rows = [{url: "https://foo.com"}];
@@ -596,25 +570,6 @@ describe("<TopSitesEdit>", () => {
     wrapper.find(".modal-overlay").simulate("click");
     assert.equal(0, wrapper.find(".modal").length);
   });
-  it("should render a TopSite for each link with the right url", () => {
-    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
-    setup({TopSites: {rows}});
-
-    // Open the modal then check the links.
-    wrapper.find(".edit").simulate("click");
-    const links = wrapper.find(TopSite);
-    assert.lengthOf(links, 2);
-    links.forEach((link, i) => assert.equal(link.props().link.url, rows[i].url));
-  });
-  it("should fill with placeholders if TopSites rows is less than TopSitesCount", () => {
-    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
-
-    setup({TopSites: {rows}, TopSitesCount: 5});
-    wrapper.find(".edit").simulate("click");
-
-    assert.lengthOf(wrapper.find(TopSite), 2, "top sites");
-    assert.lengthOf(wrapper.find(TopSitePlaceholder), 3, "placeholders");
-  });
   it("should show the 'Show more' button by default", () => {
     wrapper.find(".edit").simulate("click");
     assert.equal(1, wrapper.find(".show-more").length);
@@ -827,5 +782,40 @@ describe("<TopSiteForm>", () => {
       wrapper.setState({"url": "https://firefox.com"});
       assert.equal("https://firefox.com", wrapper.instance().cleanUrl());
     });
+  });
+});
+
+describe("<TopSiteList>", () => {
+  it("should render a TopSiteList element", () => {
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} />);
+    assert.ok(wrapper.exists());
+  });
+  it("should render a TopSite for each link with the right url", () => {
+    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} />);
+    const links = wrapper.find(TopSite);
+    assert.lengthOf(links, 2);
+    rows.forEach((row, i) => assert.equal(links.get(i).props.link.url, row.url));
+  });
+  it("should slice the TopSite rows to the TopSitesCount pref", () => {
+    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}, {url: "https://baz.com"}, {url: "https://bam.com"}, {url: "https://zoom.com"}, {url: "https://woo.com"}, {url: "https://eh.com"}];
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={TOP_SITES_DEFAULT_LENGTH} />);
+    const links = wrapper.find(TopSite);
+    assert.lengthOf(links, TOP_SITES_DEFAULT_LENGTH);
+  });
+  it("should fill with placeholders if TopSites rows is less than TopSitesCount", () => {
+    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
+    const topSitesCount = 5;
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={topSitesCount} />);
+    assert.lengthOf(wrapper.find(TopSite), 2, "topSites");
+    assert.lengthOf(wrapper.find(TopSitePlaceholder), 3, "placeholders");
+  });
+  it("should fill any holes in TopSites with placeholders", () => {
+    const rows = [{url: "https://foo.com"}];
+    rows[3] = {url: "https://bar.com"};
+    const topSitesCount = 5;
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={topSitesCount} />);
+    assert.lengthOf(wrapper.find(TopSite), 2, "topSites");
+    assert.lengthOf(wrapper.find(TopSitePlaceholder), 3, "placeholders");
   });
 });


### PR DESCRIPTION
I separated this out from my drag and drop changes. I wasn't sure if this is a bug or a feature, but I think we need to "honor" holes for drag and drop to work properly (so the user can pin a site over any placeholder past their frecent+default top sites).

r? @Mardak 