### PR TITLE
Fix Bug 1454423 - update secondary text color to pass contrast test

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -147,7 +147,7 @@
 
   .card-context {
     bottom: 0;
-    color: var(--newtab-text-secondary-color);
+    color: var(--newtab-text-tertiary-color);
     display: flex;
     font-size: 11px;
     left: 0;
@@ -157,7 +157,7 @@
   }
 
   .card-context-icon {
-    fill: var(--newtab-icon-secondary-color);
+    fill: var(--newtab-icon-tertiary-color);
     height: 22px;
     margin-inline-end: 6px;
   }

--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -26,6 +26,7 @@ body {
   --newtab-text-conditional-color: $grey-60;
   --newtab-text-primary-color: $grey-90;
   --newtab-text-secondary-color: $grey-50;
+  --newtab-text-tertiary-color: $grey-50;
   --newtab-textbox-background-color: $white;
   --newtab-textbox-border: $grey-90-20;
   @include textbox-focus($blue-60); // sass-lint:disable-line mixins-before-declarations
@@ -77,7 +78,8 @@ body {
   --newtab-link-secondary-color: $pocket-teal;
   --newtab-text-conditional-color: $grey-10;
   --newtab-text-primary-color: $grey-10;
-  --newtab-text-secondary-color: $grey-10-40;
+  --newtab-text-secondary-color: $grey-10-80;
+  --newtab-text-tertiary-color: $grey-10-40;
   --newtab-textbox-background-color: $grey-70;
   --newtab-textbox-border: $grey-10-20;
   @include textbox-focus($blue-40); // sass-lint:disable-line mixins-before-declarations


### PR DESCRIPTION
* also add a tertiary text color (only currently used for card context text)
* secondary and tertiary text color are the same in default theme for now

Before:
<img width="1029" alt="screen shot 2018-04-16 at 3 00 27 pm" src="https://user-images.githubusercontent.com/36629/38829430-fe9a1586-4186-11e8-9358-39ae14cd3fd3.png">
<img width="357" alt="screen shot 2018-04-16 at 3 00 19 pm" src="https://user-images.githubusercontent.com/36629/38829437-03e2e630-4187-11e8-90bf-ac907378636e.png">

After:
<img width="1035" alt="screen shot 2018-04-16 at 2 59 31 pm" src="https://user-images.githubusercontent.com/36629/38829443-07e84824-4187-11e8-8d40-6e5a7deb9227.png">
<img width="339" alt="screen shot 2018-04-16 at 2 59 39 pm" src="https://user-images.githubusercontent.com/36629/38829446-0930ed76-4187-11e8-8b25-f9516bb5f102.png">
