### PR TITLE
Fix Bug 1456082 - Storage should not have telemetry be a required argument

### DIFF
--- a/system-addon/lib/ActivityStreamStorage.jsm
+++ b/system-addon/lib/ActivityStreamStorage.jsm
@@ -4,15 +4,15 @@ this.ActivityStreamStorage = class ActivityStreamStorage {
   /**
    * @param storeNames Array of strings used to create all the required stores
    */
-  constructor(options = {}) {
-    if (!options.storeNames || !options.telemetry) {
-      throw new Error(`storeNames and telemetry are required, called only with ${Object.keys(options)}`);
+  constructor({storeNames, telemetry}) {
+    if (!storeNames) {
+      throw new Error("storeNames required");
     }
 
     this.dbName = "ActivityStream";
     this.dbVersion = 3;
-    this.storeNames = options.storeNames;
-    this.telemetry = options.telemetry;
+    this.storeNames = storeNames;
+    this.telemetry = telemetry;
   }
 
   get db() {

--- a/system-addon/test/unit/lib/ActivityStreamStorage.test.js
+++ b/system-addon/test/unit/lib/ActivityStreamStorage.test.js
@@ -22,8 +22,8 @@ describe("ActivityStreamStorage", () => {
   it("should not throw an error when accessing db", async () => {
     assert.ok(storage.db);
   });
-  it("should throw if arguments not provided", () => {
-    assert.throws(() => new ActivityStreamStorage());
+  it("should throw if required arguments not provided", () => {
+    assert.throws(() => new ActivityStreamStorage({telemetry: true}));
   });
   describe("#getDbTable", () => {
     let testStorage;


### PR DESCRIPTION
Telemetry is no longer required and updated unit test that checks for that.
