### PR TITLE
Fix Bug 1444616 - push section menu button half a pixel up

### DIFF
--- a/system-addon/content-src/components/Base/_Base.scss
+++ b/system-addon/content-src/components/Base/_Base.scss
@@ -42,23 +42,6 @@ main {
   }
 }
 
-.section-top-bar {
-  height: 16px;
-  margin-bottom: 16px;
-}
-
-.section-title {
-  font-size: $section-title-font-size;
-  font-weight: bold;
-  text-transform: uppercase;
-
-  span {
-    color: $text-secondary;
-    fill: $text-secondary;
-    vertical-align: middle;
-  }
-}
-
 .base-content-fallback {
   // Make the error message be centered against the viewport
   height: 100vh;

--- a/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/system-addon/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -5,7 +5,17 @@
   transition-property: background-color;
 
   .section-title {
+    font-size: $section-title-font-size;
+    font-weight: bold;
     margin: 0;
+    text-transform: uppercase;
+
+    span {
+      color: $text-secondary;
+      display: inline-block;
+      fill: $text-secondary;
+      vertical-align: middle;
+    }
 
     .click-target {
       cursor: pointer;
@@ -20,6 +30,8 @@
   }
 
   .section-top-bar {
+    height: 19px;
+    margin-bottom: 13px;
     position: relative;
 
     .context-menu-button {
@@ -27,7 +39,7 @@
       border: 0;
       cursor: pointer;
       fill: $grey-50;
-      height: $section-context-menu-button-height;
+      height: 100%;
       offset-inline-end: 0;
       opacity: 0;
       position: absolute;

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -107,7 +107,6 @@ $context-menu-font-size: 14px;
 $context-menu-border-radius: 5px;
 $context-menu-outer-padding: 5px;
 $context-menu-item-padding: 3px 12px;
-$section-context-menu-button-height: 20px;
 
 $error-fallback-font-size: 12px;
 $error-fallback-line-height: 1.5;


### PR DESCRIPTION
I guess it was still off by half a pixel. r? @piatra 

Before:
<img width="1024" alt="screen shot 2018-03-27 at 4 03 27 pm" src="https://user-images.githubusercontent.com/36629/37992345-70d85d6e-31d9-11e8-8142-595602ca867f.png">

After:
<img width="1021" alt="screen shot 2018-03-27 at 4 07 43 pm" src="https://user-images.githubusercontent.com/36629/37992353-770700fa-31d9-11e8-842e-969c0de94eb2.png">
