### PR TITLE
Bug 1432675 - Add Message Center experiment

### DIFF
--- a/system-addon/content-src/components/Base/Base.jsx
+++ b/system-addon/content-src/components/Base/Base.jsx
@@ -4,6 +4,7 @@ import {ConfirmDialog} from "content-src/components/ConfirmDialog/ConfirmDialog"
 import {connect} from "react-redux";
 import {ErrorBoundary} from "content-src/components/ErrorBoundary/ErrorBoundary";
 import {ManualMigration} from "content-src/components/ManualMigration/ManualMigration";
+import {MessageCenterAdmin} from "content-src/components/MessageCenterAdmin/MessageCenterAdmin";
 import {PrerenderData} from "common/PrerenderData.jsm";
 import React from "react";
 import {Search} from "content-src/components/Search/Search";
@@ -57,6 +58,10 @@ export class _Base extends React.PureComponent {
     const {props} = this;
     const {App, locale, strings} = props;
     const {initialized} = App;
+
+    if (props.Prefs.values.messageCenterExperimentEnabled && window.location.hash === "#message-center-admin") {
+      return (<MessageCenterAdmin />);
+    }
 
     if (!props.isPrerendered && !initialized) {
       return null;

--- a/system-addon/content-src/components/MessageCenterAdmin/MessageCenterAdmin.jsx
+++ b/system-addon/content-src/components/MessageCenterAdmin/MessageCenterAdmin.jsx
@@ -1,0 +1,70 @@
+import {MessageCenterUtils} from "../../message-center/message-center-content";
+import React from "react";
+
+export class MessageCenterAdmin extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onMessage = this.onMessage.bind(this);
+    this.state = {};
+  }
+
+  onMessage({data: action}) {
+    if (action.type === "ADMIN_SET_STATE") {
+      this.setState(action.data);
+    }
+  }
+
+  componentWillMount() {
+    MessageCenterUtils.sendMessage({type: "ADMIN_CONNECT_STATE"});
+    MessageCenterUtils.addListener(this.onMessage);
+  }
+
+  componentWillUnmount() {
+    MessageCenterUtils.removeListener(this.onMessage);
+  }
+
+  handleBlock(id) {
+    return () => MessageCenterUtils.blockById(id);
+  }
+
+  handleUnblock(id) {
+    return () => MessageCenterUtils.unblockById(id);
+  }
+
+  renderMessageItem(msg) {
+    const isCurrent = msg.id === this.state.currentId;
+    const isBlocked = this.state.blockList[msg.id];
+
+    let itemClassName = "message-item";
+    if (isCurrent) { itemClassName += " current"; }
+    if (isBlocked) { itemClassName += " blocked"; }
+
+    return (<tr className={itemClassName} key={msg.id}>
+      <td className="message-id"><span>{msg.id}</span></td>
+      <td>
+        <button className={`button ${(isBlocked ? "" : " primary")}`} onClick={isBlocked ? this.handleUnblock(msg.id) : this.handleBlock(msg.id)}>{isBlocked ? "Unblock" : "Block"}</button>
+      </td>
+      <td className="message-summary">
+        <pre>{JSON.stringify(msg, null, 2)}</pre>
+      </td>
+    </tr>);
+  }
+
+  renderMessages() {
+    if (!this.state.messages) {
+      return null;
+    }
+    return (<table><tbody>
+      {this.state.messages.map(msg => this.renderMessageItem(msg))}
+    </tbody></table>);
+  }
+
+  render() {
+    return (<div className="messages-admin">
+      <h1>Messages Admin</h1>
+      <button className="button primary" onClick={MessageCenterUtils.getNextMessage}>Refresh Current Message</button>
+      <h2>Messages</h2>
+      {this.renderMessages()}
+    </div>);
+  }
+}

