### PR TITLE
Refactor ManualMigration to use redux state instead of ActivityStreamPrefs

### DIFF
--- a/system-addon/lib/ManualMigration.jsm
+++ b/system-addon/lib/ManualMigration.jsm
@@ -4,7 +4,7 @@
 "use strict";
 
 const {actionCreators: ac, actionTypes: at} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
-const {Prefs} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
+
 const MIGRATION_ENDED_EVENT = "Migration:Ended";
 const MS_PER_DAY = 86400000;
 
@@ -17,7 +17,24 @@ ChromeUtils.defineModuleGetter(this, "ProfileAge", "resource://gre/modules/Profi
 this.ManualMigration = class ManualMigration {
   constructor() {
     Services.obs.addObserver(this, MIGRATION_ENDED_EVENT);
-    this._prefs = new Prefs();
+  }
+
+  get getMigrationLastShownDate() {
+    return this.store.getState().Prefs.values.migrationLastShownDate;
+  }
+
+  set setMigrationLastShownDate(newDate) {
+    this.store.dispatch(ac.SetPref("migrationLastShownDate", newDate));
+    // this.store.getState().Prefs.values.migrationLastShownDate = newDate;
+  }
+
+  get getMigrationRemainingDays() {
+    return this.store.getState().Prefs.values.migrationRemainingDays;
+  }
+
+  set setMigrationRemainingDays(newDate) {
+    this.store.dispatch(ac.SetPref("migrationRemainingDays", newDate));
+    // this.store.getState().Prefs.values.migrationRemainingDays = newDate;
   }
 
   uninit() {
@@ -34,16 +51,16 @@ this.ManualMigration = class ManualMigration {
       return true;
     }
 
-    let migrationLastShownDate = new Date(this._prefs.get("migrationLastShownDate") * 1000);
+    let migrationLastShownDate = new Date(this.getMigrationLastShownDate * 1000);
     let today = new Date();
     // Round down to midnight.
     today = new Date(today.getFullYear(), today.getMonth(), today.getDate());
     if (migrationLastShownDate < today) {
-      let migrationRemainingDays = this._prefs.get("migrationRemainingDays") - 1;
+      let migrationRemainingDays = this.getMigrationRemainingDays - 1;
 
-      this._prefs.set("migrationRemainingDays", migrationRemainingDays);
+      this.setMigrationRemainingDays(migrationRemainingDays);
       // .valueOf returns a value that is too large to store so we need to divide by 1000.
-      this._prefs.set("migrationLastShownDate", today.valueOf() / 1000);
+      this.setMigrationLastShownDate(today.valueOf() / 1000);
 
       if (migrationRemainingDays <= 0) {
         return true;

--- a/system-addon/lib/ManualMigration.jsm
+++ b/system-addon/lib/ManualMigration.jsm
@@ -19,22 +19,20 @@ this.ManualMigration = class ManualMigration {
     Services.obs.addObserver(this, MIGRATION_ENDED_EVENT);
   }
 
-  get getMigrationLastShownDate() {
+  get migrationLastShownDate() {
     return this.store.getState().Prefs.values.migrationLastShownDate;
   }
 
-  set setMigrationLastShownDate(newDate) {
+  set migrationLastShownDate(newDate) {
     this.store.dispatch(ac.SetPref("migrationLastShownDate", newDate));
-    // this.store.getState().Prefs.values.migrationLastShownDate = newDate;
   }
 
-  get getMigrationRemainingDays() {
+  get migrationRemainingDays() {
     return this.store.getState().Prefs.values.migrationRemainingDays;
   }
 
-  set setMigrationRemainingDays(newDate) {
+  set migrationRemainingDays(newDate) {
     this.store.dispatch(ac.SetPref("migrationRemainingDays", newDate));
-    // this.store.getState().Prefs.values.migrationRemainingDays = newDate;
   }
 
   uninit() {
@@ -51,16 +49,17 @@ this.ManualMigration = class ManualMigration {
       return true;
     }
 
-    let migrationLastShownDate = new Date(this.getMigrationLastShownDate * 1000);
+    let migrationLastShownDate = new Date(this.migrationLastShownDate * 1000);
     let today = new Date();
     // Round down to midnight.
     today = new Date(today.getFullYear(), today.getMonth(), today.getDate());
     if (migrationLastShownDate < today) {
-      let migrationRemainingDays = this.getMigrationRemainingDays - 1;
+      let migrationRemainingDays = this.migrationRemainingDays - 1;
 
-      this.setMigrationRemainingDays(migrationRemainingDays);
+      this.migrationRemainingDays = migrationRemainingDays;
+
       // .valueOf returns a value that is too large to store so we need to divide by 1000.
-      this.setMigrationLastShownDate(today.valueOf() / 1000);
+      this.migrationLastShownDate = today.valueOf() / 1000;
 
       if (migrationRemainingDays <= 0) {
         return true;


### PR DESCRIPTION
This PR adds test fixes to SeanPrashad's work in #3917. To test, you should run this on a clean profile and test the manual migration UI.