### PR TITLE
Bug 1436615 - Lots of memory used for activity stream PNGs encoded as data URIs

### DIFF
--- a/system-addon/lib/Screenshots.jsm
+++ b/system-addon/lib/Screenshots.jsm
@@ -5,18 +5,14 @@
 
 const EXPORTED_SYMBOLS = ["Screenshots"];
 
+Cu.importGlobalProperties(["fetch"]);
+
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 ChromeUtils.defineModuleGetter(this, "BackgroundPageThumbs",
   "resource://gre/modules/BackgroundPageThumbs.jsm");
 ChromeUtils.defineModuleGetter(this, "PageThumbs",
   "resource://gre/modules/PageThumbs.jsm");
-ChromeUtils.defineModuleGetter(this, "FileUtils",
-    "resource://gre/modules/FileUtils.jsm");
-XPCOMUtils.defineLazyServiceGetter(this, "MIMEService",
-  "@mozilla.org/mime;1", "nsIMIMEService");
-ChromeUtils.defineModuleGetter(this, "OS",
-  "resource://gre/modules/osfile.jsm");
 ChromeUtils.defineModuleGetter(this, "PrivateBrowsingUtils",
   "resource://gre/modules/PrivateBrowsingUtils.jsm");
 ChromeUtils.defineModuleGetter(this, "Services",
@@ -26,52 +22,27 @@ const GREY_10 = "#F9F9FA";
 
 this.Screenshots = {
   /**
-   * Convert bytes to a string using extremely fast String.fromCharCode without
-   * exceeding the max number of arguments that can be provided to a function.
-   */
-  _bytesToString(bytes) {
-    // NB: This comes from js/src/vm/ArgumentsObject.h ARGS_LENGTH_MAX
-    const ARGS_LENGTH_MAX = 500 * 1000;
-    let i = 0;
-    let str = "";
-    let {length} = bytes;
-    while (i < length) {
-      const start = i;
-      i += ARGS_LENGTH_MAX;
-      str += String.fromCharCode.apply(null, bytes.slice(start, i));
-    }
-    return str;
-  },
-
-  /**
    * Get a screenshot / thumbnail for a url. Either returns the disk cached
    * image or initiates a background request for the url.
    *
    * @param url {string} The url to get a thumbnail
-   * @return {Promise} Resolves a data uri string or null if failed
+   * @return {Promise} Resolves a custom object or null if failed
    */
   async getScreenshotForURL(url) {
     try {
       await BackgroundPageThumbs.captureIfMissing(url, {backgroundColor: GREY_10});
       const imgPath = PageThumbs.getThumbnailPath(url);
 
-      // OS.File object used to easily read off-thread
-      const file = await OS.File.open(imgPath, {read: true, existing: true});
+      const filePathResponse = await fetch(`file://${imgPath}`);
+      const fileContents = await filePathResponse.blob();
 
       // Check if the file is empty, which indicates there isn't actually a
       // thumbnail, so callers can show a failure state.
-      const bytes = await file.read();
-      if (bytes.length === 0) {
+      if (fileContents.size === 0) {
         return null;
       }
 
-      // nsIFile object needed for MIMEService
-      const nsFile = FileUtils.File(imgPath);
-      const contentType = MIMEService.getTypeFromFile(nsFile);
-
-      const encodedData = btoa(this._bytesToString(bytes));
-      file.close();
-      return `data:${contentType};base64,${encodedData}`;
+      return {path: imgPath, data: fileContents};
     } catch (err) {
       Cu.reportError(`getScreenshot(${url}) failed: ${err}`);
     }


### PR DESCRIPTION
This patch fixes bug 1436615 in which lots of memory is used for activity stream PNGs encoded as data URIs when sending data URIs from the parent process to the child process through IPC.

We will use blobs instead of data URIs. Screenshots will be sent as blob objects from the parent process to the child process. The Card component will receive those blob objects and generate blob object URLs. Images in the same tab which reference to the same blob object will share the same blob URL and this is achieved by keeping a global `Map` of blob paths to blob metadata (URL, reference count, and path). Blob object URLs will be revoked when they are no longer in use.

treeherder: https://treeherder.mozilla.org/#/jobs?repo=try&revision=87a4335396d684a3294ec983fc7ad06bcf6181c3