### PR TITLE
Fix Bug 1445769 - Top Sites runs `refresh` at startup even when disabled

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -130,6 +130,12 @@ function onBrowserReady() {
     }
   });
 
+  migratePref("browser.newtabpage.activity-stream.showTopSites", value => {
+    if (value === false) {
+      Services.prefs.setBoolPref("browser.newtabpage.activity-stream.feeds.topsites", false);
+    }
+  });
+
   // Old activity stream topSitesCount pref showed 6 per row
   migratePref("browser.newtabpage.activity-stream.topSitesCount", count => {
     Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesRows", Math.ceil(count / 6));

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -124,7 +124,7 @@ function onBrowserReady() {
   migratePref("browser.newtabpage.rows", rows => {
     // Just disable top sites if rows are not desired
     if (rows <= 0) {
-      Services.prefs.setBoolPref("browser.newtabpage.activity-stream.showTopSites", false);
+      Services.prefs.setBoolPref("browser.newtabpage.activity-stream.feeds.topsites", false);
     } else {
       Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesRows", rows);
     }

--- a/system-addon/common/PrerenderData.jsm
+++ b/system-addon/common/PrerenderData.jsm
@@ -57,7 +57,7 @@ class _PrerenderData {
 this.PrerenderData = new _PrerenderData({
   initialPrefs: {
     "migrationExpired": true,
-    "showTopSites": true,
+    "feeds.topsites": true,
     "showSearch": true,
     "topSitesRows": 1,
     "feeds.section.topstories": true,
@@ -73,7 +73,7 @@ this.PrerenderData = new _PrerenderData({
   // will result in users who have modified some of their preferences not being
   // able to get the benefits of prerendering.
   validation: [
-    "showTopSites",
+    "feeds.topsites",
     "showSearch",
     "topSitesRows",
     "enableWideLayout",

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -193,8 +193,7 @@ export class _Sections extends React.PureComponent {
   renderSections() {
     const sections = [];
     const enabledSections = this.props.Sections.filter(section => section.enabled);
-    const {sectionOrder} = this.props.Prefs.values;
-    const showTopSites = this.props.Prefs.values["feeds.topsites"];
+    const {sectionOrder, "feeds.topsites": showTopSites} = this.props.Prefs.values;
     // Enabled sections doesn't include Top Sites, so we add it if enabled.
     const expectedCount = enabledSections.length + ~~showTopSites;
 

--- a/system-addon/content-src/components/Sections/Sections.jsx
+++ b/system-addon/content-src/components/Sections/Sections.jsx
@@ -193,7 +193,8 @@ export class _Sections extends React.PureComponent {
   renderSections() {
     const sections = [];
     const enabledSections = this.props.Sections.filter(section => section.enabled);
-    const {sectionOrder, showTopSites} = this.props.Prefs.values;
+    const {sectionOrder} = this.props.Prefs.values;
+    const showTopSites = this.props.Prefs.values["feeds.topsites"];
     // Enabled sections doesn't include Top Sites, so we add it if enabled.
     const expectedCount = enabledSections.length + ~~showTopSites;
 

--- a/system-addon/content-src/components/TopSites/TopSites.jsx
+++ b/system-addon/content-src/components/TopSites/TopSites.jsx
@@ -109,7 +109,7 @@ export class _TopSites extends React.PureComponent {
         id="topsites"
         title={{id: "header_top_sites"}}
         extraMenuOptions={["AddTopSite"]}
-        showPrefName="showTopSites"
+        showPrefName="feeds.topsites"
         eventSource={TOP_SITES_SOURCE}
         collapsed={props.TopSites.pref ? props.TopSites.pref.collapsed : undefined}
         isFirst={props.isFirst}

--- a/system-addon/lib/AboutPreferences.jsm
+++ b/system-addon/lib/AboutPreferences.jsm
@@ -25,7 +25,7 @@ const PREFS_BEFORE_SECTIONS = [
   {
     id: "topsites",
     pref: {
-      feed: "showTopSites",
+      feed: "feeds.topsites",
       titleString: "settings_pane_topsites_header",
       descString: "prefs_topsites_description"
     },

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -100,10 +100,6 @@ const PREFS_CONFIG = new Map([
     title: "Disable snippets on activity stream",
     value: false
   }],
-  ["showTopSites", {
-    title: "Show the Top Sites section",
-    value: true
-  }],
   ["topSitesRows", {
     title: "Number of rows of Top Sites to display",
     value: 1

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -118,7 +118,7 @@ this.HighlightsFeed = class HighlightsFeed {
    */
   async fetchHighlights(options = {}) {
     // We need TopSites for deduping, so wait for TOP_SITES_UPDATED.
-    if (!this.store.getState().TopSites.initialized || !this.store.getState().Prefs.values["feeds.topsites"]) {
+    if (!this.store.getState().TopSites.initialized && this.store.getState().Prefs.values["feeds.topsites"]) {
       return;
     }
 

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -117,7 +117,7 @@ this.HighlightsFeed = class HighlightsFeed {
    * @param {bool} options.broadcast Should the update be broadcasted.
    */
   async fetchHighlights(options = {}) {
-    // We need TopSites for deduping, so wait for TOP_SITES_UPDATED.
+    // If TopSites are enabled we need them for deduping, so wait for TOP_SITES_UPDATED.
     if (!this.store.getState().TopSites.initialized && this.store.getState().Prefs.values["feeds.topsites"]) {
       return;
     }

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -118,7 +118,7 @@ this.HighlightsFeed = class HighlightsFeed {
    */
   async fetchHighlights(options = {}) {
     // We need TopSites for deduping, so wait for TOP_SITES_UPDATED.
-    if (!this.store.getState().TopSites.initialized) {
+    if (!this.store.getState().TopSites.initialized && this.store.getState().Prefs.values["feeds.topsites"]) {
       return;
     }
 

--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -118,7 +118,7 @@ this.HighlightsFeed = class HighlightsFeed {
    */
   async fetchHighlights(options = {}) {
     // We need TopSites for deduping, so wait for TOP_SITES_UPDATED.
-    if (!this.store.getState().TopSites.initialized && this.store.getState().Prefs.values["feeds.topsites"]) {
+    if (!this.store.getState().TopSites.initialized || !this.store.getState().Prefs.values["feeds.topsites"]) {
       return;
     }
 

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -361,7 +361,7 @@ class SectionsFeed {
 
   get enabledSectionIds() {
     let sections = this.store.getState().Sections.filter(section => section.enabled).map(s => s.id);
-    // Top Sites is a special case. Append if show pref is on.
+    // Top Sites is a special case. Append if the feed is enabled.
     if (this.store.getState().Prefs.values["feeds.topsites"]) {
       sections.push("topsites");
     }

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -362,7 +362,7 @@ class SectionsFeed {
   get enabledSectionIds() {
     let sections = this.store.getState().Sections.filter(section => section.enabled).map(s => s.id);
     // Top Sites is a special case. Append if show pref is on.
-    if (this.store.getState().Prefs.values.showTopSites) {
+    if (this.store.getState().Prefs.values["feeds.topsites"]) {
       sections.push("topsites");
     }
     return sections;

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -28,7 +28,7 @@ const ACTIVITY_STREAM_ENDPOINT_PREF = "browser.newtabpage.activity-stream.teleme
 // This is a mapping table between the user preferences and its encoding code
 const USER_PREFS_ENCODING = {
   "showSearch": 1 << 0,
-  "showTopSites": 1 << 1,
+  "feeds.topsites": 1 << 1,
   "feeds.section.topstories": 1 << 2,
   "feeds.section.highlights": 1 << 3,
   "feeds.snippets": 1 << 4,

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -375,9 +375,7 @@ this.TopSitesFeed = class TopSitesFeed {
     switch (action.type) {
       case at.INIT:
         // If the feed was previously disabled PREFS_INITIAL_VALUES was never received
-        if (!DEFAULT_TOP_SITES.length) {
-          this.refreshDefaults(this.store.getState().Prefs.values[DEFAULT_SITES_PREF]);
-        }
+        this.refreshDefaults(this.store.getState().Prefs.values[DEFAULT_SITES_PREF]);
         this.refresh({broadcast: true});
         break;
       case at.SYSTEM_TICK:

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -374,6 +374,10 @@ this.TopSitesFeed = class TopSitesFeed {
   onAction(action) {
     switch (action.type) {
       case at.INIT:
+        // If the feed was previously disabled PREFS_INITIAL_VALUES was never received
+        if (!DEFAULT_TOP_SITES.length) {
+          this.refreshDefaults(this.store.getState().Prefs.values[DEFAULT_SITES_PREF]);
+        }
         this.refresh({broadcast: true});
         break;
       case at.SYSTEM_TICK:

--- a/system-addon/test/functional/mochitest/browser_as_render.js
+++ b/system-addon/test/functional/mochitest/browser_as_render.js
@@ -13,7 +13,7 @@ test_newtab(function test_render_topsites() {
 
 test_newtab({
   async before({pushPrefs}) {
-    await pushPrefs(["browser.newtabpage.activity-stream.showTopSites", false]);
+    await pushPrefs(["browser.newtabpage.activity-stream.feeds.topsites", false]);
   },
   test: function test_render_no_topsites() {
     let topSites = content.document.querySelector(".top-sites-list");

--- a/system-addon/test/unit/content-src/components/Sections.test.jsx
+++ b/system-addon/test/unit/content-src/components/Sections.test.jsx
@@ -30,12 +30,12 @@ describe("<Sections>", () => {
       assert.equal(section.props().enabled, true);
     });
   });
-  it("should render Top Sites if showTopSites pref is true", () => {
-    wrapper = shallow(<Sections Sections={FAKE_SECTIONS} Prefs={{values: {showTopSites: true, sectionOrder: "topsites,topstories,highlights"}}} />);
+  it("should render Top Sites if feeds.topsites pref is true", () => {
+    wrapper = shallow(<Sections Sections={FAKE_SECTIONS} Prefs={{values: {"feeds.topsites": true, "sectionOrder": "topsites,topstories,highlights"}}} />);
     assert.equal(wrapper.find(TopSites).length, 1);
   });
-  it("should NOT render Top Sites if showTopSites pref is false", () => {
-    wrapper = shallow(<Sections Sections={FAKE_SECTIONS} Prefs={{values: {showTopSites: false, sectionOrder: "topsites,topstories,highlights"}}} />);
+  it("should NOT render Top Sites if feeds.topsites pref is false", () => {
+    wrapper = shallow(<Sections Sections={FAKE_SECTIONS} Prefs={{values: {"feeds.topsites": false, "sectionOrder": "topsites,topstories,highlights"}}} />);
     assert.equal(wrapper.find(TopSites).length, 0);
   });
   it("should render the sections in the order specifed by sectionOrder pref", () => {

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -178,10 +178,10 @@ describe("Highlights Feed", () => {
       await feed.fetchHighlights(options);
       return sectionsManagerStub.updateSection.firstCall.args[1].rows;
     };
-
     it("should return early if if are not TopSites initialised", async () => {
       sandbox.spy(feed.linksCache, "request");
       feed.store.state.TopSites.initialized = false;
+      feed.store.state.Prefs.values["feeds.topsites"] = true;
 
       // Initially TopSites is uninitialised and fetchHighlights should return.
       await feed.fetchHighlights();
@@ -218,6 +218,15 @@ describe("Highlights Feed", () => {
       assert.equal(highlights[4].url, links[5].url);
       assert.equal(highlights[5].url, links[2].url);
       assert.equal(highlights[6].url, links[3].url);
+    });
+    it("should fetch Highlights if TopSites are not enabled", async () => {
+      sandbox.spy(feed.linksCache, "request");
+      feed.store.state.Prefs.values["feeds.topsites"] = false;
+
+      await feed.fetchHighlights();
+
+      assert.calledOnce(feed.linksCache.request);
+      assert.calledOnce(fakeNewTabUtils.activityStreamLinks.getHighlights);
     });
     it("should add hostname and hasImage to each link", async () => {
       links = [{url: "https://mozilla.org"}];

--- a/system-addon/test/unit/lib/SectionsManager.test.js
+++ b/system-addon/test/unit/lib/SectionsManager.test.js
@@ -389,8 +389,8 @@ describe("SectionsFeed", () => {
       state: {
         Prefs: {
           values: {
-            sectionOrder: "topsites,topstories,highlights",
-            showTopSites: true
+            "sectionOrder": "topsites,topstories,highlights",
+            "feeds.topsites": true
           }
         },
         Sections: [{initialized: false}]


### PR DESCRIPTION
Only two small issues found when migrating the pref because our code never expected Topsites to be "really turned off".
* `HighlightsFeed.fetchHighlights` waiting on topsites to be initialised
* The `TopSitesFeed` not having `DEFAULT_SITES` if you open the browser and the section was previously disabled