### PR TITLE
Fix Bug 1451001 - add black fill and hairline for cards in dark theme

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -52,14 +52,13 @@
   }
 
   .card-preview-image-outer {
-    background-color: var(--newtab-background-color);
     border-radius: $border-radius $border-radius 0 0;
     height: $card-preview-image-height;
     overflow: hidden;
     position: relative;
 
     &::after {
-      border-bottom: 1px solid $black-5;
+      border-bottom: 1px solid var(--newtab-card-hairline-color);
       bottom: 0;
       content: '';
       position: absolute;

--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -44,6 +44,7 @@
   // Cards
   --newtab-card-background-color: $white;
   --newtab-card-active-outline-color: $grey-30;
+  --newtab-card-hairline-color: $black-10;
 }
 
 // Dark theme
@@ -92,6 +93,7 @@
   // Cards
   --newtab-card-background-color: $grey-90;
   --newtab-card-active-outline-color: $grey-60;
+  --newtab-card-hairline-color: $grey-10-20;
 }
 
 // scss variables related to the theme.


### PR DESCRIPTION
Before:
<img width="345" alt="screen shot 2018-04-03 at 7 27 40 pm" src="https://user-images.githubusercontent.com/36629/38280784-3146e566-3775-11e8-8c6a-e0eaa5dc6ba7.png">
<img width="345" alt="screen shot 2018-04-03 at 7 27 28 pm" src="https://user-images.githubusercontent.com/36629/38280785-32be0276-3775-11e8-8f46-4dc35e0cf1f5.png">

After:
<img width="361" alt="screen shot 2018-04-03 at 4 17 20 pm" src="https://user-images.githubusercontent.com/36629/38280788-37752e16-3775-11e8-81ff-3ae86167e840.png">
<img width="360" alt="screen shot 2018-04-03 at 4 17 34 pm" src="https://user-images.githubusercontent.com/36629/38280789-392bcdfa-3775-11e8-8fb8-336beb1f6fc8.png">
