### PR TITLE
WIP - Bug 1449338 - Replace search icon with logo of user's search engine

### DIFF
--- a/system-addon/content-src/components/Search/Search.jsx
+++ b/system-addon/content-src/components/Search/Search.jsx
@@ -63,10 +63,12 @@ export class _Search extends React.PureComponent {
    * in order to execute searches in various tests
    */
   render() {
+    let icon = this.props.Prefs.values.searchEngineIcon;
     return (<div className="search-wrapper">
       <label htmlFor="newtab-search-text" className="search-label">
         <span className="sr-only"><FormattedMessage id="search_web_placeholder" /></span>
       </label>
+      <span className="search-icon" style={{backgroundImage: `url('${icon}')`}} />
       <input
         id="newtab-search-text"
         maxLength="256"
@@ -85,4 +87,4 @@ export class _Search extends React.PureComponent {
   }
 }
 
-export const Search = connect()(injectIntl(_Search));
+export const Search = connect(state => ({Prefs: state.Prefs}))(injectIntl(_Search));

--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -36,14 +36,13 @@
     box-shadow: var(--newtab-textbox-focus-boxshadow);
   }
 
-  .search-label {
-    background: $search-glyph-image no-repeat $search-glyph-left-position center / $search-glyph-size;
-    -moz-context-properties: fill;
-    fill: var(--newtab-search-icon-color);
-    height: 100%;
-    offset-inline-start: 0;
+  .search-icon {
+    background-size: 18px 18px;
+    height: 18px;
+    margin: 8px;
+    pointer-events: none;
     position: absolute;
-    width: $search-input-left-label-width;
+    width: 18px;
   }
 
   .search-button {


### PR DESCRIPTION
People want this bug to land this week for uplift so looking for some early feedback

This seems to mostly work, the only issue I have found is when wikipedia is set, the icon url is `resource://search-plugins/images/wikipedia.ico` which doesnt seem to be able to be accessed from content?

Also needs tests, but would like confirmation that I am on the right path before adding them