### PR TITLE
fix(prerender): Make localized files different to avoid duplicate checks

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -233,11 +233,12 @@ for (const src of ${JSON.stringify(scripts, null, 2)}) {
  * it is still necessary.
  *
  * @param  {string} name The name of the global to expose
- * @param  {obj}    data The data to expose as a window global
+ * @param  {string} desc Extra description to include in a js comment
+ * @param  {obj}   state The data to expose as a window global
  * @return {str}         The js file as a string
  */
-function templateJs(name, state) {
-  return `// Note - this is a generated file.
+function templateJs(name, desc, state) {
+  return `// Note - this is a generated ${desc} file.
 window.${name} = ${JSON.stringify(state, null, 2)};
 `;
 }
@@ -261,13 +262,13 @@ function writeFiles(name, destPath, filesMap, {html, state}, options) {
 
 const STATIC_FILES = new Map([
   ["activity-stream-debug.html", ({options}) => templateHTML(options)],
-  ["activity-stream-initial-state.js", ({state}) => templateJs("gActivityStreamPrerenderedState", state)],
+  ["activity-stream-initial-state.js", ({state}) => templateJs("gActivityStreamPrerenderedState", "static", state)],
   ["activity-stream-prerendered-debug.html", ({html, options}) => templateHTML(options, html)]
 ]);
 
 const LOCALIZED_FILES = new Map([
   ["activity-stream-prerendered.html", ({html, options}) => templateHTML(options, html)],
-  ["activity-stream-strings.js", ({options: {strings}}) => templateJs("gActivityStreamStrings", strings)],
+  ["activity-stream-strings.js", ({options: {locale, strings}}) => templateJs("gActivityStreamStrings", locale, strings)],
   ["activity-stream.html", ({options}) => templateHTML(options)]
 ]);
 


### PR DESCRIPTION
r?@k88hudson We could try to be smarter in detecting and reusing, but this might just be a temporarily collision where they happen to match up:
```
0:07.81 ERROR: The following duplicated files are not allowed:
0:07.81 Nightly.app/Contents/Resources/browser/features/activity-stream@mozilla.org/chrome/content/prerendered/en-CA/activity-stream-strings.js
0:07.81 Nightly.app/Contents/Resources/browser/features/activity-stream@mozilla.org/chrome/content/prerendered/en-GB/activity-stream-strings.js
```