### PR TITLE
 Fix Bug 1440781 - Refreshing preloaded tabs interferes with spoc placement

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -207,6 +207,18 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
           // If the action is updating rows, we should consider initialized to be true.
           // This can be overridden if initialized is defined in the action.data
           const initialized = action.data.rows ? {initialized: true} : {};
+
+          if (action.data.rows && section.rows.find(card => card.pinned)) {
+            // Make sure that pinned cards stay at their current position
+            const rows = Array.from(action.data.rows);
+            section.rows.forEach((card, index) => {
+              if (card.pinned) {
+                rows.splice(index, 0, card);
+              }
+            });
+            return Object.assign({}, section, initialized, Object.assign({}, action.data, {rows}));
+          }
+
           return Object.assign({}, section, initialized, action.data);
         }
         return section;

--- a/system-addon/lib/TopStoriesFeed.jsm
+++ b/system-addon/lib/TopStoriesFeed.jsm
@@ -311,7 +311,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
         // Create a new array with a spoc inserted at index 2
         const position = SectionsManager.sections.get(SECTION_ID).order;
         let rows = this.store.getState().Sections[position].rows.slice(0, this.stories.length);
-        rows.splice(2, 0, spocs[0]);
+        rows.splice(2, 0, Object.assign(spocs[0], {pinned: true}));
 
         // Send a content update to the target tab
         const action = {type: at.SECTION_UPDATE, data: Object.assign({rows}, {id: SECTION_ID})};

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -291,6 +291,21 @@ describe("Reducers", () => {
       const updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.propertyVal(updatedSection, "initialized", true);
     });
+    it("should retain pinned cards on SECTION_UPDATE", () => {
+      const ROW = {id: "row"};
+      let newState = Sections(oldState, {type: at.SECTION_UPDATE, data: Object.assign({rows: [ROW]}, {id: "foo_bar_2"})});
+      let updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.deepEqual(updatedSection.rows, [ROW]);
+
+      const PINNED_ROW = {id: "pinned", pinned: true};
+      newState = Sections(newState, {type: at.SECTION_UPDATE, data: Object.assign({rows: [PINNED_ROW]}, {id: "foo_bar_2"})});
+      updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.deepEqual(updatedSection.rows, [PINNED_ROW]);
+
+      newState = Sections(newState, {type: at.SECTION_UPDATE, data: Object.assign({rows: [ROW]}, {id: "foo_bar_2"})});
+      updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.deepEqual(updatedSection.rows, [PINNED_ROW, ROW]);
+    });
     it("should have no effect on SECTION_UPDATE_CARD if the id or url doesn't exist", () => {
       const noIdAction = {type: at.SECTION_UPDATE_CARD, data: {id: "non-existent", url: "www.foo.bar", options: {title: "New title"}}};
       const noIdState = Sections(oldState, noIdAction);

--- a/system-addon/test/unit/lib/TopStoriesFeed.test.js
+++ b/system-addon/test/unit/lib/TopStoriesFeed.test.js
@@ -495,6 +495,8 @@ describe("Top Stories Feed", () => {
       assert.equal(action.data.rows[0].guid, "rec1");
       assert.equal(action.data.rows[1].guid, "rec2");
       assert.equal(action.data.rows[2].guid, "spoc1");
+      // Make sure spoc is marked as pinned so it doesn't get removed when preloaded tabs refresh
+      assert.equal(action.data.rows[2].pinned, true);
 
       // Second new tab shouldn't trigger a section update event (spocsPerNewTab === 0.5)
       globals.set("Math", {random: () => 0.6});
@@ -510,6 +512,8 @@ describe("Top Stories Feed", () => {
       assert.equal(action.data.rows[0].guid, "rec1");
       assert.equal(action.data.rows[1].guid, "rec2");
       assert.equal(action.data.rows[2].guid, "spoc1");
+      // Make sure spoc is marked as pinned so it doesn't get removed when preloaded tabs refresh
+      assert.equal(action.data.rows[2].pinned, true);
     });
     it("should delay inserting spoc if stories haven't been fetched", async () => {
       let fetchStub = globals.sandbox.stub();


### PR DESCRIPTION
Fixes a regression, introduced in 59, but plan is to fix for 60 only.

This PR introduces a way to mark cards as pinned, so they don't get refreshed as part of a SECTION_UPDATEs.

This is useful to avoid losing spoc cards when preloaded tabs refresh based on the latest feed data. A preloaded tab with a spoc will still refresh and all its cards will update except the spoc (pinned card) which will remain in place. This is to make sure we keep the spoc frequency as configured in the feed.