### PR TITLE
fix(topstories): Pinned cards should be cleared when section is re-initialized

### DIFF
--- a/system-addon/common/Reducers.jsm
+++ b/system-addon/common/Reducers.jsm
@@ -208,8 +208,9 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
           // This can be overridden if initialized is defined in the action.data
           const initialized = action.data.rows ? {initialized: true} : {};
 
-          if (action.data.rows && section.rows.find(card => card.pinned)) {
-            // Make sure that pinned cards stay at their current position
+          // Make sure pinned cards stay at their current position when rows are updated.
+          // Disabling a section (SECTION_UPDATE with empty rows) does not retain pinned cards.
+          if (action.data.rows && action.data.rows.length > 0 && section.rows.find(card => card.pinned)) {
             const rows = Array.from(action.data.rows);
             section.rows.forEach((card, index) => {
               if (card.pinned) {

--- a/system-addon/test/unit/common/Reducers.test.js
+++ b/system-addon/test/unit/common/Reducers.test.js
@@ -302,9 +302,15 @@ describe("Reducers", () => {
       updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.deepEqual(updatedSection.rows, [PINNED_ROW]);
 
+      // Updating the section should retain pinned card at its index
       newState = Sections(newState, {type: at.SECTION_UPDATE, data: Object.assign({rows: [ROW]}, {id: "foo_bar_2"})});
       updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.deepEqual(updatedSection.rows, [PINNED_ROW, ROW]);
+
+      // Clearing/Resetting the section should clear pinned cards
+      newState = Sections(newState, {type: at.SECTION_UPDATE, data: Object.assign({rows: []}, {id: "foo_bar_2"})});
+      updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.deepEqual(updatedSection.rows, []);
     });
     it("should have no effect on SECTION_UPDATE_CARD if the id or url doesn't exist", () => {
       const noIdAction = {type: at.SECTION_UPDATE_CARD, data: {id: "non-existent", url: "www.foo.bar", options: {title: "New title"}}};


### PR DESCRIPTION
This refines the earlier fix to *not* retain pinned cards when the section is disabled and enabled again i.e. by an .options change or when the user toggles the checkbox in the pref pane.

I think in these cases we do want the cards to update. Disabling the section causes a SECTION_UPDATE event with an empty rows array.



