### PR TITLE
Bug 1401194 - Add data-section-id to sections for web extension tests

### DIFF
--- a/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/system-addon/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -152,9 +152,11 @@ export class _CollapsibleSection extends React.PureComponent {
     const disclaimerPref = `section.${id}.showDisclaimer`;
     const needsDisclaimer = disclaimer && this.props.Prefs.values[disclaimerPref];
     const active = menuButtonHover || showContextMenu;
-
     return (
-      <section className={`collapsible-section ${this.props.className}${enableAnimation ? " animation-enabled" : ""}${collapsed ? " collapsed" : ""}${active ? " active" : ""}`}>
+      <section
+        className={`collapsible-section ${this.props.className}${enableAnimation ? " animation-enabled" : ""}${collapsed ? " collapsed" : ""}${active ? " active" : ""}`}
+        // Note: data-section-id is used for web extension api tests in mozilla central
+        data-section-id={id}>
         <div className="section-top-bar">
           <h3 className="section-title">
             <span className="click-target" onClick={this.onHeaderClick}>


### PR DESCRIPTION
This is to support tests that will be added in Bug 1401194 in order for web extension tests to identify the correct section more easily (see https://reviewboard.mozilla.org/r/213240/#comment299514)