### PR TITLE
chore(tests): Clean up unnecessary injector and wrong global setting

### DIFF
--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -32,29 +32,12 @@ describe("PlacesFeed", () => {
         addPocketEntry: sandbox.spy(() => Promise.resolve())
       }
     });
-    globals.set("PlacesUtils", {
-      history: {
-        addObserver: sandbox.spy(),
-        removeObserver: sandbox.spy(),
-        insert: sandbox.stub()
-      },
-      bookmarks: {
-        TYPE_BOOKMARK,
-        addObserver: sandbox.spy(),
-        removeObserver: sandbox.spy(),
-        SOURCES
-      }
-    });
-    global.Cc["@mozilla.org/browser/nav-history-service;1"] = {
-      getService() {
-        return global.PlacesUtils.history;
-      }
-    };
-    global.Cc["@mozilla.org/browser/nav-bookmarks-service;1"] = {
-      getService() {
-        return global.PlacesUtils.bookmarks;
-      }
-    };
+    sandbox.stub(global.PlacesUtils.bookmarks, "TYPE_BOOKMARK").value(TYPE_BOOKMARK);
+    sandbox.stub(global.PlacesUtils.bookmarks, "SOURCES").value(SOURCES);
+    sandbox.spy(global.PlacesUtils.bookmarks, "addObserver");
+    sandbox.spy(global.PlacesUtils.bookmarks, "removeObserver");
+    sandbox.spy(global.PlacesUtils.history, "addObserver");
+    sandbox.spy(global.PlacesUtils.history, "removeObserver");
     sandbox.spy(global.Services.obs, "addObserver");
     sandbox.spy(global.Services.obs, "removeObserver");
     sandbox.spy(global.Cu, "reportError");

--- a/system-addon/test/unit/utils.js
+++ b/system-addon/test/unit/utils.js
@@ -27,15 +27,6 @@ export class GlobalOverrider {
    * @param  {any} value The value to which the property should be reassigned
    */
   _override(key, value) {
-    if (key === "Components") {
-      // Components can be reassigned, but it will subsequently throw a deprecation
-      // error in Firefox which will stop execution. Adding the assignment statement
-      // to a try/catch block will prevent this from happening.
-      try {
-        global[key] = value;
-      } catch (e) {} // eslint-disable-line no-empty
-      return;
-    }
     if (!this.originalGlobals.has(key)) {
       this.originalGlobals.set(key, global[key]);
     }


### PR DESCRIPTION
r? @rlr Followup for #4064. Make unit-entry have a TEST_GLOBAL for the various Cc and alias PlacesUtils to get those Cc. Also fixes PlacesFeed test to not change global directly, which wasn't getting restored.

Basically adding dummy methods/properties on unit-entry to later sandbox.stub/spy.