### PR TITLE
fix(snippets): Use the correct FxAccounts#promiseSignUpURI method

### DIFF
--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -13,7 +13,7 @@ ChromeUtils.defineModuleGetter(this, "ShellService",
   "resource:///modules/ShellService.jsm");
 ChromeUtils.defineModuleGetter(this, "ProfileAge",
   "resource://gre/modules/ProfileAge.jsm");
-ChromeUtils.defineModuleGetter(this, "fxAccounts",
+ChromeUtils.defineModuleGetter(this, "FxAccounts",
   "resource://gre/modules/FxAccounts.jsm");
 
 // Url to fetch snippets, in the urlFormatter service format.
@@ -127,7 +127,7 @@ this.SnippetsFeed = class SnippetsFeed {
   }
 
   async showFirefoxAccounts(browser) {
-    const url = await fxAccounts.promiseAccountsSignUpURI("snippets");
+    const url = await FxAccounts.config.promiseSignUpURI("snippets");
     // We want to replace the current tab.
     browser.loadURI(url);
   }

--- a/system-addon/test/unit/lib/SnippetsFeed.test.js
+++ b/system-addon/test/unit/lib/SnippetsFeed.test.js
@@ -21,7 +21,7 @@ describe("SnippetsFeed", () => {
           this.reset = Promise.resolve(WEEK_IN_MS);
         }
       },
-      fxAccounts: {promiseAccountsSignUpURI: sandbox.stub().returns(Promise.resolve(signUpUrl))}
+      FxAccounts: {config: {promiseSignUpURI: sandbox.stub().returns(Promise.resolve(signUpUrl))}}
     });
   });
   afterEach(() => {


### PR DESCRIPTION
We are going to move `FxAccounts.promiseAccountsSignUpURI` to `FxAccounts.config.promiseSignUpURI` in [bug 1427674](https://bugzilla.mozilla.org/show_bug.cgi?id=1427674).
Please do not merge this PR until the upstream patch is merged.