### PR TITLE
Bug 1462124 - Switch .addonInfo to an async API in snippets targeting

### DIFF
--- a/docs/v2-system-addon/snippets.md
+++ b/docs/v2-system-addon/snippets.md
@@ -44,6 +44,30 @@ does not hide onboarding notifications on the **current** page, since that would
 bookmarks a user has (including default bookmarks). Note that is value is only updated once per day or when a
 a user restarts the browser.
 
+`.getAddonsInfo()`:( func) An async function that resolves with an object `{isFullData: (bool), addons: (obj)}`.
+Note that at startup, we are sometimes unable to provide full data due to performance constraits (`.isFullData` will be `false`).
+E.g.
+
+```js
+{
+  isFullData: true,
+  addons: {
+      // This is the ID of the addon
+    "someaddon@mozilla.org": {
+      type: "extension",
+      isSystem: false,
+      isWebExtension: true,
+      version: "29.0.0"
+
+      // The following properties may not be available when the browser starts up
+      name: "Firefox Screenshots",
+      userDisabled: false,
+      installDate: Date 2018-02-27T19:33:33.440Z,
+    }
+  }
+}
+```
+
 ### Expected values in gSnippetsMap
 
 Note that names and functionality of values in v4 snippets have been preserved
@@ -86,26 +110,6 @@ If we could not determine the default browser, this value is `null`. Note that
 currently this value is only checked once when the browser is initialized.
 
 `appData.isDevtoolsUser`: (bool) Has the user ever used devtools?
-
-`appData.addonInfo`: (obj) An object containing info about installed addons.
-For example:
-
-```js
-{
-  // This is the ID of the addon
-  "someaddon@mozilla.org": {
-    type: "extension",
-    isSystem: false,
-    isWebExtension: true,
-    version: "29.0.0"
-
-    // The following properties may not be available when the browser starts up
-    name: "Firefox Screenshots",
-    userDisabled: false,
-    installDate: Date 2018-02-27T19:33:33.440Z,
-  }
-}
-```
 
 ## Events
 

--- a/system-addon/common/Actions.jsm
+++ b/system-addon/common/Actions.jsm
@@ -25,6 +25,8 @@ this.globalImportContext = globalImportContext;
 // }
 const actionTypes = {};
 for (const type of [
+  "ADDONS_INFO_REQUEST",
+  "ADDONS_INFO_RESPONSE",
   "ARCHIVE_FROM_POCKET",
   "AS_ROUTER_TELEMETRY_USER_EVENT",
   "BLOCK_URL",

--- a/system-addon/content-src/lib/snippets.js
+++ b/system-addon/content-src/lib/snippets.js
@@ -83,6 +83,18 @@ export class SnippetsMap extends Map {
     });
   }
 
+  getAddonsInfo() {
+    return new Promise(resolve => {
+      this._dispatch(ac.OnlyToMain({type: at.ADDONS_INFO_REQUEST}));
+      global.addMessageListener("ActivityStream:MainToContent", function onMessage({data: action}) {
+        if (action.type === at.ADDONS_INFO_RESPONSE) {
+          resolve(action.data);
+          global.removeMessageListener("ActivityStream:MainToContent", onMessage);
+        }
+      });
+    });
+  }
+
   /**
    * connect - Attaches an indexedDB back-end to the Map so that any set values
    *           are also cached in a store. It also restores any existing values

--- a/system-addon/lib/SnippetsFeed.jsm
+++ b/system-addon/lib/SnippetsFeed.jsm
@@ -89,7 +89,7 @@ this.SnippetsFeed = class SnippetsFeed {
     });
   }
 
-  async getAddonInfo() {
+  async getAddonsInfo(target) {
     const {addons, fullData} = await AddonManager.getActiveAddons(["extension", "service"]);
     const info = {};
     for (const addon of addons) {
@@ -107,7 +107,8 @@ this.SnippetsFeed = class SnippetsFeed {
         });
       }
     }
-    return info;
+    const data = {addons: info, isFullData: fullData};
+    this.store.dispatch(ac.OnlyToOneContent({type: at.ADDONS_INFO_RESPONSE, data}, target));
   }
 
   async getTotalBookmarksCount(target) {
@@ -152,7 +153,6 @@ this.SnippetsFeed = class SnippetsFeed {
       selectedSearchEngine: await this.getSelectedSearchEngine(),
       defaultBrowser: this.isDefaultBrowser(),
       isDevtoolsUser: this.isDevtoolsUser(),
-      addonInfo: await this.getAddonInfo(),
       blockList: await this._getBlockList() || [],
       previousSessionEnd: this._previousSessionEnd
     };
@@ -193,7 +193,7 @@ this.SnippetsFeed = class SnippetsFeed {
     browser.loadURI(url);
   }
 
-  onAction(action) {
+  async onAction(action) {
     switch (action.type) {
       case at.INIT:
         this.init();
@@ -213,6 +213,9 @@ this.SnippetsFeed = class SnippetsFeed {
         break;
       case at.TOTAL_BOOKMARKS_REQUEST:
         this.getTotalBookmarksCount(action.meta.fromTarget);
+        break;
+      case at.ADDONS_INFO_REQUEST:
+        await this.getAddonsInfo(action.meta.fromTarget);
         break;
     }
   }

--- a/system-addon/test/unit/content-src/lib/snippets.test.js
+++ b/system-addon/test/unit/content-src/lib/snippets.test.js
@@ -165,6 +165,25 @@ describe("SnippetsMap", () => {
       assert.calledWith(global.removeMessageListener, INCOMING_MESSAGE_NAME, listener);
     });
   });
+  describe("#getAddonsInfo", () => {
+    it("should dispatch a ADDONS_INFO_REQUEST and resolve with the right data", async () => {
+      const addonsPromise = snippetsMap.getAddonsInfo();
+
+      assert.calledOnce(dispatch);
+      assert.equal(dispatch.firstCall.args[0].type, at.ADDONS_INFO_REQUEST);
+      assert.calledWith(global.addMessageListener, INCOMING_MESSAGE_NAME);
+
+      // Call listener
+      const [, listener] = global.addMessageListener.firstCall.args;
+      const addonsInfo = {isFullData: true, addons: {foo: {}}};
+      listener({data: {type: at.ADDONS_INFO_RESPONSE, data: addonsInfo}});
+
+      const result = await addonsPromise;
+
+      assert.equal(result, addonsInfo);
+      assert.calledWith(global.removeMessageListener, INCOMING_MESSAGE_NAME, listener);
+    });
+  });
 });
 
 describe("SnippetsProvider", () => {


### PR DESCRIPTION
Hey, do you mind taking a look at this? To test it, just basically call `gSnippets.getAddonsInfo().then(info => console.log(info))` in your console and make sure something gets logged.