### PR TITLE
chore(l10n): Switch string id from _label to _tooltip

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -141,7 +141,7 @@ edit_topsites_unpin_button=Unpin this site
 edit_topsites_edit_button=Edit this site
 edit_topsites_dismiss_button=Dismiss this site
 edit_topsites_add_button=Add
-edit_topsites_add_button_label=Add Top Site
+edit_topsites_add_button_tooltip=Add Top Site
 
 # LOCALIZATION NOTE (topsites_form_*): This is shown in the New/Edit Topsite modal.
 topsites_form_add_header=New Top Site

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -122,7 +122,7 @@ export class _TopSites extends React.PureComponent {
           <div className="add-topsites-button">
             <button
               className="add"
-              title={this.props.intl.formatMessage({id: "edit_topsites_add_button_label"})}
+              title={this.props.intl.formatMessage({id: "edit_topsites_add_button_tooltip"})}
               onClick={this.onAddButtonClick}>
               <FormattedMessage id="edit_topsites_add_button" />
             </button>


### PR DESCRIPTION
r?@rlr One more comment from https://github.com/mozilla/activity-stream-l10n/pull/10