### PR TITLE
Fix Bug 1446395 - Assign context menus in Highlights on a per card type basis

### DIFF
--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -153,6 +153,5 @@ export const LinkMenuOptions = {
   CheckPinTopSite: (site, index) => (site.isPinned ? LinkMenuOptions.UnpinTopSite(site) : LinkMenuOptions.PinTopSite(site, index)),
   CheckSavedToPocket: (site, index) => (site.pocket_id ? LinkMenuOptions.DeleteFromPocket(site) : LinkMenuOptions.SaveToPocket(site, index)),
   CheckBookmarkOrArchive: site => (site.pocket_id ? LinkMenuOptions.ArchiveFromPocket(site) : LinkMenuOptions.CheckBookmark(site)),
-  CheckDeleteHistoryOrEmpty: (site, index, eventSource, isEnabled, siteInfo) => (site.pocket_id ? LinkMenuOptions.EmptyItem() : LinkMenuOptions.DeleteUrl(site, index, eventSource, isEnabled, siteInfo)),
   OpenInPrivateWindow: (site, index, eventSource, isEnabled) => (isEnabled ? _OpenInPrivateWindow(site) : LinkMenuOptions.EmptyItem())
 };

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -100,16 +100,6 @@ describe("<LinkMenu>", () => {
     const {options} = wrapper.find(ContextMenu).props();
     assert.isDefined(options.find(o => (o.id && o.id === "menu_action_remove_bookmark")));
   });
-  it("should show Delete from History option for a site that is visited but not from Pocket if CheckDeleteHistoryOrEmpty", () => {
-    wrapper = shallowWithIntl(<LinkMenu site={{url: "", type: history}} source={"HIGHLIGHTS"} options={["CheckDeleteHistoryOrEmpty"]} dispatch={() => {}} />);
-    const {options} = wrapper.find(ContextMenu).props();
-    assert.isDefined(options.find(o => (o.id && o.id === "menu_action_delete")));
-  });
-  it("should not show a Delete from History option for a site that is Pocket'ed if CheckDeleteHistoryOrEmpty", () => {
-    wrapper = shallowWithIntl(<LinkMenu site={{url: "", pocket_id: 1234}} source={"HIGHLIGHTS"} options={["CheckDeleteHistoryOrEmpty"]} dispatch={() => {}} />);
-    const {options} = wrapper.find(ContextMenu).props();
-    assert.isUndefined(options.find(o => (o.id && o.id === "menu_action_delete")));
-  });
   it("should show Edit option", () => {
     const props = {url: "foo", label: "label"};
     const index = 5;

--- a/system-addon/test/unit/lib/SectionsManager.test.js
+++ b/system-addon/test/unit/lib/SectionsManager.test.js
@@ -5,7 +5,8 @@ import {SectionsFeed, SectionsManager} from "lib/SectionsManager.jsm";
 
 const FAKE_ID = "FAKE_ID";
 const FAKE_OPTIONS = {icon: "FAKE_ICON", title: "FAKE_TITLE"};
-const FAKE_ROWS = [{url: "1.example.com"}, {url: "2.example.com"}, {"url": "3.example.com"}];
+const FAKE_ROWS = [{url: "1.example.com", type: "bookmark"}, {url: "2.example.com", type: "pocket"}, {url: "3.example.com", type: "history"}];
+const FAKE_TRENDING_ROWS =  [{url: "bar", type: "trending"}];
 const FAKE_URL = "2.example.com";
 const FAKE_CARD_OPTIONS = {title: "Some fake title"};
 
@@ -175,6 +176,65 @@ describe("SectionsManager", () => {
       assert.calledOnce(SectionsManager.updateSections);
     });
   });
