### PR TITLE
Fix Bug 1451419 - set background of Top Site icons to $white

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -144,7 +144,7 @@ $half-base-gutter: $base-gutter / 2;
 
   // Some common styles for all icons (rich and default) in top sites
   .top-site-icon {
-    background-color: var(--newtab-background-color);
+    background-color: $white;
     background-position: center center;
     background-repeat: no-repeat;
     border-radius: $top-sites-border-radius;


### PR DESCRIPTION
I am confirming with Amy that this should also apply to the default theme.

Before:
<img width="145" alt="screen shot 2018-04-05 at 12 24 44 pm" src="https://user-images.githubusercontent.com/36629/38378810-daf157e2-38cc-11e8-8fda-210c3a5b8e4e.png">
<img width="145" alt="screen shot 2018-04-05 at 12 24 08 pm" src="https://user-images.githubusercontent.com/36629/38378814-dc3554b4-38cc-11e8-977d-c684c161c44c.png">

After:
<img width="140" alt="screen shot 2018-04-05 at 12 24 58 pm" src="https://user-images.githubusercontent.com/36629/38378820-dedda63a-38cc-11e8-8e34-de14933f7736.png">
<img width="151" alt="screen shot 2018-04-05 at 12 23 58 pm" src="https://user-images.githubusercontent.com/36629/38378823-e0297118-38cc-11e8-81e4-d64e6b09c5bb.png">
