### PR TITLE
fix(styles): Switch to border-image instead of ::after for search engine separator

### DIFF
--- a/system-addon/content-src/components/Search/_Search.scss
+++ b/system-addon/content-src/components/Search/_Search.scss
@@ -127,7 +127,12 @@
     }
 
     .contentSearchOneOffItem {
+      // Make the border slightly shorter by offsetting from the top and bottom
+      $border-offset: 18%;
+
       background-image: none;
+      border-image: linear-gradient(transparent $border-offset, var(--newtab-border-secondary-color) $border-offset, var(--newtab-border-secondary-color) 100% - $border-offset, transparent 100% - $border-offset) 1;
+      border-inline-end: 1px solid;
       position: relative;
 
       &.selected {
@@ -136,15 +141,6 @@
 
       &:active {
         background: var(--newtab-element-active-color);
-      }
-
-      &::after {
-        border-right: solid 1px var(--newtab-border-secondary-color);
-        content: '';
-        height: 22px;
-        offset-inline-end: 0;
-        position: absolute;
-        top: 5px;
       }
     }
 


### PR DESCRIPTION
Followup as suggested in https://github.com/mozilla/activity-stream/pull/4107#issuecomment-383393619

r? @rlr Turns out the icons weren't actually centered with `::after` but now they're exactly 32px from the line on each side!

before:
![screen shot 2018-04-22 at 11 29 04 am](https://user-images.githubusercontent.com/438537/39098669-3a020be2-4623-11e8-80a2-0fcc8239c2d2.png)

after:
![screen shot 2018-04-22 at 11 44 29 am](https://user-images.githubusercontent.com/438537/39098671-3cfab13c-4623-11e8-8b0a-101243320663.png)

(Open up both images in tabs and switch between the two tabs to check! ;))