+  describe("#_addCardTypeLinkMenuOptions", () => {
+    const addCardTypeLinkMenuOptionsOrig = SectionsManager._addCardTypeLinkMenuOptions;
+    const contextMenuOptionsOrig = SectionsManager.CONTEXT_MENU_OPTIONS_FOR_HIGHLIGHT_TYPES;
+    beforeEach(() => {
+      // Add a topstories section and a highlights section, with types for each card
+      SectionsManager.addSection("topstories", {FAKE_TRENDING_ROWS});
+      SectionsManager.addSection("highlights", {FAKE_ROWS});
+    });
+    it("should only call _addCardTypeLinkMenuOptions if the section update is for highlights", () => {
+      SectionsManager._addCardTypeLinkMenuOptions = sinon.spy();
+      SectionsManager.updateSection("topstories", {rows: FAKE_ROWS}, false);
+      assert.notCalled(SectionsManager._addCardTypeLinkMenuOptions);
+
+      SectionsManager.updateSection("highlights", {rows: FAKE_ROWS}, false);
+      assert.calledWith(SectionsManager._addCardTypeLinkMenuOptions, FAKE_ROWS);
+    });
+    it("should only call _addCardTypeLinkMenuOptions if the section update has rows", () => {
+      SectionsManager._addCardTypeLinkMenuOptions = sinon.spy();
+      SectionsManager.updateSection("highlights", {}, false);
+      assert.notCalled(SectionsManager._addCardTypeLinkMenuOptions);
+    });
+    it("should assign the correct context menu options based on the type of highlight", () => {
+      SectionsManager._addCardTypeLinkMenuOptions = addCardTypeLinkMenuOptionsOrig;
+
+      SectionsManager.updateSection("highlights", {rows: FAKE_ROWS}, false);
+      const highlights = SectionsManager.sections.get("highlights").FAKE_ROWS;
+
+      // FAKE_ROWS was added in the following order: bookmark, pocket, history
+      assert.deepEqual(highlights[0].contextMenuOptions, SectionsManager.CONTEXT_MENU_OPTIONS_FOR_HIGHLIGHT_TYPES.bookmark);
+      assert.deepEqual(highlights[1].contextMenuOptions, SectionsManager.CONTEXT_MENU_OPTIONS_FOR_HIGHLIGHT_TYPES.pocket);
+      assert.deepEqual(highlights[2].contextMenuOptions, SectionsManager.CONTEXT_MENU_OPTIONS_FOR_HIGHLIGHT_TYPES.history);
+    });
+    it("should throw an error if you are assigning a context menu to a non-existant highlight type", () => {
+      globals.sandbox.spy(global.Cu, "reportError");
+      SectionsManager.updateSection("highlights", {rows: [{url: "foo", type: "badtype"}]}, false);
+      const highlights = SectionsManager.sections.get("highlights").rows;
+      assert.calledOnce(Cu.reportError);
+      assert.equal(highlights[0].contextMenuOptions, undefined);
+    });
+    it("should filter out context menu options that are in CONTEXT_MENU_PREFS", () => {
+      const services = {prefs: {getBoolPref: o => SectionsManager.CONTEXT_MENU_PREFS[o] !== "RemoveMe", addObserver() {}, removeObserver() {}}};
+      globals.set("Services", services);
+      SectionsManager.CONTEXT_MENU_PREFS = {"RemoveMe": "RemoveMe"};
+      SectionsManager.CONTEXT_MENU_OPTIONS_FOR_HIGHLIGHT_TYPES = {
+        "bookmark": ["KeepMe", "RemoveMe"],
+        "pocket": ["KeepMe", "RemoveMe"],
+        "history": ["KeepMe", "RemoveMe"]
+      };
+      SectionsManager.updateSection("highlights", {rows: FAKE_ROWS}, false);
+      const highlights = SectionsManager.sections.get("highlights").FAKE_ROWS;
+
+      // Only keep context menu options that were not supposed to be removed based on CONTEXT_MENU_PREFS
+      assert.deepEqual(highlights[0].contextMenuOptions, ["KeepMe"]);
+      assert.deepEqual(highlights[1].contextMenuOptions, ["KeepMe"]);
+      assert.deepEqual(highlights[2].contextMenuOptions, ["KeepMe"]);
+      SectionsManager.CONTEXT_MENU_OPTIONS_FOR_HIGHLIGHT_TYPES = contextMenuOptionsOrig;
+      globals.restore();
+    });
+  });
   describe("#onceInitialized", () => {
     it("should call the callback immediately if SectionsManager is initialised", () => {
       SectionsManager.initialized = true;
@@ -236,7 +296,8 @@ describe("SectionsManager", () => {
         url: "bar",
         title: "title",
         description: "description",
-        image: "image"
+        image: "image",
+        type: "trending"
       }];
       SectionsManager.addSection("topstories", {rows});
       // Simulate 2 sections.
@@ -244,7 +305,8 @@ describe("SectionsManager", () => {
         url: "foo",
         title: "title",
         description: "description",
-        image: "image"
+        image: "image",
+        type: "bookmark"
       }];
       SectionsManager.addSection("highlights", {rows});
     });


### PR DESCRIPTION
Instead of assigning context menus to each card for an entire section type, this allows you to specify context menu options for each card type *only* for highlights. 
