### PR TITLE
Fix Bug 1430640 - Button labels are cut in 'Delete from history' dialog on localized build

### DIFF
--- a/system-addon/content-src/components/ConfirmDialog/_ConfirmDialog.scss
+++ b/system-addon/content-src/components/ConfirmDialog/_ConfirmDialog.scss
@@ -31,6 +31,9 @@
 
     button {
       margin-inline-end: 16px;
+      padding-inline-end: 18px;
+      padding-inline-start: 18px;
+      white-space: normal;
       width: 50%;
 
       &.done {


### PR DESCRIPTION
Verified with Aaron that this is the desirable look for long strings