### PR TITLE
Fix Bug 1454985 - use ::after for search provider dividers

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -133,9 +133,7 @@
 
     .contentSearchOneOffItem {
       background-image: none;
-      border-right: solid 1px var(--newtab-border-secondary-color);
-      height: 22px;
-      margin: 5px 0;
+      position: relative;
 
       &.selected {
         background: var(--newtab-element-hover-color);
@@ -143,6 +141,15 @@
 
       &:active {
         background: var(--newtab-element-active-color);
+      }
+
+      &::after {
+        border-right: solid 1px var(--newtab-border-secondary-color);
+        content: '';
+        height: 22px;
+        offset-inline-end: 0;
+        position: absolute;
+        top: 5px;
       }
     }
 


### PR DESCRIPTION
And... this is LTR friendly now 😄 

Before:
<img width="438" alt="screen shot 2018-04-18 at 4 56 48 pm" src="https://user-images.githubusercontent.com/36629/38957982-f0ad11c2-4329-11e8-8492-be5850f91ab6.png">

After:
<img width="413" alt="screen shot 2018-04-18 at 4 55 51 pm" src="https://user-images.githubusercontent.com/36629/38957993-f4a10d56-4329-11e8-9158-93955595be5e.png">
