### PR TITLE
Fix Bug 1428583 - Disable thumbnails if all open windows are in Private Browsing mode

### DIFF
--- a/system-addon/lib/Screenshots.jsm
+++ b/system-addon/lib/Screenshots.jsm
@@ -18,6 +18,10 @@ XPCOMUtils.defineLazyServiceGetter(this, "MIMEService",
   "@mozilla.org/mime;1", "nsIMIMEService");
 XPCOMUtils.defineLazyModuleGetter(this, "OS",
   "resource://gre/modules/osfile.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "Services",
+  "resource://gre/modules/Services.jsm");
 
 const GREY_10 = "#F9F9FA";
 
@@ -73,6 +77,11 @@ this.Screenshots = {
    @ @param onScreenshot {function} Callback for when the screenshot loads
    */
   async maybeCacheScreenshot(link, url, property, onScreenshot) {
+    const win = Services.wm.getMostRecentWindow(null);
+    const isPrivate = PrivateBrowsingUtils.isWindowPrivate(win);
+    if (isPrivate) {
+      return;
+    }
     // Nothing to do if we already have a pending screenshot or
     // if a previous request failed and returned null.
     const cache = link.__sharedCache;

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -37,7 +37,8 @@ describe("Highlights Feed", () => {
     };
     fakeScreenshot = {
       getScreenshotForURL: sandbox.spy(() => Promise.resolve(FAKE_IMAGE)),
-      maybeCacheScreenshot: Screenshots.maybeCacheScreenshot
+      maybeCacheScreenshot: Screenshots.maybeCacheScreenshot,
+      _shouldGetScreenshots: sinon.stub().returns(true)
     };
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url.match(/\/([^/]+)/)[1]);

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -60,7 +60,8 @@ describe("Top Sites Feed", () => {
     };
     fakeScreenshot = {
       getScreenshotForURL: sandbox.spy(() => Promise.resolve(FAKE_SCREENSHOT)),
-      maybeCacheScreenshot: Screenshots.maybeCacheScreenshot
+      maybeCacheScreenshot: Screenshots.maybeCacheScreenshot,
+      _shouldGetScreenshots: sinon.stub().returns(true)
     };
     filterAdultStub = sinon.stub().returns([]);
     shortURLStub = sinon.stub().callsFake(site => site.url);


### PR DESCRIPTION
Bails out of getting a screenshot of highlights and top sites if the most recent window is a private window. I think doing it here rather than in ```BackgroundPageThumbs.jsm``` has 3 advantages that I can think of...
1. If there are other components of ffx that depend on BackgroundPageThumbs to get a screenshot (even in the future) and maybe don't  care about private browsing, we shouldn't change the implementation for them
2. If we do it earlier can avoid some unnecessary code execution by doing it as soon as we know we don't need to fetch them
3. We have finer control over when to get or not get screenshots

Disadvantages:
1. More code, in more places. We have to remember to explicitly tell any feeds that need a screenshot to check for private browsing in the future. 

So here's the problem with the patch... right now if you run it with ```./mach run --private-window``` it bails out of fetching images which is what we want, but then opening a new non private window still doesn't trigger a refresh to get the images. It will wait in the next system_tick.

Any suggestions on how to deal with this @Mardak ? 