### PR TITLE
Fix Bug 1454263 - fix search drop down dividers and hover colors

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -78,9 +78,10 @@
   // Adjust the style of the contentSearchUI-generated table
   // sass-lint:disable-block class-name-format
   .contentSearchSuggestionTable {
+    background-color: var(--newtab-search-dropdown-color);
     border: 0;
     box-shadow: $context-menu-shadow;
-    transform: translateY(3px);
+    transform: translateY($textbox-shadow-size);
 
     .contentSearchHeader {
       background-color: var(--newtab-search-dropdown-header-color);
@@ -88,9 +89,17 @@
     }
 
     .contentSearchHeader,
-    .contentSearchSuggestionsList,
     .contentSearchSettingsButton {
       border-color: var(--newtab-border-secondary-color);
+    }
+
+    .contentSearchSuggestionsList {
+      border: 0;
+    }
+
+    .contentSearchOneOffsTable {
+      background-color: var(--newtab-search-dropdown-header-color);
+      border-top: solid 1px var(--newtab-border-secondary-color);
     }
 
     .contentSearchSearchWithHeaderSearchText {
@@ -119,6 +128,21 @@
     .contentSearchOneOffsTable {
       .contentSearchSuggestionsContainer {
         background-color: var(--newtab-search-dropdown-header-color);
+      }
+    }
+
+    .contentSearchOneOffItem {
+      background-image: none;
+      border-right: solid 1px var(--newtab-border-secondary-color);
+      height: 22px;
+      margin: 5px 0;
+
+      &.selected {
+        background: var(--newtab-element-hover-color);
+      }
+
+      &:active {
+        background: var(--newtab-element-active-color);
       }
     }
 

--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -1,5 +1,5 @@
 @function textbox-shadow($color) {
-  @return 0 0 0 1px $color, 0 0 0 4px rgba($color, 0.3);
+  @return 0 0 0 1px $color, 0 0 0 $textbox-shadow-size rgba($color, 0.3);
 }
 
 @mixin textbox-focus($color) {

--- a/system-addon/content-src/styles/_variables.scss
+++ b/system-addon/content-src/styles/_variables.scss
@@ -107,6 +107,8 @@ $image-path: '../data/content/assets/';
 
 $snippets-container-height: 120px;
 
+$textbox-shadow-size: 4px;
+
 @mixin fade-in {
   box-shadow: inset $inner-box-shadow, $shadow-primary;
   transition: box-shadow 150ms;


### PR DESCRIPTION
r? @Mardak 

Before:
(hovering the change search settings button)
<img width="1046" alt="screen shot 2018-04-16 at 12 49 56 pm" src="https://user-images.githubusercontent.com/36629/38823568-be64529a-4174-11e8-9365-6f35bdeaf097.png">

(hovering ebay search engine)
<img width="1043" alt="screen shot 2018-04-16 at 12 49 51 pm" src="https://user-images.githubusercontent.com/36629/38823588-c90a481c-4174-11e8-9744-ee3dc8c9c162.png">
<img width="1046" alt="screen shot 2018-04-16 at 12 49 30 pm" src="https://user-images.githubusercontent.com/36629/38823593-cd72a08e-4174-11e8-8af9-fd6d6f1223be.png">

After:
(hovering the change search settings button)
<img width="1060" alt="screen shot 2018-04-16 at 12 45 37 pm" src="https://user-images.githubusercontent.com/36629/38823605-d5dfcbca-4174-11e8-918b-6cce04faf739.png">

(hovering ebay search engine)
<img width="1055" alt="screen shot 2018-04-16 at 12 45 50 pm" src="https://user-images.githubusercontent.com/36629/38823619-dc76d53c-4174-11e8-8b28-8dc265b2310f.png">
<img width="1030" alt="screen shot 2018-04-16 at 12 46 10 pm" src="https://user-images.githubusercontent.com/36629/38823638-e54eeb2c-4174-11e8-845e-8979cdbc0a06.png">



