### PR TITLE
Bug 1464019 - Turn off asrouter snippets when snippets.feed is false

### DIFF
--- a/system-addon/content-src/asrouter/asrouter-content.jsx
+++ b/system-addon/content-src/asrouter/asrouter-content.jsx
@@ -159,6 +159,30 @@ export class ASRouterUISurface extends React.PureComponent {
 
 ASRouterUISurface.defaultProps = {document: global.document};
 
-export function initASRouter() {
-  ReactDOM.render(<ASRouterUISurface />, document.getElementById("snippets-container"));
+export class ASRouterContent {
+  constructor() {
+    this.initialized = false;
+    this.containerElement = null;
+  }
+
+  _mount() {
+    this.containerElement = global.document.getElementById("snippets-container");
+    ReactDOM.render(<ASRouterUISurface />, this.containerElement);
+  }
+
+  _unmount() {
+    ReactDOM.unmountComponentAtNode(this.containerElement);
+  }
+
+  init() {
+    this._mount();
+    this.initialized = true;
+  }
+
+  uninit() {
+    if (this.initialized) {
+      this._unmount();
+      this.initialized = false;
+    }
+  }
 }

--- a/system-addon/content-src/lib/snippets.js
+++ b/system-addon/content-src/lib/snippets.js
@@ -7,7 +7,7 @@ const SNIPPETS_ENABLED_EVENT = "Snippets:Enabled";
 const SNIPPETS_DISABLED_EVENT = "Snippets:Disabled";
 
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
-import {initASRouter} from "content-src/asrouter/asrouter-content";
+import {ASRouterContent} from "content-src/asrouter/asrouter-content";
 
 /**
  * SnippetsMap - A utility for cacheing values related to the snippet. It has
@@ -373,10 +373,11 @@ export class SnippetsProvider {
  *                         Snippet data.
  *
  * @param  {obj} store   The redux store
- * @return {obj}         Returns the snippets instance and unsubscribe function
+ * @return {obj}         Returns the snippets instance, asrouterContent instance and unsubscribe function
  */
 export function addSnippetsSubscriber(store) {
   const snippets = new SnippetsProvider(store.dispatch);
+  const asrouterContent = new ASRouterContent();
 
   let initializing = false;
 
@@ -406,11 +407,21 @@ export function addSnippetsSubscriber(store) {
       snippets.uninit();
     }
 
-    if (state.Prefs.values.asrouterExperimentEnabled) {
-      initASRouter();
+    // Turn on AS Router snippets if the experiment is enabled and the snippets pref is on;
+    // otherwise, turn it off.
+    if (
+      state.Prefs.values.asrouterExperimentEnabled &&
+      state.Prefs.values["feeds.snippets"] &&
+      !asrouterContent.initialized) {
+      asrouterContent.init();
+    } else if (
+      (!state.Prefs.values.asrouterExperimentEnabled || !state.Prefs.values["feeds.snippets"]) &&
+      asrouterContent.initialized
+    ) {
+      asrouterContent.uninit();
     }
   });
 
   // These values are returned for testing purposes
-  return snippets;
+  return {snippets, asrouterContent};
 }


### PR DESCRIPTION
This patch turns off asrouter snippets when the snippets user-facing pref is set to false

To test:
1. turn on asrouter snippets by setting `browser.newtabpage.activity-stream.asrouterExperimentEnabled` to `true`, verify asrouter snippets are showing up
2. go to about:config#home and turning snippets off
3. verify no snippets are showing on the new tab page