### PR TITLE
Fix Bug 1408026 - Render layers for the preloaded newtab after hydration

### DIFF
--- a/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamMessageChannel.test.js
@@ -91,13 +91,15 @@ describe("ActivityStreamMessageChannel", () => {
           url: "about:monkeys",
           loaded: false,
           portID: "inited",
-          simulated: true
+          simulated: true,
+          browser: {getAttribute: () => "preloaded"}
         });
         RPmessagePorts.push({
           url: "about:sheep",
           loaded: true,
           portID: "loaded",
-          simulated: true
+          simulated: true,
+          browser: {getAttribute: () => "preloaded"}
         });
 
         mm.simulateMessagesForExistingTabs();
@@ -105,12 +107,17 @@ describe("ActivityStreamMessageChannel", () => {
         assert.calledWith(mm.onActionFromContent.firstCall, {type: at.NEW_TAB_INIT, data: RPmessagePorts[0]});
         assert.calledWith(mm.onActionFromContent.secondCall, {type: at.NEW_TAB_INIT, data: RPmessagePorts[1]});
       });
-      it("should simluate load for loaded ports", () => {
-        RPmessagePorts.push({loaded: true, portID: "foo"});
+      it("should simulate load for loaded ports", () => {
+        RPmessagePorts.push({loaded: true, portID: "foo", browser: {getAttribute: () => "preloaded"}});
 
         mm.simulateMessagesForExistingTabs();
 
         assert.calledWith(mm.onActionFromContent, {type: at.NEW_TAB_LOAD}, "foo");
+      });
+      it("should set renderLayers on preloaded browsers after load", () => {
+        RPmessagePorts.push({loaded: true, portID: "foo", browser: {getAttribute: () => "preloaded"}});
+        mm.simulateMessagesForExistingTabs();
+        assert.equal(RPmessagePorts[0].browser.renderLayers, true);
       });
     });
     describe("#destroyChannel", () => {
@@ -212,7 +219,7 @@ describe("ActivityStreamMessageChannel", () => {
     });
     describe("#onNewTabLoad", () => {
       it("should dispatch a NEW_TAB_LOAD action", () => {
-        const t = {portID: "foo"};
+        const t = {portID: "foo", browser: {getAttribute: () => "preloaded"}};
         sinon.stub(mm, "onActionFromContent");
         mm.onNewTabLoad({target: t});
         assert.calledWith(mm.onActionFromContent, {type: at.NEW_TAB_LOAD}, "foo");


### PR DESCRIPTION
This is still WIP, because I'd like to know if:

1. This is the right place to handle this action, and
2. Whether or not there's a way I can only do this for preloaded tabs

@sarracini, if you have a second, can you help me with those questions?