### PR TITLE
fix(prerender): Check top before loading more scripts

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -200,7 +200,13 @@ function templateHTML(options, html) {
     <div id="snippets-container">
       <div id="snippets"></div>
     </div>
-    <script>
+    <script>(() => {
+// Clear out any prerendered content if we shouldn't continue loading
+if (top !== window) {
+  document.documentElement.innerHTML = "";
+  return;
+}
+
 // Don't directly load the following scripts as part of html to let the page
 // finish loading to render the content sooner.
 for (const src of ${JSON.stringify(scripts, null, 2)}) {
@@ -210,7 +216,7 @@ for (const src of ${JSON.stringify(scripts, null, 2)}) {
   script.async = false;
   script.src = src;
 }
-    </script>
+    })()</script>
   </body>
 </html>
 `;


### PR DESCRIPTION
r?@k88hudson Just short circuit the rest of the top level script