### PR TITLE
Turn on telemetry, endpoint pref, and button_type option for AS Router experiment

### DIFF
--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -140,6 +140,21 @@ Schema definitions/validations that can be used for tests can be found in `syste
 }
 ```
 
+# Example Activity Stream `Router` Pings
+
+```js
+{
+  "client_id": "n/a",
+  "action": ["snippets_user_event" | "onboarding_user_event"],
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "source": "pocket",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "source": "NEWTAB_FOOTER_BAR",
+  "message_id": "some_snippet_id",
+  "event": "IMPRESSION"
+}
+```
 
 | KEY | DESCRIPTION | &nbsp; |
 |-----|-------------|:-----:|
@@ -195,8 +210,9 @@ and losing focus. | :one:
 | `is_prerendered` | [Required] A boolean to signify whether the page is prerendered or not | :one:
 | `is_preloaded` | [Required] A boolean to signify whether the page is preloaded or not | :one:
 | `icon_type` | [Optional] ("tippytop", "rich_icon", "screenshot_with_icon", "screenshot", "no_image") | :one:
-| `region` | [Optional] An string maps to pref "browser.search.region", which is essentially the two letter ISO 3166-1 country code populated by the Firefox search service. Note that: 1). it reports "OTHER" for those regions with smaller Firefox user base (less than 10000) so that users cannot be uniquely identified; 2). it reports "UNSET" if this pref is missing; 3). it reports "EMPTY" if the value of this pref is an empty string. | :one:
+| `region` | [Optional] A string maps to pref "browser.search.region", which is essentially the two letter ISO 3166-1 country code populated by the Firefox search service. Note that: 1). it reports "OTHER" for those regions with smaller Firefox user base (less than 10000) so that users cannot be uniquely identified; 2). it reports "UNSET" if this pref is missing; 3). it reports "EMPTY" if the value of this pref is an empty string. | :one:
 | `profile_creation_date` | [Optional] An integer to record the age of the Firefox profile as the total number of days since the UNIX epoch. | :one:
+|`message_id` | [required] A string identifier of the message in Activity Stream Router. | :one:
 
 **Where:**
 

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -458,7 +458,7 @@ This reports the duration of the domain affinity calculation in milliseconds.
 
 ## Undesired event pings
 
-There pings record the undesired events happen in the addon for further investigation.
+These pings record the undesired events happen in the addon for further investigation.
 
 ### Addon initialization failure
 
@@ -473,5 +473,44 @@ This reports when the addon fails to initialize
   "user_prefs": 7,
   "event": "ADDON_INIT_FAILED",
   "value": -1
