### PR TITLE
Fix Bug 1454730 - change Top Site icon background to grey-70 on dark theme

### DIFF
--- a/system-addon/content-src/components/TopSites/_TopSites.scss
+++ b/system-addon/content-src/components/TopSites/_TopSites.scss
@@ -144,7 +144,7 @@ $half-base-gutter: $base-gutter / 2;
 
   // Some common styles for all icons (rich and default) in top sites
   .top-site-icon {
-    background-color: $white;
+    background-color: var(--newtab-topsites-background-color);
     background-position: center center;
     background-repeat: no-repeat;
     border-radius: $top-sites-border-radius;

--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -51,6 +51,7 @@ body {
   --newtab-search-icon-color: $grey-90-40;
 
   // Top Sites
+  --newtab-topsites-background-color: $white;
   --newtab-topsites-label-color: inherit;
 
   // Cards
@@ -104,6 +105,7 @@ body {
   --newtab-search-icon-color: $grey-10-60;
 
   // Top Sites
+  --newtab-topsites-background-color: $grey-70;
   --newtab-topsites-label-color: $grey-10-80;
 
   // Cards


### PR DESCRIPTION
This is a followup to 1d07b6188509323a80b500e2ee1f370fb1219723
r? @piatra 

Before:
![screen shot 2018-04-17 at 19 56 05](https://user-images.githubusercontent.com/36629/38904660-a890a5d0-4279-11e8-86dd-82f332e3c9da.png)

After:
![screen shot 2018-04-17 at 19 55 38](https://user-images.githubusercontent.com/36629/38904663-adc79ff4-4279-11e8-8a1c-c050f839117e.png)
