### PR TITLE
Fix tests that would never fail

### DIFF
--- a/system-addon/test/unit/content-src/components/Card.test.jsx
+++ b/system-addon/test/unit/content-src/components/Card.test.jsx
@@ -64,8 +64,7 @@ describe("<Card>", () => {
 
     assert.lengthOf(wrapper.find(".card-preview-image"), 0);
   });
-  it("should have a link menu", () => assert.ok(wrapper.find(LinkMenu)));
-  it("should have a link menu button", () => assert.ok(wrapper.find(".context-menu-button")));
+  it("should have a link menu button", () => assert.ok(wrapper.find(".context-menu-button").exists()));
   it("should render a link menu when button is clicked", () => {
     const button = wrapper.find(".context-menu-button");
     assert.equal(wrapper.find(LinkMenu).length, 0);

--- a/system-addon/test/unit/content-src/components/ConfirmDialog.test.jsx
+++ b/system-addon/test/unit/content-src/components/ConfirmDialog.test.jsx
@@ -22,10 +22,10 @@ describe("<ConfirmDialog>", () => {
     wrapper = shallowWithIntl(<ConfirmDialog dispatch={dispatch} {...ConfirmDialogProps} />);
   });
   it("should render an overlay", () => {
-    assert.ok(wrapper.find(".modal-overlay"));
+    assert.ok(wrapper.find(".modal-overlay").exists());
   });
   it("should render a modal", () => {
-    assert.ok(wrapper.find(ConfirmDialog));
+    assert.ok(wrapper.find(".confirmation-dialog").exists());
   });
   it("should not render if visible is false", () => {
     ConfirmDialogProps.visible = false;
@@ -59,7 +59,7 @@ describe("<ConfirmDialog>", () => {
       wrapper = shallowWithIntl(<ConfirmDialog dispatch={dispatch} {...ConfirmDialogProps} />);
 
       let doneLabel = wrapper.find(".actions").childAt(1).find(FormattedMessage);
-      assert.ok(doneLabel);
+      assert.ok(doneLabel.exists());
       assert.equal(doneLabel.props().id, ConfirmDialogProps.data.confirm_button_string_id);
     });
   });
@@ -67,7 +67,7 @@ describe("<ConfirmDialog>", () => {
     it("should emit AlsoToMain DIALOG_CANCEL when you click the overlay", () => {
       let overlay = wrapper.find(".modal-overlay");
 
-      assert.ok(overlay);
+      assert.ok(overlay.exists());
       overlay.simulate("click");
 
       // Two events are emitted: UserEvent+AlsoToMain.

--- a/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/LinkMenu.test.jsx
@@ -13,10 +13,10 @@ describe("<LinkMenu>", () => {
     wrapper = shallowWithIntl(<LinkMenu site={{url: ""}} options={["CheckPinTopSite", "CheckBookmark", "OpenInNewWindow"]} dispatch={() => {}} />);
   });
   it("should render a ContextMenu element", () => {
-    assert.ok(wrapper.find(ContextMenu));
+    assert.ok(wrapper.find(ContextMenu).exists());
   });
   it("should pass onUpdate, and options to ContextMenu", () => {
-    assert.ok(wrapper.find(ContextMenu));
+    assert.ok(wrapper.find(ContextMenu).exists());
     const contextMenuProps = wrapper.find(ContextMenu).props();
     ["onUpdate", "options"].forEach(prop => assert.property(contextMenuProps, prop));
   });

--- a/system-addon/test/unit/content-src/components/SectionMenu.test.jsx
+++ b/system-addon/test/unit/content-src/components/SectionMenu.test.jsx
@@ -25,10 +25,10 @@ describe("<SectionMenu>", () => {
     wrapper = shallowWithIntl(<SectionMenu {...DEFAULT_PROPS} />);
   });
   it("should render a ContextMenu element", () => {
-    assert.ok(wrapper.find(ContextMenu));
+    assert.ok(wrapper.find(ContextMenu).exists());
   });
   it("should pass onUpdate, and options to ContextMenu", () => {
-    assert.ok(wrapper.find(ContextMenu));
+    assert.ok(wrapper.find(ContextMenu).exists());
     const contextMenuProps = wrapper.find(ContextMenu).props();
     ["onUpdate", "options"].forEach(prop => assert.property(contextMenuProps, prop));
   });

--- a/system-addon/test/unit/content-src/components/TopSites.test.jsx
+++ b/system-addon/test/unit/content-src/components/TopSites.test.jsx
@@ -712,7 +712,7 @@ describe("<TopSiteForm>", () => {
     beforeEach(() => setup());
 
     it("should render the component", () => {
-      assert.ok(wrapper.find(TopSiteForm));
+      assert.ok(wrapper.find(TopSiteForm).exists());
     });
     it("should have the correct header", () => {
       assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_add_header").length, 1);
@@ -785,7 +785,7 @@ describe("<TopSiteForm>", () => {
     beforeEach(() => setup({site: {url: "https://foo.bar", label: "baz", customScreenshotURL: "http://foo"}, index: 7}));
 
     it("should render the component", () => {
-      assert.ok(wrapper.find(TopSiteForm));
+      assert.ok(wrapper.find(TopSiteForm).exists());
     });
     it("should have the correct header", () => {
       assert.equal(wrapper.findWhere(n => n.props().id === "topsites_form_edit_header").length, 1);


### PR DESCRIPTION
When writing tests recently I noticed a few that are written to never fail. The `wrapper`, even when empty has a truthy value and will pass an `assert.ok`, this is also the case for `wrapper.find('foo')`.

In `test/unit/content-src/components/Card.test.jsx`, line 67, this was passing because of the `wrapper` having a value, when in fact the link menu has never existed. This is directly contradicted by line 71, which ensures it does not exist. This is why I removed it.

`test/unit/content-src/components/ConfirmDialog.test.jsx` line 26, it fails to find ConfirmDialog, but will succeed in finding '.confirmation-dialog` - I'm assuming those are intended as the same thing. 