### PR TITLE
Fix Bug 1450875 - Wait for Sections to be added before broadcasting content

### DIFF
--- a/system-addon/lib/HighlightsFeed.jsm
+++ b/system-addon/lib/HighlightsFeed.jsm
@@ -118,7 +118,9 @@ this.HighlightsFeed = class HighlightsFeed {
    */
   async fetchHighlights(options = {}) {
     // If TopSites are enabled we need them for deduping, so wait for TOP_SITES_UPDATED.
-    if (!this.store.getState().TopSites.initialized && this.store.getState().Prefs.values["feeds.topsites"]) {
+    // Wait for SectionsManager to initialise the Sections.
+    if ((!this.store.getState().TopSites.initialized && this.store.getState().Prefs.values["feeds.topsites"]) ||
+        !this.store.getState().Sections.length) {
       return;
     }
 

--- a/system-addon/test/unit/lib/HighlightsFeed.test.js
+++ b/system-addon/test/unit/lib/HighlightsFeed.test.js
@@ -178,12 +178,23 @@ describe("Highlights Feed", () => {
       await feed.fetchHighlights(options);
       return sectionsManagerStub.updateSection.firstCall.args[1].rows;
     };
-    it("should return early if if are not TopSites initialised", async () => {
+    it("should return early if TopSites are not initialised", async () => {
       sandbox.spy(feed.linksCache, "request");
       feed.store.state.TopSites.initialized = false;
       feed.store.state.Prefs.values["feeds.topsites"] = true;
 
       // Initially TopSites is uninitialised and fetchHighlights should return.
+      await feed.fetchHighlights();
+
+      assert.notCalled(fakeNewTabUtils.activityStreamLinks.getHighlights);
+      assert.notCalled(feed.linksCache.request);
+    });
+    it("should return early if Sections are not initialised", async () => {
+      sandbox.spy(feed.linksCache, "request");
+      feed.store.state.TopSites.initialized = true;
+      feed.store.state.Prefs.values["feeds.topsites"] = true;
+      feed.store.state.Sections = [];
+
       await feed.fetchHighlights();
 
       assert.notCalled(fakeNewTabUtils.activityStreamLinks.getHighlights);


### PR DESCRIPTION
It looks like the `SectionsManager` does not initialise/add the sections until `PREFS_INITIAL_VALUES` because prefs are required for sections. `PREFS_INITIAL_VALUES` is triggered after `INIT`, but `INIT` also triggers Topsites to update and afterwards the HighlightsFeed. If the SectionsManager hasn't finished before the `HighlightsFeed.fetchHighlights` call, then we run into this issue. 

I wasn't able to reproduce, what I did was add an `await` call for a promise resolved in a `setTimeout` in `addBuiltInSection`.

I propose that we just return early if we don't have the sections available yet because when they finally become available [the feed will trigger the postInit fetch](https://github.com/mozilla/activity-stream/blob/7c6b298462b4d4a7aa685901adce3a0ba59d779a/system-addon/lib/HighlightsFeed.jsm#L53-L56)

This is just a WIP to open the discussion.

@Mardak thoughts?