### PR TITLE
fix(prefs): Switch to new string for "Sponsored Stories"

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -81,9 +81,7 @@ prefs_section_rows_option={num} row;{num} rows
 prefs_search_header=Web Search
 prefs_topsites_description=The sites you visit most
 prefs_topstories_description2=Great content from around the web, personalized for you
-# LOCALIZATION NOTE (prefs_topstories_show_sponsored_label): {provider} is
-# replaced by the name of the content provider for this section, e.g., "Pocket"
-prefs_topstories_show_sponsored_label={provider} Sponsored Stories
+prefs_topstories_options_sponsored_label=Sponsored Stories
 prefs_topstories_sponsored_learn_more=Learn more
 prefs_highlights_description=A selection of sites that you’ve saved or visited
 prefs_snippets_description=Updates from Mozilla and Firefox

--- a/system-addon/lib/SectionsManager.jsm
+++ b/system-addon/lib/SectionsManager.jsm
@@ -24,7 +24,7 @@ const BUILT_IN_SECTIONS = {
       descString: {id: "prefs_topstories_description2"},
       nestedPrefs: options.show_spocs ? [{
         name: "showSponsored",
-        titleString: {id: "prefs_topstories_show_sponsored_label", values: {provider: options.provider_name}},
+        titleString: "prefs_topstories_options_sponsored_label",
         icon: "icon-info"
       }] : []
     },


### PR DESCRIPTION
r?@sarracini Removed the string that was added for 61 about:preferences move. (While leaving `settings_pane_topstories_options_sponsored=Show Sponsored Stories` to be removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1445090)