### PR TITLE
Bug 1438200 - Use domain name as provided in Pocket feed response

### DIFF
--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -143,7 +143,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
       .filter(s => !NewTabUtils.blockedLinks.isBlocked({"url": s.url}))
       .map(s => ({
         "guid": s.id,
-        "hostname": shortURL(Object.assign({}, s, {url: s.url})),
+        "hostname": s.domain || shortURL(Object.assign({}, s, {url: s.url})),
         "type": (Date.now() - (s.published_timestamp * 1000)) <= STORIES_NOW_THRESHOLD ? "now" : "trending",
         "context": s.context,
         "icon": s.icon,


### PR DESCRIPTION
This allows Pocket to specify the host name displayed on story cards. Until now we've used `shortURL` to generate it, which works fine, but there are cases where we need to specify a different domain than in the story URL (e.g for spocs).