### PR TITLE
Fix Bug 1465623 - fix position of type icon border on highlight cards

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -258,7 +258,7 @@
       $container-size: 32px;
       background-color: var(--newtab-card-background-color);
       border-radius: $container-size / 2;
-      clip-path: inset(0 0 $container-size - ($card-height-compact - $card-preview-image-height-compact - 2 * $card-detail-vertical-spacing));
+      clip-path: inset(-1px -1px $container-size - ($card-height-compact - $card-preview-image-height-compact - 2 * $card-detail-vertical-spacing));
       height: $container-size;
       width: $container-size;
       padding: ($container-size - $icon-size) / 2;
@@ -269,13 +269,13 @@
       &::after {
         border: 1px solid var(--newtab-card-hairline-color);
         border-bottom: 0;
-        border-radius: ($container-size / 2) ($container-size / 2) 0 0;
+        border-radius: ($container-size / 2) + 1 ($container-size / 2) + 1 0 0;
         content: '';
         position: absolute;
-        height: 50%;
-        width: 100%;
-        top: 0;
-        left: 0;
+        height: ($container-size + 2) / 2;
+        width: $container-size + 2;
+        top: -1px;
+        left: -1px;
       }
 
       .card-context-icon {


### PR DESCRIPTION
Did I get that math right?

Before:
![before-default](https://user-images.githubusercontent.com/36629/40790559-4a7c7e58-64c3-11e8-8f9b-f20754b039bf.png)
![before-dark](https://user-images.githubusercontent.com/36629/40790562-4b999870-64c3-11e8-85a1-7c6d0fbddec5.png)

After:
![after-default](https://user-images.githubusercontent.com/36629/40790567-4f154224-64c3-11e8-8820-52d0181b776d.png)
![after-dark](https://user-images.githubusercontent.com/36629/40790569-50228334-64c3-11e8-835c-3212c61da807.png)
