### PR TITLE
fix Bug 1431464 - Expose devtools usage to snippets

### DIFF
--- a/docs/v2-system-addon/snippets.md
+++ b/docs/v2-system-addon/snippets.md
@@ -81,6 +81,8 @@ For example:
 If we could not determine the default browser, this value is `null`. Note that
 currently this value is only checked once when the browser is initialized.
 
+`appData.isDevtoolsUser`: (bool) Has the user ever used devtools?
+
 ## Events
 
 ActivityStream dispatches custom DOM events on the window to allow snippets

--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -49,6 +49,10 @@ this.SnippetsFeed = class SnippetsFeed {
     return null;
   }
 
+  isDevtoolsUser() {
+    return Services.prefs.getIntPref("devtools.selfxss.count") >= 5;
+  }
+
   async getProfileInfo() {
     const profileAge = new ProfileAge(null, null);
     const createdDate = await profileAge.created;
@@ -94,7 +98,8 @@ this.SnippetsFeed = class SnippetsFeed {
       onboardingFinished: Services.prefs.getBoolPref(ONBOARDING_FINISHED_PREF),
       fxaccount: Services.prefs.prefHasUserValue(FXA_USERNAME_PREF),
       selectedSearchEngine: await this.getSelectedSearchEngine(),
-      defaultBrowser: this.isDefaultBrowser()
+      defaultBrowser: this.isDefaultBrowser(),
+      isDevtoolsUser: this.isDevtoolsUser()
     };
     this._dispatchChanges(data);
   }

--- a/system-addon/test/unit/lib/SnippetsFeed.test.js
+++ b/system-addon/test/unit/lib/SnippetsFeed.test.js
@@ -40,6 +40,9 @@ describe("SnippetsFeed", () => {
     sandbox.stub(global.Services.prefs, "prefHasUserValue")
       .withArgs("services.sync.username")
       .returns(true);
+    sandbox.stub(global.Services.prefs, "getIntPref")
+      .withArgs("devtools.selfxss.count")
+      .returns(5);
 
     const feed = new SnippetsFeed();
     feed.store = {dispatch: sandbox.stub()};
@@ -63,6 +66,7 @@ describe("SnippetsFeed", () => {
     assert.property(action.data, "selectedSearchEngine");
     assert.deepEqual(action.data.selectedSearchEngine, searchData);
     assert.propertyVal(action.data, "defaultBrowser", true);
+    assert.propertyVal(action.data, "isDevtoolsUser", true);
   });
   it("should call .init on an INIT action", () => {
     const feed = new SnippetsFeed();
@@ -122,5 +126,21 @@ describe("SnippetsFeed", () => {
     const browser = {loadURI: sinon.spy()};
     await feed.showFirefoxAccounts(browser);
     assert.calledWith(browser.loadURI, signUpUrl);
+  });
+  it("should return true for isDevtoolsUser is devtools.selfxss.count is 5", async () => {
+    sandbox.stub(global.Services.prefs, "getIntPref")
+      .withArgs("devtools.selfxss.count")
+      .returns(5);
+    const feed = new SnippetsFeed();
+    const result = feed.isDevtoolsUser();
+    assert.isTrue(result);
+  });
+  it("should return false for isDevtoolsUser is devtools.selfxss.count is less than 5", async () => {
+    sandbox.stub(global.Services.prefs, "getIntPref")
+      .withArgs("devtools.selfxss.count")
+      .returns(4);
+    const feed = new SnippetsFeed();
+    const result = feed.isDevtoolsUser();
+    assert.isFalse(result);
   });
 });

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -72,6 +72,7 @@ overrider.set({
       prefHasUserValue() {},
       removeObserver() {},
       getStringPref() {},
+      getIntPref() {},
       getBoolPref() {},
       getBranch() {},
       getDefaultBranch() {


### PR DESCRIPTION
This adds a property to snippets data indicating whether or not devtools have been used.

To test this, add the following to your console on a page in which snippets are turned enabled:

```js
gSnippetsMap.get("appData.isDevtoolsUser")
```
It should be `true` (since you have used devtools)

cc @glogiotatidis 