### PR TITLE
Fix Bug 1426787 - Top sites that match defaults lose 'Remove from History' option when they are pinned

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -94,10 +94,11 @@ this.TopSitesFeed = class TopSitesFeed {
 
       // Copy all properties from a frecent link and add more
       const finder = other => other.url === link.url;
-      const copy = Object.assign({}, frecent.find(finder) || {}, link, {
-        hostname: shortURL(link),
-        isDefault: !!notBlockedDefaultSites.find(finder)
-      });
+
+      // If the link is a frecent site, do not copy over 'isDefault', else check
+      // if the site is a default site
+      const copy = Object.assign({}, frecent.find(finder) ||
+        {isDefault: !!notBlockedDefaultSites.find(finder)}, link, {hostname: shortURL(link)});
 
       // Add in favicons if we don't already have it
       if (!copy.favicon) {


### PR DESCRIPTION
Only add ```isDefault``` attribute to pinned sites that are not frecent, meaning we don't care if it is a default if it's a frecent. Prioritize frecent sites. This puts the 'remove from history' item back in the context menu of sites that are pinned + frecent + coincidentally also in the list of default sites