### PR TITLE
Fix Bug 1447891 - Top Sites keep changing dramatically

### DIFF
--- a/system-addon/content-src/components/TopSites/TopSite.jsx
+++ b/system-addon/content-src/components/TopSites/TopSite.jsx
@@ -163,8 +163,17 @@ export class TopSite extends React.PureComponent {
     }, this._getTelemetryInfo())));
   }
 
-  onLinkClick(ev) {
+  onLinkClick(event) {
     this.userEvent("CLICK");
+
+    // Specially handle a top site link click for "typed" frecency bonus as
+    // specified as a property on the link.
+    event.preventDefault();
+    const {altKey, button, ctrlKey, metaKey, shiftKey} = event;
+    this.props.dispatch(ac.OnlyToMain({
+      type: at.OPEN_LINK,
+      data: Object.assign(this.props.link, {event: {altKey, button, ctrlKey, metaKey, shiftKey}})
+    }));
   }
 
   onMenuButtonClick(event) {

--- a/system-addon/content-src/lib/link-menu-options.js
+++ b/system-addon/content-src/lib/link-menu-options.js
@@ -54,7 +54,11 @@ export const LinkMenuOptions = {
     icon: "new-window",
     action: ac.AlsoToMain({
       type: at.OPEN_NEW_WINDOW,
-      data: {url: site.url, referrer: site.referrer}
+      data: {
+        referrer: site.referrer,
+        typedBonus: site.typedBonus,
+        url: site.url
+      }
     }),
     userEvent: "OPEN_NEW_WINDOW"
   }),

--- a/system-addon/lib/PlacesFeed.jsm
+++ b/system-addon/lib/PlacesFeed.jsm
@@ -247,16 +247,21 @@ class PlacesFeed {
     };
 
     // Always include the referrer (even for http links) if we have one
-    const {event, referrer} = action.data;
+    const {event, referrer, typedBonus} = action.data;
     if (referrer) {
       params.referrerPolicy = Ci.nsIHttpChannel.REFERRER_POLICY_UNSAFE_URL;
       params.referrerURI = Services.io.newURI(referrer);
     }
 
-    const win = action._target.browser.ownerGlobal;
-
     // Pocket gives us a special reader URL to open their stories in
     const urlToOpen = action.data.type === "pocket" ? action.data.open_url : action.data.url;
+
+    // Mark the page as typed for frecency bonus before opening the link
+    if (typedBonus) {
+      PlacesUtils.history.markPageAsTyped(Services.io.newURI(urlToOpen));
+    }
+
+    const win = action._target.browser.ownerGlobal;
     win.openLinkIn(urlToOpen, where || win.whereToOpenLink(event), params);
   }
 

