### PR TITLE
fix(tests): Update mochitests for section context menus

### DIFF
--- a/system-addon/test/functional/mochitest/browser_highlights_section.js
+++ b/system-addon/test/functional/mochitest/browser_highlights_section.js
@@ -41,10 +41,10 @@ test_highlights(
 test_highlights(
   1, // Number of highlights cards
   function check_highlights_context_menu() {
-    const menuButton = content.document.querySelector(".section-list .context-menu-button");
+    const menuButton = content.document.querySelector(".card-outer .context-menu-button");
     // Open the menu.
     menuButton.click();
-    const found = content.document.querySelector(".context-menu");
+    const found = content.document.querySelector(".card-outer .context-menu");
     ok(found && !found.hidden, "Should find a visible context menu");
   }
 );

--- a/system-addon/test/functional/mochitest/browser_topsites_section.js
+++ b/system-addon/test/functional/mochitest/browser_topsites_section.js
@@ -4,7 +4,7 @@
 test_newtab(
   // it should be able to click the topsites add button to reveal the add top site modal and overlay.
   function topsites_edit() {
-    const topsitesAddBtn = content.document.querySelector(".add-topsites-button button");
+    const topsitesAddBtn = content.document.querySelector(".top-sites .context-menu a");
     topsitesAddBtn.click();
 
     let found = content.document.querySelector(".topsite-form");
@@ -23,13 +23,13 @@ test_newtab({
     await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".top-site-icon"),
       "Topsite tippytop icon not found");
     // There are only topsites on the page, the selector with find the first topsite menu button.
-    const topsiteContextBtn = content.document.querySelector(".context-menu-button");
+    const topsiteContextBtn = content.document.querySelector(".top-sites-list .context-menu-button");
     topsiteContextBtn.click();
 
-    const contextMenu = content.document.querySelector(".context-menu");
+    const contextMenu = content.document.querySelector(".top-sites-list .context-menu");
     ok(contextMenu && !contextMenu.hidden, "Should find a visible topsite context menu");
 
-    const pinUnpinTopsiteBtn = contextMenu.querySelector(".context-menu-item a");
+    const pinUnpinTopsiteBtn = contextMenu.querySelector(".top-sites-list .context-menu-item a");
     // Pin the topsite.
     pinUnpinTopsiteBtn.click();
 


### PR DESCRIPTION
r?@sarracini Needed to fix these for export because they were assuming only context menus on sites/cards. cc @rlr 