### PR TITLE
Fix Bug 1463426 - Open 'about:privatebrowsing' on onboarding 'Try Now' action

### DIFF
--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -24,8 +24,7 @@ const LOCAL_TEST_MESSAGES = [
       text: "Browse by yourself. Private Browsing with Tracking Protection blocks online trackers that follow you around the web.",
       icon: "privatebrowsing",
       button_label: "Try It Now",
-      button_action: "OPEN_PRIVATE_BROWSER_WINDOW",
-      button_action_params: "about:home"
+      button_action: "OPEN_PRIVATE_BROWSER_WINDOW"
     }
   },
   {
@@ -358,7 +357,8 @@ class _ASRouter {
         await this.sendNextMessage(target);
         break;
       case ra.OPEN_PRIVATE_BROWSER_WINDOW:
-        this.openLinkIn(action.data.button_action_params, target, {isPrivate: true, where: "window"});
+        // Forcefully open about:privatebrowsing
+        target.browser.ownerGlobal.OpenBrowserWindow({private: true});
         break;
       case ra.OPEN_URL:
         this.openLinkIn(action.data.button_action_params, target, {isPrivate: false, where: "tabshifted"});

--- a/system-addon/test/unit/asrouter/ASRouter.test.js
+++ b/system-addon/test/unit/asrouter/ASRouter.test.js
@@ -338,15 +338,12 @@ describe("ASRouter", () => {
   });
 
   describe("#onMessage: Onboarding actions", () => {
-    it("should call openLinkIn with the correct params on OPEN_PRIVATE_BROWSER_WINDOW", async () => {
-      sinon.spy(Router, "openLinkIn");
+    it("should call OpenBrowserWindow with a private window on OPEN_PRIVATE_BROWSER_WINDOW", async () => {
       let [testMessage] = Router.state.messages;
-      testMessage.button_action_params = "about:home";
       const msg = fakeAsyncMessage({type: "OPEN_PRIVATE_BROWSER_WINDOW", data: testMessage});
       await Router.onMessage(msg);
 
-      assert.calledWith(Router.openLinkIn, testMessage.button_action_params, msg.target, {isPrivate: true, where: "window"});
-      assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
+      assert.calledWith(msg.target.browser.ownerGlobal.OpenBrowserWindow, {private: true});
     });
     it("should call openLinkIn with the correct params on OPEN_URL", async () => {
       sinon.spy(Router, "openLinkIn");

--- a/system-addon/test/unit/asrouter/constants.js
+++ b/system-addon/test/unit/asrouter/constants.js
@@ -25,7 +25,8 @@ export class FakeRemotePageManager {
     this.browser = {
       ownerGlobal: {
         openTrustedLinkIn: sinon.stub(),
-        openLinkIn: sinon.stub()
+        openLinkIn: sinon.stub(),
+        OpenBrowserWindow: sinon.stub()
       }
     };
   }


### PR DESCRIPTION
I just need to make sure `OpenBrowserWindow` works on windows/linux too I think it should be fine tho