--- a/system-addon/content-src/components/MessageCenterAdmin/MessageCenterAdmin.scss
+++ b/system-addon/content-src/components/MessageCenterAdmin/MessageCenterAdmin.scss
@@ -1,0 +1,70 @@
+
+.messages-admin {
+  $monospace: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
+  max-width: 996px;
+  margin: 0 auto;
+  font-size: 14px;
+
+  h1 {
+    font-weight: 200;
+    font-size: 32px;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  .message-item {
+    &:first-child td {
+      border-top: 1px solid $black-10;
+    }
+
+    td {
+      vertical-align: top;
+      border-bottom: 1px solid $black-10;
+      padding: 8px;
+
+      &:first-child {
+        border-left: 1px solid $black-10;
+      }
+
+      &:last-child {
+        border-right: 1px solid $black-10;
+      }
+    }
+
+    &.current {
+      .message-id span {
+        background: $yellow-50;
+        padding: 2px 5px;
+      }
+    }
+
+    &.blocked {
+      .message-id,
+      .message-summary {
+        opacity: 0.5;
+      }
+
+      .message-id {
+        color: $grey-90;
+      }
+    }
+
+    .message-id {
+      font-family: $monospace;
+      font-size: 12px;
+    }
+  }
+
+  pre {
+    background: $white;
+    margin: 0;
+    padding: 8px;
+    font-size: 12px;
+    max-width: 750px;
+    overflow: auto;
+    font-family: $monospace;
+  }
+}

--- a/system-addon/content-src/lib/snippets.js
+++ b/system-addon/content-src/lib/snippets.js
@@ -7,6 +7,7 @@ const SNIPPETS_ENABLED_EVENT = "Snippets:Enabled";
 const SNIPPETS_DISABLED_EVENT = "Snippets:Disabled";
 
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
+import {initMessageCenter} from "content-src/message-center/message-center-content";
 
 /**
  * SnippetsMap - A utility for cacheing values related to the snippet. It has
@@ -373,6 +374,8 @@ export function addSnippetsSubscriber(store) {
     // state.Snippets.initialized             Is the snippets data initialized?
     // snippets.initialized:                  Is SnippetsProvider currently initialised?
     if (state.Prefs.values["feeds.snippets"] &&
+      // If the message center experiment is enabled, don't show snippets
+      !state.Prefs.values.messageCenterExperimentEnabled &&
       !state.Prefs.values.disableSnippets &&
       state.Snippets.initialized &&
       !snippets.initialized &&
@@ -388,6 +391,10 @@ export function addSnippetsSubscriber(store) {
       snippets.initialized
     ) {
       snippets.uninit();
+    }
+
+    if (state.Prefs.values.messageCenterExperimentEnabled) {
+      initMessageCenter();
     }
   });
 

--- a/system-addon/content-src/message-center/components/Button.jsx
+++ b/system-addon/content-src/message-center/components/Button.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const styles = {
+  button: {
+    border: 0,
+    backgroundColor: "#e1e1e2",
+    fontFamily: "inherit",
+    padding: "8px 15px",
+    marginLeft: "15px"
+  }
+};
+
+export const Button = props => (<button style={styles.button} {...props}>
+  {props.children}
+</button>);

--- a/system-addon/content-src/message-center/components/SnippetBase.jsx
+++ b/system-addon/content-src/message-center/components/SnippetBase.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+const defaultStyles = {
+  container: {
+    position: "fixed",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: "20px",
+    backgroundColor: "white",
+    fontSize: "12px",
+    lineHeight: "16px",
+    boxShadow: "0 -1px 4px 0 rgba(12, 12, 13, 0.1)"
+  },
+  innerWrapper: {
+    maxWidth: "992px",
+    margin: "0 auto",
+    display: "flex",
+    alignItems: "center"
+  },
+  blockButton: {
+    background: "none",
+    border: 0,
+    display: "block",
+    position: "absolute",
+    top: "50%",
+    right: "24px",
+    height: "16px",
+    width: "16px",
+    backgroundImage: "url(resource://activity-stream/data/content/assets/glyph-dismiss-16.svg)",
+    opacity: 0.5,
+    marginTop: "-8px",
+    padding: 0
+  }
+};
+
+export class SnippetBase extends React.PureComponent {
+  render() {
+    const {props} = this;
+
+    // Extend default styles
+    const styles = Object.assign({}, defaultStyles);
+    if (props.styles) {
+      Object.keys(props.styles).forEach(key => {
+        styles[key] = Object.assign({}, styles[key], props.styles[key]);
+      });
+    }
+
+    return (<div style={styles.container}>
+      <div style={styles.innerWrapper}>
+        {props.children}
+      </div>
+      <button style={styles.blockButton} onClick={props.onBlock} />
+    </div>);
+  }
+}

--- a/system-addon/content-src/message-center/message-center-content.jsx
+++ b/system-addon/content-src/message-center/message-center-content.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import {SimpleSnippet} from "./templates/SimpleSnippet";
+
+const INCOMING_MESSAGE_NAME = "MessageCenter:parent-to-child";
+const OUTGOING_MESSAGE_NAME = "MessageCenter:child-to-parent";
+
+export const MessageCenterUtils = {
+  addListener(listener) {
+    global.addMessageListener(INCOMING_MESSAGE_NAME, listener);
+  },
+  removeListener(listener) {
+    global.removeMessageListener(INCOMING_MESSAGE_NAME, listener);
+  },
+  sendMessage(action) {
+    global.sendAsyncMessage(OUTGOING_MESSAGE_NAME, action);
+  },
+  blockById(id) {
+    MessageCenterUtils.sendMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id}});
+  },
+  unblockById(id) {
+    MessageCenterUtils.sendMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id}});
+  },
+  getNextMessage() {
+    MessageCenterUtils.sendMessage({type: "GET_NEXT_MESSAGE"});
+  }
+};
+
+class MessageCenterUISurface extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onMessageFromParent = this.onMessageFromParent.bind(this);
+    this.state = {message: {}};
+  }
+
+  onBlockById(id) {
+    return () => MessageCenterUtils.blockById(id);
+  }
+
+  onMessageFromParent({data: action}) {
+    switch (action.type) {
+      case "SET_MESSAGE":
+        this.setState({message: action.data});
+        break;
+      case "CLEAR_MESSAGE":
+        this.setState({message: {}});
+        break;
+    }
+  }
+
+  componentWillMount() {
+    MessageCenterUtils.addListener(this.onMessageFromParent);
+    MessageCenterUtils.sendMessage({type: "CONNECT_UI_REQUEST"});
+  }
+
+  componentWillUnmount() {
+    MessageCenterUtils.removeMessageListener(this.onMessageFromParent);
+  }
+
+  render() {
+    const {message} = this.state;
+    if (!message.id) { return null; }
+
+    return (<SimpleSnippet
+      {...message}
+      getNextMessage={MessageCenterUtils.getNextMessage}
+      onBlock={this.onBlockById(message.id)} />);
+  }
+}
+
+export function initMessageCenter() {
+  ReactDOM.render(<MessageCenterUISurface />, document.getElementById("snippets-container"));
+}

--- a/system-addon/content-src/message-center/templates/SimpleSnippet.jsx
+++ b/system-addon/content-src/message-center/templates/SimpleSnippet.jsx
@@ -1,0 +1,31 @@
+import {Button} from "../components/Button";
+import React from "react";
+import {SnippetBase} from "../components/SnippetBase";
+
+const styles = {
+  title: {
+    display: "inline",
+    fontSize: "inherit",
+    margin: 0
+  },
+  body: {
+    display: "inline",
+    margin: 0
+  },
+  icon: {
+    height: "42px",
+    width: "42px",
+    marginRight: "15px",
+    borderRadius: "6px",
+    backgroundColor: "rgba(0,0,0,0.1)",
+    flexShrink: 0
+  }
+};
+
+export const SimpleSnippet = props => (<SnippetBase {...props}>
+  <div style={styles.icon} />
+  <div>
+    <h3 style={styles.title}>{props.content.title}</h3> <p style={styles.body}>{props.content.body}</p>
+  </div>
+  {props.content.button ? <div><Button>{props.content.button.label}</Button></div> : null}
+</SnippetBase>);

--- a/system-addon/content-src/styles/_activity-stream.scss
+++ b/system-addon/content-src/styles/_activity-stream.scss
@@ -79,35 +79,39 @@ a {
   justify-content: flex-start;
   margin: 0;
   padding: 15px 25px 0;
+}
 
-  button {
-    background-color: var(--newtab-button-secondary-color);
-    border: $border-primary;
-    border-radius: 4px;
-    color: inherit;
-    cursor: pointer;
-    margin-bottom: 15px;
-    padding: 10px 30px;
-    white-space: nowrap;
+// Default button (grey)
+.button,
+.actions button {
+  background-color: var(--newtab-button-secondary-color);
+  border: $border-primary;
+  border-radius: 4px;
+  color: inherit;
+  cursor: pointer;
+  margin-bottom: 15px;
+  padding: 10px 30px;
+  white-space: nowrap;
 
-    &:hover:not(.dismiss) {
-      box-shadow: $shadow-primary;
-      transition: box-shadow 150ms;
-    }
+  &:hover:not(.dismiss) {
+    box-shadow: $shadow-primary;
+    transition: box-shadow 150ms;
+  }
 
-    &.dismiss {
-      background-color: transparent;
-      border: 0;
-      padding: 0;
-      text-decoration: underline;
-    }
+  &.dismiss {
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    text-decoration: underline;
+  }
 
-    &.done {
-      background-color: var(--newtab-button-primary-color);
-      border: solid 1px var(--newtab-button-primary-color);
-      color: $white;
-      margin-inline-start: auto;
-    }
+  // Blue button
+  &.primary,
+  &.done {
+    background-color: var(--newtab-button-primary-color);
+    border: solid 1px var(--newtab-button-primary-color);
+    color: $white;
+    margin-inline-start: auto;
   }
 }
 
@@ -128,3 +132,4 @@ a {
 @import '../components/Card/Card';
 @import '../components/ManualMigration/ManualMigration';
 @import '../components/CollapsibleSection/CollapsibleSection';
+@import '../components/MessageCenterAdmin/MessageCenterAdmin';

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -2,6 +2,8 @@
 $blue-40: #45A1FF;
 $blue-50: #0A84FF;
 $blue-60: #0060DF;
+$blue-70: #003EAA;
+$blue-80: #002275;
 $grey-10: #F9F9FA;
 $grey-20: #EDEDF0;
 $grey-30: #D7D7DB;
@@ -13,6 +15,7 @@ $grey-80: #2A2A2E;
 $grey-90: #0C0C0D;
 $teal-70: #008EA4;
 $red-60: #D70022;
+$yellow-50: #FFE900;
 
 // Photon opacity from http://design.firefox.com/photon/visuals/color.html#opacity
 $grey-10-20: rgba($grey-10, 0.2);

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -28,6 +28,7 @@ const {TopStoriesFeed} = ChromeUtils.import("resource://activity-stream/lib/TopS
 const {HighlightsFeed} = ChromeUtils.import("resource://activity-stream/lib/HighlightsFeed.jsm", {});
 const {ActivityStreamStorage} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamStorage.jsm", {});
 const {ThemeFeed} = ChromeUtils.import("resource://activity-stream/lib/ThemeFeed.jsm", {});
+const {MessageCenterFeed} = ChromeUtils.import("resource://activity-stream/lib/MessageCenterFeed.jsm", {});
 
 const DEFAULT_SITES = new Map([
   // This first item is the global list fallback for any unexpected geos
@@ -141,6 +142,10 @@ const PREFS_CONFIG = new Map([
   ["sectionOrder", {
     title: "The rendering order for the sections",
     value: "topsites,topstories,highlights"
+  }],
+  ["messageCenterExperimentEnabled", {
+    title: "Is the message center experiment on?",
+    value: false
   }]
 ]);
 
@@ -235,6 +240,12 @@ const FEEDS_DATA = [
   {
     name: "topsites",
     factory: () => new TopSitesFeed(),
+    title: "Queries places and gets metadata for Top Sites section",
+    value: true
+  },
+  {
+    name: "messagecenterfeed",
+    factory: () => new MessageCenterFeed(),
     title: "Queries places and gets metadata for Top Sites section",
     value: true
   }

--- a/system-addon/lib/MessageCenterFeed.jsm
+++ b/system-addon/lib/MessageCenterFeed.jsm
@@ -1,0 +1,58 @@
+const {actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
+const {MessageCenterRouter} = ChromeUtils.import("resource://activity-stream/lib/MessageCenterRouter.jsm", {});
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+const ONBOARDING_FINISHED_PREF = "browser.onboarding.notification.finished";
+
+/**
+ * @class MessageCenterFeed - Connects MessageCenter singleton (see above) to Activity Stream's
+ * store so that it can use the RemotePageManager.
+ */
+class MessageCenterFeed {
+  constructor(options = {}) {
+    this.router = options.router || MessageCenterRouter;
+  }
+
+  enable() {
+    this.router.init(this.store._messageChannel.channel);
+    // Disable onboarding
+    Services.prefs.setBoolPref(ONBOARDING_FINISHED_PREF, true);
+  }
+
+  disable() {
+    if (this.router.initialized) {
+      this.router.uninit();
+      // Re-enable onboarding
+      Services.prefs.setBoolPref(ONBOARDING_FINISHED_PREF, false);
+    }
+  }
+
+  /**
+   * enableOrDisableBasedOnPref - Check the experiment pref
+   * (messageCenterExperimentEnabled) and enable or disable MessageCenter based on
+   * its value.
+   */
+  enableOrDisableBasedOnPref() {
+    const isExperimentEnabled = this.store.getState().Prefs.values.messageCenterExperimentEnabled;
+    if (!this.router.initialized && isExperimentEnabled) {
+      this.enable();
+    } else if (!isExperimentEnabled && this.router.initialized) {
+      this.disable();
+    }
+  }
+
+  onAction(action) {
+    switch (action.type) {
+      case at.INIT:
+      case at.PREF_CHANGED:
+        this.enableOrDisableBasedOnPref();
+        break;
+      case at.UNINIT:
+        this.disable();
+        break;
+    }
+  }
+}
+this.MessageCenterFeed = MessageCenterFeed;
+
+const EXPORTED_SYMBOLS = ["MessageCenterFeed"];

--- a/system-addon/lib/MessageCenterRouter.jsm
+++ b/system-addon/lib/MessageCenterRouter.jsm
@@ -1,0 +1,163 @@
+const INCOMING_MESSAGE_NAME = "MessageCenter:child-to-parent";
+const OUTGOING_MESSAGE_NAME = "MessageCenter:parent-to-child";
+
+const FAKE_MESSAGES = [
+  {
+    id: "ONBOARDING_1",
+    template: "simple_snippet",
+    content: {
+      title: "Find it faster",
+      body: "Access all of your favorite search engines with a click. Search the whole Web or just one website from the search box.",
+      button: {
+        label: "Learn More",
+        action: "OPEN_LINK",
+        params: {url: "https://mozilla.org"}
+      }
+    }
+  },
+  {
+    id: "ONBOARDING_2",
+    template: "simple_snippet",
+    content: {
+      title: "Make Firefox your go-to-browser",
+      body: "It doesn't take much to get the most from Firefox. Just set Firefox as your default browser and put control, customization, and protection on autopilot."
+    }
+  },
+  {
+    id: "ONBOARDING_3",
+    template: "simple_snippet",
+    content: {
+      title: "Did you know?",
+      body: "All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood."
+    }
+  }
+];
+
+/**
+ * getRandomItemFromArray
+ *
+ * @param {Array} arr An array of items
+ * @returns one of the items in the array
+ */
+function getRandomItemFromArray(arr) {
+  const index = Math.floor(Math.random() * arr.length);
+  return arr[index];
+}
+
+/**
+ * @class _MessageCenterRouter - Keeps track of all messages, UI surfaces, and
+ * handles blocking, rotation, etc. Inspecting MessageCenter.state will
+ * tell you what the current displayed message is in all UI surfaces.
+ *
+ * Note: This is written as a constructor rather than just a plain object
+ * so that it can be more easily unit tested.
+ */
+class _MessageCenterRouter {
+  constructor(initialState = {}) {
+    this.initialized = false;
+    this.messageChannel = null;
+    this._state = Object.assign({
+      currentId: null,
+      blockList: {},
+      messages: {}
+    }, initialState);
+    this.onMessage = this.onMessage.bind(this);
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  set state(value) {
+    throw new Error("Do not modify this.state directy. Instead, call this.setState(newState)");
+  }
+
+  /**
+   * init - Initializes the MessageRouter.
+   * It is ready when it has been connected to a RemotePageManager instance.
+   *
+   * @param {RemotePageManager} channel a RemotePageManager instance
+   * @memberof _MessageCenterRouter
+   */
+  init(channel) {
+    this.messageChannel = channel;
+    this.messageChannel.addMessageListener(INCOMING_MESSAGE_NAME, this.onMessage);
+    this.initialized = true;
+  }
+
+  uninit() {
+    this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE"});
+    this.messageChannel.removeMessageListener(INCOMING_MESSAGE_NAME, this.onMessage);
+    this.messageChannel = null;
+    this.initialized = false;
+  }
+
+  setState(callbackOrObj) {
+    const newState = (typeof callbackOrObj === "function") ? callbackOrObj(this.state) : callbackOrObj;
+    this._state = Object.assign({}, this.state, newState);
+    return new Promise(resolve => {
+      this._onStateChanged(this.state);
+      resolve();
+    });
+  }
+
+  _onStateChanged(state) {
+    this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: state});
+  }
+
+  async sendNextMessage(target, id) {
+    let message;
+    await this.setState(state => {
+      message = getRandomItemFromArray(state.messages.filter(item => item.id !== state.currentId && !state.blockList[item.id]));
+      return {currentId: message ? message.id : null};
+    });
+    if (message) {
+      target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "SET_MESSAGE", data: message});
+    } else {
+      target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE"});
+    }
+  }
+
+  async clearMessage(target, id) {
+    if (this.state.currentId === id) {
+      await this.setState({currentId: null});
+    }
+    target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE"});
+  }
+
+  async onMessage({data: action, target}) {
+    switch (action.type) {
+      case "CONNECT_UI_REQUEST":
+      case "GET_NEXT_MESSAGE":
+        await this.sendNextMessage(target);
+        break;
+      case "BLOCK_MESSAGE_BY_ID":
+        await this.setState(state => {
+          const newState = Object.assign({}, state.blockList);
+          newState[action.data.id] = true;
+          return {blockList: newState};
+        });
+        await this.clearMessage(target, action.data.id);
+        break;
+      case "UNBLOCK_MESSAGE_BY_ID":
+        await this.setState(state => {
+          const newState = Object.assign({}, state.blockList);
+          delete newState[action.data.id];
+          return {blockList: newState};
+        });
+        break;
+      case "ADMIN_CONNECT_STATE":
+        target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: this.state});
+        break;
+    }
+  }
+}
+this._MessageCenterRouter = _MessageCenterRouter;
+
+/**
+ * MessageCenterRouter - singleton instance of _MessageCenterRouter that controls all messages
+ * in the new tab page.
+ */
+this.MessageCenterRouter = new _MessageCenterRouter({messages: FAKE_MESSAGES});
+
+const EXPORTED_SYMBOLS = ["_MessageCenterRouter", "MessageCenterRouter"];

