### PR TITLE
fix(nobug): Use regular size pocket icon

### DIFF
--- a/system-addon/content-src/components/Card/types.js
+++ b/system-addon/content-src/components/Card/types.js
@@ -17,6 +17,6 @@ export const cardContextTypes = {
   },
   pocket: {
     intlID: "type_label_pocket",
-    icon: "pocket-small"
+    icon: "pocket"
   }
 };

--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -84,11 +84,6 @@
     background-image: url('#{$image-path}glyph-pocket-16.svg');
   }
 
-  &.icon-pocket-small {
-    background-image: url('#{$image-path}glyph-pocket-16.svg');
-    background-size: $smaller-icon-size;
-  }
-
   &.icon-historyItem { // sass-lint:disable-line class-name-format
     background-image: url('#{$image-path}glyph-historyItem-16.svg');
   }


### PR DESCRIPTION
Before:
<img width="209" alt="screen shot 2018-03-13 at 8 03 24 am" src="https://user-images.githubusercontent.com/7219526/37351322-31df2206-26b1-11e8-8549-ed9c0263955c.png">
After:
<img width="328" alt="screen shot 2018-03-13 at 11 19 13 am" src="https://user-images.githubusercontent.com/7219526/37351340-38b9ab6e-26b1-11e8-9567-0b3176675dcc.png">
