### PR TITLE
Fix Bug 1464536 - Compact icon type circle can overlap host name

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -219,6 +219,8 @@
 }
 
 .compact-cards {
+  $card-detail-vertical-spacing: 12px;
+
   .card-outer {
     height: $card-height-compact;
 
@@ -227,7 +229,7 @@
     }
 
     .card-details {
-      padding: 12px 16px;
+      padding: $card-detail-vertical-spacing 16px;
     }
 
     .card-host-name {
@@ -255,10 +257,11 @@
       $container-size: 32px;
       background-color: var(--newtab-card-background-color);
       border-radius: $container-size / 2;
+      clip-path: inset(0 0 $container-size - ($card-height-compact - $card-preview-image-height-compact - 2 * $card-detail-vertical-spacing));
       height: $container-size;
       width: $container-size;
       padding: ($container-size - $icon-size) / 2;
-      top: 92px;
+      top: $card-preview-image-height-compact - $icon-size;
       offset-inline-end: 12px;
       offset-inline-start: auto;
 


### PR DESCRIPTION
r?@rlr I don't think I've used so many characters to generate "4px" for `clip-path: inset(0 0 4px);`

Before:
![screen shot 2018-05-25 at 4 39 49 pm](https://user-images.githubusercontent.com/438537/40569939-cac5de84-603a-11e8-8c10-3727b6b3729d.png)

After:
![screen shot 2018-05-25 at 4 39 09 pm](https://user-images.githubusercontent.com/438537/40569942-d24ad722-603a-11e8-8f0b-c6c46a59d19b.png)

(gold background added to see the clipping)