### PR TITLE
Fix Bug 1460782 - Exception in TelemetryFeed uninit

### DIFF
--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -35,10 +35,9 @@ XPCOMUtils.defineLazyModuleGetter(this, "ActivityStream",
         (await (await fetch(uri)).text())
           .split("\n").slice(2).forEach(line => cb(line.split(" ").slice(1)));
       } catch (e) {
-        // Silently ignore any modules that fail to load.
+        // Silently ignore listings that fail to load
+        // probably because the resource: has been unloaded
       }
-
-      return null;
     };
 
     // Look for modules one level deeper than the top resource URI

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -30,8 +30,16 @@ let waitingForBrowserReady = true;
 XPCOMUtils.defineLazyModuleGetter(this, "ActivityStream",
   "resource://activity-stream/lib/ActivityStream.jsm", null, null, () => {
     // Helper to fetch a resource directory listing and call back with each item
-    const processListing = async (uri, cb) => (await (await fetch(uri)).text())
-      .split("\n").slice(2).forEach(line => cb(line.split(" ").slice(1)));
+    const processListing = async (uri, cb) => {
+      try {
+        return (await (await fetch(uri)).text())
+          .split("\n").slice(2).forEach(line => cb(line.split(" ").slice(1)));
+      } catch (e) {
+        // Silently ignore any modules that fail to load.
+      }
+
+      return null;
+    };
 
     // Look for modules one level deeper than the top resource URI
     processListing(RESOURCE_BASE, ([directory, , , type]) => {

--- a/system-addon/bootstrap.js
+++ b/system-addon/bootstrap.js
@@ -32,7 +32,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "ActivityStream",
     // Helper to fetch a resource directory listing and call back with each item
     const processListing = async (uri, cb) => {
       try {
-        return (await (await fetch(uri)).text())
+        (await (await fetch(uri)).text())
           .split("\n").slice(2).forEach(line => cb(line.split(" ").slice(1)));
       } catch (e) {
         // Silently ignore any modules that fail to load.

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -490,8 +490,13 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   uninit() {
-    Services.obs.removeObserver(this.browserOpenNewtabStart,
-      "browser-open-newtab-start");
+    try {
+      Services.obs.removeObserver(this.browserOpenNewtabStart,
+        "browser-open-newtab-start");
+    } catch (e) {
+      // wip
+      Cu.reportError(e);
+    }
 
     // Only uninit if the getter has initialized it
     if (Object.prototype.hasOwnProperty.call(this, "pingCentre")) {

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -494,8 +494,8 @@ this.TelemetryFeed = class TelemetryFeed {
       Services.obs.removeObserver(this.browserOpenNewtabStart,
         "browser-open-newtab-start");
     } catch (e) {
-      // wip
-      Cu.reportError(e);
+      // Operation can fail when uninit is called before
+      // init has finished setting up the observer
     }
 
     // Only uninit if the getter has initialized it


### PR DESCRIPTION
The problem described in [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1460782#c4) seems very likely. The feed is instantiated but the `initAction` is dispatched later because it waits for indexeddb. We could move the `addObserver` call in the constructor but I'm not sure if it has any other consequences cc @dmose ?
Guarding against exceptions than could be thrown by removeObserver seems like a common pattern.