### PR TITLE
Fix Bug 1442992 - Remove second argument from Cu.reportError call

### DIFF
--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -116,7 +116,7 @@ const SectionsManager = {
       options = JSON.parse(optionsPrefValue);
     } catch (e) {
       options = {};
-      Cu.reportError("Problem parsing options pref", e);
+      Cu.reportError(`Problem parsing options pref for ${feedPrefName}`);
     }
     const section = BUILT_IN_SECTIONS[feedPrefName](options);
     section.pref.feed = feedPrefName;


### PR DESCRIPTION
Relevant context https://bugzilla.mozilla.org/show_bug.cgi?id=1442992#c10