### PR TITLE
Fix Bug 1446195 - Update story preferences description and link

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -80,7 +80,7 @@ prefs_restore_defaults_button=Restore Defaults
 prefs_section_rows_option={num} row;{num} rows
 prefs_search_header=Web Search
 prefs_topsites_description=The sites you visit most
-prefs_topstories_description=High-quality content you might otherwise miss
+prefs_topstories_description2=Great content from around the web, personalized for you
 # LOCALIZATION NOTE (prefs_topstories_show_sponsored_label): {provider} is
 # replaced by the name of the content provider for this section, e.g., "Pocket"
 prefs_topstories_show_sponsored_label={provider} Sponsored Stories

--- a/system-addon/lib/AboutPreferences.jsm
+++ b/system-addon/lib/AboutPreferences.jsm
@@ -195,6 +195,20 @@ this.AboutPreferences = class AboutPreferences {
         label.classList.add("indent");
         label.textContent = formatString(descString);
 
+        // Specially add a link for stories
+        if (id === "topstories") {
+          const sponsoredHbox = createAppend("hbox", detailVbox);
+          sponsoredHbox.setAttribute("align", "center");
+          sponsoredHbox.appendChild(label);
+          label.classList.add("tail-with-learn-more");
+
+          const link = createAppend("label", sponsoredHbox);
+          link.classList.add("learn-sponsored");
+          link.classList.add("text-link");
+          link.setAttribute("href", sectionData.disclaimer.link.href);
+          link.textContent = formatString("prefs_topstories_sponsored_learn_more");
+        }
+
         // Add a rows dropdown if we have a pref to control and a maximum
         if (rowsPref && maxRows) {
           const detailHbox = createAppend("hbox", detailVbox);
@@ -221,20 +235,6 @@ this.AboutPreferences = class AboutPreferences {
         subcheck.classList.add("indent");
         subcheck.setAttribute("label", formatString(nested.titleString));
         linkPref(subcheck, nested.name, "bool");
-
-        // Specially add a link for sponsored content
-        if (nested.name === "showSponsored") {
-          const sponsoredHbox = createAppend("hbox", detailVbox);
-          sponsoredHbox.setAttribute("align", "center");
-          sponsoredHbox.appendChild(subcheck);
-          subcheck.classList.add("tail-with-learn-more");
-
-          const link = createAppend("label", sponsoredHbox);
-          link.classList.add("learn-sponsored");
-          link.classList.add("text-link");
-          link.setAttribute("href", sectionData.disclaimer.link.href);
-          link.textContent = formatString("prefs_topstories_sponsored_learn_more");
-        }
       });
     });
   }

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -63,7 +63,6 @@ const PREFS_CONFIG = new Map([
       read_more_endpoint: "https://getpocket.com/explore/trending?src=fx_new_tab",
       stories_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?version=3&consumer_key=$apiKey&locale_lang=${args.locale}`,
       stories_referrer: "https://getpocket.com/recommendations",
-      disclaimer_link: "https://getpocket.com/firefox/new_tab_learn_more",
       topics_endpoint: `https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=${args.locale}`,
       show_spocs: false,
       personalized: true

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -21,7 +21,7 @@ const BUILT_IN_SECTIONS = {
     id: "topstories",
     pref: {
       titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
-      descString: {id: options.provider_description || "prefs_topstories_description"},
+      descString: {id: "prefs_topstories_description2"},
       nestedPrefs: options.show_spocs ? [{
         name: "showSponsored",
         titleString: {id: "prefs_topstories_show_sponsored_label", values: {provider: options.provider_name}},
@@ -33,15 +33,14 @@ const BUILT_IN_SECTIONS = {
     icon: options.provider_icon,
     title: {id: "header_recommended_by", values: {provider: options.provider_name}},
     disclaimer: {
-      text: {id: options.disclaimer_text || "section_disclaimer_topstories"},
+      text: {id: "section_disclaimer_topstories"},
       link: {
-        // The href fallback is temporary so users in existing Shield studies get this configuration as well
-        href: options.disclaimer_link || "https://getpocket.cdn.mozilla.net/firefox/new_tab_learn_more",
-        id: options.disclaimer_linktext || "section_disclaimer_topstories_linktext"
+        href: "https://getpocket.com/firefox/new_tab_learn_more",
+        id: "section_disclaimer_topstories_linktext"
       },
-      button: {id: options.disclaimer_buttontext || "section_disclaimer_topstories_buttontext"}
+      button: {id: "section_disclaimer_topstories_buttontext"}
     },
-    privacyNoticeURL: options.privacy_notice_link || "https://www.mozilla.org/privacy/firefox/#suggest-relevant-content",
+    privacyNoticeURL: "https://www.mozilla.org/privacy/firefox/#suggest-relevant-content",
     maxRows: 1,
     availableLinkMenuOptions: ["CheckBookmarkOrArchive", "CheckSavedToPocket", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl"],
     emptyState: {

--- a/system-addon/test/unit/lib/AboutPreferences.test.js
+++ b/system-addon/test/unit/lib/AboutPreferences.test.js
@@ -232,6 +232,14 @@ describe("AboutPreferences Feed", () => {
 
         assert.equal(node.textContent, descString);
       });
+      it("should add a link for top stories", () => {
+        const href = "https://disclaimer/";
+        prefStructure = [{disclaimer: {link: {href}}, id: "topstories", pref: {descString: "some_desc"}}];
+
+        testRender();
+
+        assert.calledWith(node.setAttribute, "href", href);
+      });
       it("should render rows dropdown with appropriate number", () => {
         prefStructure = [{rowsPref: "row_pref", maxRows: 3, pref: {descString: "foo"}}];
 
@@ -250,14 +258,6 @@ describe("AboutPreferences Feed", () => {
         testRender();
 
         assert.calledWith(node.setAttribute, "label", titleString);
-      });
-      it("should add a link for sponsored", () => {
-        const href = "https://disclaimer/";
-        prefStructure = [{disclaimer: {link: {href}}, pref: {nestedPrefs: [{name: "showSponsored"}]}}];
-
-        testRender();
-
-        assert.calledWith(node.setAttribute, "href", href);
       });
     });
   });


### PR DESCRIPTION
r?@sarracini Moved the link to always be shown for stories instead of conditionally for sponsored. The old string can be replaced/removed because it wasn't actually used in 60. Also removed the option fallback stuff as it was confusingly out of sync for the disclaimer link href and the other options weren't being set (originally fixing #3796 in #3797)

Before sponsored off:
![screen shot 2018-03-28 at 9 55 32 pm](https://user-images.githubusercontent.com/438537/38070932-56de19da-32d3-11e8-8b19-8edb6d9b3d36.png)
Before sponsored on:
![screen shot 2018-03-28 at 9 54 39 pm](https://user-images.githubusercontent.com/438537/38070938-5dc5e976-32d3-11e8-9594-c3cb68380e20.png)


After sponsored off:
![screen shot 2018-03-28 at 9 57 18 pm](https://user-images.githubusercontent.com/438537/38070947-649a6484-32d3-11e8-9ddb-97ff36f49396.png)
After sponsored on:
![screen shot 2018-03-28 at 9 53 08 pm](https://user-images.githubusercontent.com/438537/38070954-6b7def5a-32d3-11e8-8180-8697a2eca459.png)
