### PR TITLE
AS Router Impression Stats

### DIFF
--- a/system-addon/content-src/asrouter/asrouter-content.jsx
+++ b/system-addon/content-src/asrouter/asrouter-content.jsx
@@ -1,16 +1,12 @@
 import {actionCreators as ac} from "common/Actions.jsm";
 import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
-import {ImpressionsWrapper} from "content-src/components/Sections/ImpressionsWrapper";
+import {ImpressionsWrapper} from "./components/ImpressionsWrapper/ImpressionsWrapper";
 import React from "react";
 import ReactDOM from "react-dom";
 import {SimpleSnippet} from "./templates/SimpleSnippet/SimpleSnippet";
 
 const INCOMING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const OUTGOING_MESSAGE_NAME = "ASRouter:child-to-parent";
-
-// Note: Provider is hardcoded right now since we only have one message provider.
-// When we have more than one, it will need to come from the message data.
-const PROVIDER = "snippets";
 
 export const ASRouterUtils = {
   addListener(listener) {
@@ -28,44 +24,45 @@ export const ASRouterUtils = {
   unblockById(id) {
     ASRouterUtils.sendMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id}});
   },
-  sendUserActionTelemetry(data) {
-    const eventType =  `${PROVIDER}_user_event`;
-    const payload = ac.ASRouterUserEvent(Object.assign({}, data, {action: eventType}));
-    global.sendAsyncMessage(AS_GENERAL_OUTGOING_MESSAGE_NAME, payload);
-  },
-  sendImpressionStats({id, campaign, template}) {
-    const eventType =  `${PROVIDER}_impression`;
-    const payload = ac.ASRouterUserEvent(Object.assign({}, {id, campaign, template}, {action: eventType}));
-    global.sendAsyncMessage(AS_GENERAL_OUTGOING_MESSAGE_NAME, payload);
-  },
   getNextMessage() {
     ASRouterUtils.sendMessage({type: "GET_NEXT_MESSAGE"});
   },
   overrideMessage(id) {
     ASRouterUtils.sendMessage({type: "OVERRIDE_MESSAGE", data: {id}});
+  },
+  sendTelemetry(ping) {
+    const payload = ac.ASRouterUserEvent(ping);
+    global.sendAsyncMessage(AS_GENERAL_OUTGOING_MESSAGE_NAME, payload);
   }
 };
+
+// Note: nextProps/prevProps refer to props passed to <ImpressionsWrapper />, not <ASRouterUISurface />
+function shouldSendImpressionOnUpdate(nextProps, prevProps) {
+  return (nextProps.message.id && (!prevProps.message || prevProps.message.id !== nextProps.message.id));
+}
 
 export class ASRouterUISurface extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onMessageFromParent = this.onMessageFromParent.bind(this);
+    this.sendImpression = this.sendImpression.bind(this);
+    this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
     this.state = {message: {}};
-    this.dispatchImpressionStats = this.dispatchImpressionStats.bind(this);
-    this.shouldSendImpressionsOnUpdate = this.shouldSendImpressionsOnUpdate.bind(this);
   }
 