--- a/system-addon/test/unit/content-src/lib/snippets.test.js
+++ b/system-addon/test/unit/content-src/lib/snippets.test.js
@@ -480,4 +480,11 @@ describe("addSnippetsSubscriber", () => {
     store.dispatch({type: at.PREF_CHANGED, data: {name: "disableSnippets", value: true}});
     assert.calledOnce(snippets.uninit);
   });
+  it("should not initialize snippets if messageCenterExperimentEnabled pref is true", () => {
+    store.dispatch({type: "FOO"});
+    store.dispatch({type: at.PREF_CHANGED, data: {name: "messageCenterExperimentEnabled", value: true}});
+
+    assert.calledOnce(store.subscribe);
+    assert.notCalled(snippets.init);
+  });
 });

--- a/system-addon/test/unit/lib/ActivityStream.test.js
+++ b/system-addon/test/unit/lib/ActivityStream.test.js
@@ -27,7 +27,8 @@ describe("ActivityStream", () => {
       "lib/TopStoriesFeed.jsm": {TopStoriesFeed: Fake},
       "lib/HighlightsFeed.jsm": {HighlightsFeed: Fake},
       "lib/ActivityStreamStorage.jsm": {ActivityStreamStorage: Fake},
-      "lib/ThemeFeed.jsm": {ThemeFeed: Fake}
+      "lib/ThemeFeed.jsm": {ThemeFeed: Fake},
+      "lib/MessageCenterFeed.jsm": {MessageCenterFeed: Fake}
     }));
     as = new ActivityStream();
     sandbox.stub(as.store, "init");
