### PR TITLE
Fix Bug 1441301 - Adjust section context menu related styling

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -23,7 +23,7 @@
       background: url('chrome://browser/skin/page-action.svg') no-repeat right center;
       border: 0;
       cursor: pointer;
-      fill: $grey-30;
+      fill: $grey-50;
       height: $context-menu-button-size;
       offset-inline-end: 0;
       opacity: 0;
@@ -34,7 +34,7 @@
       width: $context-menu-button-size;
 
       &:-moz-any(:active, :focus, :hover) {
-        fill: $grey-90-80;
+        fill: $grey-90;
       }
     }
 
@@ -57,11 +57,12 @@
   }
 
   &.active {
-    background: $grey-30-20;
+    background: $grey-20-60;
+    border-radius: 4px;
 
     .section-top-bar {
       .context-menu-button {
-        fill: $grey-90-80;
+        fill: $grey-90;
       }
     }
   }

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -22,7 +22,7 @@ $grey-90-70: rgba($grey-90, 0.7);
 $grey-90-80: rgba($grey-90, 0.8);
 $grey-90-90: rgba($grey-90, 0.9);
 
-$grey-30-20: rgba($grey-20, 0.2);
+$grey-20-60: rgba($grey-20, 0.6);
 
 $black: #000;
 $black-5: rgba($black, 0.05);


### PR DESCRIPTION
I asked @aaronrbenson to look over the colors that we landed on nightly since they looked lighter than the mockups. He requested these changes.

Don't need to track this in bugzilla do I? 😉 