-  dispatchImpressionStats() {
-    ASRouterUtils.sendImpressionStats(this.state.message);
+  sendUserActionTelemetry(extraProps = {}) {
+    const {message} = this.state;
+    const eventType =  `${message.provider}_user_event`;
+
+    ASRouterUtils.sendTelemetry(Object.assign({
+      message_id: message.id,
+      source: this.props.id,
+      action: eventType
+    }, extraProps));
   }
 
-  shouldSendImpressionsOnUpdate(prevProps) {
-    const {state} = this;
-    if (state.message.id && (!prevProps.message || prevProps.message.id !== state.message.id)) {
-      return true;
-    }
-
-    return false;
+  sendImpression() {
+    this.sendUserActionTelemetry({event: "IMPRESSION"});
   }
 
   onBlockById(id) {
@@ -89,28 +86,30 @@ export class ASRouterUISurface extends React.PureComponent {
   }
 
   componentWillUnmount() {
-    ASRouterUtils.removeMessageListener(this.onMessageFromParent);
+    ASRouterUtils.removeListener(this.onMessageFromParent);
   }
 
   render() {
     const {message} = this.state;
     if (!message.id) { return null; }
-    return (<ImpressionsWrapper document={global.document}
-        dispatchImpressionStats={this.dispatchImpressionStats}
+    return (<ImpressionsWrapper
         message={message}
-        sendOnMount={true}
-        shouldSendImpressionsOnUpdate={this.shouldSendImpressionsOnUpdate}
-        shouldSendImpressionStats={true}>
+        sendImpression={this.sendImpression}
+        shouldSendImpressionOnUpdate={shouldSendImpressionOnUpdate}
+        // This helps with testing
+        document={this.props.document}>
         <SimpleSnippet
           {...message}
           UISurface={this.props.id}
           getNextMessage={ASRouterUtils.getNextMessage}
           onBlock={this.onBlockById(message.id)}
-          sendUserActionTelemetry={ASRouterUtils.sendUserActionTelemetry} />
+          sendUserActionTelemetry={this.sendUserActionTelemetry} />
       </ImpressionsWrapper>
     );
   }
 }
+
+ASRouterUISurface.defaultProps = {document: global.document};
 
 export function initASRouter() {
   ReactDOM.render(<ASRouterUISurface id="NEWTAB_FOOTER_BAR" />, document.getElementById("snippets-container"));

--- a/system-addon/content-src/asrouter/asrouter-content.jsx
+++ b/system-addon/content-src/asrouter/asrouter-content.jsx
@@ -1,5 +1,6 @@
 import {actionCreators as ac} from "common/Actions.jsm";
 import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
+import {ImpressionsWrapper} from "content-src/components/Sections/ImpressionsWrapper";
 import React from "react";
 import ReactDOM from "react-dom";
 import {SimpleSnippet} from "./templates/SimpleSnippet/SimpleSnippet";
@@ -32,6 +33,11 @@ export const ASRouterUtils = {
     const payload = ac.ASRouterUserEvent(Object.assign({}, data, {action: eventType}));
     global.sendAsyncMessage(AS_GENERAL_OUTGOING_MESSAGE_NAME, payload);
   },
+  sendImpressionStats({id, campaign, template}) {
+    const eventType =  `${PROVIDER}_impression`;
+    const payload = ac.ASRouterUserEvent(Object.assign({}, {id, campaign, template}, {action: eventType}));
+    global.sendAsyncMessage(AS_GENERAL_OUTGOING_MESSAGE_NAME, payload);
+  },
   getNextMessage() {
     ASRouterUtils.sendMessage({type: "GET_NEXT_MESSAGE"});
   },
@@ -40,11 +46,26 @@ export const ASRouterUtils = {
   }
 };
 
-class ASRouterUISurface extends React.PureComponent {
+export class ASRouterUISurface extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onMessageFromParent = this.onMessageFromParent.bind(this);
     this.state = {message: {}};
+    this.dispatchImpressionStats = this.dispatchImpressionStats.bind(this);
+    this.shouldSendImpressionsOnUpdate = this.shouldSendImpressionsOnUpdate.bind(this);
+  }
+
+  dispatchImpressionStats() {
+    ASRouterUtils.sendImpressionStats(this.state.message);
+  }
+
+  shouldSendImpressionsOnUpdate(prevProps) {
+    const {state} = this;
+    if (state.message.id && (!prevProps.message || prevProps.message.id !== state.message.id)) {
+      return true;
+    }
+
+    return false;
   }
 
   onBlockById(id) {
@@ -74,12 +95,19 @@ class ASRouterUISurface extends React.PureComponent {
   render() {
     const {message} = this.state;
     if (!message.id) { return null; }
-    return (<SimpleSnippet
-      {...message}
-      UISurface={this.props.id}
-      getNextMessage={ASRouterUtils.getNextMessage}
-      onBlock={this.onBlockById(message.id)}
-      sendUserActionTelemetry={ASRouterUtils.sendUserActionTelemetry} />
+    return (<ImpressionsWrapper document={global.document}
+        dispatchImpressionStats={this.dispatchImpressionStats}
+        message={message}
+        sendOnMount={true}
+        shouldSendImpressionsOnUpdate={this.shouldSendImpressionsOnUpdate}
+        shouldSendImpressionStats={true}>
+        <SimpleSnippet
+          {...message}
+          UISurface={this.props.id}
+          getNextMessage={ASRouterUtils.getNextMessage}
+          onBlock={this.onBlockById(message.id)}
+          sendUserActionTelemetry={ASRouterUtils.sendUserActionTelemetry} />
+      </ImpressionsWrapper>
     );
   }
 }

--- a/system-addon/content-src/asrouter/components/ImpressionsWrapper/ImpressionsWrapper.jsx
+++ b/system-addon/content-src/asrouter/components/ImpressionsWrapper/ImpressionsWrapper.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+export const VISIBLE = "visible";
+export const VISIBILITY_CHANGE_EVENT = "visibilitychange";
+
+/**
+ * Component wrapper used to send telemetry pings on every impression.
+ */
+export class ImpressionsWrapper extends React.PureComponent {
+  // This sends an event when a user sees a set of new content. If content
+  // changes while the page is hidden (i.e. preloaded or on a hidden tab),
+  // only send the event if the page becomes visible again.
+  sendImpressionStatsOrAddListener() {
+    if (this.props.document.visibilityState === VISIBLE) {
+      this.props.dispatchImpressionStats();
+    } else {
+      // We should only ever send the latest impression stats ping, so remove any
+      // older listeners.
+      if (this._onVisibilityChange) {
+        this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
+      }
+
+      // When the page becomes visible, send the impression stats ping if the section isn't collapsed.
+      this._onVisibilityChange = () => {
+        if (this.props.document.visibilityState === VISIBLE) {
+          this.props.dispatchImpressionStats();
+          this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
+        }
+      };
+      this.props.document.addEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this._onVisibilityChange) {
+      this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.sendOnMount) {
+      this.sendImpressionStatsOrAddListener();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps && this.props.shouldSendImpressionsOnUpdate(prevProps)) {
+      this.sendImpressionStatsOrAddListener();
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/system-addon/content-src/asrouter/components/ImpressionsWrapper/ImpressionsWrapper.jsx
+++ b/system-addon/content-src/asrouter/components/ImpressionsWrapper/ImpressionsWrapper.jsx
@@ -10,9 +10,9 @@ export class ImpressionsWrapper extends React.PureComponent {
   // This sends an event when a user sees a set of new content. If content
   // changes while the page is hidden (i.e. preloaded or on a hidden tab),
   // only send the event if the page becomes visible again.
-  sendImpressionStatsOrAddListener() {
+  sendImpressionOrAddListener() {
     if (this.props.document.visibilityState === VISIBLE) {
-      this.props.dispatchImpressionStats();
+      this.props.sendImpression();
     } else {
       // We should only ever send the latest impression stats ping, so remove any
       // older listeners.
@@ -23,7 +23,7 @@ export class ImpressionsWrapper extends React.PureComponent {
       // When the page becomes visible, send the impression stats ping if the section isn't collapsed.
       this._onVisibilityChange = () => {
         if (this.props.document.visibilityState === VISIBLE) {
-          this.props.dispatchImpressionStats();
+          this.props.sendImpression();
           this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
         }
       };
@@ -39,13 +39,13 @@ export class ImpressionsWrapper extends React.PureComponent {
 
   componentDidMount() {
     if (this.props.sendOnMount) {
-      this.sendImpressionStatsOrAddListener();
+      this.sendImpressionOrAddListener();
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps && this.props.shouldSendImpressionsOnUpdate(prevProps)) {
-      this.sendImpressionStatsOrAddListener();
+    if (this.props.shouldSendImpressionOnUpdate(this.props, prevProps)) {
+      this.sendImpressionOrAddListener();
     }
   }
 
@@ -53,3 +53,8 @@ export class ImpressionsWrapper extends React.PureComponent {
     return this.props.children;
   }
 }
+
+ImpressionsWrapper.defaultProps = {
+  document: global.document,
+  sendOnMount: true
+};

--- a/system-addon/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/system-addon/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -7,7 +7,7 @@ export class SnippetBase extends React.PureComponent {
   }
 
   onBlockClicked() {
-    this.props.sendUserActionTelemetry({event: "BLOCK", source: this.props.UISurface, message_id: this.props.id});
+    this.props.sendUserActionTelemetry({event: "BLOCK"});
     this.props.onBlock();
   }
 

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -12,7 +12,7 @@ export class SimpleSnippet extends React.PureComponent {
   }
 
   onButtonClick() {
-    this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", source: this.props.UISurface, message_id: this.props.id});
+    this.props.sendUserActionTelemetry({event: "CLICK_BUTTON"});
   }
 
   render() {

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -7,31 +7,14 @@ const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 // This is a temporary endpoint until we have something for snippets
 const SNIPPETS_ENDPOINT = "https://activity-stream-icons.services.mozilla.com/v1/messages.json.br";
 
-const ONBOARDING_MESSAGES = [
+const LOCAL_TEST_MESSAGES = [
   {
-    id: "ONBOARDING_1",
+    id: "LOCAL_TEST_THEMES",
     template: "simple_snippet",
     content: {
-      title: "Find it faster",
-      text: "Access all of your favorite search engines with a click. Search the whole Web or just one website from the search box.",
-      button_label: "Learn More",
-      button_url: "https://mozilla.org"
-    }
-  },
-  {
-    id: "ONBOARDING_2",
-    template: "simple_snippet",
-    content: {
-      title: "Make Firefox your go-to-browser",
-      text: "It doesn't take much to get the most from Firefox. Just set Firefox as your default browser and put control, customization, and protection on autopilot."
-    }
-  },
-  {
-    id: "ONBOARDING_3",
-    template: "simple_snippet",
-    content: {
-      title: "Did you know?",
-      text: "All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood."
+      text: "Your browser is ready for a makeover. Don't worry, you've got tons of options.",
+      button_label: "Check them out here",
+      button_url: "https://addons.mozilla.org/en-US/firefox/themes"
     }
   }
 ];
@@ -322,7 +305,7 @@ this._ASRouter = _ASRouter;
  */
 this.ASRouter = new _ASRouter({
   providers: [
-    {id: "onboarding", type: "local", messages: ONBOARDING_MESSAGES},
+    {id: "onboarding", type: "local", messages: LOCAL_TEST_MESSAGES},
     {id: "snippets", type: "remote", url: SNIPPETS_ENDPOINT, updateCycleInMs: ONE_HOUR_IN_MS * 4}
   ]
 });

--- a/system-addon/test/unit/asrouter/asrouter-content.test.jsx
+++ b/system-addon/test/unit/asrouter/asrouter-content.test.jsx
@@ -1,0 +1,115 @@
+import {ASRouterUISurface, ASRouterUtils} from "content-src/asrouter/asrouter-content";
+import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
+import {GlobalOverrider} from "test/unit/utils";
+import {ImpressionsWrapper} from "content-src/components/Sections/ImpressionsWrapper";
+import React from "react";
+import {shallow} from "enzyme";
+
+describe("ASRouterUtils", () => {
+  let global;
+  let sandbox;
+  let fakeSendAsyncMessage;
+  beforeEach(() => {
+    global = new GlobalOverrider();
+    sandbox = sinon.sandbox.create();
+    fakeSendAsyncMessage = sandbox.stub();
+    global.set({sendAsyncMessage: fakeSendAsyncMessage});
+  });
+  afterEach(() => {
+    sandbox.restore();
+    global.restore();
+  });
+  it("should send a message with the message payload", () => {
+    ASRouterUtils.sendImpressionStats({id: 1, campaign: "foo", template: "simple"});
+
+    assert.calledOnce(fakeSendAsyncMessage);
+    assert.calledWith(fakeSendAsyncMessage, AS_GENERAL_OUTGOING_MESSAGE_NAME);
+    const [, payload] = fakeSendAsyncMessage.firstCall.args;
+    assert.propertyVal(payload.data, "id", 1);
+    assert.propertyVal(payload.data, "campaign", "foo");
+    assert.propertyVal(payload.data, "template", "simple");
+  });
+});
+
+describe("ASRouterUISurface", () => {
+  let wrapper;
+  let fakeAddMessageListener;
+  let fakeSendAsyncMessage;
+  let global;
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    fakeAddMessageListener = sandbox.stub();
+    fakeSendAsyncMessage = sandbox.stub();
+
+    global = new GlobalOverrider();
+    global.set({
+      addMessageListener: fakeAddMessageListener,
+      sendAsyncMessage: fakeSendAsyncMessage
+    });
+    wrapper = shallow(<ASRouterUISurface />);
+  });
+  afterEach(() => {
+    sandbox.restore();
+    global.restore();
+  });
+
+  it("should render the component if a message id is defined", () => {
+    wrapper.setState({message: {id: 1}});
+
+    assert.isTrue(wrapper.exists());
+  });
+
+  it("should be wrapped in a ImpressionsWrapper", () => {
+    wrapper.setState({message: {id: 1}});
+
+    assert.isTrue(wrapper.find(ImpressionsWrapper).exists());
+  });
+
+  it("should provide correct props to ImpressionsWrapper", () => {
+    wrapper.setState({message: {id: 1}});
+    const props = wrapper.find(ImpressionsWrapper).props();
+
+    assert.propertyVal(props, "sendOnMount", true);
+    assert.propertyVal(props, "shouldSendImpressionsOnUpdate", wrapper.instance().shouldSendImpressionsOnUpdate);
+    assert.propertyVal(props, "dispatchImpressionStats", wrapper.instance().dispatchImpressionStats);
+  });
+
+  it("should call ASRouterUtils.sendImpressionStats", () => {
+    const message = {id: 1};
+    wrapper.setState({message});
+    sandbox.stub(ASRouterUtils, "sendImpressionStats");
+
+    wrapper.instance().dispatchImpressionStats();
+
+    assert.calledOnce(ASRouterUtils.sendImpressionStats);
+    assert.calledWithExactly(ASRouterUtils.sendImpressionStats, message);
+  });
+
+  it("should return true only when we switch to a different message", () => {
+    const messageA = {message: {id: 1}};
+    const messageB = {message: {id: 2}};
+    let prevState = wrapper.state();
+    wrapper.setState(messageA);
+
+    // We went from no message to a message.
+    assert.isTrue(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+
+    prevState = wrapper.state();
+    wrapper.setState(messageB);
+
+    // From messageA to messageB
+    assert.isTrue(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+
+    prevState = wrapper.state();
+    wrapper.setState(messageB);
+
+    // From messageB to messageB no change
+    assert.isFalse(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+
+    wrapper.setState({});
+
+    // From messageB to no message
+    assert.isFalse(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+  });
+});

--- a/system-addon/test/unit/asrouter/asrouter-content.test.jsx
+++ b/system-addon/test/unit/asrouter/asrouter-content.test.jsx
@@ -1,9 +1,12 @@
 import {ASRouterUISurface, ASRouterUtils} from "content-src/asrouter/asrouter-content";
 import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
+import {FAKE_LOCAL_MESSAGES} from "./constants";
 import {GlobalOverrider} from "test/unit/utils";
-import {ImpressionsWrapper} from "content-src/components/Sections/ImpressionsWrapper";
+import {mount} from "enzyme";
 import React from "react";
-import {shallow} from "enzyme";
+let [FAKE_MESSAGE] = FAKE_LOCAL_MESSAGES;
+
+FAKE_MESSAGE = Object.assign({}, FAKE_MESSAGE, {provider: "fakeprovider"});
 
 describe("ASRouterUtils", () => {
   let global;
@@ -19,97 +22,148 @@ describe("ASRouterUtils", () => {
     sandbox.restore();
     global.restore();
   });
-  it("should send a message with the message payload", () => {
-    ASRouterUtils.sendImpressionStats({id: 1, campaign: "foo", template: "simple"});
+  it("should send a message with the right payload data", () => {
+    ASRouterUtils.sendTelemetry({id: 1, event: "CLICK"});
 
     assert.calledOnce(fakeSendAsyncMessage);
     assert.calledWith(fakeSendAsyncMessage, AS_GENERAL_OUTGOING_MESSAGE_NAME);
     const [, payload] = fakeSendAsyncMessage.firstCall.args;
     assert.propertyVal(payload.data, "id", 1);
-    assert.propertyVal(payload.data, "campaign", "foo");
-    assert.propertyVal(payload.data, "template", "simple");
+    assert.propertyVal(payload.data, "event", "CLICK");
   });
 });
 
 describe("ASRouterUISurface", () => {
   let wrapper;
-  let fakeAddMessageListener;
-  let fakeSendAsyncMessage;
   let global;
   let sandbox;
+  let fakeDocument;
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    fakeAddMessageListener = sandbox.stub();
-    fakeSendAsyncMessage = sandbox.stub();
-
+    fakeDocument = {
+      _listeners: new Set(),
+      _visibilityState: "hidden",
+      get visibilityState() {
+        return this._visibilityState;
+      },
+      set visibilityState(value) {
+        if (this._visibilityState === value) {
+          return;
+        }
+        this._visibilityState = value;
+        this._listeners.forEach(l => l());
+      },
+      addEventListener(event, listener) {
+        this._listeners.add(listener);
+      },
+      removeEventListener(event, listener) {
+        this._listeners.delete(listener);
+      }
+    };
     global = new GlobalOverrider();
     global.set({
-      addMessageListener: fakeAddMessageListener,
-      sendAsyncMessage: fakeSendAsyncMessage
+      addMessageListener: sandbox.stub(),
+      removeMessageListener: sandbox.stub(),
+      sendAsyncMessage: sandbox.stub()
     });
-    wrapper = shallow(<ASRouterUISurface />);
+
+    sandbox.stub(ASRouterUtils, "sendTelemetry");
+
+    wrapper = mount(<ASRouterUISurface document={fakeDocument} />);
   });
+
   afterEach(() => {
     sandbox.restore();
     global.restore();
   });
 
   it("should render the component if a message id is defined", () => {
-    wrapper.setState({message: {id: 1}});
+    wrapper.setState({message: FAKE_MESSAGE});
 
     assert.isTrue(wrapper.exists());
   });
 
-  it("should be wrapped in a ImpressionsWrapper", () => {
-    wrapper.setState({message: {id: 1}});
+  describe("impressions", () => {
+    function simulateVisibilityChange(value) {
+      fakeDocument.visibilityState = value;
+    }
 
-    assert.isTrue(wrapper.find(ImpressionsWrapper).exists());
-  });
+    it("should not send an impression if no message exists", () => {
+      simulateVisibilityChange("visible");
 
-  it("should provide correct props to ImpressionsWrapper", () => {
-    wrapper.setState({message: {id: 1}});
-    const props = wrapper.find(ImpressionsWrapper).props();
+      assert.notCalled(ASRouterUtils.sendTelemetry);
+    });
 
-    assert.propertyVal(props, "sendOnMount", true);
-    assert.propertyVal(props, "shouldSendImpressionsOnUpdate", wrapper.instance().shouldSendImpressionsOnUpdate);
-    assert.propertyVal(props, "dispatchImpressionStats", wrapper.instance().dispatchImpressionStats);
-  });
+    it("should not send an impression if the page is not visible", () => {
+      simulateVisibilityChange("hidden");
+      wrapper.setState({message: FAKE_MESSAGE});
 
-  it("should call ASRouterUtils.sendImpressionStats", () => {
-    const message = {id: 1};
-    wrapper.setState({message});
-    sandbox.stub(ASRouterUtils, "sendImpressionStats");
+      assert.notCalled(ASRouterUtils.sendTelemetry);
+    });
 
-    wrapper.instance().dispatchImpressionStats();
+    it("should send an impression ping when there is a message and the page becomes visible", () => {
+      wrapper.setState({message: FAKE_MESSAGE});
+      assert.notCalled(ASRouterUtils.sendTelemetry);
 
-    assert.calledOnce(ASRouterUtils.sendImpressionStats);
-    assert.calledWithExactly(ASRouterUtils.sendImpressionStats, message);
-  });
+      simulateVisibilityChange("visible");
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+    });
 
-  it("should return true only when we switch to a different message", () => {
-    const messageA = {message: {id: 1}};
-    const messageB = {message: {id: 2}};
-    let prevState = wrapper.state();
-    wrapper.setState(messageA);
+    it("should the right data in the ", () => {
+      wrapper.setState({message: FAKE_MESSAGE});
+      assert.notCalled(ASRouterUtils.sendTelemetry);
 
-    // We went from no message to a message.
-    assert.isTrue(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+      simulateVisibilityChange("visible");
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+    });
 
-    prevState = wrapper.state();
-    wrapper.setState(messageB);
+    it("should send an impression ping when the page is visible and a message gets loaded", () => {
+      simulateVisibilityChange("visible");
+      wrapper.setState({message: {}});
+      assert.notCalled(ASRouterUtils.sendTelemetry);
 
-    // From messageA to messageB
-    assert.isTrue(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+      wrapper.setState({message: FAKE_MESSAGE});
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+    });
 
-    prevState = wrapper.state();
-    wrapper.setState(messageB);
+    it("should send another impression ping if the message id changes", () => {
+      simulateVisibilityChange("visible");
+      wrapper.setState({message: FAKE_MESSAGE});
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
 
-    // From messageB to messageB no change
-    assert.isFalse(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+      wrapper.setState({message: FAKE_LOCAL_MESSAGES[1]});
+      assert.calledTwice(ASRouterUtils.sendTelemetry);
+    });
 
-    wrapper.setState({});
+    it("should not send another impression ping if the message id has not changed", () => {
+      simulateVisibilityChange("visible");
+      wrapper.setState({message: FAKE_MESSAGE});
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
 
-    // From messageB to no message
-    assert.isFalse(wrapper.instance().shouldSendImpressionsOnUpdate(prevState));
+      wrapper.setState({somethingElse: 123});
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+    });
+
+    it("should not send another impression ping if the message is cleared", () => {
+      simulateVisibilityChange("visible");
+      wrapper.setState({message: FAKE_MESSAGE});
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+
+      wrapper.setState({message: {}});
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+    });
+
+    it("should call .sendTelemetry with the right message data", () => {
+      simulateVisibilityChange("visible");
+      wrapper.setState({message: FAKE_MESSAGE});
+
+      assert.calledOnce(ASRouterUtils.sendTelemetry);
+      const [payload] = ASRouterUtils.sendTelemetry.firstCall.args;
+
+      assert.propertyVal(payload, "message_id", FAKE_MESSAGE.id);
+      assert.propertyVal(payload, "event", "IMPRESSION");
+      assert.propertyVal(payload, "action", `${FAKE_MESSAGE.provider}_user_event`);
+    });
   });
 });


### PR DESCRIPTION
This patch includes work done by Andrei in https://github.com/mozilla/activity-stream/pull/4127, as well as some additional follow-up work, in order to fix up a few things.

It adds a new impression ping to all messages. To test this, make sure you have the `asrouterExperiment` pref on and open your browser console to see if the correct ping is being logged. Please try opening about: newtab#asrouter and switching the message to ensure the right pings are correctly logged