### PR TITLE
Bug 1418090 - text field on start page is black on black when using a dark theme

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -25,7 +25,6 @@
     border: 0;
     border-radius: $search-border-radius;
     box-shadow: $shadow-secondary, 0 0 0 1px $black-15;
-    color: inherit;
     font-size: 15px;
     padding: 0;
     padding-inline-end: $search-button-width;

--- a/system-addon/content-src/styles/_normalize.scss
+++ b/system-addon/content-src/styles/_normalize.scss
@@ -18,6 +18,8 @@ body {
 
 button,
 input {
+  background-color: inherit;
+  color: inherit;
   font-family: inherit;
   font-size: inherit;
 }


### PR DESCRIPTION
r?@sarracini As suggested in https://bugzilla.mozilla.org/show_bug.cgi?id=1418090 we'll match the rest of the page for both text and background colors to avoid only using one. Tested on Ubuntu 16.04 with Arc-dark theme.

Before:
![screen shot 2018-02-13 at 12 35 11 pm](https://user-images.githubusercontent.com/438537/36172860-0c91ac54-10bc-11e8-83bf-4ab83cca8aac.png)

After:
![screen shot 2018-02-13 at 12 37 06 pm](https://user-images.githubusercontent.com/438537/36172869-1240a470-10bc-11e8-82ac-2c10390232e8.png)
