### PR TITLE
Bug 1431506 - Support AS actions for Web Extension click / dismiss

### DIFF
--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -85,7 +85,9 @@ for (const type of [
   "TOP_SITES_PIN",
   "TOP_SITES_UNPIN",
   "TOP_SITES_UPDATED",
-  "UNINIT"
+  "UNINIT",
+  "WEBEXT_CLICK",
+  "WEBEXT_DISMISS"
 ]) {
   actionTypes[type] = type;
 }
@@ -233,6 +235,14 @@ function SetPref(name, value, importContext = globalImportContext) {
   return importContext === UI_CODE ? SendToMain(action) : action;
 }
 
+function WebExtEvent(type, data, importContext = globalImportContext) {
+  if (!data || !data.source) {
+    throw new Error("WebExtEvent actions should include a property \"source\", the id of the webextension that should receive the event.");
+  }
+  const action = {type, data};
+  return importContext === UI_CODE ? SendToMain(action) : action;
+}
+
 this.actionTypes = actionTypes;
 
 this.actionCreators = {
@@ -244,7 +254,8 @@ this.actionCreators = {
   SendToContent,
   SendToMain,
   SendToPreloaded,
-  SetPref
+  SetPref,
+  WebExtEvent
 };
 
 // These are helpers to test for certain kinds of actions

--- a/system-addon/content-src/components/Card/Card.jsx
+++ b/system-addon/content-src/components/Card/Card.jsx
@@ -75,17 +75,27 @@ export class Card extends React.PureComponent {
       type: at.OPEN_LINK,
       data: Object.assign(this.props.link, {event: {altKey, button, ctrlKey, metaKey, shiftKey}})
     }));
