### PR TITLE
Fix Bug 1443908 - position: fixed; for Add Top Site modal

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -273,11 +273,25 @@ $half-base-gutter: $base-gutter / 2;
 
 .edit-topsites-wrapper {
   .modal {
-    offset-inline-start: -31px;
-    position: absolute;
-    top: -29px;
-    width: calc(100% + 62px);
     box-shadow: $shadow-secondary;
+    left: 0;
+    margin: 0 auto;
+    position: fixed;
+    right: 0;
+    top: 40px;
+    width: $wrapper-default-width;
+
+    @media (min-width: $break-point-small) {
+      width: $wrapper-max-width-small;
+    }
+
+    @media (min-width: $break-point-medium) {
+      width: $wrapper-max-width-medium;
+    }
+
+    @media (min-width: $break-point-large) {
+      width: $wrapper-max-width-large;
+    }
   }
 }
 


### PR DESCRIPTION
r? @piatra 

Note that it now stays at the "standard width" even on the wider layout. This change was nodded by @aaronrbenson on slack.

<img width="1068" alt="screen shot 2018-03-08 at 3 34 17 pm" src="https://user-images.githubusercontent.com/36629/37175433-8b5a88a2-22e7-11e8-946e-52f656f81e9c.png">
