### PR TITLE
Fix Bug 1432657 - Add pocket card type to highlight types

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -33,6 +33,7 @@ type_label_visited=Visited
 type_label_bookmarked=Bookmarked
 type_label_synced=Synced from another device
 type_label_recommended=Trending
+type_label_pocket=Saved to Pocket
 # LOCALIZATION NOTE(type_label_open): Open is an adjective, as in "page is open"
 type_label_open=Open
 type_label_topic=Topic
@@ -58,6 +59,8 @@ confirm_history_delete_p1=Are you sure you want to delete every instance of this
 # page from history.
 confirm_history_delete_notice_p2=This action cannot be undone.
 menu_action_save_to_pocket=Save to Pocket
+menu_action_delete_pocket=Delete from Pocket
+menu_action_archive_pocket=Archive in Pocket
 
 # LOCALIZATION NOTE (search_for_something_with): {search_term} is a placeholder
 # for what the user has typed in the search input field, e.g. 'Search for ' +

--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -25,9 +25,11 @@ this.globalImportContext = globalImportContext;
 // }
 const actionTypes = {};
 for (const type of [
+  "ARCHIVE_FROM_POCKET",
   "BLOCK_URL",
   "BOOKMARK_URL",
   "DELETE_BOOKMARK_BY_ID",
+  "DELETE_FROM_POCKET",
   "DELETE_HISTORY_URL",
   "DELETE_HISTORY_URL_CONFIRM",
   "DIALOG_CANCEL",
@@ -53,6 +55,7 @@ for (const type of [
   "PLACES_HISTORY_CLEARED",
   "PLACES_LINKS_DELETED",
   "PLACES_LINK_BLOCKED",
+  "PLACES_SAVED_TO_POCKET",
   "PREFS_INITIAL_VALUES",
   "PREF_CHANGED",
   "RICH_ICON_MISSING",

--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -265,6 +265,22 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
           return item;
         })
       }));
+    case at.PLACES_SAVED_TO_POCKET:
+      if (!action.data) {
+        return prevState;
+      }
+      return prevState.map(section => Object.assign({}, section, {
+        rows: section.rows.map(item => {
+          if (item.url === action.data.url) {
+            return Object.assign({}, item, {
+              pocket_id: action.data.pocket_id,
+              title: action.data.title,
+              type: "pocket"
+            });
+          }
+          return item;
+        })
+      }));
     case at.PLACES_BOOKMARK_REMOVED:
       if (!action.data) {
         return prevState;
@@ -291,6 +307,10 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
     case at.PLACES_LINK_BLOCKED:
       return prevState.map(section =>
         Object.assign({}, section, {rows: section.rows.filter(site => site.url !== action.data.url)}));
+    case at.DELETE_FROM_POCKET:
+    case at.ARCHIVE_FROM_POCKET:
+      return prevState.map(section =>
+        Object.assign({}, section, {rows: section.rows.filter(site => site.pocket_id !== action.data.pocket_id)}));
     default:
       return prevState;
   }

--- a/system-addon/content-src/components/Card/types.js
+++ b/system-addon/content-src/components/Card/types.js
@@ -14,5 +14,9 @@ export const cardContextTypes = {
   now: {
     intlID: "type_label_now",
     icon: "now"
+  },
+  pocket: {
+    intlID: "type_label_pocket",
+    icon: "pocket-small"
   }
 };

