### PR TITLE
Fix Bug 1424292 - Pocket referrer only sent when story has HTTPS URL

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -58,7 +58,7 @@ const PREFS_CONFIG = new Map([
       provider_name: "Pocket",
       read_more_endpoint: "https://getpocket.com/explore/trending?src=fx_new_tab",
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
-      stories_referrer: "https://getpocket.com/recommendations",
+      stories_referrer: "http://getpocket.com/recommendations",
       info_link: "https://www.mozilla.org/privacy/firefox/#pocketstories",
       disclaimer_link: "https://getpocket.cdn.mozilla.net/firefox/new_tab_learn_more",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,


### PR DESCRIPTION
Basically, lots of German publishers don't use HTTPS. The current referrer isn't sent along for these publishers, so switching the referrer to plain HTTP. This will make sure it's sent for both HTTP and HTTPS stories.

Details: https://bugzilla.mozilla.org/show_bug.cgi?id=1424292