-    this.props.dispatch(ac.UserEvent({
-      event: "CLICK",
-      source: this.props.eventSource,
-      action_position: this.props.index
-    }));
-    if (this.props.shouldSendImpressionStats) {
-      this.props.dispatch(ac.ImpressionStats({
+
+    if (this.props.isWebExtension) {
+      this.props.dispatch(ac.WebExtEvent(at.WEBEXT_CLICK, {
         source: this.props.eventSource,
-        click: 0,
-        tiles: [{id: this.props.link.guid, pos: this.props.index}]
+        url: this.props.link.url,
+        action_position: this.props.index
       }));
+    } else {
+      this.props.dispatch(ac.UserEvent({
+        event: "CLICK",
+        source: this.props.eventSource,
+        action_position: this.props.index
+      }));
+
+      if (this.props.shouldSendImpressionStats) {
+        this.props.dispatch(ac.ImpressionStats({
+          source: this.props.eventSource,
+          click: 0,
+          tiles: [{id: this.props.link.guid, pos: this.props.index}]
+        }));
+      }
     }
   }
 

--- a/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
+++ b/system-addon/content-src/components/LinkMenu/LinkMenu.jsx
@@ -15,9 +15,9 @@ export class _LinkMenu extends React.PureComponent {
     const propOptions = !site.isDefault ? props.options : DEFAULT_SITE_MENU_OPTIONS;
 
     const options = propOptions.map(o => LinkMenuOptions[o](site, index, source)).map(option => {
-      const {action, impression, id, type, userEvent} = option;
+      const {action, impression, id, string_id, type, userEvent} = option;
       if (!type && id) {
-        option.label = props.intl.formatMessage(option);
+        option.label = props.intl.formatMessage({id: string_id || id});
         option.onClick = () => {
           props.dispatch(action);
           if (userEvent) {

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -153,7 +153,7 @@ export class Section extends React.PureComponent {
         {!shouldShowEmptyState && (<ul className="section-list" style={{padding: 0}}>
           {realRows.map((link, index) => link &&
             <Card key={index} index={index} dispatch={dispatch} link={link} contextMenuOptions={contextMenuOptions}
-              eventSource={eventSource} shouldSendImpressionStats={this.props.shouldSendImpressionStats} />)}
+              eventSource={eventSource} shouldSendImpressionStats={this.props.shouldSendImpressionStats} isWebExtension={this.props.isWebExtension} />)}
           {placeholders > 0 && [...new Array(placeholders)].map((_, i) => <PlaceholderCard key={i} />)}
         </ul>)}
         {shouldShowEmptyState &&

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -57,6 +57,19 @@ export const LinkMenuOptions = {
     }),
     userEvent: "BLOCK"
   }),
+
+  // This is an option for web extentions which will result in remove items from
+  // memory and notify the web extenion, rather than using the built-in block list.
+  WebExtDismiss: (site, index, eventSource) => ({
+    id: "menu_action_webext_dismiss",
+    string_id: "menu_action_dismiss",
+    icon: "dismiss",
+    action: ac.WebExtEvent(at.WEBEXT_DISMISS, {
+      source: eventSource,
+      url: site.url,
+      action_position: index
+    })
+  }),
   DeleteUrl: site => ({
     id: "menu_action_delete",
     icon: "delete",

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -82,7 +82,7 @@ const BUILT_IN_SECTIONS = {
 };
 
 const SectionsManager = {
-  ACTIONS_TO_PROXY: ["SYSTEM_TICK", "NEW_TAB_LOAD"],
+  ACTIONS_TO_PROXY: ["WEBEXT_CLICK", "WEBEXT_DISMISS"],
   CONTEXT_MENU_PREFS: {"SaveToPocket": "extensions.pocket.enabled"},
   initialized: false,
   sections: new Map(),
@@ -223,6 +223,13 @@ const SectionsManager = {
       this.emit(this.UPDATE_SECTION_CARD, id, url, options, shouldBroadcast);
     }
   },
+  removeSectionCard(sectionId, url) {
+    if (!this.sections.has(sectionId)) {
+      return;
+    }
+    const rows = this.sections.get(sectionId).rows.filter(row => row.url !== url);
+    this.updateSection(sectionId, {rows}, true);
+  },
   onceInitialized(callback) {
     if (this.initialized) {
       callback();
@@ -326,6 +333,11 @@ class SectionsFeed {
       }
       case at.PLACES_BOOKMARK_ADDED:
         SectionsManager.updateBookmarkMetadata(action.data);
+        break;
+      case at.WEBEXT_DISMISS:
+        if (action.data) {
+          SectionsManager.removeSectionCard(action.data.source, action.data.url);
+        }
         break;
       case at.SECTION_DISABLE:
         SectionsManager.disableSection(action.data);

--- a/system-addon/test/unit/common/Actions.test.js
+++ b/system-addon/test/unit/common/Actions.test.js
@@ -196,6 +196,22 @@ describe("ActionCreators", () => {
       assert.isFalse(au.isSendToMain(action), "isSendToMain");
     });
   });
+  describe("WebExtEvent", () => {
+    it("should set the provided type", () => {
+      const action = ac.WebExtEvent(at.WEBEXT_CLICK, {source: "MyExtension", url: "foo.com"});
+      assert.equal(action.type, at.WEBEXT_CLICK);
+    });
+    it("should set the provided data", () => {
+      const data = {source: "MyExtension", url: "foo.com"};
+      const action = ac.WebExtEvent(at.WEBEXT_CLICK, data);
+      assert.equal(action.data, data);
+    });
+    it("should throw if the 'source' property is missing", () => {
+      assert.throws(() => {
+        ac.WebExtEvent(at.WEBEXT_CLICK, {});
+      });
+    });
+  });
 });
 
 describe("ActionUtils", () => {

--- a/system-addon/test/unit/content-src/components/Card.test.jsx
+++ b/system-addon/test/unit/content-src/components/Card.test.jsx
@@ -195,6 +195,17 @@ describe("<Card>", () => {
         tiles: [{id: DEFAULT_PROPS.link.guid, pos: DEFAULT_PROPS.index}]
       }));
     });
+    it("should notify Web Extensions with WEBEXT_CLICK if props.isWebExtension is true", () => {
+      wrapper = mountWithIntl(<Card {...DEFAULT_PROPS} isWebExtension={true} eventSource={"MyExtension"} index={3} />);
+      const card = wrapper.find(".card");
+      const event = {preventDefault() {}};
+      card.simulate("click", event);
+      assert.calledWith(DEFAULT_PROPS.dispatch, ac.WebExtEvent(at.WEBEXT_CLICK, {
+        source: "MyExtension",
+        url: DEFAULT_PROPS.link.url,
+        action_position: 3
+      }));
+    });
   });
 });
 


### PR DESCRIPTION
This adds some new `CLICK` and `DISMISS` actions for web extension sections and allows the `SectionManager` to notify those web extensions when they happen. This is so that web extension authors can choose to respond to clicks/dismisses as they see fit.