### PR TITLE
Fix Bug 1448394 - fix cut off g in Trending

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -151,19 +151,20 @@
     display: flex;
     font-size: 11px;
     left: 0;
-    padding: 12px 16px 12px 14px;
+    padding: 9px 16px 9px 14px;
     position: absolute;
     right: 0;
   }
 
   .card-context-icon {
     fill: $fill-secondary;
+    height: 22px;
     margin-inline-end: 6px;
   }
 
   .card-context-label {
     flex-grow: 1;
-    line-height: $icon-size;
+    line-height: 22px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
r? @piatra 

I added some extra breathing room. It looks like this was only broken on wide layouts with the bigger font size that comes with that.

Before:
![screen shot 2018-03-28 at 12 04 06](https://user-images.githubusercontent.com/36629/38041735-83704aa2-3280-11e8-9a3e-c621168f687e.png)

After:
![screen shot 2018-03-28 at 12 02 36](https://user-images.githubusercontent.com/36629/38041739-88d9ce82-3280-11e8-938a-51d75e1eeb86.png)
