### PR TITLE
Use headless mode for unit tests

### DIFF
--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -26,9 +26,16 @@ preprocessors[PATHS.testFilesPattern] = [
 
 module.exports = function(config) {
   const isTDD = config.tdd;
+  const browsers = isTDD ? ["Firefox"] : ["FirefoxHeadless"];
   config.set({
     singleRun: !isTDD,
-    browsers: ["Firefox"], // require("karma-firefox-launcher")
+    browsers, // require("karma-firefox-launcher")
+    customLaunchers: {
+      FirefoxHeadless: {
+        base: "Firefox",
+        flags: ["--headless"]
+      }
+    },
     frameworks: [
       "chai", // require("chai") require("karma-chai")
       "mocha", // require("mocha") require("karma-mocha")

--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -26,10 +26,10 @@ preprocessors[PATHS.testFilesPattern] = [
 
 module.exports = function(config) {
   const isTDD = config.tdd;
-  const browsers = isTDD ? ["Firefox"] : ["FirefoxHeadless"];
+  const browsers = isTDD ? ["Firefox"] : ["FirefoxHeadless"]; // require("karma-firefox-launcher")
   config.set({
     singleRun: !isTDD,
-    browsers, // require("karma-firefox-launcher")
+    browsers,
     customLaunchers: {
       FirefoxHeadless: {
         base: "Firefox",


### PR DESCRIPTION
You've seen it at the lightning talks, now in our repo!
This makes it so that `testmc:unit` runs in headless mode but `tddmc` still starts up regular firefox.
I like it because it doesn't steal the focus to start firefox, I don't know of any negative. 
Lmk if you think it's a good idea and I'll go ahead and make a bug for it too. 