### PR TITLE
Fix Bug 1465902 - Do not send a bundle of messages if we do not have enough messages to fill the bundle

### DIFF
--- a/system-addon/lib/ASRouter.jsm
+++ b/system-addon/lib/ASRouter.jsm
@@ -238,13 +238,21 @@ class _ASRouter {
     bundledMessages.push({content: originalMessage.content, id: originalMessage.id});
     for (const msg of this.state.messages) {
       if (msg.bundled && msg.template === originalMessage.template && msg.id !== originalMessage.id && !this.state.blockList.includes(msg.id)) {
-        // only copy the content - that's what the UI cares about
+        // Only copy the content - that's what the UI cares about
         bundledMessages.push({content: msg.content, id: msg.id});
       }
+
+      // Stop once we have enough messages to fill a bundle
       if (bundledMessages.length === originalMessage.bundled) {
         break;
       }
     }
+
+    // If we did not find enough messages to fill the bundle, do not send the bundle down
+    if (bundledMessages.length < originalMessage.bundled) {
+      return null;
+    }
+
     return {bundle: bundledMessages, provider: originalMessage.provider, template: originalMessage.template};
   }
 
@@ -260,7 +268,7 @@ class _ASRouter {
     if (message && message.bundled) {
       bundledMessages = this._getBundledMessages(message);
     }
-    if (message && !bundledMessages) {
+    if (message && !message.bundled) {
       // If we only need to send 1 message, send the message
       target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "SET_MESSAGE", data: message});
     } else if (bundledMessages) {

--- a/system-addon/test/unit/asrouter/ASRouter.test.js
+++ b/system-addon/test/unit/asrouter/ASRouter.test.js
@@ -188,13 +188,26 @@ describe("ASRouter", () => {
     });
     it("should send a message back to the to the target if there is a bundle, too", async () => {
       // force the only message to be a bundled message so getRandomItemFromArray picks it
-      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
+      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 1, content: {title: "Foo1", body: "Foo123-1"}}]});
       const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
       await Router.onMessage(msg);
       const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
       assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].type, "SET_BUNDLED_MESSAGES");
       assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[0].content, currentMessage.content);
+    });
+    it("should return a null bundle if we do not have enough messages to fill the bundle", async () => {
+      // force the only message to be a bundled message that needs 2 messages in the bundle
+      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
+      const bundle = Router._getBundledMessages(Router.state.messages[0]);
+      assert.equal(bundle, null);
+    });
+    it("should send a CLEAR_ALL message if no bundle available", async () => {
+      // force the only message to be a bundled message that needs 2 messages in the bundle
+      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
+      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      await Router.onMessage(msg);
+      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
     });
     it("should send a CLEAR_ALL message if no messages are available", async () => {
       await Router.setState({messages: []});


### PR DESCRIPTION
Return a null bundle if we don't have enough items to fill the bundle. This is so we don't encounter the case where you get the onboarding overlay with only 1 or 2 messages