### PR TITLE
Fix Bug 1428108 - Enable activity-stream.debug by default in local builds

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -134,6 +134,11 @@ const PREFS_CONFIG = new Map([
   ["tippyTop.service.endpoint", {
     title: "Tippy Top service manifest url",
     value: "https://activity-stream-icons.services.mozilla.com/v1/icons.json.br"
+  }],
+  ["debug", {
+    title: "Enable debug mode",
+    value: false,
+    value_local_dev: true
   }]
 ]);
 


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1428108

@dmose Is this what you had in mind? Local builds will now load react-dev and react-dom-dev.