### PR TITLE
Fix Bug 1433227 - Different sharedCache reference between migrated LinksCache objects

### DIFF
--- a/system-addon/lib/LinksCache.jsm
+++ b/system-addon/lib/LinksCache.jsm
@@ -104,13 +104,13 @@ this.LinksCache = class LinksCache {
             }
           } else {
             // Share data among link copies and new links from future requests
-            newLink.__sharedCache = {
-              // Provide a helper to update the cached link
-              updateLink(property, value) {
-                newLink[property] = value;
-              }
-            };
+            newLink.__sharedCache = {};
           }
+          // Provide a helper to update the cached link
+          newLink.__sharedCache.updateLink = (property, value) => {
+            newLink[property] = value;
+          };
+
           return newLink;
         }));
       });

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -684,6 +684,23 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(fakeNewTabUtils.pinnedLinks.pin);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 2);
     });
+    it("should properly update LinksCache object properties between migrations", async () => {
+      fakeNewTabUtils.pinnedLinks.links = [{url: "https://foo.com/"}];
+
+      let pinnedLinks = await feed.pinnedCache.request();
+      assert.equal(pinnedLinks.length, 1);
+      feed.pinnedCache.expire();
+      pinnedLinks[0].__sharedCache.updateLink("screenshot", "foo");
+
+      pinnedLinks = await feed.pinnedCache.request();
+      assert.propertyVal(pinnedLinks[0], "screenshot", "foo");
+
+      feed.pinnedCache.expire();
+      pinnedLinks[0].__sharedCache.updateLink("screenshot", "bar");
+
+      pinnedLinks = await feed.pinnedCache.request();
+      assert.propertyVal(pinnedLinks[0], "screenshot", "bar");
+    });
   });
   describe("#drop", () => {
     it("should pin site in specified slot that is free", () => {

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -695,6 +695,7 @@ describe("Top Sites Feed", () => {
       pinnedLinks = await feed.pinnedCache.request();
       assert.propertyVal(pinnedLinks[0], "screenshot", "foo");
 
+      // Force cache expiration in order to trigger a migration of objects
       feed.pinnedCache.expire();
       pinnedLinks[0].__sharedCache.updateLink("screenshot", "bar");
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1433227