### PR TITLE
Fix Bug 1384094 - High CPU. network traffic and memory usage when open Newtab page if you have opened / bookmarked a problematic/ huge game page in the past

### DIFF
--- a/system-addon/test/unit/lib/Screenshots.test.js
+++ b/system-addon/test/unit/lib/Screenshots.test.js
@@ -1,6 +1,6 @@
 "use strict";
+import {EMPTY_SCREENSHOT, Screenshots} from "lib/Screenshots.jsm";
 import {GlobalOverrider} from "test/unit/utils";
-import {Screenshots} from "lib/Screenshots.jsm";
 
 const URL = "foo.com";
 const FAKE_THUMBNAIL_PATH = "fake/path/thumb.jpg";
@@ -24,7 +24,10 @@ describe("Screenshots", () => {
       }
     };
     globals.set("BackgroundPageThumbs", {captureIfMissing: sandbox.spy(() => Promise.resolve())});
-    globals.set("PageThumbs", {getThumbnailPath: sandbox.spy(() => Promise.resolve(FAKE_THUMBNAIL_PATH))});
+    globals.set("PageThumbs", {
+      _store: sandbox.stub(),
+      getThumbnailPath: sandbox.spy(() => Promise.resolve(FAKE_THUMBNAIL_PATH))
+    });
     globals.set("PrivateBrowsingUtils", {isWindowPrivate: sandbox.spy(() => false)});
     globals.set("OS", {File: {open: sandbox.spy(() => Promise.resolve({read: () => [], close: () => {}}))}});
     globals.set("FileUtils", {File: sandbox.spy(() => {})});
@@ -56,10 +59,13 @@ describe("Screenshots", () => {
       await Screenshots.getScreenshotForURL(URL);
       assert.calledOnce(global.MIMEService.getTypeFromFile);
     });
-    it("should throw if something goes wrong", async () => {
+    it("should get empty if something goes wrong", async () => {
       globals.set("BackgroundPageThumbs", {captureIfMissing: () => new Error("Cannot capture tumbnail")});
+
       const screenshot = await Screenshots.getScreenshotForURL(URL);
-      assert.equal(screenshot, null);
+
+      assert.calledOnce(global.PageThumbs._store);
+      assert.equal(screenshot, EMPTY_SCREENSHOT);
     });
   });
 


### PR DESCRIPTION
r?@sarracini This somewhat conflicts with #3891 which expects a `null` return value. So depending on which one lands first, there needs to be some fixup. But that's also why I expose `EMPTY_SCREENSHOT`. @piatra 

Tested with dummy pages, e.g., add "localhost", as well as the problematic pages from the bugs: https://bugzilla.mozilla.org/attachment.cgi?id=8889875

Also tested that expiration also doesn't get rid of these empty files if they're a top site.

![screen shot 2018-03-22 at 1 54 55 pm](https://user-images.githubusercontent.com/438537/37797994-add2dcf8-2dd8-11e8-8770-b4da8134d397.png)
