### PR TITLE
chore(mc): Port Bug 1433958 - Change code that sets nsIURI.ref to use nsIURIMutator r=mayhemer

### DIFF
--- a/system-addon/lib/FaviconFeed.jsm
+++ b/system-addon/lib/FaviconFeed.jsm
@@ -124,7 +124,7 @@ this.FaviconFeed = class FaviconFeed {
     if (domain in sitesByDomain) {
       let iconUri = Services.io.newURI(sitesByDomain[domain].image_url);
       // The #tippytop is to be able to identify them for telemetry.
-      iconUri.ref = "tippytop";
+      iconUri = iconUri.mutate().setRef("tippytop").finalize();
       PlacesUtils.favicons.setAndFetchFaviconForPage(
         Services.io.newURI(url),
         iconUri,

--- a/system-addon/test/unit/lib/FaviconFeed.test.js
+++ b/system-addon/test/unit/lib/FaviconFeed.test.js
@@ -207,7 +207,7 @@ describe("FaviconFeed", () => {
 
       assert.calledOnce(global.PlacesUtils.favicons.setAndFetchFaviconForPage);
       assert.calledWith(global.PlacesUtils.favicons.setAndFetchFaviconForPage,
-        {spec: url},
+        sinon.match({spec: url}),
         {ref: "tippytop", spec: `${url}/icon.png`},
         false,
         global.PlacesUtils.favicons.FAVICON_LOAD_NON_PRIVATE,

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -94,7 +94,19 @@ overrider.set({
       getBaseDomain({spec}) { return spec.match(/\/([^/]+)/)[1]; },
       getPublicSuffix() {}
     },
-    io: {newURI(url) { return {spec: url}; }},
+    io: {
+      newURI: spec => ({
+        mutate: () => ({
+          setRef: ref => ({
+            finalize: () => ({
+              ref,
+              spec
+            })
+          })
+        }),
+        spec
+      })
+    },
     search: {
       init(cb) { cb(); },
       getVisibleEngines: () => [{identifier: "google"}, {identifier: "bing"}],


### PR DESCRIPTION
r?@k88hudson https://hg.mozilla.org/mozilla-central/rev/d39e5d03e446

So many nested objects for unit-entry ;)

I needed to do sinon.match to ignore the `mutate` method.