### PR TITLE
fix(styles): Only use osx property for mac css

### DIFF
--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -61,7 +61,6 @@ body {
 
 // Dark theme
 .dark-theme {
-  -moz-osx-font-smoothing: grayscale;
   // General styles
   --newtab-background-color: $grey-80;
   --newtab-border-primary-color: $grey-10-80;

--- a/system-addon/content-src/styles/activity-stream-mac.scss
+++ b/system-addon/content-src/styles/activity-stream-mac.scss
@@ -4,4 +4,8 @@ $os-infopanel-arrow-height: 10px;
 $os-infopanel-arrow-offset-end: 7px;
 $os-infopanel-arrow-width: 18px;
 
+.dark-theme {
+  -moz-osx-font-smoothing: grayscale;
+}
+
 @import './activity-stream';


### PR DESCRIPTION
Followup to #4089 to avoid test failures:

TEST-UNEXPECTED-FAIL | browser/base/content/test/static/browser_parsable_css.js | Got error message for resource://activity-stream/css/activity-stream.css: Unknown property ‘-moz-osx-font-smoothing’. Declaration dropped. -

r? @rlr or @k88hudson ?