### PR TITLE
Fix modal icon width

### DIFF
--- a/system-addon/content-src/styles/_icons.scss
+++ b/system-addon/content-src/styles/_icons.scss
@@ -39,6 +39,7 @@
   }
 
   &.icon-modal-delete {
+    flex-shrink: 0;
     background-image: url('#{$image-path}glyph-modal-delete-32.svg');
     background-size: $larger-icon-size;
     height: $larger-icon-size;


### PR DESCRIPTION
Before:
<img width="814" alt="screen shot 2018-04-23 at 1 47 06 pm" src="https://user-images.githubusercontent.com/7219526/39144674-70b7d22a-46ff-11e8-9209-00ad595224cb.png">

After:
<img width="1005" alt="screen shot 2018-04-23 at 2 06 36 pm" src="https://user-images.githubusercontent.com/7219526/39144699-903db13c-46ff-11e8-9127-3ea5a6b66541.png">

