### PR TITLE
fix(lint): disable forced CSS prop sorting; fixes bug 1434655

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -22,4 +22,5 @@ rules:
   no-vendor-prefixes: 0
   no-warn: 1
   placeholder-in-extend: 2
-  property-sort-order: [2, {ignore-custom-properties: true}]
+  property-sort-order: 0
+


### PR DESCRIPTION
As discussed at the most recent retrospective.