### PR TITLE
Fix Bug 1455081 - update icon and text tertiary colors in dark theme

### DIFF
--- a/system-addon/content-src/styles/_theme.scss
+++ b/system-addon/content-src/styles/_theme.scss
@@ -73,14 +73,14 @@ body {
   --newtab-element-hover-color: $grey-10-10;
   --newtab-icon-primary-color: $grey-10-80;
   --newtab-icon-secondary-color: $grey-10-40;
-  --newtab-icon-tertiary-color: $grey-10-20;
+  --newtab-icon-tertiary-color: $grey-10-40;
   --newtab-inner-box-shadow-color: $grey-10-20;
   --newtab-link-primary-color: $blue-40;
   --newtab-link-secondary-color: $pocket-teal;
   --newtab-text-conditional-color: $grey-10;
   --newtab-text-primary-color: $grey-10;
   --newtab-text-secondary-color: $grey-10-80;
-  --newtab-text-tertiary-color: $grey-10-40;
+  --newtab-text-tertiary-color: $grey-10-60;
   --newtab-textbox-background-color: $grey-70;
   --newtab-textbox-border: $grey-10-20;
   @include textbox-focus($blue-40); // sass-lint:disable-line mixins-before-declarations


### PR DESCRIPTION
Only variable value tweaking now. I see the light at the end of the tunnel 😅 

Before:
<img width="1032" alt="screen shot 2018-04-18 at 4 00 38 pm" src="https://user-images.githubusercontent.com/36629/38957180-de387fb0-4327-11e8-8a87-84f7457d43c8.png">

After:
<img width="1045" alt="screen shot 2018-04-18 at 3 40 45 pm" src="https://user-images.githubusercontent.com/36629/38957189-e45fc9a2-4327-11e8-9e63-faee962495b9.png">
