### PR TITLE
Bug 1461787 - Add endpoint pref, button_type to ASRouter experiment

### DIFF
--- a/system-addon/content-src/asrouter/components/Button/Button.jsx
+++ b/system-addon/content-src/asrouter/components/Button/Button.jsx
@@ -3,6 +3,6 @@ import {safeURI} from "../../template-utils";
 
 export const Button = props => (<a href={safeURI(props.url)}
   onClick={props.onClick}
-  className="ASRouterButton">
+  className={props.className || "ASRouterButton"}>
   {props.children}
 </a>);

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -15,14 +15,31 @@ export class SimpleSnippet extends React.PureComponent {
     this.props.sendUserActionTelemetry({event: "CLICK_BUTTON"});
   }
 
+  renderTitle() {
+    const {title} = this.props.content;
+    return title ? <h3 className="title">{title}</h3> : null;
+  }
+
+  renderButton(className) {
+    const {props} = this;
+    return (<Button
+      className={className}
+      onClick={this.onButtonClick}
+      url={props.content.button_url}>
+      {props.content.button_label}
+    </Button>);
+  }
+
   render() {
     const {props} = this;
+    const hasLink = props.content.button_url && props.content.button_type === "anchor";
+    const hasButton = props.content.button_url && !props.content.button_type;
     return (<SnippetBase {...props} className="SimpleSnippet">
       <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon" />
       <div>
-        {props.content.title ? <h3 className="title">{props.content.title}</h3> : null} <p className="body">{props.content.text}</p>
+        {this.renderTitle()} <p className="body">{props.content.text}</p> {hasLink ? this.renderButton("ASRouterAnchor") : null}
       </div>
-      {props.content.button_url ? <div><Button onClick={this.onButtonClick} url={props.content.button_url}>{props.content.button_label}</Button></div> : null}
+      {hasButton ? <div>{this.renderButton()}</div> : null}
     </SnippetBase>);
   }
 }

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -16,4 +16,9 @@
     margin-inline-end: 12px;
     flex-shrink: 0;
   }
+
+  .ASRouterAnchor {
+    color: inherit;
+    text-decoration: underline;
+  }
 }

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -4,20 +4,11 @@ Cu.importGlobalProperties(["fetch"]);
 const INCOMING_MESSAGE_NAME = "ASRouter:child-to-parent";
 const OUTGOING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
-// This is a temporary endpoint until we have something for snippets
-const SNIPPETS_ENDPOINT = "https://activity-stream-icons.services.mozilla.com/v1/messages.json.br";
-
-const LOCAL_TEST_MESSAGES = [
-  {
-    id: "LOCAL_TEST_THEMES",
-    template: "simple_snippet",
-    content: {
-      text: "Your browser is ready for a makeover. Don't worry, you've got tons of options.",
-      button_label: "Check them out here",
-      button_url: "https://addons.mozilla.org/en-US/firefox/themes"
-    }
-  }
-];
+const SNIPPETS_ENDPOINT_PREF = "browser.newtabpage.activity-stream.asrouter.snippetsUrl";
+// Note: currently a restart is required when this pref is changed, this will be fixed in Bug 1462114
+const SNIPPETS_ENDPOINT = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_PREF,
+  "https://activity-stream-icons.services.mozilla.com/v1/messages.json.br");
+const LOCAL_TEST_MESSAGES = [];
 
 const MessageLoaderUtils = {
   /**

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -154,6 +154,10 @@ const PREFS_CONFIG = new Map([
   ["asrouterExperimentEnabled", {
     title: "Is the message center experiment on?",
     value: false
+  }],
+  ["asrouter.snippetsUrl", {
+    title: "A custom URL for the AS router snippets",
+    value: ""
   }]
 ]);
 


### PR DESCRIPTION
These are some final changes for the 61 experiment, including making the as endpoint changeable via a pref, as well as adding "button_type" option for messages that allows them to be anchor-style buttons.

You can test this by:
- setting `browser.newtabpage.activity-stream.asrouter.snippetsUrl` to `https://gist.github.com/k88hudson/2d627d17ebd3e622e5b05e060d98b182/raw` and **restarting** the browser
- make sure the correct url shows up on about:newtab#asrouter
- make sure both types of snippets show up correctly

The two types of buttons look like this:

anchor
![image](https://user-images.githubusercontent.com/1455535/40079153-e5a6ddb8-5854-11e8-8a4b-b8ade3dfe83c.png)

default/button
![image](https://user-images.githubusercontent.com/1455535/40079188-fb3cc5ca-5854-11e8-84cc-188932817142.png)