--- a/system-addon/content-src/components/ContextMenu/ContextMenu.jsx
+++ b/system-addon/content-src/components/ContextMenu/ContextMenu.jsx
@@ -34,7 +34,7 @@ export class ContextMenu extends React.PureComponent {
       <ul role="menu" className="context-menu-list">
         {this.props.options.map((option, i) => (option.type === "separator" ?
           (<li key={i} className="separator" />) :
-          (<ContextMenuItem key={i} option={option} hideContext={this.hideContext} />)
+          (option.type !== "empty" && <ContextMenuItem key={i} option={option} hideContext={this.hideContext} />)
         ))}
       </ul>
     </span>);

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -7,6 +7,7 @@ import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
  */
 export const LinkMenuOptions = {
   Separator: () => ({type: "separator"}),
+  EmptyItem: () => ({type: "empty"}),
   RemoveBookmark: site => ({
     id: "menu_action_remove_bookmark",
     icon: "bookmark-added",
@@ -48,7 +49,7 @@ export const LinkMenuOptions = {
     icon: "dismiss",
     action: ac.AlsoToMain({
       type: at.BLOCK_URL,
-      data: site.url
+      data: {url: site.url, pocket_id: site.pocket_id}
     }),
     impression: ac.ImpressionStats({
       source: eventSource,
@@ -77,7 +78,7 @@ export const LinkMenuOptions = {
       type: at.DIALOG_OPEN,
       data: {
         onConfirm: [
-          ac.AlsoToMain({type: at.DELETE_HISTORY_URL, data: {url: site.url, forceBlock: site.bookmarkGuid}}),
+          ac.AlsoToMain({type: at.DELETE_HISTORY_URL, data: {url: site.url, pocket_id: site.pocket_id, forceBlock: site.bookmarkGuid}}),
           ac.UserEvent({event: "DELETE", source: eventSource, action_position: index})
         ],
         eventSource,
@@ -121,6 +122,24 @@ export const LinkMenuOptions = {
     }),
     userEvent: "SAVE_TO_POCKET"
   }),
+  DeleteFromPocket: site => ({
+    id: "menu_action_delete_pocket",
+    icon: "delete",
+    action: ac.AlsoToMain({
+      type: at.DELETE_FROM_POCKET,
+      data: {pocket_id: site.pocket_id}
+    }),
+    userEvent: "DELETE_FROM_POCKET"
+  }),
+  ArchiveFromPocket: site => ({
+    id: "menu_action_archive_pocket",
+    icon: "check",
+    action: ac.AlsoToMain({
+      type: at.ARCHIVE_FROM_POCKET,
+      data: {pocket_id: site.pocket_id}
+    }),
+    userEvent: "ARCHIVE_FROM_POCKET"
+  }),
   EditTopSite: (site, index) => ({
     id: "edit_topsites_button_text",
     icon: "edit",
@@ -130,5 +149,8 @@ export const LinkMenuOptions = {
     }
   }),
   CheckBookmark: site => (site.bookmarkGuid ? LinkMenuOptions.RemoveBookmark(site) : LinkMenuOptions.AddBookmark(site)),
-  CheckPinTopSite: (site, index) => (site.isPinned ? LinkMenuOptions.UnpinTopSite(site) : LinkMenuOptions.PinTopSite(site, index))
+  CheckPinTopSite: (site, index) => (site.isPinned ? LinkMenuOptions.UnpinTopSite(site) : LinkMenuOptions.PinTopSite(site, index)),
+  CheckSavedToPocket: (site, index) => (site.pocket_id ? LinkMenuOptions.DeleteFromPocket(site) : LinkMenuOptions.SaveToPocket(site, index)),
+  CheckBookmarkOrArchive: site => (site.pocket_id ? LinkMenuOptions.ArchiveFromPocket(site) : LinkMenuOptions.CheckBookmark(site)),
+  CheckDeleteHistoryOrEmpty: (site, index, eventSource) => (site.pocket_id ? LinkMenuOptions.EmptyItem() : LinkMenuOptions.DeleteUrl(site, index, eventSource))
 };

--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -84,6 +84,11 @@
     background-image: url('#{$image-path}glyph-pocket-16.svg');
   }
 
+  &.icon-pocket-small {
+    background-image: url('#{$image-path}glyph-pocket-16.svg');
+    background-size: $smaller-icon-size;
+  }
+
   &.icon-historyItem { // sass-lint:disable-line class-name-format
     background-image: url('#{$image-path}glyph-historyItem-16.svg');
   }

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -121,6 +121,10 @@ const PREFS_CONFIG = new Map([
     title: "Collapse the Highlights section",
     value: false
   }],
+  ["section.highlights.includePocket", {
+    title: "Boolean flag that decides whether or not to show saved Pocket stories in highlights.",
+    value: true
+  }],
   ["section.topstories.collapsed", {
     title: "Collapse the Top Stories section",
     value: false

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -42,7 +42,7 @@ const BUILT_IN_SECTIONS = {
     },
     privacyNoticeURL: options.privacy_notice_link || "https://www.mozilla.org/privacy/firefox/#suggest-relevant-content",
     maxRows: 1,
-    availableLinkMenuOptions: ["CheckBookmark", "SaveToPocket", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl"],
+    availableLinkMenuOptions: ["CheckBookmarkOrArchive", "CheckSavedToPocket", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl"],
     emptyState: {
       message: {id: "topstories_empty_state", values: {provider: options.provider_name}},
       icon: "check"
@@ -62,7 +62,7 @@ const BUILT_IN_SECTIONS = {
     icon: "highlights",
     title: {id: "header_highlights"},
     maxRows: 3,
-    availableLinkMenuOptions: ["CheckBookmark", "SaveToPocket", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl", "DeleteUrl"],
+    availableLinkMenuOptions: ["CheckBookmarkOrArchive", "CheckSavedToPocket", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl", "CheckDeleteHistoryOrEmpty"],
     emptyState: {
       message: {id: "highlights_empty_state"},
       icon: "highlights"

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -83,7 +83,9 @@ export const UserEventAction = Joi.object().keys({
       "SECTION_MENU_EXPAND",
       "SECTION_MENU_MANAGE",
       "SECTION_MENU_ADD_TOPSITE",
-      "SECTION_MENU_PRIVACY_NOTICE"
+      "SECTION_MENU_PRIVACY_NOTICE",
+      "DELETE_FROM_POCKET",
+      "ARCHIVE_FROM_POCKET"
     ]).required(),
     source: Joi.valid(["TOP_SITES", "TOP_STORIES", "HIGHLIGHTS"]),
     action_position: Joi.number().integer()

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -75,6 +75,41 @@ describe("<LinkMenu>", () => {
     const {options} = wrapper.find(ContextMenu).props();
     assert.isDefined(options.find(o => (o.id && o.id === "menu_action_bookmark")));
   });
+  it("should show Save to Pocket option for an unsaved Pocket item if CheckSavedToPocket in options list", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: "", bookmarkGuid: 0}} source={"HIGHLIGHTS"} options={["CheckSavedToPocket"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_save_to_pocket")));
+  });
+  it("should show Delete from Pocket option for a saved Pocket item if CheckSavedToPocket in options list", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: "", pocket_id: 1234}} source={"HIGHLIGHTS"} options={["CheckSavedToPocket"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_delete_pocket")));
+  });
+  it("should show Archive from Pocket option for a saved Pocket item if CheckBookmarkOrArchive", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: "", pocket_id: 1234}} source={"HIGHLIGHTS"} options={["CheckBookmarkOrArchive"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_archive_pocket")));
+  });
+  it("should show Bookmark option for an unbookmarked site if CheckBookmarkOrArchive in options list and no pocket_id", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: ""}} source={"HIGHLIGHTS"} options={["CheckBookmarkOrArchive"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_bookmark")));
+  });
+  it("should show Unbookmark option for a bookmarked site if CheckBookmarkOrArchive in options list and no pocket_id", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: "", bookmarkGuid: 1234}} source={"HIGHLIGHTS"} options={["CheckBookmarkOrArchive"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_remove_bookmark")));
+  });
+  it("should show Delete from History option for a site that is visited but not from Pocket if CheckDeleteHistoryOrEmpty", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: "", type: history}} source={"HIGHLIGHTS"} options={["CheckDeleteHistoryOrEmpty"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_delete")));
+  });
+  it("should not show a Delete from History option for a site that is Pocket'ed if CheckDeleteHistoryOrEmpty", () => {
+    wrapper = shallowWithIntl(<LinkMenu site={{url: "", pocket_id: 1234}} source={"HIGHLIGHTS"} options={["CheckDeleteHistoryOrEmpty"]} dispatch={() => {}} />);
+    const {options} = wrapper.find(ContextMenu).props();
+    assert.isUndefined(options.find(o => (o.id && o.id === "menu_action_delete")));
+  });
   it("should show Edit option", () => {
     const props = {url: "foo", label: "label"};
     const index = 5;
@@ -104,20 +139,22 @@ describe("<LinkMenu>", () => {
   describe(".onClick", () => {
     const FAKE_INDEX = 3;
     const FAKE_SOURCE = "TOP_SITES";
-    const FAKE_SITE = {url: "https://foo.com", referrer: "https://foo.com/ref", title: "bar", bookmarkGuid: 1234, hostname: "foo", type: "history"};
+    const FAKE_SITE = {url: "https://foo.com", pocket_id: "1234", referrer: "https://foo.com/ref", title: "bar", bookmarkGuid: 1234, hostname: "foo", type: "history"};
     const dispatch = sinon.stub();
-    const propOptions = ["Separator", "RemoveBookmark", "AddBookmark", "OpenInNewWindow", "OpenInPrivateWindow", "BlockUrl", "DeleteUrl", "PinTopSite", "UnpinTopSite", "SaveToPocket", "WebExtDismiss"];
+    const propOptions = ["Separator", "RemoveBookmark", "AddBookmark", "OpenInNewWindow", "OpenInPrivateWindow", "BlockUrl", "DeleteUrl", "PinTopSite", "UnpinTopSite", "SaveToPocket", "DeleteFromPocket", "ArchiveFromPocket", "WebExtDismiss"];
     const expectedActionData = {
       menu_action_remove_bookmark: FAKE_SITE.bookmarkGuid,
       menu_action_bookmark: {url: FAKE_SITE.url, title: FAKE_SITE.title, type: FAKE_SITE.type},
       menu_action_open_new_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
       menu_action_open_private_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
-      menu_action_dismiss: FAKE_SITE.url,
+      menu_action_dismiss: {url: FAKE_SITE.url, pocket_id: FAKE_SITE.pocket_id},
       menu_action_webext_dismiss: {source: "TOP_SITES", url: FAKE_SITE.url, action_position: 3},
-      menu_action_delete: {url: FAKE_SITE.url, forceBlock: FAKE_SITE.bookmarkGuid},
+      menu_action_delete: {url: FAKE_SITE.url, pocket_id: FAKE_SITE.pocket_id, forceBlock: FAKE_SITE.bookmarkGuid},
       menu_action_pin: {site: {url: FAKE_SITE.url}, index: FAKE_INDEX},
       menu_action_unpin: {site: {url: FAKE_SITE.url}},
-      menu_action_save_to_pocket: {site: {url: FAKE_SITE.url, title: FAKE_SITE.title}}
+      menu_action_save_to_pocket: {site: {url: FAKE_SITE.url, title: FAKE_SITE.title}},
+      menu_action_delete_pocket: {pocket_id: "1234"},
+      menu_action_archive_pocket: {pocket_id: "1234"}
     };
 
     const {options} = shallowWithIntl(<LinkMenu site={FAKE_SITE} dispatch={dispatch} index={FAKE_INDEX} options={propOptions} source={FAKE_SOURCE} shouldSendImpressionStats={true} />)


### PR DESCRIPTION
1. Allows Pocket items to be shown in highlights
2. Adds a "remove from pocket list" option in context menu (includes string + icon)
3. Adds functionality to actually remove the item from the pocket list via context menu
4. Adds a "saved to pocket" highlight  context  type (includes string + small version of regular pocket icon)
5. Preemptively updates UI when removing a pocket item via the reducer 

Has the same behaviour as when you bookmark a trending story - update the card itself then next time you refresh it shows it in the highlights section
