### PR TITLE
Fix Bug 1441278 - Missing line numbers in failing unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "husky": "0.14.3",
     "istanbul-instrumenter-loader": "0.2.0",
     "joi-browser": "13.0.1",
-    "karma": "2.0.0",
+    "karma": "1.7.1",
     "karma-chai": "0.1.0",
     "karma-coverage": "1.1.1",
     "karma-firefox-launcher": "1.1.0",


### PR DESCRIPTION
WFM now

>  @webpack:///system-addon/test/unit/content-src/components/PreferencesPane.test.jsx:101:4 <- system-addon/test/unit/unit-entry.js:89146:5