### PR TITLE
Fix Bug 1463381 - change color of context text and icon on Pocket cards

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -147,7 +147,7 @@
 
   .card-context {
     bottom: 0;
-    color: var(--newtab-text-tertiary-color);
+    color: var(--newtab-text-secondary-color);
     display: flex;
     font-size: 11px;
     offset-inline-start: 0;
@@ -156,7 +156,7 @@
   }
 
   .card-context-icon {
-    fill: var(--newtab-icon-tertiary-color);
+    fill: var(--newtab-text-secondary-color);
     height: 22px;
     margin-inline-end: 6px;
   }


### PR DESCRIPTION
tiny r? @Mardak 

Before:
<img width="1022" alt="screen shot 2018-05-31 at 12 01 41 pm" src="https://user-images.githubusercontent.com/36629/40793443-67e28ef4-64ca-11e8-83fa-e43335aac636.png">
<img width="1021" alt="screen shot 2018-05-31 at 12 01 30 pm" src="https://user-images.githubusercontent.com/36629/40793446-6919e0b0-64ca-11e8-8bb0-222711acfb6b.png">

After:
<img width="1017" alt="screen shot 2018-05-31 at 11 55 09 am" src="https://user-images.githubusercontent.com/36629/40793447-6d12b318-64ca-11e8-81ff-e6377a164b2a.png">
<img width="1057" alt="screen shot 2018-05-31 at 11 57 38 am" src="https://user-images.githubusercontent.com/36629/40793453-6ee4ca6e-64ca-11e8-9852-4238f3ea00ff.png">
