### PR TITLE
(nobug): Add strings for New Windows and Tabs section of prefs

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -115,6 +115,19 @@ time_label_day={number}d
 # in English, while "Home" should be localized matching the about:preferences
 # sidebar mozilla-central string for the panel that has preferences related to
 # what is shown for the homepage, new windows, and new tabs.
+prefs_new_windows_tabs_header=New Windows and Tabs
+prefs_new_windows_description=Choose what you see when you open your homepage, new windows, and new tabs.
+
+prefs_homepage_choice_label=Homepage and new windows:
+prefs_newtab_choice_label=New tabs:
+prefs_homepage_newtab_choice_1_firefox_home=Firefox Home
+prefs_homepage_newtab_choice_2_custom=Custom URL(s)
+prefs_homepage_newtab_choice_3_blank=Blank Page
+
+prefs_homepage_custom_url_placeholder=Paste a URL
+prefs_homepage_custom_url_current_pages_button=Use Current Pages
+prefs_homepage_custom_url_use_bookmark_button=Use Bookmark
+
 prefs_home_header=Firefox Home Content
 prefs_home_description=Choose what content you want on your Firefox Home screen.
 prefs_restore_defaults_button=Restore Defaults
@@ -155,6 +168,14 @@ settings_pane_snippets_header=Snippets
 settings_pane_snippets_body=Read short and sweet updates from Mozilla about Firefox, internet culture, and the occasional random meme.
 settings_pane_done_button=Done
 settings_pane_topstories_options_sponsored=Show Sponsored Stories
+
+# LOCALIZATION NOTE(extension_notice_*): These are shown in the new Home section in about:preferences for configuring
+# the page shown on about:home and about:newtab. Each notice has a "Manage Extensions" button next to it that links to about:addons
+extension_notice_new_windows_home=An extension is controlling the page you see on new windows and home.
+extension_notice_new_tabs=An extension is controlling the page you see on new tabs.
+extension_notice_new_windows_tabs_home=An extension is controlling the page you see on new tabs, new windows, and home.
+extension_notice_multiple=There are extensions controlling the pages you see on new windows, new tabs, and home.
+extension_notice_manage_extensions_button=Manage Extensions
 
 # LOCALIZATION NOTE (edit_topsites_*): This is shown in the Edit Top Sites modal
 # dialog.


### PR DESCRIPTION
These are additional strings for the New Windows and Tabs section of the new about:preferences section. Designs are here: https://mozilla.invisionapp.com/share/65FPNL9RH4V#/screens/280785532

@flodolo UX has decided these are necessary in order to land the other sections of  about:preferences, however due to the fact we don't have much time left in 60 to implement it there's a good chance we will push landing the feature to 61. In your opinion would it be OK to export these now or is it better to wait?