+}
+```
+## Activity Stream Router pings
+
+These pings record the impression and user interactions within Activity Stream Router.
+
+### Impression ping
+
+This reports the impression of Activity Stream Router.
+
+```js
+{
+  "client_id": "n/a",
+  "action": ["snippets_user_event" | "onboarding_user_event"],
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "source": "pocket",
+  "addon_version": "1.0.12",
+  "locale": "en-US",
+  "source": "NEWTAB_FOOTER_BAR",
+  "message_id": "some_snippet_id",
+  "event": "IMPRESSION"
+}
+```
+
+
+### User interaction pings
+
+This reports the user's interaction with Activity Stream Router.
+
+```js
+{
+  "client_id": "n/a",
+  "action": ["snippets_user_event" | "onboarding_user_event"],
+  "addon_version": "1.0.12",
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "locale": "en-US",
+  "source": "NEWTAB_FOOTER_BAR",
+  "message_id": "some_snippet_id",
+  "event": ["CLICK_BUTTION" | "BLOCK"]
 }
 ```

--- a/system-addon/content-src/asrouter/components/Button/Button.jsx
+++ b/system-addon/content-src/asrouter/components/Button/Button.jsx
@@ -3,6 +3,6 @@ import {safeURI} from "../../template-utils";
 
 export const Button = props => (<a href={safeURI(props.url)}
   onClick={props.onClick}
-  className="ASRouterButton">
+  className={props.className || "ASRouterButton"}>
   {props.children}
 </a>);

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -15,14 +15,31 @@ export class SimpleSnippet extends React.PureComponent {
     this.props.sendUserActionTelemetry({event: "CLICK_BUTTON"});
   }
 
+  renderTitle() {
+    const {title} = this.props.content;
+    return title ? <h3 className="title">{title}</h3> : null;
+  }
+
+  renderButton(className) {
+    const {props} = this;
+    return (<Button
+      className={className}
+      onClick={this.onButtonClick}
+      url={props.content.button_url}>
+      {props.content.button_label}
+    </Button>);
+  }
+
   render() {
     const {props} = this;
+    const hasLink = props.content.button_url && props.content.button_type === "anchor";
+    const hasButton = props.content.button_url && !props.content.button_type;
     return (<SnippetBase {...props} className="SimpleSnippet">
       <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon" />
       <div>
-        {props.content.title ? <h3 className="title">{props.content.title}</h3> : null} <p className="body">{props.content.text}</p>
+        {this.renderTitle()} <p className="body">{props.content.text}</p> {hasLink ? this.renderButton("ASRouterAnchor") : null}
       </div>
-      {props.content.button_url ? <div><Button onClick={this.onButtonClick} url={props.content.button_url}>{props.content.button_label}</Button></div> : null}
+      {hasButton ? <div>{this.renderButton()}</div> : null}
     </SnippetBase>);
   }
 }

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -16,4 +16,9 @@
     margin-inline-end: 12px;
     flex-shrink: 0;
   }
+
+  .ASRouterAnchor {
+    color: inherit;
+    text-decoration: underline;
+  }
 }

--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -4,20 +4,11 @@ Cu.importGlobalProperties(["fetch"]);
 const INCOMING_MESSAGE_NAME = "ASRouter:child-to-parent";
 const OUTGOING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
-// This is a temporary endpoint until we have something for snippets
-const SNIPPETS_ENDPOINT = "https://activity-stream-icons.services.mozilla.com/v1/messages.json.br";
-
-const LOCAL_TEST_MESSAGES = [
-  {
-    id: "LOCAL_TEST_THEMES",
-    template: "simple_snippet",
-    content: {
-      text: "Your browser is ready for a makeover. Don't worry, you've got tons of options.",
-      button_label: "Check them out here",
-      button_url: "https://addons.mozilla.org/en-US/firefox/themes"
-    }
-  }
-];
+const SNIPPETS_ENDPOINT_PREF = "browser.newtabpage.activity-stream.asrouter.snippetsUrl";
+// Note: currently a restart is required when this pref is changed, this will be fixed in Bug 1462114
+const SNIPPETS_ENDPOINT = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_PREF,
+  "https://activity-stream-icons.services.mozilla.com/v1/messages.json.br");
+const LOCAL_TEST_MESSAGES = [];
 
 const MessageLoaderUtils = {
   /**

--- a/system-addon/lib/ActivityStream.jsm
+++ b/system-addon/lib/ActivityStream.jsm
@@ -154,6 +154,10 @@ const PREFS_CONFIG = new Map([
   ["asrouterExperimentEnabled", {
     title: "Is the message center experiment on?",
     value: false
+  }],
+  ["asrouter.snippetsUrl", {
+    title: "A custom URL for the AS router snippets",
+    value: ""
   }]
 ]);
 

--- a/system-addon/lib/TelemetryFeed.jsm
+++ b/system-addon/lib/TelemetryFeed.jsm
@@ -368,8 +368,10 @@ this.TelemetryFeed = class TelemetryFeed {
   createASRouterEvent(action) {
     const appInfo = this.store.getState().App;
     const ping = {
+      client_id: "n/a",
       addon_version: appInfo.version,
-      locale: Services.locale.getAppLocaleAsLangTag()
+      locale: Services.locale.getAppLocaleAsLangTag(),
+      impression_id: this._impressionId
     };
     return Object.assign(ping, action.data);
   }
@@ -406,9 +408,7 @@ this.TelemetryFeed = class TelemetryFeed {
 
   handleASRouterUserEvent(action) {
     let event = this.createASRouterEvent(action);
-    // TODO call this.sendASRouterEvent(event) once the ping gets finalized
-    // and data reviewed
-    console.log(event); // eslint-disable-line
+    this.sendASRouterEvent(event);
   }
 
   handleUndesiredEvent(action) {

--- a/system-addon/test/schemas/pings.js
+++ b/system-addon/test/schemas/pings.js
@@ -200,6 +200,17 @@ export const SessionPing = Joi.object().keys(Object.assign({}, baseKeys, {
   }).required()
 }));
 
+export const ASRouterEventPing = Joi.object().keys({
+  client_id: Joi.string().required(),
+  action: Joi.string().required(),
+  impression_id: Joi.string().required(),
+  source: Joi.string().required(),
+  addon_version: Joi.string().required(),
+  locale: Joi.string().required(),
+  message_id: Joi.string().required(),
+  event: Joi.string().required()
+});
+
 export const UTSessionPing = Joi.array().items(
   Joi.string().required().valid("activity_stream"),
   Joi.string().required().valid("end"),

--- a/system-addon/test/unit/lib/TelemetryFeed.test.js
+++ b/system-addon/test/unit/lib/TelemetryFeed.test.js
@@ -1,6 +1,7 @@
 /* global Services */
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import {
+  ASRouterEventPing,
   BasePing,
   ImpressionStatsPing,
   PerfPing,
@@ -474,12 +475,17 @@ describe("TelemetryFeed", () => {
   });
   describe("#createASRouterEvent", () => {
     it("should create a valid AS Router event", async () => {
-      const data = {source: "SNIPPETS", event: "CLICK"};
+      const data = {
+        action: "snippet_user_event",
+        source: "SNIPPETS",
+        event: "CLICK",
+        message_id: "snippets_message_01"
+      };
       const action = ac.ASRouterUserEvent(data);
       const ping = await instance.createASRouterEvent(action);
 
-      // TODO check the payload with the Joi schema
-
+      assert.validate(ping, ASRouterEventPing);
+      assert.propertyVal(ping, "client_id", "n/a");
       assert.propertyVal(ping, "source", "SNIPPETS");
       assert.propertyVal(ping, "event", "CLICK");
     });


### PR DESCRIPTION
This patch turns on telemetry and adds a few final changes to match the spec for our intended snippets/AS Router experiment in Firefox 61. It will need to be uplifted.