### PR TITLE
Fix Bug 1449292 - TopSites don't update their custom screenshot

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -103,13 +103,15 @@ this.TopSitesFeed = class TopSitesFeed {
       // Copy all properties from a frecent link and add more
       const finder = other => other.url === link.url;
 
+      // Remove frecent link's screenshot if pinned link has a custom one
       const frecentSite = frecent.find(finder);
+      if (frecentSite && link.customScreenshotURL) {
+        delete frecentSite.screenshot;
+      }
       // If the link is a frecent site, do not copy over 'isDefault', else check
       // if the site is a default site
       const copy = Object.assign({}, frecentSite ||
-        {isDefault: !!notBlockedDefaultSites.find(finder)}, link, {hostname: shortURL(link)},
-        // If the pinned site has a customScreenshotURL the frecent screenshot will be incorrect
-        (frecentSite && !link.screenshot) && {screenshot: link.customScreenshotURL ? undefined : frecentSite.screenshot});
+        {isDefault: !!notBlockedDefaultSites.find(finder)}, link, {hostname: shortURL(link)});
 
       // Add in favicons if we don't already have it
       if (!copy.favicon) {

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -81,7 +81,7 @@ this.TopSitesFeed = class TopSitesFeed {
     }, []));
   }
 
-  async getLinksWithDefaults(action) {
+  async getLinksWithDefaults() {
     // Get at least 2 rows so toggling between 1 and 2 rows has sites
     const numItems = Math.max(this.store.getState().Prefs.values.topSitesRows, 2) * TOP_SITES_MAX_SITES_PER_ROW;
     const frecent = (await this.frecentCache.request({
@@ -103,10 +103,13 @@ this.TopSitesFeed = class TopSitesFeed {
       // Copy all properties from a frecent link and add more
       const finder = other => other.url === link.url;
 
+      const frecentSite = frecent.find(finder);
       // If the link is a frecent site, do not copy over 'isDefault', else check
       // if the site is a default site
-      const copy = Object.assign({}, frecent.find(finder) ||
-        {isDefault: !!notBlockedDefaultSites.find(finder)}, link, {hostname: shortURL(link)});
+      const copy = Object.assign({}, frecentSite ||
+        {isDefault: !!notBlockedDefaultSites.find(finder)}, link, {hostname: shortURL(link)},
+        // If the pinned site has a customScreenshotURL the frecent screenshot will be incorrect
+        (frecentSite && !link.screenshot) && {screenshot: link.customScreenshotURL ? undefined : frecentSite.screenshot});
 
       // Add in favicons if we don't already have it
       if (!copy.favicon) {

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -298,6 +298,38 @@ describe("Top Sites Feed", () => {
         const internal = Object.keys(result[0]).filter(key => key.startsWith("__"));
         assert.equal(internal.join(""), "");
       });
+      it("should copy the screenshot of the frecent site if pinned site doesn't have customScreenshotURL", async () => {
+        links = [{url: "https://foo.com/", screenshot: "screenshot"}];
+        fakeNewTabUtils.pinnedLinks.links = [{url: "https://foo.com/"}];
+
+        const result = await feed.getLinksWithDefaults();
+
+        assert.equal(result[0].screenshot, links[0].screenshot);
+      });
+      it("should not copy the frecent screenshot if customScreenshotURL is set", async () => {
+        links = [{url: "https://foo.com/", screenshot: "screenshot"}];
+        fakeNewTabUtils.pinnedLinks.links = [{url: "https://foo.com/", customScreenshotURL: "custom"}];
+
+        const result = await feed.getLinksWithDefaults();
+
+        assert.isUndefined(result[0].screenshot);
+      });
+      it("should keep the same screenshot if no frecent site is found", async () => {
+        links = [];
+        fakeNewTabUtils.pinnedLinks.links = [{url: "https://foo.com/", screenshot: "custom"}];
+
+        const result = await feed.getLinksWithDefaults();
+
+        assert.equal(result[0].screenshot, "custom");
+      });
+      it("should not overwrite pinned site screenshot", async () => {
+        links = [{url: "https://foo.com/", screenshot: "foo"}];
+        fakeNewTabUtils.pinnedLinks.links = [{url: "https://foo.com/", screenshot: "bar"}];
+
+        const result = await feed.getLinksWithDefaults();
+
+        assert.equal(result[0].screenshot, "bar");
+      });
       describe("concurrency", () => {
         let resolvers;
         beforeEach(() => {


### PR DESCRIPTION
This scenario didn't really show up in development because it required some amount of history.

You can have frecent topsites which are low quality (have a screenshot not a hi-res icon). If you were to set a screenshot for these, we would not do a lookup in the frecent cache to clear the old screenshot and because of 
https://github.com/mozilla/activity-stream/blob/e8ef6e23b38c4eed36c6d0bf3f04516290b86ad9/system-addon/lib/TopSitesFeed.jsm#L203-L205
We would not fetch the new screenshot.