### PR TITLE
Bug 1428274 - AS Router should handle 204, 302, 500 codes approrpiately

### DIFF
--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -79,9 +79,16 @@ const MessageLoaderUtils = {
     let remoteMessages = [];
     if (provider.url) {
       try {
-        remoteMessages = (await (await fetch(provider.url)).json())
-          .messages
-          .map(msg => ({...msg, provider_url: provider.url}));
+        const response = await fetch(provider.url);
+        if (
+          // Empty response
+          response.status !== 204 &&
+          (response.ok || response.status === 302)
+        ) {
+          remoteMessages = (await response.json())
+            .messages
+            .map(msg => ({...msg, provider_url: provider.url}));
+        }
       } catch (e) {
         Cu.reportError(e);
       }


### PR DESCRIPTION
I added some tests here to make sure AS Router handles different error codes correctly.

Does the behaviour in these tests look reasonable to you @glogiotatidis?