### PR TITLE
Fix Bug 1455931 - TopSites refresh should wait for tippytop provider to initialize

### DIFF
--- a/system-addon/lib/TopSitesFeed.jsm
+++ b/system-addon/lib/TopSitesFeed.jsm
@@ -44,8 +44,7 @@ this.TopSitesFeed = class TopSitesFeed {
     PageThumbs.addExpirationFilter(this);
   }
 
-  async init() {
-    await this._tippyTopProvider.init();
+  init() {
     // If the feed was previously disabled PREFS_INITIAL_VALUES was never received
     this.refreshDefaults(this.store.getState().Prefs.values[DEFAULT_SITES_PREF]);
     this._storage = this.store.dbStorage.getDbTable("sectionPrefs");
@@ -175,6 +174,9 @@ this.TopSitesFeed = class TopSitesFeed {
    * @param {bool} options.broadcast Should the update be broadcasted.
    */
   async refresh(options = {}) {
+    if (!this._tippyTopProvider.initialized) {
+      await this._tippyTopProvider.init();
+    }
     const links = await this.getLinksWithDefaults();
     const newAction = {type: at.TOP_SITES_UPDATED, data: {links}};
     let storedPrefs;

--- a/system-addon/test/unit/lib/TopSitesFeed.test.js
+++ b/system-addon/test/unit/lib/TopSitesFeed.test.js
@@ -470,13 +470,6 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(feed.refresh);
       assert.calledWithExactly(feed.refresh, {broadcast: true});
     });
-    it("should initialise _tippyTopProvider", async () => {
-      feed._tippyTopProvider.initialized = false;
-
-      await feed.init();
-
-      assert.isTrue(feed._tippyTopProvider.initialized);
-    });
     it("should initialise the storage", async () => {
       await feed.init();
 
@@ -487,6 +480,22 @@ describe("Top Sites Feed", () => {
   describe("#refresh", () => {
     beforeEach(() => {
       sandbox.stub(feed, "_fetchIcon");
+    });
+    it("should wait for tippytop to initialize", async () => {
+      feed._tippyTopProvider.initialized = false;
+      sinon.stub(feed._tippyTopProvider, "init").resolves();
+
+      await feed.refresh();
+
+      assert.calledOnce(feed._tippyTopProvider.init);
+    });
+    it("should not init the tippyTopProvider if already initialized", async () => {
+      feed._tippyTopProvider.initialized = true;
+      sinon.stub(feed._tippyTopProvider, "init").resolves();
+
+      await feed.refresh();
+
+      assert.notCalled(feed._tippyTopProvider.init);
     });
     it("should broadcast TOP_SITES_UPDATED", async () => {
       sinon.stub(feed, "getLinksWithDefaults").returns(Promise.resolve([]));


### PR DESCRIPTION
10x try run seems ok https://treeherder.mozilla.org/#/jobs?repo=try&revision=2f365be13e9300da2d1323e3f024b040639c8b8a&selectedJob=175553460
While previously (without the patch) it failed on the second attempt.