@@ -167,6 +168,10 @@ describe("ActivityStream", () => {
     });
     it("should create a Theme feed", () => {
       const feed = as.feeds.get("feeds.theme")();
+      assert.instanceOf(feed, Fake);
+    });
+    it("should create a MessageCenter feed", () => {
+      const feed = as.feeds.get("feeds.messagecenterfeed")();
       assert.instanceOf(feed, Fake);
     });
   });

--- a/system-addon/test/unit/message-center/MessageCenterRouter.test.js
+++ b/system-addon/test/unit/message-center/MessageCenterRouter.test.js
@@ -1,0 +1,189 @@
+import {_MessageCenterRouter, MessageCenterRouter} from "lib/MessageCenterRouter.jsm";
+import {CHILD_TO_PARENT_MESSAGE_NAME, EXPERIMENT_PREF, PARENT_TO_CHILD_MESSAGE_NAME} from "./constants";
+import {actionTypes as at} from "common/Actions.jsm";
+import {MessageCenterFeed} from "lib/MessageCenterFeed.jsm";
+
+const ONBOARDING_FINISHED_PREF = "browser.onboarding.notification.finished";
+
+// Stubs methods on RemotePageManager
+class FakeRemotePageManager {
+  constructor() {
+    this.addMessageListener = sinon.stub();
+    this.sendAsyncMessage = sinon.stub();
+    this.removeMessageListener = sinon.stub();
+  }
+}
+
+// Creates a message object that looks like messages returned by RemotePageManager listeners
+function createRemoteMessage(action) {
+  return {data: action, target: new FakeRemotePageManager()};
+}
+
+const FAKE_MESSAGES = [
+  {id: "foo", template: "simple_template", content: {title: "Foo", body: "Foo123"}},
+  {id: "bar", template: "fancy_template", content: {title: "Foo", body: "Foo123"}},
+  {id: "baz", content: {title: "Foo", body: "Foo123"}}
+];
+const FAKE_MESSAGE_IDS = FAKE_MESSAGES.map(message => message.id);
+
+describe("MessageCenterRouter", () => {
+  let Router;
+  let channel;
+  beforeEach(() => {
+    Router = new _MessageCenterRouter({messages: FAKE_MESSAGES});
+    channel = new FakeRemotePageManager();
+    Router.init(channel);
+  });
+  describe(".state", () => {
+    it("should throw if an attempt to set .state was made", () => {
+      assert.throws(() => {
+        Router.state = {};
+      });
+    });
+  });
+  describe("#init", () => {
+    it("should add a message listener to the RemotePageManager for incoming messages", () => {
+      assert.calledWith(channel.addMessageListener, CHILD_TO_PARENT_MESSAGE_NAME);
+      const [, listenerAdded] = channel.addMessageListener.firstCall.args;
+      assert.isFunction(listenerAdded);
+    });
+  });
+  describe("#uninit", () => {
+    it("should remove the message listener on the RemotePageManager", () => {
+      const [, listenerAdded] = channel.addMessageListener.firstCall.args;
+      assert.isFunction(listenerAdded);
+
+      Router.uninit();
+
+      assert.calledWith(channel.removeMessageListener, CHILD_TO_PARENT_MESSAGE_NAME, listenerAdded);
+    });
+  });
+  describe("#onMessage: CONNECT_UI_REQUEST", () => {
+    it("should set state.currentId to a message id", async () => {
+      await Router.onMessage(createRemoteMessage({type: "CONNECT_UI_REQUEST"}));
+
+      assert.include(FAKE_MESSAGE_IDS, Router.state.currentId);
+    });
+    it("should send a message back to the to the target", async () => {
+      const msg = createRemoteMessage({type: "CONNECT_UI_REQUEST"});
+      await Router.onMessage(msg);
+
+      const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.currentId);
+      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: currentMessage});
+    });
+    it("should send a CLEAR_MESSAGE message and set state.currentId to null if no messages are available", async () => {
+      await Router.setState({messages: []});
+      const msg = createRemoteMessage({type: "CONNECT_UI_REQUEST"});
+      await Router.onMessage(msg);
+
+      assert.isNull(Router.state.currentId);
+      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE"});
+    });
+  });
+  describe("#onMessage: BLOCK_MESSAGE_BY_ID", () => {
+    it("should add the id to the blockList, state.currentId to null if it is the blocked message id, and send a CLEAR_MESSAGE message", async () => {
+      await Router.setState({currentId: "foo"});
+      const msg = createRemoteMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo"}});
+      await Router.onMessage(msg);
+
+      assert.isTrue(Router.state.blockList.foo);
+      assert.isNull(Router.state.currentId);
+      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE"});
+    });
+  });
+  describe("#onMessage: UNBLOCK_MESSAGE_BY_ID", () => {
+    it("should remove the id from the blockList", async () => {
+      await Router.onMessage(createRemoteMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
+      assert.isTrue(Router.state.blockList.foo);
+      await Router.onMessage(createRemoteMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
+
+      assert.isUndefined(Router.state.blockList.foo);
+    });
+  });
+
+  describe("#onMessage: ADMIN_CONNECT_STATE", () => {
+    it("should send a message containing the whole state", async () => {
+      const msg = createRemoteMessage({type: "ADMIN_CONNECT_STATE"});
+      await Router.onMessage(msg);
+
+      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: Router.state});
+    });
+  });
+});
+
+describe("MessageCenterFeed", () => {
+  let Router;
+  let feed;
+  let prefs;
+  let channel;
+  let sandbox;
+  beforeEach(() => {
+    Router = new _MessageCenterRouter();
+    feed = new MessageCenterFeed({router: Router});
+    sandbox = sinon.sandbox.create();
+    sandbox.spy(global.Services.prefs, "setBoolPref");
+
+    // Add prefs to feed.store
+    prefs = {};
+    channel = new FakeRemotePageManager();
+    feed.store = {_messageChannel: {channel}, getState: () => ({Prefs: {values: prefs}})};
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  it("should set .router to the MessageCenterRouter singleton if none is specified in options", () => {
+    feed = new MessageCenterFeed();
+    assert.equal(feed.router, MessageCenterRouter);
+
+    feed = new MessageCenterFeed({});
+    assert.equal(feed.router, MessageCenterRouter);
+  });
+  describe("#onAction: INIT", () => {
+    it("should initialize the MessageCenterRouter if it is not initialized and override onboardin if the experiment pref is true", () => {
+      // Router starts out not initialized
+      sinon.stub(Router, "init");
+      prefs[EXPERIMENT_PREF] = true;
+
+      // call .onAction with INIT
+      feed.onAction({type: at.INIT});
+
+      assert.calledWith(Router.init, channel);
+      assert.calledWith(global.Services.prefs.setBoolPref, ONBOARDING_FINISHED_PREF, true);
+    });
+    it("should not re-initialize the MessageCenterRouter if it is already initialized", () => {
+      // Router starts initialized
+      Router.init(new FakeRemotePageManager());
+      sinon.stub(Router, "init");
+      prefs[EXPERIMENT_PREF] = true;
+
+      // call .onAction with INIT
+      feed.onAction({type: at.INIT});
+
+      assert.notCalled(Router.init);
+    });
+  });
+  describe("#onAction: PREF_CHANGE", () => {
+    it("should uninitialize the MessageCenterRouter if it is already initialized and the experiment pref is false", () => {
+      // Router starts initialized
+      Router.init(new FakeRemotePageManager());
+      sinon.stub(Router, "uninit");
+      prefs[EXPERIMENT_PREF] = false;
+
+      // call .onAction with INIT
+      feed.onAction({type: at.PREF_CHANGED});
+
+      assert.calledOnce(Router.uninit);
+    });
+  });
+  describe("#onAction: UNINIT", () => {
+    it("should uninitialize the MessageCenterRouter and restore onboarding", () => {
+      Router.init(new FakeRemotePageManager());
+      sinon.stub(Router, "uninit");
+
+      feed.onAction({type: at.UNINIT});
+
+      assert.calledOnce(Router.uninit);
+      assert.calledWith(global.Services.prefs.setBoolPref, ONBOARDING_FINISHED_PREF, false);
+    });
+  });
+});

--- a/system-addon/test/unit/message-center/constants.js
+++ b/system-addon/test/unit/message-center/constants.js
@@ -1,0 +1,3 @@
+export const CHILD_TO_PARENT_MESSAGE_NAME = "MessageCenter:child-to-parent";
+export const PARENT_TO_CHILD_MESSAGE_NAME = "MessageCenter:parent-to-child";
+export const EXPERIMENT_PREF = "messageCenterExperimentEnabled";

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -112,6 +112,7 @@ const TEST_GLOBAL = {
       getStringPref() {},
       getIntPref() {},
       getBoolPref() {},
+      setBoolPref() {},
       getBranch() {},
       getDefaultBranch() {
         return {


### PR DESCRIPTION
This patch creates an experiment that demonstrates:

- React/JS based templates
- A template router in the main process
- An admin panel to block/unblock/view messages

You can test it by setting the `messageCenterExperimentEnabled` pref to true. When you do that, you should see:

- a snippet pop up at the bottom of every new tab page
- an admin panel when you visit `about:newtab#message-center-admin` 