### PR TITLE
Fix Bug 1423256 - Add title and link elements back.

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -187,7 +187,7 @@ function templateHTML(options, html) {
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'; img-src http: https: data: blob:; style-src 'unsafe-inline'; child-src 'none'; object-src 'none'; report-uri https://tiles.services.mozilla.com/v4/links/activity-stream/csp">
-    <title>${options.strings.title}</title>
+    <title>${options.strings.newtab_page_title}</title>
     <link rel="icon" type="image/png" href="chrome://branding/content/icon32.png"/>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />
     <link rel="stylesheet" href="${options.baseUrl}css/activity-stream.css" />

--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -187,6 +187,8 @@ function templateHTML(options, html) {
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'; img-src http: https: data: blob:; style-src 'unsafe-inline'; child-src 'none'; object-src 'none'; report-uri https://tiles.services.mozilla.com/v4/links/activity-stream/csp">
+    <title>${options.title}</title>
+    <link rel="icon" type="image/png" id="favicon" href="chrome://branding/content/icon32.png"/>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />
     <link rel="stylesheet" href="${options.baseUrl}css/activity-stream.css" />
   </head>
@@ -304,6 +306,7 @@ function main() { // eslint-disable-line max-statements
     const options = Object.assign({}, baseOptions, {
       direction: getTextDirection(locale),
       locale,
+      title: strings.newtab_page_title,
       strings
     });
 

--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -187,8 +187,8 @@ function templateHTML(options, html) {
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'; img-src http: https: data: blob:; style-src 'unsafe-inline'; child-src 'none'; object-src 'none'; report-uri https://tiles.services.mozilla.com/v4/links/activity-stream/csp">
-    <title>${options.title}</title>
-    <link rel="icon" type="image/png" id="favicon" href="chrome://branding/content/icon32.png"/>
+    <title>${options.strings.title}</title>
+    <link rel="icon" type="image/png" href="chrome://branding/content/icon32.png"/>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />
     <link rel="stylesheet" href="${options.baseUrl}css/activity-stream.css" />
   </head>
@@ -306,7 +306,6 @@ function main() { // eslint-disable-line max-statements
     const options = Object.assign({}, baseOptions, {
       direction: getTextDirection(locale),
       locale,
-      title: strings.newtab_page_title,
       strings
     });
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1423256

This PR adds title and link elements back.
* This fixes cases like session restore where title is completely missing. Related to the icon it looks like https://bugzilla.mozilla.org/show_bug.cgi?id=1422074 was not needed.
* Adding it back fixes the case for "Duplicate Tab" when the icon would not show up.
* It also fixes the case where navigating New Tab -> Website -> (Back Button) would display the favicon of `website`

There was also an event listener ([see PR](https://github.com/mozilla/activity-stream/commit/20b392dd7e35d2a369ced71971f7fdbde782a5ef#diff-92b55e4a266df72d234dd8551ab6ca10)) that was removed when the link element was removed. I did not add it back in this PR because I'm not sure of the use case it covered (I'm not seeing any case where it would be needed). It could be that it is handled by https://reviewboard.mozilla.org/r/201000/diff/2#index_header

There is still a favicon flicker on about:home/new window, this is tracked in https://bugzilla.mozilla.org/show_bug.cgi?id=1403648 because the mechanism to find out if we are on about:home is async 