### PR TITLE
Upgrade babel to support ChromeUtils (for Bug 1431533)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -489,15 +489,15 @@
       }
     },
     "babel-plugin-jsm-to-commonjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-commonjs/-/babel-plugin-jsm-to-commonjs-0.2.0.tgz",
-      "integrity": "sha1-yrniaqJReHQZ6WhRqA5PY1MjpSs=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-commonjs/-/babel-plugin-jsm-to-commonjs-0.3.0.tgz",
+      "integrity": "sha1-qAHU143CZsLguyHHZv8hFtlHA6s=",
       "dev": true
     },
     "babel-plugin-jsm-to-esmodules": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-esmodules/-/babel-plugin-jsm-to-esmodules-0.2.2.tgz",
-      "integrity": "sha1-8bIXXHlOdQjREOUtR03vG2APbxA=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsm-to-esmodules/-/babel-plugin-jsm-to-esmodules-0.3.0.tgz",
+      "integrity": "sha1-wxVBYwkrSWbX5u7Gg4+CCdqYSJQ=",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
-    "babel-plugin-jsm-to-commonjs": "0.2.0",
-    "babel-plugin-jsm-to-esmodules": "0.2.2",
+    "babel-plugin-jsm-to-commonjs": "0.3.0",
+    "babel-plugin-jsm-to-esmodules": "0.3.0",
     "babel-plugin-transform-async-to-module-method": "6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "babel-preset-react": "6.24.1",

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {actionTypes: at} = Components.utils.import("resource://activity-stream/common/Actions.jsm", {});
-const {Dedupe} = Components.utils.import("resource://activity-stream/common/Dedupe.jsm", {});
+const {actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
+const {Dedupe} = ChromeUtils.import("resource://activity-stream/common/Dedupe.jsm", {});
 
 const TOP_SITES_DEFAULT_LENGTH = 6;
 const TOP_SITES_SHOWMORE_LENGTH = 12;


### PR DESCRIPTION
Relevant commits are here:
https://github.com/k88hudson/babel-plugin-jsm-to-commonjs/commit/c4227a3fb7d75e71637abab6ff9635f08d54d75a
https://github.com/k88hudson/babel-plugin-jsm-to-esmodules/commit/24032c428074e8950e38bd3487aa6f5153af4b28

I converted one file (Actions.jsm) to ensure tests are passing.