### PR TITLE
fix Bug 1431525 - Add addonInfo to snippets data

### DIFF
--- a/docs/v2-system-addon/snippets.md
+++ b/docs/v2-system-addon/snippets.md
@@ -83,6 +83,26 @@ currently this value is only checked once when the browser is initialized.
 
 `appData.isDevtoolsUser`: (bool) Has the user ever used devtools?
 
+`appData.addonInfo`: (obj) An object containing info about installed addons.
+For example:
+
+```js
+{
+  // This is the ID of the addon
+  "someaddon@mozilla.org": {
+    type: "extension",
+    isSystem: false,
+    isWebExtension: true,
+    version: "29.0.0"
+
+    // The following properties may not be available when the browser starts up
+    name: "Firefox Screenshots",
+    userDisabled: false,
+    installDate: Date 2018-02-27T19:33:33.440Z,
+  }
+}
+```
+
 ## Events
 
 ActivityStream dispatches custom DOM events on the window to allow snippets

--- a/system-addon/test/unit/lib/SnippetsFeed.test.js
+++ b/system-addon/test/unit/lib/SnippetsFeed.test.js
@@ -5,6 +5,26 @@ import {SnippetsFeed} from "lib/SnippetsFeed.jsm";
 const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 const searchData = {searchEngineIdentifier: "google", engines: ["searchEngine-google", "searchEngine-bing"]};
 const signUpUrl = "https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=snippets";
+const FAKE_ADDONS = {
+  foo: {
+    name: "Foo",
+    version: "0.1.0",
+    type: "foo",
+    isSystem: false,
+    isWebExtension: true,
+    userDisabled: false,
+    installDate: 1231921
+  },
+  bar: {
+    name: "Bar",
+    version: "0.2.0",
+    type: "bar",
+    isSystem: false,
+    isWebExtension: false,
+    userDisabled: false,
+    installDate: 1231921
+  }
+};
 
 let overrider = new GlobalOverrider();
 
@@ -43,6 +63,14 @@ describe("SnippetsFeed", () => {
     sandbox.stub(global.Services.prefs, "getIntPref")
       .withArgs("devtools.selfxss.count")
       .returns(5);
+    sandbox.stub(global.AddonManager, "getActiveAddons")
+      .returns(Promise.resolve({
+        addons: [
+          Object.assign({id: "foo"}, FAKE_ADDONS.foo),
+          Object.assign({id: "bar"}, FAKE_ADDONS.bar)
+        ],
+        fullData: true
+      }));
 
     const feed = new SnippetsFeed();
     feed.store = {dispatch: sandbox.stub()};
@@ -67,6 +95,7 @@ describe("SnippetsFeed", () => {
     assert.deepEqual(action.data.selectedSearchEngine, searchData);
     assert.propertyVal(action.data, "defaultBrowser", true);
     assert.propertyVal(action.data, "isDevtoolsUser", true);
+    assert.deepEqual(action.data.addonInfo, FAKE_ADDONS);
   });
   it("should call .init on an INIT action", () => {
     const feed = new SnippetsFeed();

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -26,6 +26,11 @@ chai.use(chaiAssertions);
 let overrider = new GlobalOverrider();
 
 overrider.set({
+  AddonManager: {
+    getActiveAddons() {
+      return Promise.resolve({addons: [], fullData: false});
+    }
+  },
   AppConstants: {MOZILLA_OFFICIAL: true},
   ChromeUtils: {
     defineModuleGetter() {},


### PR DESCRIPTION
To test this, add the following to your console on a page in which snippets are enabled:

```js
gSnippetsMap.get("appData.addonInfo")
```