### PR TITLE
Fix Bug 1428727 - better shifting of pinned sites during drag n drop

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -241,20 +241,43 @@ this.TopSitesFeed = class TopSitesFeed {
   /**
    * Insert a site to pin at a position shifting over any other pinned sites.
    */
-  _insertPin(site, index) {
+  _insertPin(site, index, draggedFromIndex) {
     // Don't insert any pins past the end of the visible top sites. Otherwise,
     // we can end up with a bunch of pinned sites that can never be unpinned again
     // from the UI.
-    if (index >= this.store.getState().Prefs.values.topSitesCount) {
+    const {topSitesCount} = this.store.getState().Prefs.values;
+    if (index >= topSitesCount) {
       return;
     }
 
-    // For existing sites, recursively push it and others to the next positions
     let pinned = NewTabUtils.pinnedLinks.links;
-    if (pinned.length > index && pinned[index]) {
-      this._insertPin(pinned[index], index + 1);
+    if (!pinned[index]) {
+      this._pinSiteAt(site, index);
+    } else {
+      pinned[draggedFromIndex] = null;
+      // Find the hole to shift the pinned site(s) towards. We shift towards the
+      // hole left by the site being dragged.
+      let holeIndex = index;
+      const indexStep = index > draggedFromIndex ? -1 : 1;
+      while (pinned[holeIndex]) {
+        holeIndex += indexStep;
+      }
+      if (holeIndex >= topSitesCount || holeIndex < 0) {
+        // There are no holes, so we will effectively unpin the last slot and shifting
+        // towards it. This only happens when adding a new top site to an already
+        // fully pinned grid.
+        holeIndex = topSitesCount - 1;
+      }
+
+      // Shift towards the hole.
+      const shiftingStep = holeIndex > index ? -1 : 1;
+      while (holeIndex !== index) {
+        const nextIndex = holeIndex + shiftingStep;
+        this._pinSiteAt(pinned[nextIndex], holeIndex);
+        holeIndex = nextIndex;
+      }
+      this._pinSiteAt(site, index);
     }
-    this._pinSiteAt(site, index);
   }
 
   /**
@@ -263,7 +286,9 @@ this.TopSitesFeed = class TopSitesFeed {
   insert(action) {
     // Inserting a top site pins it in the specified slot, pushing over any link already
     // pinned in the slot (unless it's the last slot, then it replaces).
-    this._insertPin(action.data.site, action.data.index || 0);
+    this._insertPin(
+      action.data.site, action.data.index || 0,
+      action.data.draggedFromIndex !== undefined ? action.data.draggedFromIndex : this.store.getState().Prefs.values.topSitesCount);
     this._broadcastPinnedSitesUpdated();
   }
 

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -879,7 +879,7 @@ describe("<TopSiteList>", () => {
     instance.onDragEvent({type: "drop"}, 3);
     assert.calledTwice(dispatch);
     assert.calledWith(dispatch, {
-      data: {index: 3, site: {label: "foo", url: "https://foo.com"}},
+      data: {draggedFromIndex: 7, index: 3, site: {label: "foo", url: "https://foo.com"}},
       meta: {from: "ActivityStream:Content", to: "ActivityStream:Main"},
       type: "TOP_SITES_INSERT"
     });
@@ -916,18 +916,18 @@ describe("<TopSiteList>", () => {
       draggedTitle: "foo"
     });
     site1.isPinned = true;
-    assert.deepEqual(instance._makeTopSitesPreview(1), [site2, site1, site3]);
-    assert.deepEqual(instance._makeTopSitesPreview(2), [site2, site3, site1]);
-    assert.deepEqual(instance._makeTopSitesPreview(3), [site2, site3, null, site1]);
+    assert.deepEqual(instance._makeTopSitesPreview(1), [site2, site1, site3, null, null, null]);
+    assert.deepEqual(instance._makeTopSitesPreview(2), [site2, site3, site1, null, null, null]);
+    assert.deepEqual(instance._makeTopSitesPreview(3), [site2, site3, null, site1, null, null]);
     site2.isPinned = true;
-    assert.deepEqual(instance._makeTopSitesPreview(1), [site3, site1, site2]);
-    assert.deepEqual(instance._makeTopSitesPreview(2), [site3, site2, site1]);
+    assert.deepEqual(instance._makeTopSitesPreview(1), [site2, site1, site3, null, null, null]);
+    assert.deepEqual(instance._makeTopSitesPreview(2), [site3, site2, site1, null, null, null]);
     site3.isPinned = true;
-    assert.deepEqual(instance._makeTopSitesPreview(1), [null, site1, site2, site3]);
-    assert.deepEqual(instance._makeTopSitesPreview(2), [null, site2, site1, site3]);
+    assert.deepEqual(instance._makeTopSitesPreview(1), [site2, site1, site3, null, null, null]);
+    assert.deepEqual(instance._makeTopSitesPreview(2), [site2, site3, site1, null, null, null]);
     site2.isPinned = false;
-    assert.deepEqual(instance._makeTopSitesPreview(1), [site2, site1, site3]);
-    assert.deepEqual(instance._makeTopSitesPreview(2), [site2, null, site1, site3]);
+    assert.deepEqual(instance._makeTopSitesPreview(1), [site2, site1, site3, null, null, null]);
+    assert.deepEqual(instance._makeTopSitesPreview(2), [site2, site3, site1, null, null, null]);
     site3.isPinned = false;
     site1.isPinned = false;
     instance.setState({
@@ -936,7 +936,7 @@ describe("<TopSiteList>", () => {
       draggedTitle: "bar"
     });
     site2.isPinned = true;
-    assert.deepEqual(instance._makeTopSitesPreview(0), [site2, site1, site3]);
-    assert.deepEqual(instance._makeTopSitesPreview(2), [site1, site3, site2]);
+    assert.deepEqual(instance._makeTopSitesPreview(0), [site2, site1, site3, null, null, null]);
+    assert.deepEqual(instance._makeTopSitesPreview(2), [site1, site3, site2, null, null, null]);
   });
 });


### PR DESCRIPTION
@Mardak this is what I was thinking. And no recursion! I haven't made the corresponding changes to the feed yet. Thoughts?

I'll show UX tomorrow. But I am pretty sure this is closer to what tiles was doing.

Before:
<img src="https://d2ffutrenqvap3.cloudfront.net/items/0d0a1b3t3Z2U430c463t/Screen%20Recording%202018-01-11%20at%2008.43%20PM.gif" />

After:
<img src="https://d2ffutrenqvap3.cloudfront.net/items/1Y061k2E3E2R3o0o080k/Screen%20Recording%202018-01-11%20at%2008.40%20PM.gif" />