### PR TITLE
Bug 1429825 - Dragging and Dropping a Top Site in the same position with the trackpad wrongly opens the site

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -25,7 +25,14 @@ export class TopSiteLink extends React.PureComponent {
 
   onDragEvent(event) {
     switch (event.type) {
+      case "click":
+        // Stop any link clicks if we started any dragging
+        if (this.dragged) {
+          event.preventDefault();
+        }
+        break;
       case "dragstart":
+        this.dragged = true;
         event.dataTransfer.effectAllowed = "move";
         event.dataTransfer.setData("text/topsite-index", this.props.index);
         event.target.blur();
@@ -41,6 +48,10 @@ export class TopSiteLink extends React.PureComponent {
           event.preventDefault();
           this.props.onDragEvent(event, this.props.index);
         }
+        break;
+      case "mousedown":
+        // Reset at the first mouse event of a potential drag
+        this.dragged = false;
         break;
     }
   }
@@ -80,9 +91,10 @@ export class TopSiteLink extends React.PureComponent {
     let draggableProps = {};
     if (isDraggable) {
       draggableProps = {
-        draggable: true,
+        onClick: this.onDragEvent,
+        onDragEnd: this.onDragEvent,
         onDragStart: this.onDragEvent,
-        onDragEnd: this.onDragEvent
+        onMouseDown: this.onDragEvent
       };
     }
     return (<li className={topSiteOuterClassName} onDrop={this.onDragEvent} onDragOver={this.onDragEvent} onDragEnter={this.onDragEvent} onDragLeave={this.onDragEvent} {...draggableProps}>

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -335,6 +335,61 @@ describe("<TopSiteLink>", () => {
     const wrapper = shallow(<TopSiteLink className="foo bar" />);
     assert.ok(wrapper.find("li").hasClass("top-site-outer foo bar"));
   });
+  describe("#onDragEvent", () => {
+    let simulate;
+    let wrapper;
+    beforeEach(() => {
+      wrapper = shallow(<TopSiteLink isDraggable={true} onDragEvent={() => {}} />);
+      simulate = type => {
+        const event = {
+          dataTransfer: {setData() {}, types: {includes() {}}},
+          preventDefault() {
+            this.prevented = true;
+          },
+          target: {blur() {}},
+          type
+        };
+        wrapper.simulate(type, event);
+        return event;
+      };
+    });
+    it("should allow clicks without dragging", () => {
+      simulate("mousedown");
+      simulate("mouseup");
+
+      const event = simulate("click");
+
+      assert.notOk(event.prevented);
+    });
+    it("should prevent clicks after dragging", () => {
+      simulate("mousedown");
+      simulate("dragstart");
+      simulate("dragenter");
+      simulate("drop");
+      simulate("dragend");
+      simulate("mouseup");
+
+      const event = simulate("click");
+
+      assert.ok(event.prevented);
+    });
+    it("should allow clicks after dragging then clicking", () => {
+      simulate("mousedown");
+      simulate("dragstart");
+      simulate("dragenter");
+      simulate("drop");
+      simulate("dragend");
+      simulate("mouseup");
+      simulate("click");
+
+      simulate("mousedown");
+      simulate("mouseup");
+
+      const event = simulate("click");
+
+      assert.notOk(event.prevented);
+    });
+  });
 });
 
 describe("<TopSite>", () => {


### PR DESCRIPTION
r?@rlr When dumping out various mouse events and barely dragging a top site, sometimes I see:
```
mousedown
dragstart
dragenter
drop
dragend
mouseup
click
```

And other times I get:
```
mousedown
dragstart
dragenter
drop
dragend
```

So I just made it cancel any `click`s after a `dragstart`.