### PR TITLE
Fix (nobug): Add babel-plugin-jsm-to-commonjs back in, fix PlacesFeed test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -488,6 +488,12 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-jsm-to-commonjs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-commonjs/-/babel-plugin-jsm-to-commonjs-0.2.0.tgz",
+      "integrity": "sha1-yrniaqJReHQZ6WhRqA5PY1MjpSs=",
+      "dev": true
+    },
     "babel-plugin-jsm-to-esmodules": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-esmodules/-/babel-plugin-jsm-to-esmodules-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
+    "babel-plugin-jsm-to-commonjs": "0.2.0",
     "babel-plugin-jsm-to-esmodules": "0.2.2",
     "babel-plugin-transform-async-to-module-method": "6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -217,7 +217,7 @@ describe("PlacesFeed", () => {
       it("should have a various empty functions for xpconnect happiness", () => {
         observer.onBeginUpdateBatch();
         observer.onEndUpdateBatch();
-        observer.onVisit();
+        observer.onVisits();
         observer.onTitleChanged();
         observer.onFrecencyChanged();
         observer.onManyFrecenciesChanged();


### PR DESCRIPTION
I accidentally broke a bunch of tests in the patch that converted to using jsm-to-esmodules (since our injector requires common-js, not esmodules). There was also a small error that wasn't caught in https://github.com/mozilla/activity-stream/commit/e51ee0272e93f4821f76ddb05f7d77d661aebb66 because tests weren't running properly. 

This must not have been caught due to the jsm-to-commonjs package being in travis's cache