### PR TITLE
Changing disclaimer_link to hit getpocket.com directly…

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -60,7 +60,7 @@ const PREFS_CONFIG = new Map([
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "http://getpocket.com/recommendations",
       info_link: "https://www.mozilla.org/privacy/firefox/#pocketstories",
-      disclaimer_link: "https://getpocket.cdn.mozilla.net/firefox/new_tab_learn_more",
+      disclaimer_link: "https://getpocket.com/firefox/new_tab_learn_more.php",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       show_spocs: false,
       personalized: true


### PR DESCRIPTION
(due to CDN not forwarding Accept-Language)

NOT urgent.