### PR TITLE
Fix Bug 1404890 - Move new tab settings for sections to about:preferences

### DIFF
--- a/system-addon/lib/AboutPreferences.jsm
+++ b/system-addon/lib/AboutPreferences.jsm
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+Cu.importGlobalProperties(["fetch"]);
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.defineModuleGetter(this, "PluralForm", "resource://gre/modules/PluralForm.jsm");
+const {actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
+
+const PREFERENCES_LOADED_EVENT = "sync-pane-loaded";
+const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
+// These "section" objects are formatted in a way to be similar to the ones from
+// SectionsManager to construct the preferences view.
+const PREFS_BEFORE_SECTIONS = [
+  {
+    id: "search",
+    pref: {
+      feed: "showSearch",
+      titleString: "prefs_search_header"
+    },
+    icon: "chrome://browser/skin/search-glass.svg"
+  },
+  {
+    id: "topsites",
+    pref: {
+      feed: "showTopSites",
+      titleString: "settings_pane_topsites_header",
+      descString: "prefs_topsites_description"
+    },
+    icon: "topsites",
+    maxRows: 2,
+    rowsPref: "topSitesRows"
+  }
+];
+const PREFS_AFTER_SECTIONS = [
+  {
+    id: "snippets",
+    pref: {
+      feed: "feeds.snippets",
+      titleString: "settings_pane_snippets_header",
+      descString: "prefs_snippets_description"
+    },
+    icon: "info"
+  }
+];
+
+// This CSS is added to the whole about:preferences page
+const CUSTOM_CSS = `
+#homeContentsGroup checkbox[src] .checkbox-icon {
+  margin-inline-end: 8px;
+  margin-inline-start: 4px;
+  width: 16px;
+}
+`;
+
+this.AboutPreferences = class AboutPreferences {
+  constructor() {
+    Services.obs.addObserver(this, PREFERENCES_LOADED_EVENT);
+  }
+
+  uninit() {
+    Services.obs.removeObserver(this, PREFERENCES_LOADED_EVENT);
+  }
+
+  onAction(action) {
+    switch (action.type) {
+      case at.UNINIT:
+        this.uninit();
+        break;
+    }
+  }
+
+  async observe(window) {
+    this.renderPreferences(window, await this.strings, [...PREFS_BEFORE_SECTIONS,
+      ...this.store.getState().Sections, ...PREFS_AFTER_SECTIONS]);
+  }
+
+  /**
+   * Get strings from a js file that the content page would have loaded. The
+   * file should be a single variable assignment of a JSON/JS object of strings.
+   */
+  get strings() {
+    return this._strings || (this._strings = new Promise(async resolve => {
+      let data = {};
+      try {
+        const locale = Cc["@mozilla.org/browser/aboutnewtab-service;1"]
+          .getService(Ci.nsIAboutNewTabService).activityStreamLocale;
+        const request = await fetch(`resource://activity-stream/prerendered/${locale}/activity-stream-strings.js`);
+        const text = await request.text();
+        const [json] = text.match(/{[^]*}/);
+        data = JSON.parse(json);
+      } catch (ex) {
+        Cu.reportError("Failed to load strings for Activity Stream about:preferences");
+      }
+      resolve(data);
+    }));
+  }
+
+  /**
+   * Render preferences to an about:preferences content window with the provided
+   * strings and preferences structure.
+   */
+  renderPreferences({document, Preferences}, strings, prefStructure) {
+    // Helper to create a new element and append it
+    const createAppend = (tag, parent) => parent.appendChild(
+      document.createElementNS(XUL_NS, tag));
+
+    // Helper to get strings and format with values if necessary
+    const formatString = id => {
+      if (typeof id === "string") {
+        return strings[id] || id;
+      }
+      let string = strings[id.id] || JSON.stringify(id);
+      if (id.values) {
+        Object.entries(id.values).forEach(([key, val]) => {
+          string = string.replace(new RegExp(`{${key}}`, "g"), val);
+        });
+      }
+      return string;
+    };
+
+    // Helper to link a UI element to a preference for updating
+    const linkPref = (element, name, type) => {
+      const fullPref = `browser.newtabpage.activity-stream.${name}`;
+      element.setAttribute("preference", fullPref);
+      Preferences.add({id: fullPref, type});
+
+      // Prevent changing the UI if the preference can't be changed
+      element.disabled = Preferences.get(fullPref).locked;
+    };
+
+    // Add in custom styling
+    document.insertBefore(document.createProcessingInstruction("xml-stylesheet",
+      `href="data:text/css,${encodeURIComponent(CUSTOM_CSS)}" type="text/css"`),
+      document.documentElement);
+
+    // Insert a new group immediately after the homepage one
+    const homeGroup = document.getElementById("homepageGroup");
+    const contentsGroup = homeGroup.insertAdjacentElement("afterend", homeGroup.cloneNode());
+    contentsGroup.id = "homeContentsGroup";
+    contentsGroup.setAttribute("data-subcategory", "contents");
+    const caption = createAppend("caption", contentsGroup);
+    caption.setAttribute("label", formatString("prefs_home_header"));
+    const description = createAppend("description", contentsGroup);
+    description.textContent = formatString("prefs_home_description");
+
+    // Add preferences for each section
+    prefStructure.forEach(sectionData => {
+      const {
+        id,
+        pref: prefData,
+        icon = "webextension",
+        maxRows,
+        rowsPref,
+        shouldHidePref
+      } = sectionData;
+      const {
+        feed: name,
+        titleString,
+        descString,
+        nestedPrefs = []
+      } = prefData || {};
+
+      // Don't show any sections that we don't want to expose in preferences UI
+      if (shouldHidePref) {
+        return;
+      }
+
+      // Use full icon spec for certain protocols or fall back to packaged icon
+      const iconUrl = !icon.search(/^(chrome|moz-extension|resource):/) ? icon :
+        `resource://activity-stream/data/content/assets/glyph-${icon}-16.svg`;
+
+      // Add the main preference for turning on/off a section
+      const sectionVbox = createAppend("vbox", contentsGroup);
+      sectionVbox.setAttribute("data-subcategory", id);
+      const checkbox = createAppend("checkbox", sectionVbox);
+      checkbox.setAttribute("label", formatString(titleString));
+      checkbox.setAttribute("src", iconUrl);
+      linkPref(checkbox, name, "bool");
+
+      // Add more details for the section (e.g., description, more prefs)
+      const detailVbox = createAppend("vbox", sectionVbox);
+      detailVbox.classList.add("indent");
+      detailVbox.classList.add("tip-caption");
+      if (descString) {
+        const label = createAppend("label", detailVbox);
+        label.classList.add("indent");
+        label.textContent = formatString(descString);
+
+        // Add a rows dropdown if we have a pref to control and a maximum
+        if (rowsPref && maxRows) {
+          const detailHbox = createAppend("hbox", detailVbox);
+          detailHbox.setAttribute("align", "center");
+          label.setAttribute("flex", 1);
+          detailHbox.appendChild(label);
+
+          // Add appropriate number of localized entries to the dropdown
+          const menulist = createAppend("menulist", detailHbox);
+          for (let num = 1; num <= maxRows; num++) {
+            const plurals = formatString({id: "prefs_section_rows_option", values: {num}});
+            menulist.appendItem(PluralForm.get(num, plurals), num);
+          }
+          linkPref(menulist, rowsPref, "int");
+        }
+      }
+
+      // Add a checkbox pref for any nested preferences
+      nestedPrefs.forEach(nested => {
+        const subcheck = createAppend("checkbox", detailVbox);
+        subcheck.classList.add("indent");
+        subcheck.setAttribute("label", formatString(nested.titleString));
+        linkPref(subcheck, nested.name, "bool");
+
+        // Specially add a link for sponsored content
+        if (nested.name === "showSponsored") {
+          const sponsoredHbox = createAppend("hbox", detailVbox);
+          sponsoredHbox.setAttribute("align", "center");
+          sponsoredHbox.appendChild(subcheck);
+          subcheck.classList.add("tail-with-learn-more");
+
+          const link = createAppend("label", sponsoredHbox);
+          link.classList.add("learn-sponsored");
+          link.classList.add("text-link");
+          link.setAttribute("href", sectionData.disclaimer.link.href);
+          link.textContent = formatString("prefs_topstories_sponsored_learn_more");
+        }
+      });
+    });
+  }
+};
+
+const EXPORTED_SYMBOLS = ["AboutPreferences"];

--- a/system-addon/lib/AboutPreferences.jsm
+++ b/system-addon/lib/AboutPreferences.jsm
@@ -56,7 +56,7 @@ const CUSTOM_CSS = `
 `;
 
 this.AboutPreferences = class AboutPreferences {
-  constructor() {
+  init() {
     Services.obs.addObserver(this, PREFERENCES_LOADED_EVENT);
   }
 
@@ -66,6 +66,9 @@ this.AboutPreferences = class AboutPreferences {
 
   onAction(action) {
     switch (action.type) {
+      case at.INIT:
+        this.init();
+        break;
       case at.UNINIT:
         this.uninit();
         break;
@@ -109,7 +112,7 @@ this.AboutPreferences = class AboutPreferences {
 
     // Helper to get strings and format with values if necessary
     const formatString = id => {
-      if (typeof id === "string") {
+      if (typeof id !== "object") {
         return strings[id] || id;
       }
       let string = strings[id.id] || JSON.stringify(id);
@@ -231,4 +234,5 @@ this.AboutPreferences = class AboutPreferences {
   }
 };
 
-const EXPORTED_SYMBOLS = ["AboutPreferences"];
+this.PREFERENCES_LOADED_EVENT = PREFERENCES_LOADED_EVENT;
+const EXPORTED_SYMBOLS = ["AboutPreferences", "PREFERENCES_LOADED_EVENT"];

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -11,6 +11,7 @@ ChromeUtils.defineModuleGetter(this, "AppConstants",
 // NB: Eagerly load modules that will be loaded/constructed/initialized in the
 // common case to avoid the overhead of wrapping and detecting lazy loading.
 const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
+const {AboutPreferences} = ChromeUtils.import("resource://activity-stream/lib/AboutPreferences.jsm", {});
 const {DefaultPrefs} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 const {ManualMigration} = ChromeUtils.import("resource://activity-stream/lib/ManualMigration.jsm", {});
 const {NewTabInit} = ChromeUtils.import("resource://activity-stream/lib/NewTabInit.jsm", {});
@@ -157,6 +158,12 @@ const PREFS_CONFIG = new Map([
 
 // Array of each feed's FEEDS_CONFIG factory and values to add to PREFS_CONFIG
 const FEEDS_DATA = [
+  {
+    name: "aboutpreferences",
+    factory: () => new AboutPreferences(),
+    title: "about:preferences rendering",
+    value: true
+  },
   {
     name: "migration",
     factory: () => new ManualMigration(),

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -55,13 +55,11 @@ const PREFS_CONFIG = new Map([
       api_key_pref: "extensions.pocket.oAuthConsumerKey",
       // Use the opposite value as what default value the feed would have used
       hidden: !PREFS_CONFIG.get("feeds.section.topstories").getValue(args),
-      provider_description: "pocket_description",
       provider_icon: "pocket",
       provider_name: "Pocket",
       read_more_endpoint: "https://getpocket.com/explore/trending?src=fx_new_tab",
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=3&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "https://getpocket.com/recommendations",
-      privacy_notice_link: "https://www.mozilla.org/privacy/firefox/#suggest-relevant-content",
       disclaimer_link: "https://getpocket.com/firefox/new_tab_learn_more",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       show_spocs: false,

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -10,6 +10,9 @@ const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://act
 
 ChromeUtils.defineModuleGetter(this, "PlacesUtils", "resource://gre/modules/PlacesUtils.jsm");
 
+// We need to support both content sidebar and about:preferences for experiments
+let ABOUT_PREFERENCES = true;
+
 /*
  * Generators for built in sections, keyed by the pref name for their feed.
  * Built in sections may depend on options stored as serialised JSON in the pref
@@ -20,10 +23,10 @@ const BUILT_IN_SECTIONS = {
     id: "topstories",
     pref: {
       titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
-      descString: {id: options.provider_description || "pocket_description"},
+      descString: {id: ABOUT_PREFERENCES ? "prefs_topstories_description" : options.provider_description || "pocket_description"},
       nestedPrefs: options.show_spocs ? [{
         name: "showSponsored",
-        titleString: {id: "settings_pane_topstories_options_sponsored"},
+        titleString: {id: ABOUT_PREFERENCES ? "prefs_topstories_show_sponsored_label" : "settings_pane_topstories_options_sponsored", values: {provider: options.provider_name}},
         icon: "icon-info"
       }] : []
     },
@@ -54,7 +57,7 @@ const BUILT_IN_SECTIONS = {
     id: "highlights",
     pref: {
       titleString: {id: "settings_pane_highlights_header"},
-      descString: {id: "settings_pane_highlights_body2"}
+      descString: {id: ABOUT_PREFERENCES ? "prefs_highlights_description" : "settings_pane_highlights_body2"}
     },
     shouldHidePref:  false,
     eventSource: "HIGHLIGHTS",
@@ -76,6 +79,7 @@ const SectionsManager = {
   initialized: false,
   sections: new Map(),
   init(prefs = {}) {
+    ABOUT_PREFERENCES = prefs["feeds.aboutpreferences"];
     for (const feedPrefName of Object.keys(BUILT_IN_SECTIONS)) {
       const optionsPrefName = `${feedPrefName}.options`;
       this.addBuiltInSection(feedPrefName, prefs[optionsPrefName]);

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -10,9 +10,6 @@ const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://act
 
 ChromeUtils.defineModuleGetter(this, "PlacesUtils", "resource://gre/modules/PlacesUtils.jsm");
 
-// We need to support both content sidebar and about:preferences for experiments
-let ABOUT_PREFERENCES = true;
-
 /*
  * Generators for built in sections, keyed by the pref name for their feed.
  * Built in sections may depend on options stored as serialised JSON in the pref
@@ -23,10 +20,10 @@ const BUILT_IN_SECTIONS = {
     id: "topstories",
     pref: {
       titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
-      descString: {id: ABOUT_PREFERENCES ? "prefs_topstories_description" : options.provider_description || "pocket_description"},
+      descString: {id: options.provider_description || "prefs_topstories_description"},
       nestedPrefs: options.show_spocs ? [{
         name: "showSponsored",
-        titleString: {id: ABOUT_PREFERENCES ? "prefs_topstories_show_sponsored_label" : "settings_pane_topstories_options_sponsored", values: {provider: options.provider_name}},
+        titleString: {id: "prefs_topstories_show_sponsored_label", values: {provider: options.provider_name}},
         icon: "icon-info"
       }] : []
     },
@@ -57,7 +54,7 @@ const BUILT_IN_SECTIONS = {
     id: "highlights",
     pref: {
       titleString: {id: "settings_pane_highlights_header"},
-      descString: {id: ABOUT_PREFERENCES ? "prefs_highlights_description" : "settings_pane_highlights_body2"}
+      descString: {id: "prefs_highlights_description"}
     },
     shouldHidePref:  false,
     eventSource: "HIGHLIGHTS",
@@ -79,7 +76,6 @@ const SectionsManager = {
   initialized: false,
   sections: new Map(),
   init(prefs = {}) {
-    ABOUT_PREFERENCES = prefs["feeds.aboutpreferences"];
     for (const feedPrefName of Object.keys(BUILT_IN_SECTIONS)) {
       const optionsPrefName = `${feedPrefName}.options`;
       this.addBuiltInSection(feedPrefName, prefs[optionsPrefName]);

--- a/system-addon/test/unit/lib/AboutPreferences.test.js
+++ b/system-addon/test/unit/lib/AboutPreferences.test.js
@@ -1,0 +1,258 @@
+/* global Services */
+import {AboutPreferences, PREFERENCES_LOADED_EVENT} from "lib/AboutPreferences.jsm";
+import {actionTypes as at} from "common/Actions.jsm";
+import {GlobalOverrider} from "test/unit/utils";
+
+describe("AboutPreferences Feed", () => {
+  let globals;
+  let sandbox;
+  let Sections;
+  let instance;
+
+  beforeEach(() => {
+    globals = new GlobalOverrider();
+    sandbox = globals.sandbox;
+    Sections = [];
+    instance = new AboutPreferences();
+    instance.store = {getState: () => ({Sections})};
+  });
+  afterEach(() => {
+    globals.restore();
+  });
+
+  describe("#onAction", () => {
+    it("should call .init() on an INIT action", () => {
+      const stub = sandbox.stub(instance, "init");
+
+      instance.onAction({type: at.INIT});
+
+      assert.calledOnce(stub);
+    });
+    it("should call .uninit() on an UNINIT action", () => {
+      const stub = sandbox.stub(instance, "uninit");
+
+      instance.onAction({type: at.UNINIT});
+
+      assert.calledOnce(stub);
+    });
+  });
+  describe("#observe", () => {
+    it("should watch for about:preferences loading", () => {
+      sandbox.stub(Services.obs, "addObserver");
+
+      instance.init();
+
+      assert.calledOnce(Services.obs.addObserver);
+      assert.calledWith(Services.obs.addObserver, instance, PREFERENCES_LOADED_EVENT);
+    });
+    it("should stop watching on uninit", () => {
+      sandbox.stub(Services.obs, "removeObserver");
+
+      instance.uninit();
+
+      assert.calledOnce(Services.obs.removeObserver);
+      assert.calledWith(Services.obs.removeObserver, instance, PREFERENCES_LOADED_EVENT);
+    });
+    it("should try to render on event", async () => {
+      const stub = sandbox.stub(instance, "renderPreferences");
+      instance._strings = {};
+      Sections.push({});
+
+      await instance.observe(window, PREFERENCES_LOADED_EVENT);
+
+      assert.calledOnce(stub);
+      assert.equal(stub.firstCall.args[0], window);
+      assert.deepEqual(stub.firstCall.args[1], instance._strings);
+      assert.include(stub.firstCall.args[2], Sections[0]);
+    });
+  });
+  describe("#strings", () => {
+    let activityStreamLocale;
+    let fetchStub;
+    let fetchText;
+    beforeEach(() => {
+      global.Cc["@mozilla.org/browser/aboutnewtab-service;1"] = {
+        getService() {
+          return {activityStreamLocale};
+        }
+      };
+      fetchStub = sandbox.stub().resolves({text: () => Promise.resolve(fetchText)});
+      globals.set("fetch", fetchStub);
+    });
+    it("should use existing strings if they exist", async () => {
+      instance._strings = {};
+
+      const strings = await instance.strings;
+
+      assert.equal(strings, instance._strings);
+    });
+    it("should report failure if missing", async () => {
+      sandbox.stub(Cu, "reportError");
+
+      const strings = await instance.strings;
+
+      assert.calledOnce(Cu.reportError);
+      assert.deepEqual(strings, {});
+    });
+    it("should fetch with the appropriate locale", async () => {
+      activityStreamLocale = "en-TEST";
+
+      await instance.strings;
+
+      assert.calledOnce(fetchStub);
+      assert.include(fetchStub.firstCall.args[0], activityStreamLocale);
+    });
+    it("should extract strings from js text", async () => {
+      const testStrings = {hello: "world"};
+      fetchText = `var strings = ${JSON.stringify(testStrings)};`;
+
+      const strings = await instance.strings;
+
+      assert.deepEqual(strings, testStrings);
+    });
+  });
+  describe("#renderPreferences", () => {
+    let node;
+    let strings;
+    let prefStructure;
+    let Preferences;
+    const testRender = () => instance.renderPreferences({
+      document: {
+        createElementNS: sandbox.stub().returns(node),
+        createProcessingInstruction: sandbox.stub(),
+        getElementById: sandbox.stub().returns(node),
+        insertBefore: sandbox.stub().returnsArg(0)
+      },
+      Preferences
+    }, strings, prefStructure);
+    beforeEach(() => {
+      node = {
+        appendChild: sandbox.stub().returnsArg(0),
+        appendItem: sandbox.stub(),
+        classList: {add: sandbox.stub()},
+        cloneNode: sandbox.stub().returnsThis(),
+        insertAdjacentElement: sandbox.stub().returnsArg(1),
+        setAttribute: sandbox.stub()
+      };
+      strings = {};
+      prefStructure = [];
+      Preferences = {
+        add: sandbox.stub(),
+        get: sandbox.stub().returns({})
+      };
+    });
+    describe("#formatString", () => {
+      it("should fall back to string id if missing", () => {
+        testRender();
+
+        assert.equal(node.textContent, "prefs_home_description");
+      });
+      it("should use provided plain string", () => {
+        strings = {prefs_home_description: "hello"};
+
+        testRender();
+
+        assert.equal(node.textContent, "hello");
+      });
+      it("should fall back to string object if missing", () => {
+        const titleString = {id: "foo"};
+        prefStructure = [{pref: {titleString}}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "label", JSON.stringify(titleString));
+      });
+      it("should use provided string object id", () => {
+        strings = {foo: "bar"};
+        prefStructure = [{pref: {titleString: {id: "foo"}}}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "label", "bar");
+      });
+      it("should use values in string object", () => {
+        strings = {foo: "l{n}{n}t"};
+        prefStructure = [{pref: {titleString: {id: "foo", values: {n: 3}}}}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "label", "l33t");
+      });
+    });
+    describe("#linkPref", () => {
+      it("should add a pref to the global", () => {
+        prefStructure = [{}];
+
+        testRender();
+
+        assert.calledOnce(Preferences.add);
+      });
+      it("should skip adding if not shown", () => {
+        prefStructure = [{shouldHidePref: true}];
+
+        testRender();
+
+        assert.notCalled(Preferences.add);
+      });
+    });
+    describe("pref icon", () => {
+      it("should default to webextension icon", () => {
+        prefStructure = [{}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "src", "resource://activity-stream/data/content/assets/glyph-webextension-16.svg");
+      });
+      it("should use desired glyph icon", () => {
+        prefStructure = [{icon: "highlights"}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "src", "resource://activity-stream/data/content/assets/glyph-highlights-16.svg");
+      });
+      it("should use specified chrome icon", () => {
+        const icon = "chrome://the/icon.svg";
+        prefStructure = [{icon}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "src", icon);
+      });
+    });
+    describe("description line", () => {
+      it("should render a description", () => {
+        const descString = "the_desc";
+        prefStructure = [{pref: {descString}}];
+
+        testRender();
+
+        assert.equal(node.textContent, descString);
+      });
+      it("should render rows dropdown with appropriate number", () => {
+        prefStructure = [{rowsPref: "row_pref", maxRows: 3, pref: {descString: "foo"}}];
+
+        testRender();
+
+        assert.calledThrice(node.appendItem);
+      });
+    });
+    describe("nested prefs", () => {
+      it("should render a nested pref", () => {
+        const titleString = "im_nested";
+        prefStructure = [{pref: {nestedPrefs: [{titleString}]}}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "label", titleString);
+      });
+      it("should add a link for sponsored", () => {
+        const href = "https://disclaimer/";
+        prefStructure = [{disclaimer: {link: {href}}, pref: {nestedPrefs: [{name: "showSponsored"}]}}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "href", href);
+      });
+    });
+  });
+});

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -13,6 +13,7 @@ describe("ActivityStream", () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     ({ActivityStream, PREFS_CONFIG} = injector({
+      "lib/AboutPreferences.jsm": {AboutPreferences: Fake},
       "lib/ManualMigration.jsm": {ManualMigration: Fake},
       "lib/NewTabInit.jsm": {NewTabInit: Fake},
       "lib/PlacesFeed.jsm": {PlacesFeed: Fake},
@@ -132,6 +133,10 @@ describe("ActivityStream", () => {
         }
       }
       assert.isAbove(feedCount, 0);
+    });
+    it("should create a AboutPreferences feed", () => {
+      const feed = as.feeds.get("feeds.aboutpreferences")();
+      assert.instanceOf(feed, Fake);
     });
     it("should create a ManualMigration feed", () => {
       const feed = as.feeds.get("feeds.migration")();

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -50,6 +50,7 @@ overrider.set({
   fetch() {},
   // eslint-disable-next-line object-shorthand
   Image: function() {}, // NB: This is a function/constructor
+  PluralForm: {get() {}},
   Preferences: FakePrefs,
   Services: {
     locale: {


### PR DESCRIPTION
r?@k88hudson Added a new feed (only so it can access `Sections` state -- originally I had it as part of `PrefsFeed`, but turns out `Preferences` https://searchfox.org/mozilla-central/source/toolkit/content/preferencesBindings.js manages all the updating just fine.)

There is an unused string ` +prefs_restore_defaults_button=Restore Defaults ` which would be needed for bug 1434751. Pretty sure there aren't others to add to activity stream, although there are others that would be needed as part of mozilla-central: https://docs.google.com/document/d/1uI7xtTuI9pw9rbOzN7q1kjUeIOEH3wfJtFr-4-degzQ

Design: https://mozilla.invisionapp.com/share/EGFI16P8Y36#/screens

Screenshot (with testing a locked search pref):
![screen shot 2018-03-01 at 2 59 23 pm](https://user-images.githubusercontent.com/438537/36879336-12e36c8c-1d78-11e8-8faf-d1921e747210.png)

There are no tests for the new jsm right now, but I'll try adding some to at least make sure it handles actions/events. But for testing the details of what gets rendered, that could get tricky and content-src's coverage is different, so not sure if we should treat it differently from other jsms.