### PR TITLE
chore(telemetry): Change telemetry for onboarding from 'TRY_NOW' to regular button click

### DIFF
--- a/system-addon/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/system-addon/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -9,7 +9,7 @@ class OnboardingCard extends React.PureComponent {
 
   onClick() {
     const {props} = this;
-    props.sendUserActionTelemetry({event: "TRY_NOW", message_id: props.id});
+    props.sendUserActionTelemetry({event: "CLICK_BUTTON", message_id: props.id});
     props.onAction(props.content);
   }
 


### PR DESCRIPTION
This should match the same button click event that the other snippets has, is that ok @ncloudioj? Changed it based on the convo we had yesterday