### PR TITLE
chore(telemetry): Backport Bug 1420285 - Changes to TelemetryFeed for preloaded sessions

### DIFF
--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -246,7 +246,7 @@ this.TelemetryFeed = class TelemetryFeed {
    */
   handleNewTabInit(action) {
     const session = this.addSession(au.getPortIdOfSender(action), action.data.url);
-    session.perf.is_preloaded = action.data.browser.getAttribute("isPreloadBrowser") === "true";
+    session.perf.is_preloaded = action.data.browser.getAttribute("preloadedState") === "preloaded";
   }
 
   /**

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -677,18 +677,19 @@ describe("TelemetryFeed", () => {
   describe("#handleNewTabInit", () => {
     it("should set the session as preloaded if the browser is preloaded", () => {
       const session = {perf: {}};
+      let preloadedBrowser = {getAttribute() { return "preloaded"; }};
       sandbox.stub(instance, "addSession").returns(session);
 
       instance.onAction(ac.SendToMain({
         type: at.NEW_TAB_INIT,
-        data: {url: "about:newtab", browser}
+        data: {url: "about:newtab", browser: preloadedBrowser}
       }));
 
       assert.ok(session.perf.is_preloaded);
     });
     it("should set the session as non-preloaded if the browser is non-preloaded", () => {
       const session = {perf: {}};
-      let nonPreloadedBrowser = {getAttribute() { return "false"; }};
+      let nonPreloadedBrowser = {getAttribute() { return ""; }};
       sandbox.stub(instance, "addSession").returns(session);
 
       instance.onAction(ac.SendToMain({


### PR DESCRIPTION
Fixes #3916 

Backports changes from bug 1420285 found here: https://hg.mozilla.org/mozilla-central/rev/b30d693096e3 for TelemetryFeed.jsm

browser attribute name and possible values changed