### PR TITLE
Fix Bug 1465818 - Add semver-based version and information about allowed tags

### DIFF
--- a/system-addon/content-src/asrouter/schemas/message-format.md
+++ b/system-addon/content-src/asrouter/schemas/message-format.md
@@ -28,7 +28,7 @@ The following tags are allowed in the content of the snippet: `i, b, u, strong, 
 Links cannot be rendered using regular anchor tags because [Fluent does not allow for href attributes](https://github.com/projectfluent/fluent.js/blob/a03d3aa833660f8c620738b26c80e46b1a4edb05/fluent-dom/src/overlay.js#L13). They will be wrapped in custom tags, for example `<cta>link</cta>` and the url will be provided as part of the payload:
 ```
 {
- "id": "7899",
+  "id": "7899",
   "content": {
     "text": "Use the CMD (CTRL) + T keyboard shortcut to <cta>open a new tab quickly!</cta>",
     "links": {

--- a/system-addon/content-src/asrouter/schemas/message-format.md
+++ b/system-addon/content-src/asrouter/schemas/message-format.md
@@ -28,8 +28,14 @@ The following tags are allowed in the content of the snippet: `i, b, u, strong, 
 Links cannot be rendered using regular anchor tags because [Fluent does not allow for href attributes](https://github.com/projectfluent/fluent.js/blob/a03d3aa833660f8c620738b26c80e46b1a4edb05/fluent-dom/src/overlay.js#L13). They will be wrapped in custom tags, for example `<cta>link</cta>` and the url will be provided as part of the payload:
 ```
 {
-  "links": {
-    "cta": "https://..."
+ "id": "7899",
+  "content": {
+    "text": "Use the CMD (CTRL) + T keyboard shortcut to <cta>open a new tab quickly!</cta>",
+    "links": {
+      "cta": {
+        "url": "https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly"
+      }
+    }
   }
 }
 ```

--- a/system-addon/content-src/asrouter/schemas/message-format.md
+++ b/system-addon/content-src/asrouter/schemas/message-format.md
@@ -6,7 +6,7 @@ Field name | Type     | Required | Description | Example / Note
 `template` | `string` | Yes | An id matching an existing Activity Stream Router template | [See example](https://github.com/mozilla/activity-stream/blob/33669c67c2269078a6d3d6d324fb48175d98f634/system-addon/content-src/message-center/templates/SimpleSnippet.jsx)
 `publish_start` | `date` | No | When to start showing the message | `1524474850876`
 `publish_end` | `date` | No | When to stop showing the message | `1524474850876`
-`content` | `object` | Yes | An object containing all variables/props to be rendered in the template. Values should not contain HTML (supporting a subset will be addressed in 62) | [See example below](#message-example)
+`content` | `object` | Yes | An object containing all variables/props to be rendered in the template. Subset of allowed tags detailed below. | [See example below](#HTML-subset)
 `campaign` | `string` | No | Campaign id that the message belongs to | `RustWebAssembly`
 `targeting` | `string` `JEXL` | Yes | A [JEXL expression](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#jexl-basics) with all targeting information needed in order to decide if the message is shown | Not yet implemented, [some examples](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#examples)
 
@@ -21,3 +21,18 @@ Field name | Type     | Required | Description | Example / Note
   }
 }
 ```
+
+### HTML subset
+The following tags are allowed in the content of the snippet: `i, b, u, strong, em, br`.
+
+Links cannot be rendered using regular anchor tags because [Fluent does not allow for href attributes](https://github.com/projectfluent/fluent.js/blob/a03d3aa833660f8c620738b26c80e46b1a4edb05/fluent-dom/src/overlay.js#L13). They will be wrapped in custom tags, for example `<cta>link</cta>` and the url will be provided as part of the payload:
+```
+{
+  "links": {
+    "cta": "https://..."
+  }
+}
+```
+If a tag that is not on the allowed is used, the text content will be extracted and displayed.
+
+Grouping multiple allowed elements is not possible, only the first level will be used: "<u><b>text</b></u>" will be interpreted as "<u>text</u>".

--- a/system-addon/content-src/asrouter/schemas/message-format.md
+++ b/system-addon/content-src/asrouter/schemas/message-format.md
@@ -6,7 +6,7 @@ Field name | Type     | Required | Description | Example / Note
 `template` | `string` | Yes | An id matching an existing Activity Stream Router template | [See example](https://github.com/mozilla/activity-stream/blob/33669c67c2269078a6d3d6d324fb48175d98f634/system-addon/content-src/message-center/templates/SimpleSnippet.jsx)
 `publish_start` | `date` | No | When to start showing the message | `1524474850876`
 `publish_end` | `date` | No | When to stop showing the message | `1524474850876`
-`content` | `object` | Yes | An object containing all variables/props to be rendered in the template. Subset of allowed tags detailed below. | [See example below](#HTML-subset)
+`content` | `object` | Yes | An object containing all variables/props to be rendered in the template. Subset of allowed tags detailed below. | [See example below](#html-subset)
 `campaign` | `string` | No | Campaign id that the message belongs to | `RustWebAssembly`
 `targeting` | `string` `JEXL` | Yes | A [JEXL expression](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#jexl-basics) with all targeting information needed in order to decide if the message is shown | Not yet implemented, [some examples](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#examples)
 
@@ -35,4 +35,4 @@ Links cannot be rendered using regular anchor tags because [Fluent does not allo
 ```
 If a tag that is not on the allowed is used, the text content will be extracted and displayed.
 
-Grouping multiple allowed elements is not possible, only the first level will be used: "<u><b>text</b></u>" will be interpreted as "<u>text</u>".
+Grouping multiple allowed elements is not possible, only the first level will be used: `<u><b>text</b></u>` will be interpreted as `<u>text</u>`.

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -1,6 +1,7 @@
 {
   "title": "SimpleSnippet",
   "description": "A simple template with an icon, text, and optional button.",
+  "version": "0.1.0",
   "type": "object",
   "properties": {
     "title": {
@@ -27,6 +28,11 @@
       "type": "string",
       "enum": ["anchor", "button"],
       "description": "(**temporary**, until we get html support in text field Bug 1457233) Style for button, either a regular button or a text link."
+    },
+    "links": {
+      "[a-z0-9]*": {
+        "url": "string"
+      }
     }
   },
   "additionalProperties": false,

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -30,8 +30,11 @@
       "description": "(**temporary**, until we get html support in text field Bug 1457233) Style for button, either a regular button or a text link."
     },
     "links": {
-      "[a-z0-9]*": {
-        "url": "string"
+      "additionalProperties": {
+        "url": {
+          "type": "string",
+          "description": "The url where the link points to."
+        }
       }
     }
   },


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1457233#c8 mentioning the allowed tags in the documentation.