### PR TITLE
Fix Bug 1463453 - The onboarding sections are misaligned between themselves when displayed vertically

### DIFF
--- a/system-addon/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
+++ b/system-addon/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
@@ -63,7 +63,7 @@
 
     @media(max-width: 850px) {
       height: 75px;
-      width: 160px;
+      min-width: 80px;
       background-size: 80px;
     }
 


### PR DESCRIPTION
Sorry quick fix:
Before
<img width="749" alt="screen shot 2018-05-29 at 1 05 56 pm" src="https://user-images.githubusercontent.com/7219526/40674052-a4f6ca92-6341-11e8-93ac-2edb592bcc2c.png">

After
<img width="757" alt="screen shot 2018-05-29 at 1 05 35 pm" src="https://user-images.githubusercontent.com/7219526/40674059-ab662134-6341-11e8-92fe-d12b47a31786.png">

