### PR TITLE
AS router Snippet template should respect theme variables

### DIFF
--- a/system-addon/content-src/components/MessageCenterAdmin/MessageCenterAdmin.scss
+++ b/system-addon/content-src/components/MessageCenterAdmin/MessageCenterAdmin.scss
@@ -1,12 +1,13 @@
 
 .messages-admin {
+  $border-color: var(--newtab-border-secondary-color);
   $monospace: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
   max-width: 996px;
   margin: 0 auto;
   font-size: 14px;
   // Reset .outer-wrapper styles
   display: inherit;
-  padding: 0;
+  padding: 0 0 42px;
 
   h1 {
     font-weight: 200;
@@ -20,20 +21,20 @@
 
   .message-item {
     &:first-child td {
-      border-top: 1px solid $black-10;
+      border-top: 1px solid $border-color;
     }
 
     td {
       vertical-align: top;
-      border-bottom: 1px solid $black-10;
+      border-bottom: 1px solid $border-color;
       padding: 8px;
 
       &:first-child {
-        border-left: 1px solid $black-10;
+        border-left: 1px solid $border-color;
       }
 
       &:last-child {
-        border-right: 1px solid $black-10;
+        border-right: 1px solid $border-color;
       }
     }
 
@@ -41,6 +42,10 @@
       .message-id span {
         background: $yellow-50;
         padding: 2px 5px;
+
+        .dark-theme & {
+          color: $black;
+        }
       }
     }
 
@@ -51,7 +56,7 @@
       }
 
       .message-id {
-        color: $grey-90;
+        opacity: 0.5;
       }
     }
 
@@ -62,7 +67,7 @@
   }
 
   pre {
-    background: $white;
+    background: var(--newtab-textbox-background-color);
     margin: 0;
     padding: 8px;
     font-size: 12px;

--- a/system-addon/content-src/message-center/components/Button.jsx
+++ b/system-addon/content-src/message-center/components/Button.jsx
@@ -2,11 +2,14 @@ import React from "react";
 
 const styles = {
   button: {
-    border: 0,
-    backgroundColor: "#e1e1e2",
+    whiteSpace: "nowrap",
+    borderRadius: "4px",
+    border: "1px solid var(--newtab-border-secondary-color)",
+    backgroundColor: "var(--newtab-button-secondary-color)",
     fontFamily: "inherit",
     padding: "8px 15px",
-    marginLeft: "15px"
+    marginLeft: "12px",
+    color: "inherit"
   }
 };
 

--- a/system-addon/content-src/message-center/components/SnippetBase.jsx
+++ b/system-addon/content-src/message-center/components/SnippetBase.jsx
@@ -6,11 +6,14 @@ const defaultStyles = {
     bottom: 0,
     left: 0,
     right: 0,
-    padding: "20px",
-    backgroundColor: "white",
+    padding: "12px",
+    backgroundColor: "var(--newtab-card-background-color)",
+    color: "var(--newtab-text-primary-color)",
     fontSize: "12px",
     lineHeight: "16px",
-    boxShadow: "0 -1px 4px 0 rgba(12, 12, 13, 0.1)"
+    boxShadow: "0 -1px 4px 0 rgba(12, 12, 13, 0.1)",
+    display: "flex",
+    alignItems: "center"
   },
   innerWrapper: {
     maxWidth: "992px",
@@ -24,10 +27,13 @@ const defaultStyles = {
     display: "block",
     position: "absolute",
     top: "50%",
-    right: "24px",
+    offsetInlineEnd: "24px",
     height: "16px",
     width: "16px",
     backgroundImage: "url(resource://activity-stream/data/content/assets/glyph-dismiss-16.svg)",
+    // Note: this doesn't actually seem to be working
+    MozContextProperties: "fill",
+    fill: "var(--newtab-icon-primary-color)",
     opacity: 0.5,
     marginTop: "-8px",
     padding: 0


### PR DESCRIPTION
These are some style changes so that the AS router templates respect dark theme. Mostly I'm looking for feedback on whether I used the right variables and if everything looks ok in dark/light themes

**To Test**:
- set `browser.newtabpage.activity-stream.messageCenterExperimentEnabled` pref to `true` in `about:config`
- check the bottom bar snippet looks right in both dark / light themes