### PR TITLE
Fix #1447752 - set search input background to $white

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -22,6 +22,7 @@
   width: 100%;
 
   input {
+    background-color: $white;
     border: 0;
     border-radius: $search-border-radius;
     box-shadow: $shadow-secondary, 0 0 0 1px $black-15;


### PR DESCRIPTION
r? @Mardak 