### PR TITLE
fix(preferences): Use plain DOM instead of XBL appendItem

### DIFF
--- a/system-addon/lib/AboutPreferences.jsm
+++ b/system-addon/lib/AboutPreferences.jsm
@@ -204,9 +204,12 @@ this.AboutPreferences = class AboutPreferences {
 
           // Add appropriate number of localized entries to the dropdown
           const menulist = createAppend("menulist", detailHbox);
+          const menupopup = createAppend("menupopup", menulist);
           for (let num = 1; num <= maxRows; num++) {
             const plurals = formatString({id: "prefs_section_rows_option", values: {num}});
-            menulist.appendItem(PluralForm.get(num, plurals), num);
+            const item = createAppend("menuitem", menupopup);
+            item.setAttribute("label", PluralForm.get(num, plurals));
+            item.setAttribute("value", num);
           }
           linkPref(menulist, rowsPref, "int");
         }

--- a/system-addon/test/unit/lib/AboutPreferences.test.js
+++ b/system-addon/test/unit/lib/AboutPreferences.test.js
@@ -133,7 +133,6 @@ describe("AboutPreferences Feed", () => {
     beforeEach(() => {
       node = {
         appendChild: sandbox.stub().returnsArg(0),
-        appendItem: sandbox.stub(),
         classList: {add: sandbox.stub()},
         cloneNode: sandbox.stub().returnsThis(),
         insertAdjacentElement: sandbox.stub().returnsArg(1),
@@ -238,7 +237,9 @@ describe("AboutPreferences Feed", () => {
 
         testRender();
 
-        assert.calledThrice(node.appendItem);
+        assert.calledWith(node.setAttribute, "value", 1);
+        assert.calledWith(node.setAttribute, "value", 2);
+        assert.calledWith(node.setAttribute, "value", 3);
       });
     });
     describe("nested prefs", () => {


### PR DESCRIPTION
r? @sarracini. Followup to #4015 for various failures everywhere. Basically inlines `appendItem` from https://searchfox.org/mozilla-central/rev/8976abf9cab8eb4661665cc86bd355cd08238011/toolkit/content/widgets/menulist.xml#322-341

TEST-UNEXPECTED-FAIL | browser/extensions/formautofill/test/browser/browser_privacyPreferences.js | A promise chain failed to handle a rejection: menulist.appendItem is not a function - stack: renderPreferences/<@resource://activity-stream/lib/AboutPreferences.jsm:206:13