### PR TITLE
Fix Bug 1442383 - Activity stream spends a lot time fetching highlights after bookmark sync

### DIFF
--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -114,6 +114,7 @@ class BookmarksObserver extends Observer {
     // default bookmarks, added when the profile is created.
     if (type !== PlacesUtils.bookmarks.TYPE_BOOKMARK ||
         source === PlacesUtils.bookmarks.SOURCES.IMPORT_REPLACE ||
+        source === PlacesUtils.bookmarks.SOURCES.SYNC ||
         (uri.scheme !== "http" && uri.scheme !== "https")) {
       return;
     }
@@ -139,8 +140,9 @@ class BookmarksObserver extends Observer {
    * @param  {str} uri
    * @param  {str} guid      The unique id of the bookmark
    */
-  onItemRemoved(id, folderId, index, type, uri, guid) {
-    if (type === PlacesUtils.bookmarks.TYPE_BOOKMARK) {
+  onItemRemoved(id, folderId, index, type, uri, guid, parentGuid, source) { // eslint-disable-line max-params
+    if (type === PlacesUtils.bookmarks.TYPE_BOOKMARK &&
+        source !== PlacesUtils.bookmarks.SOURCES.SYNC) {
       this.dispatch({
         type: at.PLACES_BOOKMARK_REMOVED,
         data: {url: uri.spec, bookmarkGuid: guid}

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -7,7 +7,8 @@ const FAKE_BOOKMARK = {bookmarkGuid: "xi31", bookmarkTitle: "Foo", dateAdded: 12
 const TYPE_BOOKMARK = 0; // This is fake, for testing
 const SOURCES = {
   DEFAULT: 0,
-  IMPORT_REPLACE: 3
+  IMPORT_REPLACE: 3,
+  SYNC: 6
 };
 
 const BLOCKED_EVENT = "newtab-linkBlocked"; // The event dispatched in NewTabUtils when a link is blocked;
@@ -363,6 +364,15 @@ describe("PlacesFeed", () => {
 
         assert.notCalled(dispatch);
       });
+      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has SYNC source", async () => {
+        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
+        const args = [null, null, null, TYPE_BOOKMARK,
+          {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
+          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.SYNC];
+        await observer.onItemAdded(...args);
+
+        assert.notCalled(dispatch);
+      });
       it("should ignore events that are not of TYPE_BOOKMARK", async () => {
         const args = [null, null, null, "nottypebookmark"];
         await observer.onItemAdded(...args);
@@ -371,47 +381,18 @@ describe("PlacesFeed", () => {
     });
     describe("#onItemRemoved", () => {
       it("should ignore events that are not of TYPE_BOOKMARK", async () => {
-        await observer.onItemRemoved(null, null, null, "nottypebookmark", null, "123foo");
+        await observer.onItemRemoved(null, null, null, "nottypebookmark", null, "123foo", "", SOURCES.DEFAULT);
+        assert.notCalled(dispatch);
+      });
+      it("should not dispatch a PLACES_BOOKMARK_REMOVED action - has SYNC source", async () => {
+        const args = [null, null, null, TYPE_BOOKMARK, {spec: "foo.com"}, "123foo", "", SOURCES.SYNC];
+        await observer.onItemRemoved(...args);
+
         assert.notCalled(dispatch);
       });
       it("should dispatch a PLACES_BOOKMARK_REMOVED action with the right URL and bookmarkGuid", () => {
-        observer.onItemRemoved(null, null, null, TYPE_BOOKMARK, {spec: "foo.com"}, "123foo");
+        observer.onItemRemoved(null, null, null, TYPE_BOOKMARK, {spec: "foo.com"}, "123foo", "", SOURCES.DEFAULT);
         assert.calledWith(dispatch, {type: at.PLACES_BOOKMARK_REMOVED, data: {bookmarkGuid: "123foo", url: "foo.com"}});
-      });
-    });
-    describe("#onItemChanged", () => {
-      beforeEach(() => {
-        sandbox.stub(global.NewTabUtils.activityStreamProvider, "getBookmark")
-          .withArgs(FAKE_BOOKMARK.guid).returns(Promise.resolve(FAKE_BOOKMARK));
-      });
-      it("has an empty function to keep xpconnect happy", async () => {
-        await observer.onItemChanged();
-      });
-      // Disabled in Issue 3203, see observer.onItemChanged for more information.
-      it.skip("should dispatch a PLACES_BOOKMARK_CHANGED action with the bookmark data", async () => {
-        const args = [null, "title", null, null, null, TYPE_BOOKMARK, null, FAKE_BOOKMARK.guid];
-        await observer.onItemChanged(...args);
-
-        assert.calledWith(dispatch, {type: at.PLACES_BOOKMARK_CHANGED, data: FAKE_BOOKMARK});
-      });
-      it.skip("should catch errors gracefully", async () => {
-        const e = new Error("test error");
-        global.NewTabUtils.activityStreamProvider.getBookmark.restore();
-        sandbox.stub(global.NewTabUtils.activityStreamProvider, "getBookmark")
-          .returns(Promise.reject(e));
-
-        const args = [null, "title", null, null, null, TYPE_BOOKMARK, null, FAKE_BOOKMARK.guid];
-        await observer.onItemChanged(...args);
-
-        assert.calledWith(global.Cu.reportError, e);
-      });
-      it.skip("should ignore events that are not of TYPE_BOOKMARK", async () => {
-        await observer.onItemChanged(null, "title", null, null, null, "nottypebookmark");
-        assert.notCalled(dispatch);
-      });
-      it.skip("should ignore events that are not changes to uri/title", async () => {
-        await observer.onItemChanged(null, "tags", null, null, null, TYPE_BOOKMARK);
-        assert.notCalled(dispatch);
       });
     });
     describe("Other empty methods (to keep code coverage happy)", () => {
@@ -420,6 +401,7 @@ describe("PlacesFeed", () => {
         observer.onEndUpdateBatch();
         observer.onItemVisited();
         observer.onItemMoved();
+        observer.onItemChanged();
       });
     });
   });


### PR DESCRIPTION
This patch does 2 things as per the conversation in [bug 1442383](https://bugzilla.mozilla.org/show_bug.cgi?id=1442383):
1. it ignores all bookmark added/removed notifications that came from sync by checking `SOURCES.SYNC`
2. when sync is finished and we receive the notification `weave:engine:sync:applied`, it refreshes highlights to check if there were some important bookmarks either added or removed that should show up in activity stream

In addition, there were some tests for `onItemChanged` that were being skipped that are now removed as per [this comment from bug 1440276](https://github.com/mozilla/activity-stream/pull/4005#pullrequestreview-100580633) 