### PR TITLE
chore(mc): Backport of Bug 1440276 - Activity Stream spikes after Bookmark activity, triggering lots of main thread work

### DIFF
--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -90,6 +90,7 @@ class HistoryObserver extends Observer {
 class BookmarksObserver extends Observer {
   constructor(dispatch) {
     super(dispatch, Ci.nsINavBookmarkObserver);
+    this.skipTags = true;
   }
 
   /**
@@ -147,48 +148,6 @@ class BookmarksObserver extends Observer {
     }
   }
 
-  /**
-   * onItemChanged - Called when a bookmark is modified
-   *
-   * @param  {str} id           description
-   * @param  {str} property     The property that was modified (e.g. uri, title)
-   * @param  {bool} isAnnotation
-   * @param  {any} value
-   * @param  {int} lastModified
-   * @param  {int} type         Indicates if the bookmark is an actual bookmark,
-   *                             a folder, or a separator.
-   * @param  {int} parent
-   * @param  {str} guid         The unique id of the bookmark
-   */
-  async onItemChanged(...args) {
-
-    /*
-    // Disabled due to performance cost, see Issue 3203 /
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1392267.
-    //
-    // If this is used, please consider avoiding the call to
-    // NewTabUtils.activityStreamProvider.getBookmark which performs an additional
-    // fetch to the database.
-    // If you need more fields, please talk to the places team.
-
-    const property = args[1];
-    const type = args[5];
-    const guid = args[7];
-
-    // Only process this event if it is a TYPE_BOOKMARK, and uri or title was the property changed.
-    if (type !== PlacesUtils.bookmarks.TYPE_BOOKMARK || !["uri", "title"].includes(property)) {
-      return;
-    }
-    try {
-      // bookmark: {bookmarkGuid, bookmarkTitle, lastModified, url}
-      const bookmark = await NewTabUtils.activityStreamProvider.getBookmark(guid);
-      this.dispatch({type: at.PLACES_BOOKMARK_CHANGED, data: bookmark});
-    } catch (e) {
-      Cu.reportError(e);
-    }
-    */
-  }
-
   // Empty functions to make xpconnect happy
   onBeginUpdateBatch() {}
 
@@ -197,6 +156,10 @@ class BookmarksObserver extends Observer {
   onItemVisited() {}
 
   onItemMoved() {}
+
+  // Disabled due to performance cost, see Issue 3203 /
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1392267.
+  onItemChanged() {}
 }
 
 class PlacesFeed {


### PR DESCRIPTION
Adds a ```skipTags: true``` property to the observer so it knows that it should not notify observers when adding/removing tags during a sync.
Also removes unused code for ```onItemChanged()```

This doesn't actually work yet with ```onItemChanged```.... posted my findings on https://bugzilla.mozilla.org/show_bug.cgi?id=1440276

_Update: Since this bug now involves some changes in ```nsNavBookmarks.cpp```, I'm going to make the changes to ```PlacesFeed.jsm``` also in m-c and this will become a backport PR of those changes_