### PR TITLE
Port Bug 1442465 - Part 4.2: Stop unnecessarily awaiting on BrowserTestUtils.removeTab (simple part). r=dao

### DIFF
--- a/system-addon/test/functional/mochitest/browser_as_load_location.js
+++ b/system-addon/test/functional/mochitest/browser_as_load_location.js
@@ -20,7 +20,7 @@ async function checkNewtabLoads(selector, message) {
   ok(found, message);
 
   // avoid leakage
-  await BrowserTestUtils.removeTab(gBrowser.selectedTab);
+  BrowserTestUtils.removeTab(gBrowser.selectedTab);
 }
 
 // Test with activity stream on

--- a/system-addon/test/functional/mochitest/head.js
+++ b/system-addon/test/functional/mochitest/head.js
@@ -154,7 +154,7 @@ function test_newtab(testInfo) { // eslint-disable-line no-unused-vars
     } finally {
       // Clean up for next tests
       await scopedPopPrefs();
-      await BrowserTestUtils.removeTab(tab);
+      BrowserTestUtils.removeTab(tab);
     }
   };
 


### PR DESCRIPTION
r?@sarracini 
https://hg.mozilla.org/mozilla-central/rev/ba58e9052ab9