### PR TITLE
 Fix Bug 1443243 - Preloaded tab is sending impression ping after section was disabled

### DIFF
--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -49,7 +49,7 @@ export class Section extends React.PureComponent {
         props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
       }
 
-      // When the page becoems visible, send the impression stats ping if the section isn't collapsed.
+      // When the page becomes visible, send the impression stats ping if the section isn't collapsed.
       this._onVisibilityChange = () => {
         if (props.document.visibilityState === VISIBLE) {
           const {id, Prefs} = this.props;
@@ -90,6 +90,12 @@ export class Section extends React.PureComponent {
       )
     ) {
       this.sendImpressionStatsOrAddListener();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this._onVisibilityChange) {
+      this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
     }
   }
 

--- a/system-addon/test/unit/content-src/components/Sections.test.jsx
+++ b/system-addon/test/unit/content-src/components/Sections.test.jsx
@@ -241,6 +241,23 @@ describe("<Section>", () => {
       // Did we remove the event listener?
       assert.calledWith(props.document.removeEventListener, "visibilitychange", listener);
     });
+    it("should remove visibility change listener when section is removed", () => {
+      const props = {
+        dispatch: sinon.spy(),
+        document: {
+          visibilityState: "hidden",
+          addEventListener: sinon.spy(),
+          removeEventListener: sinon.spy()
+        }
+      };
+
+      const section = renderSection(props);
+      assert.calledWith(props.document.addEventListener, "visibilitychange");
+      const [, listener] = props.document.addEventListener.firstCall.args;
+
+      section.unmount();
+      assert.calledWith(props.document.removeEventListener, "visibilitychange", listener);
+    });
     it("should send an impression if props are updated and props.rows are different", () => {
       const props = {dispatch: sinon.spy()};
       wrapper = renderSection(props);


### PR DESCRIPTION
Fixed this by removing the visibility change listener when the section is removed. A new one will be attached anyway when a section is (re-)created. The listener was firing for sections that no longer exist.