### PR TITLE
chore(lint): Fix sentance/sentence codespell warning

### DIFF
--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -184,7 +184,7 @@ firstrun_content=Get your bookmarks, history, passwords and other settings on al
 firstrun_learn_more_link=Learn more about Firefox Accounts
 
 # LOCALIZATION NOTE (firstrun_form_header and firstrun_form_sub_header):
-# firstrun_form_sub_header is a continuation of firstrun_form_header, they are one sentance.
+# firstrun_form_sub_header is a continuation of firstrun_form_header, they are one sentence.
 # firstrun_form_header is displayed more boldly as the call to action.
 firstrun_form_header=Enter your email
 firstrun_form_sub_header=to continue to Firefox Sync.


### PR DESCRIPTION
Was preparing to export with #4149 and ran into
```
browser/locales/en-US/chrome/browser/activity-stream/newtab.properties
  187  warning  sentance  ==> sentence  (codespell)

✖ 1 problem (0 errors, 1 warning)
abort: Lint run failed (if you really need to you can --skip-lint)
```