--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -161,6 +161,9 @@ this.TopSitesFeed = class TopSitesFeed {
 
         // Remove internal properties that might be updated after dispatch
         delete link.__sharedCache;
+
+        // Indicate that these links should get a frecency bonus when clicked
+        link.typedBonus = true;
       }
     }
 

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -176,13 +176,23 @@ describe("<LinkMenu>", () => {
   describe(".onClick", () => {
     const FAKE_INDEX = 3;
     const FAKE_SOURCE = "TOP_SITES";
-    const FAKE_SITE = {url: "https://foo.com", pocket_id: "1234", referrer: "https://foo.com/ref", title: "bar", bookmarkGuid: 1234, hostname: "foo", type: "bookmark", path: "foo"};
+    const FAKE_SITE = {
+      bookmarkGuid: 1234,
+      hostname: "foo",
+      path: "foo",
+      pocket_id: "1234",
+      referrer: "https://foo.com/ref",
+      title: "bar",
+      type: "bookmark",
+      typedBonus: true,
+      url: "https://foo.com"
+    };
     const dispatch = sinon.stub();
     const propOptions = ["ShowFile", "CopyDownloadLink", "GoToDownloadPage", "RemoveDownload", "Separator", "RemoveBookmark", "AddBookmark", "OpenInNewWindow", "OpenInPrivateWindow", "BlockUrl", "DeleteUrl", "PinTopSite", "UnpinTopSite", "SaveToPocket", "DeleteFromPocket", "ArchiveFromPocket", "WebExtDismiss"];
     const expectedActionData = {
       menu_action_remove_bookmark: FAKE_SITE.bookmarkGuid,
       menu_action_bookmark: {url: FAKE_SITE.url, title: FAKE_SITE.title, type: FAKE_SITE.type},
-      menu_action_open_new_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
+      menu_action_open_new_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer, typedBonus: FAKE_SITE.typedBonus},
       menu_action_open_private_window: {url: FAKE_SITE.url, referrer: FAKE_SITE.referrer},
       menu_action_dismiss: {url: FAKE_SITE.url, pocket_id: FAKE_SITE.pocket_id},
       menu_action_webext_dismiss: {source: "TOP_SITES", url: FAKE_SITE.url, action_position: 3},

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -543,20 +543,20 @@ describe("<TopSite>", () => {
       ["CheckPinTopSite", "EditTopSite", "Separator", "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl", "DeleteUrl"]);
   });
 
-  describe("#trackClick", () => {
+  describe("#onLinkClick", () => {
     it("should call dispatch when the link is clicked", () => {
       const dispatch = sinon.stub();
       const wrapper = shallow(<TopSite link={link} index={3} dispatch={dispatch} />);
 
-      wrapper.find(TopSiteLink).simulate("click", {});
+      wrapper.find(TopSiteLink).simulate("click", {preventDefault() {}});
 
-      assert.calledOnce(dispatch);
+      assert.calledTwice(dispatch);
     });
     it("should dispatch a UserEventAction with the right data", () => {
       const dispatch = sinon.stub();
       const wrapper = shallow(<TopSite link={Object.assign({}, link, {iconType: "rich_icon", isPinned: true})} index={3} dispatch={dispatch} />);
 
-      wrapper.find(TopSiteLink).simulate("click", {});
+      wrapper.find(TopSiteLink).simulate("click", {preventDefault() {}});
 
       const [action] = dispatch.firstCall.args;
       assert.isUserEventAction(action);
@@ -566,6 +566,16 @@ describe("<TopSite>", () => {
       assert.propertyVal(action.data, "action_position", 3);
       assert.propertyVal(action.data.value, "card_type", "pinned");
       assert.propertyVal(action.data.value, "icon_type", "rich_icon");
+    });
+    it("should dispatch OPEN_LINK with the right data", () => {
+      const dispatch = sinon.stub();
+      const wrapper = shallow(<TopSite link={Object.assign({}, link, {typedBonus: true})} index={3} dispatch={dispatch} />);
+
+      wrapper.find(TopSiteLink).simulate("click", {preventDefault() {}});
+
+      const [action] = dispatch.secondCall.args;
+      assert.propertyVal(action, "type", at.OPEN_LINK);
+      assert.propertyVal(action.data, "typedBonus", true);
     });
   });
 });

--- a/system-addon/test/unit/lib/PlacesFeed.test.js
+++ b/system-addon/test/unit/lib/PlacesFeed.test.js
@@ -180,6 +180,27 @@ describe("PlacesFeed", () => {
       assert.propertyVal(params, "referrerPolicy", 5);
       assert.propertyVal(params.referrerURI, "spec", "foo.com/ref");
     });
+    it("should mark link with typed bonus as typed before opening OPEN_LINK", () => {
+      const callOrder = [];
+      sinon.stub(global.PlacesUtils.history, "markPageAsTyped").callsFake(() => {
+        callOrder.push("markPageAsTyped");
+      });
+      const openLinkIn = sinon.stub().callsFake(() => {
+        callOrder.push("openLinkIn");
+      });
+      const openLinkAction = {
+        type: at.OPEN_LINK,
+        data: {
+          typedBonus: true,
+          url: "foo.com"
+        },
+        _target: {browser: {ownerGlobal: {openLinkIn, whereToOpenLink: e => "tab"}}}
+      };
+
+      feed.onAction(openLinkAction);
+
+      assert.sameOrderedMembers(callOrder, ["markPageAsTyped", "openLinkIn"]);
+    });
     it("should open the pocket link if it's a pocket story on OPEN_LINK", () => {
       const openLinkIn = sinon.stub();
       const openLinkAction = {

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -166,10 +166,18 @@ describe("Top Sites Feed", () => {
     describe("general", () => {
       it("should get the links from NewTabUtils", async () => {
         const result = await feed.getLinksWithDefaults();
-        const reference = links.map(site => Object.assign({}, site, {hostname: shortURLStub(site)}));
+        const reference = links.map(site => Object.assign({}, site, {
+          hostname: shortURLStub(site),
+          typedBonus: true
+        }));
 
         assert.deepEqual(result, reference);
         assert.calledOnce(global.NewTabUtils.activityStreamLinks.getTopSites);
+      });
+      it("should indicate the links get typed bonus", async () => {
+        const result = await feed.getLinksWithDefaults();
+
+        assert.propertyVal(result[0], "typedBonus", true);
       });
       it("should not filter out adult sites when pref is false", async () => {
         await feed.getLinksWithDefaults();
@@ -193,6 +201,7 @@ describe("Top Sites Feed", () => {
         const topsite = {
           frecency: FAKE_FRECENCY,
           hostname: shortURLStub({url}),
+          typedBonus: true,
           url
         };
         const blockedDefaultSite = {url: "https://foo.com"};
@@ -222,7 +231,11 @@ describe("Top Sites Feed", () => {
         links = [{frecency: FAKE_FRECENCY, url: "foo.com"}];
 
         const result = await feed.getLinksWithDefaults();
-        const reference = [...links, ...DEFAULT_TOP_SITES].map(s => Object.assign({}, s, {hostname: shortURLStub(s)}));
+        const reference = [...links, ...DEFAULT_TOP_SITES].map(s =>
+          Object.assign({}, s, {
+            hostname: shortURLStub(s),
+            typedBonus: true
+          }));
 
         assert.deepEqual(result, reference);
       });
@@ -233,7 +246,11 @@ describe("Top Sites Feed", () => {
           links.push({frecency: FAKE_FRECENCY, url: `foo${i}.com`});
         }
         const result = await feed.getLinksWithDefaults();
-        const reference = [...links, DEFAULT_TOP_SITES[0]].map(s => Object.assign({}, s, {hostname: shortURLStub(s)}));
+        const reference = [...links, DEFAULT_TOP_SITES[0]].map(s =>
+          Object.assign({}, s, {
+            hostname: shortURLStub(s),
+            typedBonus: true
+          }));
 
         assert.lengthOf(result, numVisible);
         assert.deepEqual(result, reference);
@@ -484,7 +501,10 @@ describe("Top Sites Feed", () => {
     });
     it("should dispatch an action with the links returned", async () => {
       await feed.refresh({broadcast: true});
-      const reference = links.map(site => Object.assign({}, site, {hostname: shortURLStub(site)}));
+      const reference = links.map(site => Object.assign({}, site, {
+        hostname: shortURLStub(site),
+        typedBonus: true
+      }));
 
       assert.calledOnce(feed.store.dispatch);
       assert.propertyVal(feed.store.dispatch.firstCall.args[0], "type", at.TOP_SITES_UPDATED);

--- a/system-addon/test/unit/unit-entry.js
+++ b/system-addon/test/unit/unit-entry.js
@@ -66,6 +66,7 @@ const TEST_GLOBAL = {
         return this;
       },
       insert() {},
+      markPageAsTyped() {},
       removeObserver() {}
     }
   },


### PR DESCRIPTION
r?@piatra Handles regular clicks, modified clicks, and actions from the context menu.

Initially I only modified `TopSite.onLinkClick` to set a typed flag, but that wasn't enough for the context menu stuff, so I ended up setting the flag in the feed.

Oh, and this doesn't fix the OS-level context menu…