### PR TITLE
Fix Bug 1433353 - Use referrerpolicy to send Pocket referrer when story has HTTP URL

### DIFF
--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -58,7 +58,7 @@ const PREFS_CONFIG = new Map([
       provider_name: "Pocket",
       read_more_endpoint: "https://getpocket.com/explore/trending?src=fx_new_tab",
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
-      stories_referrer: "http://getpocket.com/recommendations",
+      stories_referrer: "https://getpocket.com/recommendations",
       info_link: "https://www.mozilla.org/privacy/firefox/#pocketstories",
       disclaimer_link: "https://getpocket.com/firefox/new_tab_learn_more.php",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -30,7 +30,7 @@ overrider.set({
   AppConstants: {MOZILLA_OFFICIAL: true},
   Components: {
     classes: {},
-    interfaces: {},
+    interfaces: {nsIHttpChannel: {REFERRER_POLICY_UNSAFE_URL: 5}},
     utils: {
       import() {},
       importGlobalProperties() {},


### PR DESCRIPTION
r?@csadilek Cleaned up `openNewWindow` to be `openLink` to avoid duplicate referrer processing.