### PR TITLE
chore (prefs): migrate topSitesCount to topSitesRows

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -146,9 +146,13 @@ function onBrowserReady() {
     if (rows <= 0) {
       Services.prefs.setBoolPref("browser.newtabpage.activity-stream.showTopSites", false);
     } else {
-      // Assume we want a full row (6 sites per row)
-      Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesCount", rows * 6);
+      Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesRows", rows);
     }
+  });
+
+  // Old activity stream topSitesCount pref showed 6 per row
+  migratePref("browser.newtabpage.activity-stream.topSitesCount", count => {
+    Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesRows", Math.ceil(count / 6));
   });
 }
 

--- a/system-addon/common/PrerenderData.jsm
+++ b/system-addon/common/PrerenderData.jsm
@@ -51,7 +51,7 @@ this.PrerenderData = new _PrerenderData({
     "migrationExpired": true,
     "showTopSites": true,
     "showSearch": true,
-    "topSitesCount": 12,
+    "topSitesRows": 2,
     "collapseTopSites": false,
     "section.highlights.collapsed": false,
     "section.topstories.collapsed": false,
@@ -67,7 +67,7 @@ this.PrerenderData = new _PrerenderData({
   validation: [
     "showTopSites",
     "showSearch",
-    "topSitesCount",
+    "topSitesRows",
     "collapseTopSites",
     "section.highlights.collapsed",
     "section.topstories.collapsed",

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -6,8 +6,8 @@
 const {actionTypes: at} = Components.utils.import("resource://activity-stream/common/Actions.jsm", {});
 const {Dedupe} = Components.utils.import("resource://activity-stream/common/Dedupe.jsm", {});
 
-const TOP_SITES_DEFAULT_LENGTH = 6;
-const TOP_SITES_SHOWMORE_LENGTH = 12;
+const TOP_SITES_DEFAULT_ROWS = 2;
+const TOP_SITES_MAX_SITES_PER_ROW = 6;
 
 const dedupe = new Dedupe(site => site && site.url);
 
@@ -323,10 +323,10 @@ function PreferencesPane(prevState = INITIAL_STATE.PreferencesPane, action) {
 }
 
 this.INITIAL_STATE = INITIAL_STATE;
-this.TOP_SITES_DEFAULT_LENGTH = TOP_SITES_DEFAULT_LENGTH;
-this.TOP_SITES_SHOWMORE_LENGTH = TOP_SITES_SHOWMORE_LENGTH;
+this.TOP_SITES_DEFAULT_ROWS = TOP_SITES_DEFAULT_ROWS;
+this.TOP_SITES_MAX_SITES_PER_ROW = TOP_SITES_MAX_SITES_PER_ROW;
 
 this.reducers = {TopSites, App, Snippets, Prefs, Dialog, Sections, PreferencesPane};
 this.insertPinned = insertPinned;
 
-this.EXPORTED_SYMBOLS = ["reducers", "INITIAL_STATE", "insertPinned", "TOP_SITES_DEFAULT_LENGTH", "TOP_SITES_SHOWMORE_LENGTH"];
+this.EXPORTED_SYMBOLS = ["reducers", "INITIAL_STATE", "insertPinned", "TOP_SITES_DEFAULT_ROWS", "TOP_SITES_MAX_SITES_PER_ROW"];

--- a/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
+++ b/system-addon/content-src/components/PreferencesPane/PreferencesPane.jsx
@@ -1,6 +1,5 @@
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import {FormattedMessage, injectIntl} from "react-intl";
-import {TOP_SITES_DEFAULT_LENGTH, TOP_SITES_SHOWMORE_LENGTH} from "common/Reducers.jsm";
 import {connect} from "react-redux";
 import React from "react";
 
@@ -55,8 +54,8 @@ export class _PreferencesPane extends React.PureComponent {
 
   handlePrefChange({target: {name, checked}}) {
     let value = checked;
-    if (name === "topSitesCount") {
-      value = checked ? TOP_SITES_SHOWMORE_LENGTH : TOP_SITES_DEFAULT_LENGTH;
+    if (name === "topSitesRows") {
+      value = checked ? 2 : 1;
     }
     this.props.dispatch(ac.SetPref(name, value));
   }
@@ -120,9 +119,9 @@ export class _PreferencesPane extends React.PureComponent {
 
                 <PreferencesInput
                   className="showMoreTopSites"
-                  prefName="topSitesCount"
+                  prefName="topSitesRows"
                   disabled={!prefs.showTopSites}
-                  value={prefs.topSitesCount !== TOP_SITES_DEFAULT_LENGTH}
+                  value={prefs.topSitesRows === 2}
                   onChange={this.handlePrefChange}
                   titleString={{id: "settings_pane_topsites_options_showmore"}}
                   labelClassName="icon icon-topsites" />

--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -8,6 +8,7 @@ import {
 } from "./TopSitesConstants";
 import {LinkMenu} from "content-src/components/LinkMenu/LinkMenu";
 import React from "react";
+import {TOP_SITES_MAX_SITES_PER_ROW} from "common/Reducers.jsm";
 
 export class TopSiteLink extends React.PureComponent {
   constructor(props) {
@@ -284,7 +285,7 @@ export class _TopSiteList extends React.PureComponent {
   _getTopSites() {
     // Make a copy of the sites to truncate or extend to desired length
     let topSites = this.props.TopSites.rows.slice();
-    topSites.length = this.props.TopSitesCount;
+    topSites.length = this.props.TopSitesRows * TOP_SITES_MAX_SITES_PER_ROW;
     return topSites;
   }
 

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -5,6 +5,7 @@ import {CollapsibleSection} from "content-src/components/CollapsibleSection/Coll
 import {ComponentPerfTimer} from "content-src/components/ComponentPerfTimer/ComponentPerfTimer";
 import {connect} from "react-redux";
 import React from "react";
+import {TOP_SITES_MAX_SITES_PER_ROW} from "common/Reducers.jsm";
 import {TopSiteForm} from "./TopSiteForm";
 import {TopSiteList} from "./TopSite";
 
@@ -72,7 +73,7 @@ export class _TopSites extends React.PureComponent {
    * Return the TopSites to display based on prefs.
    */
   _getTopSites() {
-    return this.props.TopSites.rows.slice(0, this.props.TopSitesCount);
+    return this.props.TopSites.rows.slice(0, this.props.TopSitesRows * TOP_SITES_MAX_SITES_PER_ROW);
   }
 
   componentDidUpdate() {
@@ -115,7 +116,7 @@ export class _TopSites extends React.PureComponent {
     const editSite = this.props.TopSites.rows[editIndex] || {};
     return (<ComponentPerfTimer id="topsites" initialized={props.TopSites.initialized} dispatch={props.dispatch}>
       <CollapsibleSection className="top-sites" icon="topsites" title={<FormattedMessage id="header_top_sites" />} infoOption={infoOption} prefName="collapseTopSites" Prefs={props.Prefs} dispatch={props.dispatch}>
-        <TopSiteList TopSites={props.TopSites} TopSitesCount={props.TopSitesCount} dispatch={props.dispatch} intl={props.intl} />
+        <TopSiteList TopSites={props.TopSites} TopSitesRows={props.TopSitesRows} dispatch={props.dispatch} intl={props.intl} />
         <div className="edit-topsites-wrapper">
           <div className="add-topsites-button">
             <button
@@ -148,5 +149,5 @@ export class _TopSites extends React.PureComponent {
 export const TopSites = connect(state => ({
   TopSites: state.TopSites,
   Prefs: state.Prefs,
-  TopSitesCount: state.Prefs.values.topSitesCount
+  TopSitesRows: state.Prefs.values.topSitesRows
 }))(injectIntl(_TopSites));

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -106,9 +106,9 @@ const PREFS_CONFIG = new Map([
     title: "Collapse the Top Sites section",
     value: false
   }],
-  ["topSitesCount", {
-    title: "Number of Top Sites to display",
-    value: 12
+  ["topSitesRows", {
+    title: "Number of rows of Top Sites to display",
+    value: 2
   }],
   ["telemetry", {
     title: "Enable system error and usage data collection",

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -10,7 +10,7 @@ const {actionTypes: at} = Cu.import("resource://activity-stream/common/Actions.j
 
 const {shortURL} = Cu.import("resource://activity-stream/lib/ShortURL.jsm", {});
 const {SectionsManager} = Cu.import("resource://activity-stream/lib/SectionsManager.jsm", {});
-const {TOP_SITES_SHOWMORE_LENGTH} = Cu.import("resource://activity-stream/common/Reducers.jsm", {});
+const {TOP_SITES_DEFAULT_ROWS, TOP_SITES_MAX_SITES_PER_ROW} = Cu.import("resource://activity-stream/common/Reducers.jsm", {});
 const {Dedupe} = Cu.import("resource://activity-stream/common/Dedupe.jsm", {});
 
 XPCOMUtils.defineLazyModuleGetter(this, "filterAdult",
@@ -25,7 +25,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "PageThumbs",
   "resource://gre/modules/PageThumbs.jsm");
 
 const HIGHLIGHTS_MAX_LENGTH = 9;
-const MANY_EXTRA_LENGTH = HIGHLIGHTS_MAX_LENGTH * 5 + TOP_SITES_SHOWMORE_LENGTH;
+const MANY_EXTRA_LENGTH = HIGHLIGHTS_MAX_LENGTH * 5 + TOP_SITES_DEFAULT_ROWS * TOP_SITES_MAX_SITES_PER_ROW;
 const SECTION_ID = "highlights";
 
 this.HighlightsFeed = class HighlightsFeed {

--- a/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
+++ b/system-addon/test/unit/content-src/components/PreferencesPane.test.jsx
@@ -165,17 +165,17 @@ describe("<PreferencesPane>", () => {
     const section = wrapper.findWhere(prefInput => prefInput.props().prefName === "feeds.snippets");
     assert.lengthOf(section, 0);
   });
-  it("should dispatch a SetPref with the right value for topSitesCount when unchecked", () => {
+  it("should dispatch a SetPref with the right value for topSitesRows when unchecked", () => {
     const showMoreTopSitesWrapper = wrapper.find(".showMoreTopSites");
-    showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesCount", checked: false}});
+    showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesRows", checked: false}});
     assert.calledOnce(dispatch);
-    assert.calledWith(dispatch, ac.SetPref("topSitesCount", 6));
+    assert.calledWith(dispatch, ac.SetPref("topSitesRows", 1));
   });
-  it("should dispatch a SetPref with the right value for topSitesCount when checked", () => {
+  it("should dispatch a SetPref with the right value for topSitesRows when checked", () => {
     const showMoreTopSitesWrapper = wrapper.find(".showMoreTopSites");
-    showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesCount", checked: true}});
+    showMoreTopSitesWrapper.simulate("change", {target: {name: "topSitesRows", checked: true}});
     assert.calledOnce(dispatch);
-    assert.calledWith(dispatch, ac.SetPref("topSitesCount", 12));
+    assert.calledWith(dispatch, ac.SetPref("topSitesRows", 2));
   });
   it("should render nested PreferencesInput for nested Section pref", () => {
     const nestedPrefsWrapper = wrapper.find(".showSection");

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -1,11 +1,11 @@
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import {MIN_CORNER_FAVICON_SIZE, MIN_RICH_FAVICON_SIZE} from "content-src/components/TopSites/TopSitesConstants";
 import {mountWithIntl, shallowWithIntl} from "test/unit/utils";
+import {TOP_SITES_DEFAULT_ROWS, TOP_SITES_MAX_SITES_PER_ROW} from "common/Reducers.jsm";
 import {TopSite, TopSiteLink, _TopSiteList as TopSiteList, TopSitePlaceholder} from "content-src/components/TopSites/TopSite";
 import {LinkMenu} from "content-src/components/LinkMenu/LinkMenu";
 import React from "react";
 import {shallow} from "enzyme";
-import {TOP_SITES_DEFAULT_LENGTH} from "common/Reducers.jsm";
 import {TopSiteForm} from "content-src/components/TopSites/TopSiteForm";
 import {_TopSites as TopSites} from "content-src/components/TopSites/TopSites";
 
@@ -16,7 +16,7 @@ const perfSvc = {
 
 const DEFAULT_PROPS = {
   TopSites: {initialized: true, rows: []},
-  TopSitesCount: TOP_SITES_DEFAULT_LENGTH,
+  TopSitesRows: TOP_SITES_DEFAULT_ROWS,
   dispatch() {},
   intl: {formatMessage: x => x},
   perfSvc
@@ -666,26 +666,27 @@ describe("<TopSiteList>", () => {
     assert.lengthOf(links, 2);
     rows.forEach((row, i) => assert.equal(links.get(i).props.link.url, row.url));
   });
-  it("should slice the TopSite rows to the TopSitesCount pref", () => {
-    const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}, {url: "https://baz.com"}, {url: "https://bam.com"}, {url: "https://zoom.com"}, {url: "https://woo.com"}, {url: "https://eh.com"}];
-    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={TOP_SITES_DEFAULT_LENGTH} />);
+  it("should slice the TopSite rows to the TopSitesRows pref", () => {
+    const rows = [];
+    for (let i = 0; i < TOP_SITES_DEFAULT_ROWS * TOP_SITES_MAX_SITES_PER_ROW + 3; i++) {
+      rows.push({url: `https://foo${i}.com`});
+    }
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesRows={TOP_SITES_DEFAULT_ROWS} />);
     const links = wrapper.find(TopSite);
-    assert.lengthOf(links, TOP_SITES_DEFAULT_LENGTH);
+    assert.lengthOf(links, TOP_SITES_DEFAULT_ROWS * TOP_SITES_MAX_SITES_PER_ROW);
   });
-  it("should fill with placeholders if TopSites rows is less than TopSitesCount", () => {
+  it("should fill with placeholders if TopSites rows is less than TopSitesRows", () => {
     const rows = [{url: "https://foo.com"}, {url: "https://bar.com"}];
-    const topSitesCount = 5;
-    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={topSitesCount} />);
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesRows={1} />);
     assert.lengthOf(wrapper.find(TopSite), 2, "topSites");
-    assert.lengthOf(wrapper.find(TopSitePlaceholder), 3, "placeholders");
+    assert.lengthOf(wrapper.find(TopSitePlaceholder), TOP_SITES_MAX_SITES_PER_ROW - 2, "placeholders");
   });
   it("should fill any holes in TopSites with placeholders", () => {
     const rows = [{url: "https://foo.com"}];
     rows[3] = {url: "https://bar.com"};
-    const topSitesCount = 5;
-    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesCount={topSitesCount} />);
+    const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesRows={1} />);
     assert.lengthOf(wrapper.find(TopSite), 2, "topSites");
-    assert.lengthOf(wrapper.find(TopSitePlaceholder), 3, "placeholders");
+    assert.lengthOf(wrapper.find(TopSitePlaceholder), TOP_SITES_MAX_SITES_PER_ROW - 2, "placeholders");
   });
   it("should update state onDragStart and clear it onDragEnd", () => {
     const wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} />);
@@ -756,7 +757,7 @@ describe("<TopSiteList>", () => {
     const site2 = {url: "https://bar.com"};
     const site3 = {url: "https://baz.com"};
     const rows = [site1, site2, site3];
-    let wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} />);
+    let wrapper = shallow(<TopSiteList {...DEFAULT_PROPS} TopSites={{rows}} TopSitesRows={1} />);
     let instance = wrapper.instance();
     instance.setState({
       draggedIndex: 0,

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -2,14 +2,14 @@
 
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import {FakePrefs, GlobalOverrider} from "test/unit/utils";
-import {insertPinned, TOP_SITES_SHOWMORE_LENGTH} from "common/Reducers.jsm";
+import {insertPinned, TOP_SITES_DEFAULT_ROWS, TOP_SITES_MAX_SITES_PER_ROW} from "common/Reducers.jsm";
 import injector from "inject!lib/TopSitesFeed.jsm";
 import {Screenshots} from "lib/Screenshots.jsm";
 
 const FAKE_FAVICON = "data987";
 const FAKE_FAVICON_SIZE = 128;
 const FAKE_FRECENCY = 200;
-const FAKE_LINKS = new Array(TOP_SITES_SHOWMORE_LENGTH).fill(null).map((v, i) => ({
+const FAKE_LINKS = new Array(TOP_SITES_DEFAULT_ROWS * TOP_SITES_MAX_SITES_PER_ROW).fill(null).map((v, i) => ({
   frecency: FAKE_FRECENCY,
   url: `http://www.site${i}.com`
 }));
@@ -76,7 +76,7 @@ describe("Top Sites Feed", () => {
     ({TopSitesFeed, DEFAULT_TOP_SITES} = injector({
       "lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs},
       "common/Dedupe.jsm": {Dedupe: fakeDedupe},
-      "common/Reducers.jsm": {insertPinned, TOP_SITES_SHOWMORE_LENGTH},
+      "common/Reducers.jsm": {insertPinned, TOP_SITES_DEFAULT_ROWS, TOP_SITES_MAX_SITES_PER_ROW},
       "lib/FilterAdult.jsm": {filterAdult: filterAdultStub},
       "lib/Screenshots.jsm": {Screenshots: fakeScreenshot},
       "lib/TippyTopProvider.jsm": {TippyTopProvider: FakeTippyTopProvider},
@@ -87,7 +87,7 @@ describe("Top Sites Feed", () => {
       dispatch: sinon.spy(),
       getState() { return this.state; },
       state: {
-        Prefs: {values: {filterAdult: false, topSitesCount: 6}},
+        Prefs: {values: {filterAdult: false, topSitesRows: 2}},
         TopSites: {rows: Array(12).fill("site")}
       }
     };
@@ -219,15 +219,16 @@ describe("Top Sites Feed", () => {
 
         assert.deepEqual(result, reference);
       });
-      it("should only add defaults up to TOP_SITES_SHOWMORE_LENGTH", async () => {
+      it("should only add defaults up to the number of visible slots", async () => {
         links = [];
-        for (let i = 0; i < TOP_SITES_SHOWMORE_LENGTH - 1; i++) {
+        const numVisible = TOP_SITES_DEFAULT_ROWS * TOP_SITES_MAX_SITES_PER_ROW;
+        for (let i = 0; i < numVisible - 1; i++) {
           links.push({frecency: FAKE_FRECENCY, url: `foo${i}.com`});
         }
         const result = await feed.getLinksWithDefaults();
         const reference = [...links, DEFAULT_TOP_SITES[0]].map(s => Object.assign({}, s, {hostname: shortURLStub(s)}));
 
-        assert.lengthOf(result, TOP_SITES_SHOWMORE_LENGTH);
+        assert.lengthOf(result, numVisible);
         assert.deepEqual(result, reference);
       });
       it("should not throw if NewTabUtils returns null", () => {
@@ -237,11 +238,15 @@ describe("Top Sites Feed", () => {
         });
       });
       it("should get more if the user has asked for more", async () => {
-        feed.store.state.Prefs.values.topSitesCount = TOP_SITES_SHOWMORE_LENGTH + 1;
+        links = new Array(4 * TOP_SITES_MAX_SITES_PER_ROW).fill(null).map((v, i) => ({
+          frecency: FAKE_FRECENCY,
+          url: `http://www.site${i}.com`
+        }));
+        feed.store.state.Prefs.values.topSitesRows = 3;
 
         const result = await feed.getLinksWithDefaults();
 
-        assert.propertyVal(result, "length", feed.store.state.Prefs.values.topSitesCount);
+        assert.propertyVal(result, "length", feed.store.state.Prefs.values.topSitesRows * TOP_SITES_MAX_SITES_PER_ROW);
       });
     });
     describe("caching", () => {
@@ -253,7 +258,7 @@ describe("Top Sites Feed", () => {
       });
       it("should ignore the cache when requesting more", async () => {
         await feed.getLinksWithDefaults();
-        feed.store.state.Prefs.values.topSitesCount *= 3;
+        feed.store.state.Prefs.values.topSitesRows *= 3;
 
         await feed.getLinksWithDefaults();
 
@@ -325,7 +330,7 @@ describe("Top Sites Feed", () => {
       beforeEach(() => {
         ({TopSitesFeed, DEFAULT_TOP_SITES} = injector({
           "lib/ActivityStreamPrefs.jsm": {Prefs: FakePrefs},
-          "common/Reducers.jsm": {insertPinned, TOP_SITES_SHOWMORE_LENGTH},
+          "common/Reducers.jsm": {insertPinned, TOP_SITES_DEFAULT_ROWS, TOP_SITES_MAX_SITES_PER_ROW},
           "lib/Screenshots.jsm": {Screenshots: fakeScreenshot}
         }));
         sandbox.stub(global.Services.eTLD, "getPublicSuffix").returns("com");
@@ -339,7 +344,7 @@ describe("Top Sites Feed", () => {
 
         const sites = await feed.getLinksWithDefaults();
 
-        assert.lengthOf(sites, TOP_SITES_SHOWMORE_LENGTH);
+        assert.lengthOf(sites, TOP_SITES_DEFAULT_ROWS * TOP_SITES_MAX_SITES_PER_ROW);
         assert.equal(sites[0].url, fakeNewTabUtils.pinnedLinks.links[0].url);
         assert.equal(sites[1].url, fakeNewTabUtils.pinnedLinks.links[1].url);
         assert.equal(sites[0].hostname, sites[1].hostname);
@@ -645,7 +650,7 @@ describe("Top Sites Feed", () => {
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site, 0);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site1, 1);
     });
-    it("should unpin the site if all slots are already pinned", () => {
+    it("should unpin the last site if all slots are already pinned", () => {
       const site1 = {url: "example.com"};
       const site2 = {url: "example.org"};
       const site3 = {url: "example.net"};
@@ -653,6 +658,7 @@ describe("Top Sites Feed", () => {
       const site5 = {url: "example.info"};
       const site6 = {url: "example.news"};
       fakeNewTabUtils.pinnedLinks.links = [site1, site2, site3, site4, site5, site6];
+      feed.store.state.Prefs.values.topSitesRows = 1;
       const site = {url: "foo.bar", label: "foo"};
       feed.insert({data: {site}});
       assert.equal(fakeNewTabUtils.pinnedLinks.pin.callCount, 6);
@@ -734,7 +740,7 @@ describe("Top Sites Feed", () => {
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site1, 2);
       assert.calledWith(fakeNewTabUtils.pinnedLinks.pin, site2, 3);
     });
-    it("should not insert past the topSitesCount", () => {
+    it("should not insert past the visible top sites", () => {
       const site1 = {url: "foo.bar", label: "foo"};
       feed.insert({data: {index: 42, site: site1, draggedFromIndex: 0}});
       assert.notCalled(fakeNewTabUtils.pinnedLinks.pin);


### PR DESCRIPTION
@Mardak, this was more tedious then I thought but it *should* help make it easier to implement the wider top sites with 8 across. And it's a better match to how we are allowing users to change # of rows. Thoughts? Did I do the migration right? r?