### PR TITLE
Fix Bug 1457239 - Setting for number of rows is truncated making the label not readable unless you click on it

### DIFF
--- a/system-addon/lib/AboutPreferences.jsm
+++ b/system-addon/lib/AboutPreferences.jsm
@@ -231,6 +231,7 @@ this.AboutPreferences = class AboutPreferences {
 
           // Add appropriate number of localized entries to the dropdown
           const menulist = createAppend("menulist", detailHbox);
+          menulist.setAttribute("crop", "none");
           const menupopup = createAppend("menupopup", menulist);
           for (let num = 1; num <= maxRows; num++) {
             const plurals = formatString({id: "prefs_section_rows_option", values: {num}});


### PR DESCRIPTION
r?@k88hudson Simple! ? https://searchfox.org/mozilla-central/search?q=crop%3D"none

Before:
![screen shot 2018-05-25 at 12 24 19 am](https://user-images.githubusercontent.com/438537/40532410-36e06f30-5fb4-11e8-8c31-cd83a65f4e9c.png)


After:
![screen shot 2018-05-25 at 12 23 48 am](https://user-images.githubusercontent.com/438537/40532406-3362864a-5fb4-11e8-87a9-9d4cb61bb064.png)
