### PR TITLE
Use moz-osx-font-smoothing: grayscale for dark theme

### DIFF
--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -47,6 +47,7 @@ body {
 
 // Dark theme
 .dark-theme {
+  -moz-osx-font-smoothing: grayscale;
   // General styles
   --newtab-background-color: $grey-80;
   --newtab-border-primary-color: $grey-10-80;


### PR DESCRIPTION
What do we think about using `moz-osx-font-smoothing: grayscale` when the dark theme is enabled? it makes some of the type look a lot sharper, especially with the reversed text. Is there any reason we might not want to do this?

<img width="802" alt="image" src="https://user-images.githubusercontent.com/1455535/38701664-7a625340-3e6c-11e8-9402-8e53527ce5b0.png">
