### PR TITLE
Fix Bug 1440970 - Fix top sites context menu position

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -41,6 +41,10 @@
     .context-menu {
       top: 16px;
     }
+
+    @media (max-width: $break-point-widest + $card-width * 1.5) {
+      @include context-menu-open-left;
+    }
   }
 
   &:hover,
@@ -60,10 +64,6 @@
         fill: $grey-90-80;
       }
     }
-  }
-
-  @media (max-width: $break-point-widest + $card-width * 1.5) {
-    @include context-menu-open-left;
   }
 
   .section-disclaimer {


### PR DESCRIPTION
Followup fix for e939451 that caused link menus to always open to the left.