### PR TITLE
Fix Bug 1423703 - Use negotiated locales, rather than requested in Activity Stream

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -339,7 +339,7 @@ function main() { // eslint-disable-line max-statements
   }
 
   // Provide some help to copy/paste locales if tests are failing
-  console.log(`\nIf aboutNewTabService tests are failing for unexpected locales, make sure its list is updated:\nconst ACTIVITY_STREAM_LOCALES = new Set("${localizedLocales.join(" ")}".split(" "));`);
+  console.log(`\nIf aboutNewTabService tests are failing for unexpected locales, make sure its list is updated:\nconst ACTIVITY_STREAM_LOCALES = "${localizedLocales.join(" ")}".split(" ");`);
 }
 
 main();

--- a/mozilla-central-patches/b1423703-applocale.diff
+++ b/mozilla-central-patches/b1423703-applocale.diff
@@ -1,0 +1,48 @@
+diff --git a/browser/components/newtab/aboutNewTabService.js b/browser/components/newtab/aboutNewTabService.js
+index 545916bd4c08..fba2f953e363 100644
+--- a/browser/components/newtab/aboutNewTabService.js
++++ b/browser/components/newtab/aboutNewTabService.js
+@@ -23,3 +23,3 @@ const TOPIC_LOCALES_CHANGE = "intl:requested-locales-changed";
+ // https://github.com/mozilla/activity-stream/blob/master/bin/render-activity-stream-html.js
+-const ACTIVITY_STREAM_LOCALES = new Set("en-US ach ar ast az be bg bn-BD bn-IN br bs ca cak cs cy da de dsb el en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hu hy-AM ia id it ja ka kab kk km kn ko lij lo lt ltg lv mk ml mr ms my nb-NO ne-NP nl nn-NO pa-IN pl pt-BR pt-PT rm ro ru si sk sl sq sr sv-SE ta te th tl tr uk ur uz vi zh-CN zh-TW".split(" "));
++const ACTIVITY_STREAM_LOCALES = "en-US ach ar ast az be bg bn-BD bn-IN br bs ca cak cs cy da de dsb el en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hu hy-AM ia id it ja ka kab kk km kn ko lij lo lt ltg lv mk ml mr ms my nb-NO ne-NP nl nn-NO pa-IN pl pt-BR pt-PT rm ro ru si sk sl sq sr sv-SE ta te th tl tr uk ur uz vi zh-CN zh-TW".split(" ");
+ 
+@@ -181,22 +181,10 @@ AboutNewTabService.prototype = {
+     // Debug files are specially packaged in a non-localized directory
+-    let path;
+-    if (this._activityStreamDebug) {
+-      path = "static";
+-    } else {
+-      // Use the exact match locale if it's packaged
+-      const locale = Services.locale.getRequestedLocale();
+-      if (ACTIVITY_STREAM_LOCALES.has(locale)) {
+-        path = locale;
+-      } else {
+-        // Fall back to a shared-language packaged locale
+-        const language = locale.split("-")[0];
+-        if (ACTIVITY_STREAM_LOCALES.has(language)) {
+-          path = language;
+-        } else {
+-          // Just use the default locale as a final fallback
+-          path = "en-US";
+-        }
+-      }
+-    }
+-    this._activityStreamPath = `${path}/`;
++    this._activityStreamPath = `${this._activityStreamDebug ? "static" :
++      // Pick the best available locale to match the app locales
++      Services.locale.negotiateLanguages(
++        Services.locale.getAppLocalesAsLangTags(),
++        ACTIVITY_STREAM_LOCALES,
++        // defaultLocale's strings aren't necessarily packaged, but en-US' are
++        "en-US"
++      )[0]}/`;
+   },
+diff --git a/browser/components/newtab/tests/browser/browser.ini b/browser/components/newtab/tests/browser/browser.ini
+index 0486f7cb7a03..2fa74306477d 100644
+--- a/browser/components/newtab/tests/browser/browser.ini
++++ b/browser/components/newtab/tests/browser/browser.ini
+@@ -3,2 +3,3 @@
+ [browser_packaged_as_locales.js]
++skip-if=true # bug 1423703 comment 20
+ [browser_newtab_overrides.js]

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -292,7 +292,7 @@ this.ActivityStream = class ActivityStream {
       this.geo = "";
     }
 
