### PR TITLE
chore(mc): Port Bug 1432992 - Remove definitions of Ci, Cr, Cc, and Cu

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -150,7 +150,7 @@ function getStrings(locale, allStrings) {
  * Get the text direction of the locale.
  */
 function getTextDirection(locale) {
-  return RTL_LIST.indexOf(locale.split("-")[0]) >= 0 ? "rtl" : "ltr";
+  return RTL_LIST.includes(locale.split("-")[0]) ? "rtl" : "ltr";
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2838,9 +2838,9 @@
       }
     },
     "eslint-plugin-mozilla": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.7.0.tgz",
-      "integrity": "sha512-NGEqMrGqkhnpJ0dWHb2m4YuIjWKLBWpypcgfZtF8gDG/ZychOQeaWM38NQPX90jdytKqsJ/XKWhZ3wxJaAT+ig==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.8.1.tgz",
+      "integrity": "sha512-qbELyk6w000u4G+y6giHIZUYRMmcPn+hO4UMxL2cHtB4nCD5Kod2tbTsgt2HHk0w2frrqmOHDTYB820E7l5uDQ==",
       "dev": true,
       "requires": {
         "ini-parser": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "4.17.0",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-mozilla": "0.7.0",
+    "eslint-plugin-mozilla": "0.8.1",
     "eslint-plugin-no-unsanitized": "2.0.2",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-react": "7.6.1",

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]);
 

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 // NB: Eagerly load modules that will be loaded/constructed/initialized in the

--- a/system-addon/lib/ActivityStreamMessageChannel.jsm
+++ b/system-addon/lib/ActivityStreamMessageChannel.jsm
@@ -4,7 +4,6 @@
 
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource:///modules/AboutNewTab.jsm");
 ChromeUtils.import("resource://gre/modules/RemotePageManager.jsm");
 

