### PR TITLE
fix(screenshots): Ignore failures when trying to write empty file

### DIFF
--- a/system-addon/lib/Screenshots.jsm
+++ b/system-addon/lib/Screenshots.jsm
@@ -81,7 +81,11 @@ this.Screenshots = {
     // failure, so do the same thing here. The empty file should not expire with
     // the usual filtering process to avoid repeated background requests, which
     // can cause unwanted high CPU, network and memory usage - Bug 1384094
-    PageThumbs._store(url, url, null, true);
+    try {
+      await PageThumbs._store(url, url, null, true);
+    } catch (err) {
+      // Probably failed to create the empty file, but not much more we can do.
+    }
     return null;
   },
 


### PR DESCRIPTION
r? @sarracini try looks better

before https://treeherder.mozilla.org/#/jobs?repo=try&revision=bb65bbbae92907a67a5210562142f8e15cd67e1f
after https://treeherder.mozilla.org/#/jobs?repo=try&revision=0f2f3337a6a431153107f65d24195c11c17a4889