-    this.locale = Services.locale.getRequestedLocale();
+    this.locale = Services.locale.getAppLocaleAsLangTag();
 
     // Update the pref config of those with dynamic values
     for (const pref of PREFS_CONFIG.keys()) {

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -259,7 +259,7 @@ this.TelemetryFeed = class TelemetryFeed {
     const appInfo = this.store.getState().App;
     const ping = {
       addon_version: appInfo.version,
-      locale: Services.locale.getRequestedLocale(),
+      locale: Services.locale.getAppLocaleAsLangTag(),
       user_prefs: this.userPreferences
     };
 

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -171,7 +171,7 @@ describe("ActivityStream", () => {
     it("should be false with expected geo and unexpected locale", () => {
       sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
       sandbox.stub(global.Services.prefs, "getStringPref").returns("US");
-      sandbox.stub(global.Services.locale, "getRequestedLocale").returns("no-LOCALE");
+      sandbox.stub(global.Services.locale, "getAppLocaleAsLangTag").returns("no-LOCALE");
 
       as._updateDynamicPrefs();
 
@@ -180,7 +180,7 @@ describe("ActivityStream", () => {
     it("should be true with expected geo and locale", () => {
       sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
       sandbox.stub(global.Services.prefs, "getStringPref").returns("US");
-      sandbox.stub(global.Services.locale, "getRequestedLocale").returns("en-US");
+      sandbox.stub(global.Services.locale, "getAppLocaleAsLangTag").returns("en-US");
 
       as._updateDynamicPrefs();
 
@@ -193,7 +193,7 @@ describe("ActivityStream", () => {
         .returns("US")
         .onSecondCall()
         .returns("NOGEO");
-      sandbox.stub(global.Services.locale, "getRequestedLocale").returns("en-US");
+      sandbox.stub(global.Services.locale, "getAppLocaleAsLangTag").returns("en-US");
 
       as._updateDynamicPrefs();
       as._updateDynamicPrefs();
@@ -224,7 +224,7 @@ describe("ActivityStream", () => {
     });
     it("should set true with expected geo and locale", () => {
       sandbox.stub(global.Services.prefs, "getStringPref").returns("US");
-      sandbox.stub(global.Services.locale, "getRequestedLocale").returns("en-US");
+      sandbox.stub(global.Services.locale, "getAppLocaleAsLangTag").returns("en-US");
 
       as._updateDynamicPrefs();
       clock.tick(1);

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -32,7 +32,6 @@ describe("Top Stories Feed", () => {
     FakePrefs.prototype.prefs.apiKeyPref = "test-api-key";
 
     globals = new GlobalOverrider();
-    globals.set("Services", {locale: {getRequestedLocale: () => "en-CA"}, obs: {addObserver: () => {}, removeObserver: () => {}}});
     globals.set("PlacesUtils", {history: {}});
     clock = sinon.useFakeTimers();
     shortURLStub = sinon.stub().callsFake(site => site.url);
@@ -129,8 +128,6 @@ describe("Top Stories Feed", () => {
       assert.called(Components.utils.reportError);
     });
     it("should report error for missing api key", () => {
-      let fakeServices = {prefs: {getCharPref: sinon.spy()}, locale: {getRequestedLocale: sinon.spy()}};
-      globals.set("Services", fakeServices);
       globals.sandbox.spy(global.Components.utils, "reportError");
       sectionsManagerStub.sections.set("topstories", {
         options: {

--- a/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
+++ b/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
@@ -36,7 +36,7 @@ describe("User Domain Affinity Provider", () => {
 
   beforeEach(() => {
     globals = new GlobalOverrider();
-    globals.set("Services", {locale: {getRequestedLocale: () => "en-CA"}, io: {newURI: u => ({host: "www.somedomain.org"})}});
+    globals.set("Services", {io: {newURI: u => ({host: "www.somedomain.org"})}});
     globals.set("PlacesUtils", {
       history: {
         getNewQuery: () => ({"TIME_RELATIVE_NOW": 1}),

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -48,10 +48,8 @@ overrider.set({
   Preferences: FakePrefs,
   Services: {
     locale: {
+      getAppLocaleAsLangTag() { return "en-US"; },
       getAppLocalesAsLangTags() {},
-      getRequestedLocale() {
-        return "en-US";
-      },
       negotiateLanguages() {}
     },
     urlFormatter: {formatURL: str => str},


### PR DESCRIPTION
Switch from `getRequestedLocale` to `getAppLocaleAsLangTag` (and `getAppLocalesAsLangTags` for negotiate in aboutNewTabService). Skips the mochitest for now as per bug as fixing it would depend on some other changes for 60. r?@k88hudson 