### PR TITLE
Fix Bug 1465178 - Telemetry source in AS Router is null

### DIFF
--- a/system-addon/content-src/asrouter/asrouter-content.jsx
+++ b/system-addon/content-src/asrouter/asrouter-content.jsx
@@ -68,17 +68,16 @@ export class ASRouterUISurface extends React.PureComponent {
       throw new Error(`You must provide a message_id for bundled messages`);
     }
     const eventType = `${message.provider || bundle.provider}_user_event`;
-
     ASRouterUtils.sendTelemetry({
       message_id: message.id || extraProps.message_id,
-      source: this.props.id,
+      source: extraProps.id,
       action: eventType,
       ...extraProps
     });
   }
 
-  sendImpression() {
-    this.sendUserActionTelemetry({event: "IMPRESSION"});
+  sendImpression(extraProps) {
+    this.sendUserActionTelemetry({event: "IMPRESSION", ...extraProps});
   }
 
   onBlockById(id) {
@@ -124,6 +123,7 @@ export class ASRouterUISurface extends React.PureComponent {
   renderSnippets() {
     return (
       <ImpressionsWrapper
+        id="NEWTAB_FOOTER_BAR"
         message={this.state.message}
         sendImpression={this.sendImpression}
         shouldSendImpressionOnUpdate={shouldSendImpressionOnUpdate}

--- a/system-addon/content-src/asrouter/components/ImpressionsWrapper/ImpressionsWrapper.jsx
+++ b/system-addon/content-src/asrouter/components/ImpressionsWrapper/ImpressionsWrapper.jsx
@@ -12,7 +12,7 @@ export class ImpressionsWrapper extends React.PureComponent {
   // only send the event if the page becomes visible again.
   sendImpressionOrAddListener() {
     if (this.props.document.visibilityState === VISIBLE) {
-      this.props.sendImpression();
+      this.props.sendImpression({id: this.props.id});
     } else {
       // We should only ever send the latest impression stats ping, so remove any
       // older listeners.
@@ -23,7 +23,7 @@ export class ImpressionsWrapper extends React.PureComponent {
       // When the page becomes visible, send the impression stats ping if the section isn't collapsed.
       this._onVisibilityChange = () => {
         if (this.props.document.visibilityState === VISIBLE) {
-          this.props.sendImpression();
+          this.props.sendImpression({id: this.props.id});
           this.props.document.removeEventListener(VISIBILITY_CHANGE_EVENT, this._onVisibilityChange);
         }
       };

--- a/system-addon/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/system-addon/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -7,7 +7,7 @@ export class SnippetBase extends React.PureComponent {
   }
 
   onBlockClicked() {
-    this.props.sendUserActionTelemetry({event: "BLOCK"});
+    this.props.sendUserActionTelemetry({event: "BLOCK", id: this.props.UISurface});
     this.props.onBlock();
   }
 

--- a/system-addon/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/system-addon/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -9,7 +9,7 @@ class OnboardingCard extends React.PureComponent {
 
   onClick() {
     const {props} = this;
-    props.sendUserActionTelemetry({event: "CLICK_BUTTON", message_id: props.id});
+    props.sendUserActionTelemetry({event: "CLICK_BUTTON", message_id: props.id, id: props.UISurface});
     props.onAction(props.content);
   }
 
@@ -39,7 +39,11 @@ export class OnboardingMessage extends React.PureComponent {
       <ModalOverlay {...props} button_label={"Start Browsing"} title={"Welcome to Firefox"}>
         <div className="onboardingMessageContainer">
           {props.bundle.map(message => (
-            <OnboardingCard key={message.id} sendUserActionTelemetry={props.sendUserActionTelemetry} onAction={props.onAction} {...message} />
+            <OnboardingCard key={message.id}
+              sendUserActionTelemetry={props.sendUserActionTelemetry}
+              onAction={props.onAction}
+              UISurface={props.UISurface}
+              {...message} />
           ))}
         </div>
       </ModalOverlay>

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -12,7 +12,7 @@ export class SimpleSnippet extends React.PureComponent {
   }
 
   onButtonClick() {
-    this.props.sendUserActionTelemetry({event: "CLICK_BUTTON"});
+    this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", id: this.props.UISurface});
   }
 
   renderTitle() {

--- a/system-addon/test/unit/asrouter/asrouter-content.test.jsx
+++ b/system-addon/test/unit/asrouter/asrouter-content.test.jsx
@@ -89,6 +89,25 @@ describe("ASRouterUISurface", () => {
     assert.isTrue(wrapper.exists());
   });
 
+  describe("snippets", () => {
+    it("should send correct event and source when snippet link is clicked", () => {
+      const content = {button_url: "https://foo.com", button_type: "anchor", button_label: "foo", ...FAKE_MESSAGE.content};
+      const message = Object.assign({}, FAKE_MESSAGE, {content});
+      wrapper.setState({message});
+
+      wrapper.find("a.ASRouterAnchor").simulate("click");
+      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "event", "CLICK_BUTTON");
+      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "source", "NEWTAB_FOOTER_BAR");
+    });
+    it("should send correct event and source when snippet is blocked", () => {
+      wrapper.setState({message: FAKE_MESSAGE});
+
+      wrapper.find(".blockButton").simulate("click");
+      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "event", "BLOCK");
+      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "source", "NEWTAB_FOOTER_BAR");
+    });
+  });
+
   describe("impressions", () => {
     function simulateVisibilityChange(value) {
       fakeDocument.visibilityState = value;
@@ -115,12 +134,13 @@ describe("ASRouterUISurface", () => {
       assert.calledOnce(ASRouterUtils.sendTelemetry);
     });
 
-    it("should the right data in the ", () => {
+    it("should send the correct impression source", () => {
       wrapper.setState({message: FAKE_MESSAGE});
-      assert.notCalled(ASRouterUtils.sendTelemetry);
-
       simulateVisibilityChange("visible");
+
       assert.calledOnce(ASRouterUtils.sendTelemetry);
+      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "event", "IMPRESSION");
+      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "source", "NEWTAB_FOOTER_BAR");
     });
 
     it("should send an impression ping when the page is visible and a message gets loaded", () => {
@@ -169,6 +189,7 @@ describe("ASRouterUISurface", () => {
       assert.propertyVal(payload, "message_id", FAKE_MESSAGE.id);
       assert.propertyVal(payload, "event", "IMPRESSION");
       assert.propertyVal(payload, "action", `${FAKE_MESSAGE.provider}_user_event`);
+      assert.propertyVal(payload, "source", "NEWTAB_FOOTER_BAR");
     });
   });
 });

--- a/system-addon/test/unit/asrouter/templates/SimpleSnippet.test.jsx
+++ b/system-addon/test/unit/asrouter/templates/SimpleSnippet.test.jsx
@@ -18,6 +18,13 @@ function mountAndCheckProps(content = {}) {
 }
 
 describe("SimpleSnippet", () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
   it("should render .text", () => {
     const wrapper = mountAndCheckProps({text: "bar"});
     assert.equal(wrapper.find(".body").text(), "bar");

--- a/system-addon/test/unit/asrouter/templates/SimpleSnippet.test.jsx
+++ b/system-addon/test/unit/asrouter/templates/SimpleSnippet.test.jsx
@@ -18,13 +18,6 @@ function mountAndCheckProps(content = {}) {
 }
 
 describe("SimpleSnippet", () => {
-  let sandbox;
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-  });
-  afterEach(() => {
-    sandbox.restore();
-  });
   it("should render .text", () => {
     const wrapper = mountAndCheckProps({text: "bar"});
     assert.equal(wrapper.find(".body").text(), "bar");


### PR DESCRIPTION
The events I tested for:
* snippet impressions
* snippet dismiss
* snippet click event (link)
* onboarding "Try it Now" button

"Start Browsing" the button that closes the tour doesn't have telemetry attached, not sure if that is intended or not.