### PR TITLE
Prepare for Bug 1369722 - Use non-browser environment for jsms

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
     "plugin:mozilla/recommended" // require("eslint-plugin-mozilla")
   ],
   "rules": {
-    "mozilla/use-services": 2,
     "promise/param-names": 2,
     "promise/catch-or-return": 2,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2448,9 +2448,9 @@
       }
     },
     "eslint-plugin-mozilla": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.4.9.tgz",
-      "integrity": "sha512-g9XR1jV39RmLTToyPlRh2wpfOk1da+GJlQaF0s6E+9mPEue0JNCt1rH5dnk3xWzOVOrbDJDdETu5V90qzvGI7w==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.4.10.tgz",
+      "integrity": "sha512-l1wVwlndbnHfdABQ5xLef3Kh9ThQjp8wLj86+tDls6SAZBjT0Nv6QdVa9GD6CwOI5Rp7xpAukhMslC7XGb02kw==",
       "dev": true,
       "requires": {
         "ini-parser": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "4.12.0",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-mozilla": "0.4.9",
+    "eslint-plugin-mozilla": "0.4.10",
     "eslint-plugin-no-unsanitized": "2.0.1",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-react": "7.5.1",

--- a/system-addon/common/PerfService.jsm
+++ b/system-addon/common/PerfService.jsm
@@ -17,6 +17,7 @@ if (typeof Services !== "undefined") {
   usablePerfObj = Services.appShell.hiddenDOMWindow.performance;
 } else if (typeof performance !== "undefined") {
   // we must be running in content space
+  // eslint-disable-next-line no-undef
   usablePerfObj = performance;
 } else {
   // This is a dummy object so this file doesn't crash in the node prerendering


### PR DESCRIPTION
In [bug 1369722](https://bugzilla.mozilla.org/show_bug.cgi?id=1369722) I'm working on updating the environment for .jsm files so that it is more accurate (currently we assume 'browser' which is too much).

This patch adds a simple ignore for something that is already checked.

Whilst here, I'm also upgrading e-p-m to 0.4.10 and as it now specifies mozilla/use-services by default, removing that from the activity stream definition.