--- a/system-addon/lib/ActivityStreamPrefs.jsm
+++ b/system-addon/lib/ActivityStreamPrefs.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
 ChromeUtils.import("resource://gre/modules/Preferences.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/system-addon/lib/FaviconFeed.jsm
+++ b/system-addon/lib/FaviconFeed.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 Cu.importGlobalProperties(["fetch", "URL"]);

--- a/system-addon/lib/FilterAdult.jsm
+++ b/system-addon/lib/FilterAdult.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 ChromeUtils.defineModuleGetter(this, "Services",

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 const {actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});

--- a/system-addon/lib/ManualMigration.jsm
+++ b/system-addon/lib/ManualMigration.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {Prefs} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const MIGRATION_ENDED_EVENT = "Migration:Ended";

--- a/system-addon/lib/NewTabInit.jsm
+++ b/system-addon/lib/NewTabInit.jsm
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
-
 const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 
 /**

--- a/system-addon/lib/PersistentCache.jsm
+++ b/system-addon/lib/PersistentCache.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 ChromeUtils.defineModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm");

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 

--- a/system-addon/lib/PrefsFeed.jsm
+++ b/system-addon/lib/PrefsFeed.jsm
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
-
 const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {Prefs} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const {PrerenderData} = ChromeUtils.import("resource://activity-stream/common/PrerenderData.jsm", {});

--- a/system-addon/lib/Screenshots.jsm
+++ b/system-addon/lib/Screenshots.jsm
@@ -5,7 +5,6 @@
 
 this.EXPORTED_SYMBOLS = ["Screenshots"];
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 ChromeUtils.defineModuleGetter(this, "BackgroundPageThumbs",

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/EventEmitter.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/system-addon/lib/ShortURL.jsm
+++ b/system-addon/lib/ShortURL.jsm
@@ -1,4 +1,3 @@
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 

--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
-
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 const {actionTypes: at, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});

--- a/system-addon/lib/Store.jsm
+++ b/system-addon/lib/Store.jsm
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
-
 const {ActivityStreamMessageChannel} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamMessageChannel.jsm", {});
 const {Prefs} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const {reducers} = ChromeUtils.import("resource://activity-stream/common/Reducers.jsm", {});

--- a/system-addon/lib/SystemTickFeed.jsm
+++ b/system-addon/lib/SystemTickFeed.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 const {actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const {interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 

--- a/system-addon/lib/TippyTopProvider.jsm
+++ b/system-addon/lib/TippyTopProvider.jsm
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const {utils: Cu} = Components;
-
 Cu.importGlobalProperties(["fetch", "URL"]);
 
 const TIPPYTOP_JSON_PATH = "resource://activity-stream/data/content/tippytop/top_sites.json";

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/NewTabUtils.jsm");

--- a/system-addon/lib/UTEventReporting.jsm
+++ b/system-addon/lib/UTEventReporting.jsm
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const {interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 /**

--- a/system-addon/lib/UserDomainAffinityProvider.jsm
+++ b/system-addon/lib/UserDomainAffinityProvider.jsm
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 const history = Cc["@mozilla.org/browser/nav-history-service;1"].getService(Ci.nsINavHistoryService);

--- a/system-addon/ping-centre/PingCentre.jsm
+++ b/system-addon/ping-centre/PingCentre.jsm
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const {interfaces: Ci, utils: Cu} = Components;
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]);

--- a/system-addon/test/functional/mochitest/browser_getScreenshots.js
+++ b/system-addon/test/functional/mochitest/browser_getScreenshots.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-let Cu = Components.utils;
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 // a blue page

--- a/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
@@ -230,16 +230,16 @@ describe("ActivityStreamMessageChannel", () => {
       let sandbox;
       beforeEach(() => {
         sandbox = sinon.sandbox.create();
-        sandbox.spy(global.Components.utils, "reportError");
+        sandbox.spy(global.Cu, "reportError");
       });
       afterEach(() => sandbox.restore());
       it("should report an error if the msg.data is missing", () => {
         mm.onMessage({target: {portID: "foo"}});
-        assert.calledOnce(global.Components.utils.reportError);
+        assert.calledOnce(global.Cu.reportError);
       });
       it("should report an error if the msg.data.type is missing", () => {
         mm.onMessage({target: {portID: "foo"}, data: "foo"});
-        assert.calledOnce(global.Components.utils.reportError);
+        assert.calledOnce(global.Cu.reportError);
       });
       it("should call onActionFromContent", () => {
         sinon.stub(mm, "onActionFromContent");

--- a/system-addon/test/unit/lib/FilterAdult.test.js
+++ b/system-addon/test/unit/lib/FilterAdult.test.js
@@ -10,7 +10,7 @@ describe("filterAdult", () => {
       init: sinon.stub(),
       update: sinon.stub()
     };
-    global.Components.classes["@mozilla.org/security/hash;1"] = {
+    global.Cc["@mozilla.org/security/hash;1"] = {
       createInstance() {
         return hashStub;
       }

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -42,19 +42,19 @@ describe("PlacesFeed", () => {
       }
     });
     globals.set("Pocket", {savePage: sandbox.spy()});
-    global.Components.classes["@mozilla.org/browser/nav-history-service;1"] = {
+    global.Cc["@mozilla.org/browser/nav-history-service;1"] = {
       getService() {
         return global.PlacesUtils.history;
       }
     };
-    global.Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"] = {
+    global.Cc["@mozilla.org/browser/nav-bookmarks-service;1"] = {
       getService() {
         return global.PlacesUtils.bookmarks;
       }
     };
     sandbox.spy(global.Services.obs, "addObserver");
     sandbox.spy(global.Services.obs, "removeObserver");
-    sandbox.spy(global.Components.utils, "reportError");
+    sandbox.spy(global.Cu, "reportError");
 
     feed = new PlacesFeed();
     feed.store = {dispatch: sinon.spy()};
@@ -336,7 +336,7 @@ describe("PlacesFeed", () => {
         const args = [null, "title", null, null, null, TYPE_BOOKMARK, null, FAKE_BOOKMARK.guid];
         await observer.onItemChanged(...args);
 
-        assert.calledWith(global.Components.utils.reportError, e);
+        assert.calledWith(global.Cu.reportError, e);
       });
       it.skip("should ignore events that are not of TYPE_BOOKMARK", async () => {
         await observer.onItemChanged(null, "title", null, null, null, "nottypebookmark");

--- a/system-addon/test/unit/lib/SectionsManager.test.js
+++ b/system-addon/test/unit/lib/SectionsManager.test.js
@@ -65,14 +65,14 @@ describe("SectionsManager", () => {
   });
   describe("#addBuiltInSection", () => {
     it("should not report an error if options is undefined", () => {
-      globals.sandbox.spy(global.Components.utils, "reportError");
+      globals.sandbox.spy(global.Cu, "reportError");
       SectionsManager.addBuiltInSection("feeds.section.topstories", undefined);
-      assert.notCalled(Components.utils.reportError);
+      assert.notCalled(Cu.reportError);
     });
     it("should report an error if options is malformed", () => {
-      globals.sandbox.spy(global.Components.utils, "reportError");
+      globals.sandbox.spy(global.Cu, "reportError");
       SectionsManager.addBuiltInSection("feeds.section.topstories", "invalid");
-      assert.calledOnce(Components.utils.reportError);
+      assert.calledOnce(Cu.reportError);
     });
   });
   describe("#addSection", () => {

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -47,7 +47,7 @@ describe("TelemetryFeed", () => {
     globals = new GlobalOverrider();
     sandbox = globals.sandbox;
     clock = sinon.useFakeTimers();
-    sandbox.spy(global.Components.utils, "reportError");
+    sandbox.spy(global.Cu, "reportError");
     globals.set("gUUIDGenerator", {generateUUID: () => FAKE_UUID});
     globals.set("PingCentre", PingCentre);
     globals.set("UTEventReporting", UTEventReporting);
@@ -559,7 +559,7 @@ describe("TelemetryFeed", () => {
 
       instance.uninit();
 
-      assert.called(global.Components.utils.reportError);
+      assert.called(global.Cu.reportError);
     });
     it("should make this.browserOpenNewtabStart() stop observing browser-open-newtab-start", async () => {
       await instance.init();

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -121,14 +121,14 @@ describe("Top Stories Feed", () => {
       assert.notCalled(fetchStub);
     });
     it("should report error for invalid configuration", () => {
-      globals.sandbox.spy(global.Components.utils, "reportError");
+      globals.sandbox.spy(global.Cu, "reportError");
       sectionsManagerStub.sections.set("topstories", {options: {api_key_pref: "invalid"}});
       instance.init();
 
-      assert.called(Components.utils.reportError);
+      assert.called(Cu.reportError);
     });
     it("should report error for missing api key", () => {
-      globals.sandbox.spy(global.Components.utils, "reportError");
+      globals.sandbox.spy(global.Cu, "reportError");
       sectionsManagerStub.sections.set("topstories", {
         options: {
           "stories_endpoint": "https://somedomain.org/stories?key=$apiKey",
@@ -137,7 +137,7 @@ describe("Top Stories Feed", () => {
       });
       instance.init();
 
-      assert.called(Components.utils.reportError);
+      assert.called(Cu.reportError);
     });
     it("should load data from cache on init", () => {
       instance.loadCachedData = sinon.spy();
@@ -207,7 +207,7 @@ describe("Top Stories Feed", () => {
     it("should report error for unexpected stories response", async () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
-      globals.sandbox.spy(global.Components.utils, "reportError");
+      globals.sandbox.spy(global.Cu, "reportError");
 
       instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: false, status: 400});
@@ -216,7 +216,7 @@ describe("Top Stories Feed", () => {
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, instance.stories_endpoint);
       assert.notCalled(sectionsManagerStub.updateSection);
-      assert.called(Components.utils.reportError);
+      assert.called(Cu.reportError);
     });
     it("should exclude blocked (dismissed) URLs", async () => {
       let fetchStub = globals.sandbox.stub();
@@ -283,7 +283,7 @@ describe("Top Stories Feed", () => {
     it("should report error for unexpected topics response", async () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
-      globals.sandbox.spy(global.Components.utils, "reportError");
+      globals.sandbox.spy(global.Cu, "reportError");
 
       instance.topics_endpoint = "topics-endpoint";
       fetchStub.resolves({ok: false, status: 400});
@@ -292,7 +292,7 @@ describe("Top Stories Feed", () => {
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, instance.topics_endpoint);
       assert.notCalled(instance.store.dispatch);
-      assert.called(Components.utils.reportError);
+      assert.called(Cu.reportError);
     });
   });
   describe("#personalization", () => {

--- a/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
+++ b/system-addon/test/unit/lib/UserDomainAffinityProvider.test.js
@@ -44,7 +44,7 @@ describe("User Domain Affinity Provider", () => {
         executeQuery: () => ({root: {childCount: 1, getChild: index => ({uri: "www.somedomain.org", accessCount: 1})}})
       }
     });
-    global.Components.classes["@mozilla.org/browser/nav-history-service;1"] = {
+    global.Cc["@mozilla.org/browser/nav-history-service;1"] = {
       getService() {
         return global.PlacesUtils.history;
       }

--- a/system-addon/test/unit/ping-centre/PingCentre.test.js
+++ b/system-addon/test/unit/ping-centre/PingCentre.test.js
@@ -54,7 +54,7 @@ describe("PingCentre", () => {
       currentEnvironment: {profile: {creationDate: FAKE_PROFILE_CREATION_DATE}}
     });
     globals.set("AppConstants", {MOZ_UPDATE_CHANNEL: FAKE_UPDATE_CHANNEL});
-    sandbox.spy(global.Components.utils, "reportError");
+    sandbox.spy(global.Cu, "reportError");
   });
 
   afterEach(() => {
@@ -361,7 +361,7 @@ describe("PingCentre", () => {
 
       await tSender.sendPing(fakePingJSON);
 
-      assert.called(Components.utils.reportError);
+      assert.called(Cu.reportError);
     });
 
     it("should log an error using Cu.reportError if fetch rejects", async () => {
@@ -369,7 +369,7 @@ describe("PingCentre", () => {
 
       await tSender.sendPing(fakePingJSON);
 
-      assert.called(Components.utils.reportError);
+      assert.called(Cu.reportError);
     });
 
     it("should log if logging is on && if action is not activity_stream_performance", async () => {
@@ -433,7 +433,7 @@ describe("PingCentre", () => {
 
       tSender.uninit();
 
-      assert.called(global.Components.utils.reportError);
+      assert.called(global.Cu.reportError);
     });
   });
 

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -27,23 +27,20 @@ let overrider = new GlobalOverrider();
 
 overrider.set({
   AppConstants: {MOZILLA_OFFICIAL: true},
-  Components: {
-    classes: {},
-    interfaces: {nsIHttpChannel: {REFERRER_POLICY_UNSAFE_URL: 5}},
-    utils: {
-      import() {},
-      importGlobalProperties() {},
-      reportError() {},
-      now: () => window.performance.now()
-    },
-    isSuccessCode: () => true
-  },
   ChromeUtils: {
     defineModuleGetter() {},
     import() {}
   },
+  Components: {isSuccessCode: () => true},
   // eslint-disable-next-line object-shorthand
   ContentSearchUIController: function() {}, // NB: This is a function/constructor
+  Cc: {},
+  Ci: {nsIHttpChannel: {REFERRER_POLICY_UNSAFE_URL: 5}},
+  Cu: {
+    importGlobalProperties() {},
+    now: () => window.performance.now(),
+    reportError() {}
+  },
   dump() {},
   fetch() {},
   // eslint-disable-next-line object-shorthand


### PR DESCRIPTION
Things applied cleanly again :)
`activity-stream/system-addon$ git -C ../../mozilla-central sh a9a499cb3f84e69bbcb1bdbc84ffbfad8807c728 browser/extensions/activity-stream | patch -p4`

@Standard8 `eslint-plugin-mozilla` needs to be bumped to include https://hg.mozilla.org/mozilla-central/rev/e51fa5f76367 from https://bugzilla.mozilla.org/show_bug.cgi?id=767640

(There's an unrelated change that we'll need to fix when updating our dependency)
```
activity-stream/bin/render-activity-stream-html.js (1/0)
  ✖  153:10  use .includes instead of .indexOf  mozilla/use-includes-instead-of-indexOf
```