### PR TITLE
Fix Bug 1425489 - Default to two rows of Top Sites

### DIFF
--- a/system-addon/common/PrerenderData.jsm
+++ b/system-addon/common/PrerenderData.jsm
@@ -51,7 +51,7 @@ this.PrerenderData = new _PrerenderData({
     "migrationExpired": true,
     "showTopSites": true,
     "showSearch": true,
-    "topSitesCount": 6,
+    "topSitesCount": 12,
     "collapseTopSites": false,
     "section.highlights.collapsed": false,
     "section.topstories.collapsed": false,

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -108,7 +108,7 @@ const PREFS_CONFIG = new Map([
   }],
   ["topSitesCount", {
     title: "Number of Top Sites to display",
-    value: 6
+    value: 12
   }],
   ["telemetry", {
     title: "Enable system error and usage data collection",


### PR DESCRIPTION
tiny r? @Mardak 

My only concern is the first run experience will now have a row of placeholders. Is that OK @aaronrbenson @bryanbell ? Or do we need to add 6 more default sites?

<img width="1161" alt="screen shot 2017-12-18 at 4 21 49 pm" src="https://user-images.githubusercontent.com/36629/34128740-b1a3ae56-e40f-11e7-806c-f6340db9a57d.png">
