### PR TITLE
fix (styles): fix pocket disclaimer text for wide layout

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -162,6 +162,9 @@
   }
 
   .section-disclaimer {
+    $max-button-width: 130px;
+    $min-button-height: 26px;
+
     color: $grey-60;
     font-size: 13px;
     margin-bottom: 16px;
@@ -169,17 +172,11 @@
 
     .section-disclaimer-text {
       display: inline-block;
+      min-height: $min-button-height;
+      width: calc(100% - #{$max-button-width});
 
-      @media (min-width: $break-point-small) {
+      @media (max-width: $break-point-medium) {
         width: $card-width;
-      }
-
-      @media (min-width: $break-point-medium) {
-        width: 340px;
-      }
-
-      @media (min-width: $break-point-large) {
-        width: 610px;
       }
     }
 
@@ -194,8 +191,8 @@
       border-radius: 4px;
       cursor: pointer;
       margin-top: 2px;
-      max-width: 130px;
-      min-height: 26px;
+      max-width: $max-button-width;
+      min-height: $min-button-height;
       offset-inline-end: 0;
 
       &:hover:not(.dismiss) {


### PR DESCRIPTION
Reported by Nate in Slack.

Before:
<img width="1019" alt="screen shot 2018-02-13 at 7 46 31 pm" src="https://user-images.githubusercontent.com/36629/36182247-a97e7ecc-10f6-11e8-88a1-0959385a30bc.png">

After:
<img width="1017" alt="screen shot 2018-02-13 at 7 45 12 pm" src="https://user-images.githubusercontent.com/36629/36182248-adab9d5e-10f6-11e8-9c8f-873f2570456e.png">
