### PR TITLE
Fix Bug 1438565 - Send source and action_position with DELETE ping

### DIFF
--- a/system-addon/content-src/components/ConfirmDialog/ConfirmDialog.jsx
+++ b/system-addon/content-src/components/ConfirmDialog/ConfirmDialog.jsx
@@ -31,7 +31,7 @@ export class _ConfirmDialog extends React.PureComponent {
 
   _handleCancelBtn() {
     this.props.dispatch({type: actionTypes.DIALOG_CANCEL});
-    this.props.dispatch(ac.UserEvent({event: actionTypes.DIALOG_CANCEL}));
+    this.props.dispatch(ac.UserEvent({event: actionTypes.DIALOG_CANCEL, source: this.props.data.eventSource}));
   }
 
   _handleConfirmBtn() {

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -70,7 +70,7 @@ export const LinkMenuOptions = {
       action_position: index
     })
   }),
-  DeleteUrl: site => ({
+  DeleteUrl: (site, index, eventSource) => ({
     id: "menu_action_delete",
     icon: "delete",
     action: {
@@ -78,7 +78,7 @@ export const LinkMenuOptions = {
       data: {
         onConfirm: [
           ac.AlsoToMain({type: at.DELETE_HISTORY_URL, data: {url: site.url, forceBlock: site.bookmarkGuid}}),
-          ac.UserEvent({event: "DELETE"})
+          ac.UserEvent({event: "DELETE", source: eventSource, action_position: index})
         ],
         body_string_id: ["confirm_history_delete_p1", "confirm_history_delete_notice_p2"],
         confirm_button_string_id: "menu_action_delete",

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -80,6 +80,7 @@ export const LinkMenuOptions = {
           ac.AlsoToMain({type: at.DELETE_HISTORY_URL, data: {url: site.url, forceBlock: site.bookmarkGuid}}),
           ac.UserEvent({event: "DELETE", source: eventSource, action_position: index})
         ],
+        eventSource,
         body_string_id: ["confirm_history_delete_p1", "confirm_history_delete_notice_p2"],
         confirm_button_string_id: "menu_action_delete",
         cancel_button_string_id: "topsites_form_cancel_button",

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -79,7 +79,7 @@ export const UserEventAction = Joi.object().keys({
       "UNPIN",
       "SAVE_TO_POCKET"
     ]).required(),
-    source: Joi.valid(["TOP_SITES", "TOP_STORIES"]),
+    source: Joi.valid(["TOP_SITES", "TOP_STORIES", "HIGHLIGHTS"]),
     action_position: Joi.number().integer()
   }).required(),
   meta: Joi.object().keys({

--- a/system-addon/test/unit/content-src/components/ConfirmDialog.test.jsx
+++ b/system-addon/test/unit/content-src/components/ConfirmDialog.test.jsx
@@ -15,7 +15,8 @@ describe("<ConfirmDialog>", () => {
       data: {
         onConfirm: [],
         cancel_button_string_id: "manual_migration_cancel_button",
-        confirm_button_string_id: "manual_migration_import_button"
+        confirm_button_string_id: "manual_migration_import_button",
+        eventSource: "HIGHLIGHTS"
       }
     };
     wrapper = shallowWithIntl(<ConfirmDialog dispatch={dispatch} {...ConfirmDialogProps} />);
@@ -83,7 +84,7 @@ describe("<ConfirmDialog>", () => {
       // Two events are emitted: UserEvent+AlsoToMain.
       assert.calledTwice(dispatch);
       assert.isUserEventAction(dispatch.secondCall.args[0]);
-      assert.calledWith(dispatch, ac.UserEvent({event: at.DIALOG_CANCEL}));
+      assert.calledWith(dispatch, ac.UserEvent({event: at.DIALOG_CANCEL, source: "HIGHLIGHTS"}));
     });
     it("should emit AlsoToMain DIALOG_CANCEL on cancel", () => {
       let cancelButton = wrapper.find(".actions").childAt(0);
@@ -105,7 +106,7 @@ describe("<ConfirmDialog>", () => {
       // Two events are emitted: UserEvent+AlsoToMain.
       assert.calledTwice(dispatch);
       assert.isUserEventAction(dispatch.secondCall.args[0]);
-      assert.calledWith(dispatch, ac.UserEvent({event: at.DIALOG_CANCEL}));
+      assert.calledWith(dispatch, ac.UserEvent({event: at.DIALOG_CANCEL, source: "HIGHLIGHTS"}));
     });
     it("should emit UserEvent on primary button", () => {
       Object.assign(ConfirmDialogProps.data, {

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -144,6 +144,9 @@ describe("<LinkMenu>", () => {
         // to block this if we delete it
         if (option.id === "menu_action_delete") {
           assert.deepEqual(option.action.data.onConfirm[0].data, expectedActionData[option.id]);
+          // Test UserEvent send correct meta about item deleted
+          assert.propertyVal(option.action.data.onConfirm[1].data, "action_position", FAKE_INDEX);
+          assert.propertyVal(option.action.data.onConfirm[1].data, "source", FAKE_SOURCE);
         } else {
           assert.deepEqual(option.action.data, expectedActionData[option.id]);
         }


### PR DESCRIPTION
I initially thought this was a lot worse but it looks like we "didn't lose" all the clicks.

`DeleteUrl` has a userEvent of [`DIALOG_OPEN`](https://github.com/mozilla/activity-stream/blob/a050adee0eebcc47c310ed9d9fb9973f1a07e1bd/system-addon/content-src/lib/link-menu-options.js#L89) defined which is [handled by the `LinkMenu`](https://github.com/mozilla/activity-stream/blob/a050adee0eebcc47c310ed9d9fb9973f1a07e1bd/system-addon/content-src/components/LinkMenu/LinkMenu.jsx#L23-L28).

If you sum up the DIALOG_OPEN events from Highlights and from Topsites they roughly add up to the DELETE count with n/a source (+/- some CANCEL events I suppose).

update: The bug mentioned the DELETE event but looks like DIALOG_CANCEL also has no source