### PR TITLE
Bug 1462569 - Add entrypoint query params when sending users to FxA

### DIFF
--- a/system-addon/content-src/components/StartupOverlay/StartupOverlay.jsx
+++ b/system-addon/content-src/components/StartupOverlay/StartupOverlay.jsx
@@ -62,7 +62,7 @@ export class _StartupOverlay extends React.PureComponent {
             </div>
             <div className="firstrun-sign-in">
               <p className="form-header"><FormattedMessage id="firstrun_form_header" /><span><FormattedMessage id="firstrun_form_sub_header" /></span></p>
-              <form method="get" action="https://accounts.firefox.com" target="_blank" rel="noopener noreferrer" onSubmit={this.onSubmit}>
+              <form method="get" action="https://accounts.firefox.com?entrypoint=activity-stream-firstrun&utm_source=activity-stream&utm_campaign=firstrun" target="_blank" rel="noopener noreferrer" onSubmit={this.onSubmit}>
                 <input name="service" type="hidden" value="sync" />
                 <input name="action" type="hidden" value="email" />
                 <input name="context" type="hidden" value="fx_desktop_v3" />


### PR DESCRIPTION
r?@sarracini 

Bugzilla Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1462569

Adds `utm_campaign`, `entrypoint`, and `utm_source` params to fxa url.