### PR TITLE
Fix Bug 1433215 - Add blockList persistance to Message Center

### DIFF
--- a/system-addon/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/system-addon/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -33,7 +33,7 @@ export class ASRouterAdmin extends React.PureComponent {
 
   renderMessageItem(msg) {
     const isCurrent = msg.id === this.state.currentId;
-    const isBlocked = this.state.blockList[msg.id];
+    const isBlocked = this.state.blockList.includes(msg.id);
 
     let itemClassName = "message-item";
     if (isCurrent) { itemClassName += " current"; }

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -61,7 +61,7 @@ class _ASRouter {
   constructor(initialState = {}) {
     this.initialized = false;
     this.messageChannel = null;
-    this._storage = new ActivityStreamStorage("snippets");
+    this._storage = null;
     this._state = Object.assign({
       currentId: null,
       blockList: [],
@@ -85,10 +85,11 @@ class _ASRouter {
    * @param {RemotePageManager} channel a RemotePageManager instance
    * @memberof _ASRouter
    */
-  async init(channel) {
+  async init(channel, storage) {
     this.messageChannel = channel;
     this.messageChannel.addMessageListener(INCOMING_MESSAGE_NAME, this.onMessage);
     this.initialized = true;
+    this._storage = storage;
 
     const blockList = await this._storage.get("blockList");
     this.setState({blockList});

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -117,7 +117,7 @@ class _ASRouter {
   async sendNextMessage(target, id) {
     let message;
     await this.setState(state => {
-      message = getRandomItemFromArray(state.messages.filter(item => item.id !== state.currentId && !state.blockList[item.id]));
+      message = getRandomItemFromArray(state.messages.filter(item => item.id !== state.currentId && !state.blockList.includes(item.id)));
       return {currentId: message ? message.id : null};
     });
     if (message) {

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -141,20 +141,20 @@ class _ASRouter {
         await this.sendNextMessage(target);
         break;
       case "BLOCK_MESSAGE_BY_ID":
-        await this.setState(async state => {
-          const blockList = state.blockList.slice();
+        await this.setState(state => {
+          const blockList = [...state.blockList];
           blockList.push(action.data.id);
-          await this._storage.set("blockList", blockList);
+          this._storage.set("blockList", blockList);
 
           return {blockList};
         });
         await this.clearMessage(target, action.data.id);
         break;
       case "UNBLOCK_MESSAGE_BY_ID":
-        await this.setState(async state => {
-          const blockList = state.blockList.slice();
+        await this.setState(state => {
+          const blockList = [...state.blockList];
           blockList.splice(blockList.indexOf(action.data.id), 1);
-          await this._storage.set("blockList", blockList);
+          this._storage.set("blockList", blockList);
 
           return {blockList};
         });

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -141,20 +141,20 @@ class _ASRouter {
         await this.sendNextMessage(target);
         break;
       case "BLOCK_MESSAGE_BY_ID":
-        await this.setState(state => {
+        await this.setState(async state => {
           const blockList = state.blockList.slice();
           blockList.push(action.data.id);
-          this._storage.set("blockList", blockList);
+          await this._storage.set("blockList", blockList);
 
           return {blockList};
         });
         await this.clearMessage(target, action.data.id);
         break;
       case "UNBLOCK_MESSAGE_BY_ID":
-        await this.setState(state => {
+        await this.setState(async state => {
           const blockList = state.blockList.slice();
           blockList.splice(blockList.indexOf(action.data.id), 1);
-          this._storage.set("blockList", blockList);
+          await this._storage.set("blockList", blockList);
 
           return {blockList};
         });

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -91,7 +91,7 @@ class _ASRouter {
     this.initialized = true;
 
     const blockList = await this._storage.get("blockList");
-    await this.setState({blockList});
+    this.setState({blockList});
   }
 
   uninit() {
@@ -101,8 +101,8 @@ class _ASRouter {
     this.initialized = false;
   }
 
-  async setState(callbackOrObj) {
-    const newState = (typeof callbackOrObj === "function") ? await callbackOrObj(this.state) : callbackOrObj;
+  setState(callbackOrObj) {
+    const newState = (typeof callbackOrObj === "function") ? callbackOrObj(this.state) : callbackOrObj;
     this._state = Object.assign({}, this.state, newState);
     return new Promise(resolve => {
       this._onStateChanged(this.state);
@@ -141,7 +141,7 @@ class _ASRouter {
         await this.sendNextMessage(target);
         break;
       case "BLOCK_MESSAGE_BY_ID":
-        await this.setState(state => {
+        this.setState(state => {
           const blockList = [...state.blockList];
           blockList.push(action.data.id);
           this._storage.set("blockList", blockList);
@@ -151,7 +151,7 @@ class _ASRouter {
         await this.clearMessage(target, action.data.id);
         break;
       case "UNBLOCK_MESSAGE_BY_ID":
-        await this.setState(state => {
+        this.setState(state => {
           const blockList = [...state.blockList];
           blockList.splice(blockList.indexOf(action.data.id), 1);
           this._storage.set("blockList", blockList);

--- a/system-addon/lib/ASRouterFeed.jsm
+++ b/system-addon/lib/ASRouterFeed.jsm
@@ -14,7 +14,8 @@ class ASRouterFeed {
   }
 
   async enable() {
-    await this.router.init(this.store._messageChannel.channel);
+    await this.router.init(this.store._messageChannel.channel,
+      this.store.dbStorage.getDbTable("snippets"));
     // Disable onboarding
     Services.prefs.setBoolPref(ONBOARDING_FINISHED_PREF, true);
   }

--- a/system-addon/lib/ASRouterFeed.jsm
+++ b/system-addon/lib/ASRouterFeed.jsm
@@ -32,10 +32,10 @@ class ASRouterFeed {
    * (asrouterExperimentEnabled) and enable or disable ASRouter based on
    * its value.
    */
-  async enableOrDisableBasedOnPref() {
+  enableOrDisableBasedOnPref() {
     const isExperimentEnabled = this.store.getState().Prefs.values.asrouterExperimentEnabled;
     if (!this.router.initialized && isExperimentEnabled) {
-      await this.enable();
+      this.enable();
     } else if (!isExperimentEnabled && this.router.initialized) {
       this.disable();
     }

--- a/system-addon/lib/ASRouterFeed.jsm
+++ b/system-addon/lib/ASRouterFeed.jsm
@@ -13,8 +13,8 @@ class ASRouterFeed {
     this.router = options.router || ASRouter;
   }
 
-  enable() {
-    this.router.init(this.store._messageChannel.channel);
+  async enable() {
+    await this.router.init(this.store._messageChannel.channel);
     // Disable onboarding
     Services.prefs.setBoolPref(ONBOARDING_FINISHED_PREF, true);
   }
@@ -32,10 +32,10 @@ class ASRouterFeed {
    * (asrouterExperimentEnabled) and enable or disable ASRouter based on
    * its value.
    */
-  enableOrDisableBasedOnPref() {
+  async enableOrDisableBasedOnPref() {
     const isExperimentEnabled = this.store.getState().Prefs.values.asrouterExperimentEnabled;
     if (!this.router.initialized && isExperimentEnabled) {
-      this.enable();
+      await this.enable();
     } else if (!isExperimentEnabled && this.router.initialized) {
       this.disable();
     }

--- a/system-addon/test/unit/asrouter/ASRouter.test.js
+++ b/system-addon/test/unit/asrouter/ASRouter.test.js
@@ -35,12 +35,12 @@ describe("ASRouter", () => {
     sandbox = sinon.sandbox.create();
     blockList = [];
     Router = new _ASRouter({messages: FAKE_MESSAGES});
-    Router._storage = {
+    const storage = {
       get: sandbox.stub().returns(Promise.resolve(blockList)),
       set: sandbox.stub().returns(Promise.resolve())
     };
     channel = new FakeRemotePageManager();
-    await Router.init(channel);
+    await Router.init(channel, storage);
   });
   afterEach(() => {
     sandbox.restore();
@@ -196,7 +196,11 @@ describe("ASRouterFeed", () => {
     // Add prefs to feed.store
     prefs = {};
     channel = new FakeRemotePageManager();
-    feed.store = {_messageChannel: {channel}, getState: () => ({Prefs: {values: prefs}})};
+    feed.store = {
+      _messageChannel: {channel},
+      getState: () => ({Prefs: {values: prefs}}),
+      dbStorage: {getDbTable: sandbox.stub().returns({})}
+    };
   });
   afterEach(() => {
     sandbox.restore();
@@ -225,6 +229,8 @@ describe("ASRouterFeed", () => {
       await feed.enable();
 
       assert.calledWith(Router.init, channel);
+      assert.calledOnce(feed.store.dbStorage.getDbTable);
+      assert.calledWithExactly(feed.store.dbStorage.getDbTable, "snippets");
       assert.calledWith(global.Services.prefs.setBoolPref, ONBOARDING_FINISHED_PREF, true);
     });
     it("should not re-initialize the ASRouter if it is already initialized", () => {

--- a/system-addon/test/unit/asrouter/ASRouter.test.js
+++ b/system-addon/test/unit/asrouter/ASRouter.test.js
@@ -72,10 +72,10 @@ describe("ASRouter", () => {
       await Router.setState(() => ({blockList: []}));
     });
     it("should not return a blocked message", async () => {
-      await Router.setState(() => ({blockList: [FAKE_MESSAGE_IDS[0]]}));
+      await Router.setState(() => ({blockList: [FAKE_MESSAGE_IDS[0], FAKE_MESSAGE_IDS[1]]}));
       const targetStub = {sendAsyncMessage: sandbox.stub()};
 
-      await Router.sendNextMessage(targetStub, FAKE_MESSAGE_IDS[1]);
+      await Router.sendNextMessage(targetStub, null);
 
       assert.calledOnce(targetStub.sendAsyncMessage);
       assert.equal(Router.state.currentId, FAKE_MESSAGE_IDS[2]);

--- a/system-addon/test/unit/asrouter/ASRouter.test.js
+++ b/system-addon/test/unit/asrouter/ASRouter.test.js
@@ -107,6 +107,8 @@ describe("ASRouter", () => {
       assert.isTrue(Router.state.blockList.includes("foo"));
       assert.isNull(Router.state.currentId);
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE"});
+      assert.calledOnce(Router._storage.set);
+      assert.calledWithExactly(Router._storage.set, "blockList", ["foo"]);
     });
   });
   describe("#onMessage: UNBLOCK_MESSAGE_BY_ID", () => {
@@ -116,6 +118,12 @@ describe("ASRouter", () => {
       await Router.onMessage(createRemoteMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
 
       assert.isFalse(Router.state.blockList.includes("foo"));
+    });
+    it("should save the blockList", async () => {
+      await Router.onMessage(createRemoteMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
+
+      assert.calledOnce(Router._storage.set);
+      assert.calledWithExactly(Router._storage.set, "blockList", []);
     });
   });
   describe("#onMessage: ADMIN_CONNECT_STATE", () => {


### PR DESCRIPTION
This uses the same object storage as snippets since both block based on string ids. Modified the Message Center blocklist to be an array.