### PR TITLE
Fix Bug 1444616 - fix context menu button alignment

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -159,8 +159,8 @@ export class _CollapsibleSection extends React.PureComponent {
           <h3 className="section-title">
             <span className="click-target" onClick={this.onHeaderClick}>
               {this.renderIcon()}
-              {title}
-            {isCollapsible && <span className={`collapsible-arrow icon ${collapsed ? "icon-arrowhead-forward-small" : "icon-arrowhead-down-small"}`} />}
+              {getFormattedMessage(title)}
+              {isCollapsible && <span className={`collapsible-arrow icon ${collapsed ? "icon-arrowhead-forward-small" : "icon-arrowhead-down-small"}`} />}
             </span>
           </h3>
           <div>

--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -27,7 +27,7 @@
       border: 0;
       cursor: pointer;
       fill: $grey-50;
-      height: $context-menu-button-size;
+      height: $section-context-menu-button-height;
       offset-inline-end: 0;
       opacity: 0;
       position: absolute;

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -144,7 +144,7 @@ export class Section extends React.PureComponent {
     // <section> <-- HTML5 element
     return (<ComponentPerfTimer {...this.props}>
       <CollapsibleSection className="section" icon={icon}
-        title={getFormattedMessage(title)}
+        title={title}
         id={id}
         eventSource={eventSource}
         disclaimer={disclaimer}

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -107,7 +107,7 @@ export class _TopSites extends React.PureComponent {
         className="top-sites"
         icon="topsites"
         id="topsites"
-        title={props.intl.formatMessage({id: "header_top_sites"})}
+        title={{id: "header_top_sites"}}
         extraMenuOptions={["AddTopSite"]}
         showPrefName="showTopSites"
         eventSource={TOP_SITES_SOURCE}

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -107,6 +107,7 @@ $context-menu-font-size: 14px;
 $context-menu-border-radius: 5px;
 $context-menu-outer-padding: 5px;
 $context-menu-item-padding: 3px 12px;
+$section-context-menu-button-height: 20px;
 
 $error-fallback-font-size: 12px;
 $error-fallback-line-height: 1.5;


### PR DESCRIPTION
tiny r?

Before:
<img width="1088" alt="screen shot 2018-03-23 at 8 54 40 am" src="https://user-images.githubusercontent.com/36629/37830483-b6b6dc52-2e78-11e8-97fe-d1750569f7c7.png">

After:
<img width="1080" alt="screen shot 2018-03-23 at 8 55 11 am" src="https://user-images.githubusercontent.com/36629/37830493-be3e4794-2e78-11e8-872e-706848622ef0.png">
