### PR TITLE
Fix Bug 1431469 - expose previous session end (UNINIT) to snippets

### DIFF
--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -155,7 +155,8 @@ this.SnippetsFeed = class SnippetsFeed {
       defaultBrowser: this.isDefaultBrowser(),
       isDevtoolsUser: this.isDevtoolsUser(),
       addonInfo: await this.getAddonInfo(),
-      blockList: await this._getBlockList() || []
+      blockList: await this._getBlockList() || [],
+      previousSessionEnd: this._previousSessionEnd
     };
     this._dispatchChanges(data);
   }
@@ -169,6 +170,7 @@ this.SnippetsFeed = class SnippetsFeed {
 
   async init() {
     await this._storage.init();
+    this._previousSessionEnd = await this._storage.get("previousSessionEnd");
     await this._refresh();
     Services.prefs.addObserver(ONBOARDING_FINISHED_PREF, this._refresh);
     Services.prefs.addObserver(SNIPPETS_URL_PREF, this._refresh);
@@ -178,6 +180,7 @@ this.SnippetsFeed = class SnippetsFeed {
   }
 
   uninit() {
+    this._storage.set("previousSessionEnd", Date.now());
     Services.prefs.removeObserver(ONBOARDING_FINISHED_PREF, this._refresh);
     Services.prefs.removeObserver(SNIPPETS_URL_PREF, this._refresh);
     Services.prefs.removeObserver(TELEMETRY_PREF, this._refresh);

--- a/system-addon/test/unit/lib/ActivityStreamStorage.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamStorage.test.js
@@ -9,7 +9,7 @@ describe("ActivityStreamStorage", () => {
   let storage;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    indexedDB = {open: sandbox.stub().returns(Promise.resolve())};
+    indexedDB = {open: sandbox.stub().returns(Promise.resolve({}))};
     overrider.set({IndexedDB: indexedDB});
     storage = new ActivityStreamStorage("storage_test");
   });
@@ -18,6 +18,10 @@ describe("ActivityStreamStorage", () => {
   });
   it("should throw an error if you try to use it without init", () => {
     assert.throws(() => storage.db);
+  });
+  it("should not throw an error if you called init", async () => {
+    await storage.init();
+    assert.ok(storage.db);
   });
   it("should revert key value parameters for put", () => {
     const stub = sandbox.stub();


### PR DESCRIPTION
I was wondering if we really need to pass the current session start? Snippets could just use Date.now() and that should be good enough?

r? @k88hudson 
cc: @piatra 