### PR TITLE
Fix Bug 1466608 - increase highlight title font size to 12px

### DIFF
--- a/system-addon/content-src/components/Card/_Card.scss
+++ b/system-addon/content-src/components/Card/_Card.scss
@@ -221,6 +221,7 @@
 
 .compact-cards {
   $card-detail-vertical-spacing: 12px;
+  $card-title-font-size: 12px;
 
   .card-outer {
     height: $card-height-compact;
@@ -240,9 +241,9 @@
     .card-text {
       .card-title,
       &:not(.no-description) .card-title {
-        font-size: 10px;
-        line-height: 12px;
-        max-height: 12px;
+        font-size: $card-title-font-size;
+        line-height: $card-title-font-size + 1;
+        max-height: $card-title-font-size + 1;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;


### PR DESCRIPTION
Before:
![screen shot 2018-06-04 at 17 19 32](https://user-images.githubusercontent.com/36629/40942253-a198f706-681b-11e8-9b8b-8e4bf28dce25.png)

After:
![screen shot 2018-06-04 at 17 18 52](https://user-images.githubusercontent.com/36629/40942260-a6d4b70a-681b-11e8-96b0-f635b2c31473.png)
