### PR TITLE
Add --display-optimization-bailout, use jsm-to-esmodules 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -488,10 +488,10 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-jsm-to-commonjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-commonjs/-/babel-plugin-jsm-to-commonjs-0.2.0.tgz",
-      "integrity": "sha1-yrniaqJReHQZ6WhRqA5PY1MjpSs=",
+    "babel-plugin-jsm-to-esmodules": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-esmodules/-/babel-plugin-jsm-to-esmodules-0.2.2.tgz",
+      "integrity": "sha1-8bIXXHlOdQjREOUtR03vG2APbxA=",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "buildmc": "npm-run-all buildmc:*",
     "prebuildmc": "npm run cleanmc",
     "buildmc:locales": "pontoon-to-json --src locales --dest system-addon/data",
-    "buildmc:webpack": "webpack --config webpack.system-addon.config.js",
+    "buildmc:webpack": "webpack --config webpack.system-addon.config.js --display-optimization-bailout",
     "buildmc:css": "node-sass system-addon/content-src/styles -o system-addon/css",
     "buildmc:html": "rimraf system-addon/prerendered && webpack --config webpack.prerender.config.js && node ./bin/render-activity-stream-html.js",
     "buildmc:copy": "cpx \"system-addon/**/{,.}*\" $npm_package_config_mc_dir/browser/extensions/activity-stream",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
-    "babel-plugin-jsm-to-commonjs": "0.2.0",
+    "babel-plugin-jsm-to-esmodules": "0.2.2",
     "babel-plugin-transform-async-to-module-method": "6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "babel-preset-react": "6.24.1",

--- a/webpack.system-addon.config.js
+++ b/webpack.system-addon.config.js
@@ -25,7 +25,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: "babel-loader",
         // Converts .jsm files into common-js modules
-        options: {plugins: [["jsm-to-commonjs", {basePath: resourcePathRegEx, replace: true}]]}
+        options: {plugins: [["jsm-to-esmodules", {basePath: resourcePathRegEx, replace: true}]]}
       }
     ]
   },

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -18,7 +18,7 @@ scripts:
   buildmc:
     pre: =>cleanmc
     locales: pontoon-to-json --src locales --dest system-addon/data
-    webpack: webpack --config webpack.system-addon.config.js
+    webpack: webpack --config webpack.system-addon.config.js --display-optimization-bailout
     css: node-sass system-addon/content-src/styles -o system-addon/css
     html: rimraf system-addon/prerendered && webpack --config webpack.prerender.config.js && node ./bin/render-activity-stream-html.js
     # Copy over all of the system-addon directory


### PR DESCRIPTION
This patch will result in some changes to the compiled JS since it allows for all our jsms imported via webpack to be ES modules rather than commonjs – I made this change after noticing in the `--display-optimization-bailout` was skipping those files.