### PR TITLE
Bug 1457227 - convert currentId to lastMessageId

### DIFF
--- a/system-addon/content-src/asrouter/asrouter-content.jsx
+++ b/system-addon/content-src/asrouter/asrouter-content.jsx
@@ -98,8 +98,17 @@ export class ASRouterUISurface extends React.PureComponent {
         this.setState({bundle: action.data});
         break;
       case "CLEAR_MESSAGE":
-        this.setState({message: {}, bundle: {}});
+        if (action.data.id === this.state.message.id) {
+          this.setState({message: {}});
+        }
         break;
+      case "CLEAR_BUNDLE":
+        if (this.state.bundle.bundle) {
+          this.setState({bundle: {}});
+        }
+        break;
+      case "CLEAR_ALL":
+        this.setState({message: {}, bundle: {}});
     }
   }
 

--- a/system-addon/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/system-addon/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -51,7 +51,7 @@ export class ASRouterAdmin extends React.PureComponent {
   }
 
   renderMessageItem(msg) {
-    const isCurrent = msg.id === this.state.currentId;
+    const isCurrent = msg.id === this.state.lastMessageId;
     const isBlocked = this.state.blockList.includes(msg.id);
 
     let itemClassName = "message-item";


### PR DESCRIPTION
This pull request fixes an issue where if a AS router message is blocked, other preloaded browsers with the message don't also get blocked.

