### PR TITLE
Fix Bug 1463836 - AS Router Remote Provider Message Previewing

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -14,10 +14,7 @@ const OUTGOING_MESSAGE_NAME = "ASRouter:child-to-parent";
 
 // List of hosts for endpoints that serve router messages.
 // Key is allowed host, value is a name for the endpoint host.
-const WHITELIST_HOSTS = {
-  "activity-stream-icons.services.mozilla.com": "snippets",
-  "gist.githubusercontent.com": "staging"
-};
+const WHITELIST_HOSTS = {"https://snippets-admin.moz.works": "preview"};
 
 export const ASRouterUtils = {
   addListener(listener) {

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -12,10 +12,6 @@ import {SimpleSnippet} from "./templates/SimpleSnippet/SimpleSnippet";
 const INCOMING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const OUTGOING_MESSAGE_NAME = "ASRouter:child-to-parent";
 
-// List of hosts for endpoints that serve router messages.
-// Key is allowed host, value is a name for the endpoint host.
-const WHITELIST_HOSTS = {"https://snippets-admin.moz.works": "preview"};
-
 export const ASRouterUtils = {
   addListener(listener) {
     global.addMessageListener(INCOMING_MESSAGE_NAME, listener);
@@ -56,19 +52,13 @@ export const ASRouterUtils = {
   getEndpoint() {
     if (window.location.href.includes("endpoint")) {
       const params = new URLSearchParams(window.location.href.slice(window.location.href.indexOf("endpoint")));
-      let endpoint;
       try {
-        endpoint = new URL(params.get("endpoint"));
-      } catch (e) {
-        return null;
-      }
-      if (endpoint.protocol === "https:" && WHITELIST_HOSTS[endpoint.host]) {
+        const endpoint = new URL(params.get("endpoint"));
         return {
           url: endpoint.href,
-          id: WHITELIST_HOSTS[endpoint.host],
           snippetId: params.get("snippetId")
         };
-      }
+      } catch (e) {}
     }
 
     return null;
@@ -191,14 +181,6 @@ export class ASRouterUISurface extends React.PureComponent {
         break;
       case "CLEAR_ALL":
         this.setState({message: {}, bundle: {}});
-    }
-  }
-
-  componentDidUpdate() {
-    const endpoint = ASRouterUtils.getEndpoint();
-    // Force to show the message with the id provided in the URL
-    if (endpoint && endpoint.snippetId && this.state.message.id !== endpoint.snippetId) {
-      ASRouterUtils.overrideMessage(endpoint.snippetId);
     }
   }
 

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -16,7 +16,8 @@ export class ASRouterAdmin extends React.PureComponent {
   }
 
   componentWillMount() {
-    ASRouterUtils.sendMessage({type: "ADMIN_CONNECT_STATE"});
+    const endpoint = ASRouterUtils.getEndpoint();
+    ASRouterUtils.sendMessage({type: "ADMIN_CONNECT_STATE", data: {endpoint}});
     ASRouterUtils.addListener(this.onMessage);
   }
 

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -298,7 +298,13 @@ class _ASRouter {
 
   async sendNextMessage(target) {
     const msgs = this._getUnblockedMessages();
-    let message = await ASRouterTargeting.findMatchingMessage(msgs, target);
+    let message = null;
+    const previewMsgs = this.state.messages.filter(item => item.provider === "preview");
+    if (!previewMsgs.length) {
+      message = await ASRouterTargeting.findMatchingMessage(msgs, target);
+    } else {
+      [message] = previewMsgs;
+    }
     await this.setState({lastMessageId: message ? message.id : null});
 
     await this._sendMessageToTarget(message, target);

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -23,7 +23,7 @@ const SNIPPETS_ENDPOINT = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_PREF,
 // Key is allowed host, value is a name for the endpoint host.
 const WHITELIST_HOSTS = {
   "activity-stream-icons.services.mozilla.com": "production",
-  "snippets-admin.moz.works": "preview"
+  "snippets-admin.mozilla.org": "preview"
 };
 
 const MessageLoaderUtils = {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -405,7 +405,7 @@ class _ASRouter {
         break;
       case "ADMIN_CONNECT_STATE":
         if (action.data && action.data.endpoint) {
-          this._addEndpoint(action.data.endpoint);
+          this._addPreviewEndpoint(action.data.endpoint.url);
           await this.loadMessagesFromAllProviders();
         } else {
           target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: this.state});

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -337,7 +337,10 @@ class _ASRouter {
     try {
       const endpoint = new URL(url);
       if (!WHITELIST_HOSTS[endpoint.host]) {
-        Cu.reportError(`The preview URL host ${endpoint.host} is not in the whitelist`);
+        Cu.reportError(`The preview URL host ${endpoint.host} is not in the whitelist.`);
+      }
+      if (endpoint.protocol !== "https:") {
+        Cu.reportError(`The URL protocol is not https.`);
       }
       return (endpoint.protocol === "https:" && WHITELIST_HOSTS[endpoint.host]);
     } catch (e) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -346,7 +346,7 @@ class _ASRouter {
         Cu.reportError(`The preview URL host ${endpoint.host} is not in the whitelist.`);
       }
       if (endpoint.protocol !== "https:") {
-        Cu.reportError(`The URL protocol is not https.`);
+        Cu.reportError("The URL protocol is not https.");
       }
       return (endpoint.protocol === "https:" && WHITELIST_HOSTS[endpoint.host]);
     } catch (e) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -300,10 +300,11 @@ class _ASRouter {
     const msgs = this._getUnblockedMessages();
     let message = null;
     const previewMsgs = this.state.messages.filter(item => item.provider === "preview");
-    if (!previewMsgs.length) {
-      message = await ASRouterTargeting.findMatchingMessage(msgs, target);
-    } else {
+    // Always send preview messages when available
+    if (previewMsgs.length) {
       [message] = previewMsgs;
+    } else {
+      message = await ASRouterTargeting.findMatchingMessage(msgs, target);
     }
     await this.setState({lastMessageId: message ? message.id : null});
 

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -336,7 +336,10 @@ class _ASRouter {
   _validPreviewEndpoint(url) {
     try {
       const endpoint = new URL(url);
-      return endpoint.protocol === "https:" && WHITELIST_HOSTS[endpoint.host];
+      if (!WHITELIST_HOSTS[endpoint.host]) {
+        Cu.reportError(`The preview URL host ${endpoint.host} is not in the whitelist`);
+      }
+      return (endpoint.protocol === "https:" && WHITELIST_HOSTS[endpoint.host]);
     } catch (e) {
       return false;
     }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -216,6 +216,25 @@ describe("ASRouter", () => {
 
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
     });
+    it("should add the endpoint provided on CONNECT_UI_REQUEST", async () => {
+      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url: "foo"}}});
+      await Router.onMessage(msg);
+
+      assert.isDefined(Router.state.providers.find(p => p.url === "foo"));
+    });
+    it("should add the endpoint provided on ADMIN_CONNECT_STATE", async () => {
+      const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE", data: {endpoint: {url: "foo"}}});
+      await Router.onMessage(msg);
+
+      assert.isDefined(Router.state.providers.find(p => p.url === "foo"));
+    });
+    it("should not add the same endpoint twice", async () => {
+      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url: "foo"}}});
+      await Router.onMessage(msg);
+      await Router.onMessage(msg);
+
+      assert.lengthOf(Router.state.providers.filter(p => p.url === "foo"), 1);
+    });
   });
 
   describe("#onMessage: BLOCK_MESSAGE_BY_ID", () => {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -444,4 +444,13 @@ describe("ASRouter", () => {
       assert.calledOnce(msg.target.browser.ownerGlobal.openTrustedLinkIn);
     });
   });
+
+  describe("valid preview endpoint", () => {
+    it("should report an error if url protocol is not https", () => {
+      sandbox.stub(Cu, "reportError");
+
+      assert.equal(false, Router._validPreviewEndpoint("http://foo.com"));
+      assert.calledTwice(Cu.reportError);
+    });
+  });
 });

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -344,7 +344,7 @@ describe("ASRouter", () => {
     });
     it("should return the preview message if that's available", async () => {
       const expectedObj = {provider: "preview"};
-      sandbox.stub(Router, "_getUnblockedMessages").returns([expectedObj, {provider: "external"}]);
+      Router.setState({messages: [expectedObj]});
 
       await Router.sendNextMessage(channel);
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -217,21 +217,21 @@ describe("ASRouter", () => {
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
     });
     it("should add the endpoint provided on CONNECT_UI_REQUEST", async () => {
-      const url = "https://snippets-admin.moz.works/foo";
+      const url = "https://snippets-admin.mozilla.org/foo";
       const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url}}});
       await Router.onMessage(msg);
 
       assert.isDefined(Router.state.providers.find(p => p.url === url));
     });
     it("should add the endpoint provided on ADMIN_CONNECT_STATE", async () => {
-      const url = "https://snippets-admin.moz.works/foo";
+      const url = "https://snippets-admin.mozilla.org/foo";
       const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE", data: {endpoint: {url}}});
       await Router.onMessage(msg);
 
       assert.isDefined(Router.state.providers.find(p => p.url === url));
     });
     it("should not add the same endpoint twice", async () => {
-      const url = "https://snippets-admin.moz.works/foo";
+      const url = "https://snippets-admin.mozilla.org/foo";
       const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url}}});
       await Router.onMessage(msg);
       await Router.onMessage(msg);


### PR DESCRIPTION

Endpoint: https://gist.githubusercontent.com/piatra/70234f08696c0a0509d7ba5568cd830f/raw/68370f34abc134142c64b6f0a9b9258a06de7aa3/messages.json
Example url: `about:newtab?endpoint=https://gist.githubusercontent.com/piatra/70234f08696c0a0509d7ba5568cd830f/raw/68370f34abc134142c64b6f0a9b9258a06de7aa3/messages.json&snippetId=42`
When navigating to this URL it should automatically load the correct snippet. 
On every refresh we want to fetch data from the endpoint again. The workflow would be:
* snippet creator makes v0 of snippet
* copy-paste the url and open it in a new tab
* make changes to snippet -> refresh the same page, get the latest/updated content

ASRouterAdmin will add the endpoint (if found in the URL) only for debugging purposes, snippet creators are interested in landing on `about:newtab` and will probably never see the admin.