### PR TITLE
Fix Bug 1435863 - Add source map support for css, js in Activity Stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 firefox/
 *.update.rdf
 system-addon/data/content/activity-stream.bundle.js
+system-addon/data/content/*.js.map
 system-addon/data/locales.json
 system-addon/css/
 system-addon/prerendered/

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prebuildmc": "npm run cleanmc",
     "buildmc:locales": "pontoon-to-json --src locales --dest system-addon/data",
     "buildmc:webpack": "webpack --config webpack.system-addon.config.js --display-optimization-bailout",
-    "buildmc:css": "node-sass system-addon/content-src/styles -o system-addon/css",
+    "buildmc:css": "node-sass --source-map true --source-map-contents system-addon/content-src/styles -o system-addon/css",
     "buildmc:html": "rimraf system-addon/prerendered && webpack --config webpack.prerender.config.js && node ./bin/render-activity-stream-html.js",
     "buildmc:copy": "cpx \"system-addon/**/{,.}*\" $npm_package_config_mc_dir/browser/extensions/activity-stream",
     "buildmc:version": "node ./bin/update-version.js $npm_package_config_mc_dir/browser/extensions/activity-stream",

--- a/system-addon/jar.mn
+++ b/system-addon/jar.mn
@@ -17,13 +17,27 @@
   content/vendor/react-intl.js (./vendor/react-intl.js)
   content/vendor/redux.js (./vendor/redux.js)
   content/vendor/react-redux.js (./vendor/react-redux.js)
-  content/data/ (./data/*)
+  content/data/content/assets/ (./data/content/assets/*)
+  content/data/content/tippytop/ (./data/content/tippytop/*)
+  content/data/content/activity-stream.bundle.js (./data/content/activity-stream.bundle.js)
+#ifndef RELEASE_OR_BETA
+  content/data/content/activity-stream.bundle.js.map (./data/content/activity-stream.bundle.js.map)
+#endif
 #ifdef XP_MACOSX
   content/css/activity-stream.css (./css/activity-stream-mac.css)
+#ifndef RELEASE_OR_BETA
+  content/css/activity-stream-mac.css.map (./css/activity-stream-mac.css.map)
+#endif
 #elifdef XP_WIN
   content/css/activity-stream.css (./css/activity-stream-windows.css)
+#ifndef RELEASE_OR_BETA
+  content/css/activity-stream-windows.css.map (./css/activity-stream-windows.css.map)
+#endif
 #else
   content/css/activity-stream.css (./css/activity-stream-linux.css)
+#ifndef RELEASE_OR_BETA
+  content/css/activity-stream-linux.css.map (./css/activity-stream-linux.css.map)
+#endif
 #endif
   content/prerendered/static/activity-stream-initial-state.js (./prerendered/static/activity-stream-initial-state.js)
 #ifndef RELEASE_OR_BETA

--- a/webpack.system-addon.config.js
+++ b/webpack.system-addon.config.js
@@ -11,6 +11,7 @@ module.exports = {
     path: absolute("data/content"),
     filename: "activity-stream.bundle.js"
   },
+  devtool: "sourcemaps",
   plugins: [new webpack.optimize.ModuleConcatenationPlugin()],
   module: {
     rules: [

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -19,7 +19,7 @@ scripts:
     pre: =>cleanmc
     locales: pontoon-to-json --src locales --dest system-addon/data
     webpack: webpack --config webpack.system-addon.config.js --display-optimization-bailout
-    css: node-sass system-addon/content-src/styles -o system-addon/css
+    css: node-sass --source-map true --source-map-contents system-addon/content-src/styles -o system-addon/css
     html: rimraf system-addon/prerendered && webpack --config webpack.prerender.config.js && node ./bin/render-activity-stream-html.js
     # Copy over all of the system-addon directory
     copy: cpx "system-addon/**/{,.}*" $npm_package_config_mc_dir/browser/extensions/activity-stream


### PR DESCRIPTION
<img src="https://media.giphy.com/media/9K2nFglCAQClO/200.gif" />
I've added source maps such that they will be included in all builds for Firefox (they are external, so won't be loaded until devtools are opened, but they do add ~`360kb` of additional files to be downloaded). What do you think @sarracini @Mardak? Or should we perhaps only include them for non-release channels? 
