### PR TITLE
Bug 1464126 - Implement the rest of simple template vars in AS Router

### DIFF
--- a/system-addon/content-src/asrouter/components/Button/Button.jsx
+++ b/system-addon/content-src/asrouter/components/Button/Button.jsx
@@ -1,8 +1,26 @@
 import React from "react";
 import {safeURI} from "../../template-utils";
 
-export const Button = props => (<a href={safeURI(props.url)}
-  onClick={props.onClick}
-  className={props.className || "ASRouterButton"}>
-  {props.children}
-</a>);
+const ALLOWED_STYLE_TAGS = ["color", "backgroundColor"];
+
+export const Button = props => {
+  const style = {};
+
+  // Add allowed style tags from props, e.g. props.color becomes style={color: props.color}
+  for (const tag of ALLOWED_STYLE_TAGS) {
+    if (typeof props[tag] !== "undefined") {
+      style[tag] = props[tag];
+    }
+  }
+  // remove border if bg is set to something custom
+  if (style.backgroundColor) {
+    style.border = "0";
+  }
+
+  return (<a href={safeURI(props.url)}
+    onClick={props.onClick}
+    className={props.className || "ASRouterButton"}
+    style={style}>
+    {props.children}
+  </a>);
+};

--- a/system-addon/content-src/asrouter/components/Button/_Button.scss
+++ b/system-addon/content-src/asrouter/components/Button/_Button.scss
@@ -5,6 +5,9 @@
   background-color: var(--newtab-button-secondary-color);
   font-family: inherit;
   padding: 8px 15px;
-  margin-left: 12px;
+  margin-inline-start: 12px;
   color: inherit;
+  .tall & {
+    margin-inline-start: 20px;
+  }
 }

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -20,12 +20,19 @@ export class SimpleSnippet extends React.PureComponent {
     return title ? <h3 className="title">{title}</h3> : null;
   }
 
+  renderTitleIcon() {
+    const titleIcon = safeURI(this.props.content.title_icon);
+    return titleIcon ? <span className="titleIcon" style={{backgroundImage: `url("${titleIcon}")`}} /> : null;
+  }
+
   renderButton(className) {
     const {props} = this;
     return (<Button
       className={className}
       onClick={this.onButtonClick}
-      url={props.content.button_url}>
+      url={props.content.button_url}
+      color={props.content.button_color}
+      backgroundColor={props.content.button_background_color}>
       {props.content.button_label}
     </Button>);
   }
@@ -34,10 +41,11 @@ export class SimpleSnippet extends React.PureComponent {
     const {props} = this;
     const hasLink = props.content.button_url && props.content.button_type === "anchor";
     const hasButton = props.content.button_url && !props.content.button_type;
-    return (<SnippetBase {...props} className="SimpleSnippet">
+    const className = `SimpleSnippet${props.content.tall ? " tall" : ""}`;
+    return (<SnippetBase {...props} className={className}>
       <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon" />
       <div>
-        {this.renderTitle()} <p className="body">{props.content.text}</p> {hasLink ? this.renderButton("ASRouterAnchor") : null}
+        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{props.content.text}</p> {hasLink ? this.renderButton("ASRouterAnchor") : null}
       </div>
       {hasButton ? <div>{this.renderButton()}</div> : null}
     </SnippetBase>);

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "SimpleSnippet",
   "description": "A simple template with an icon, text, and optional button.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "object",
   "properties": {
     "title": {
@@ -16,6 +16,10 @@
       "type": "string",
       "description": "Snippet icon. 64x64px. SVG or PNG preferred."
     },
+    "title_icon": {
+      "type": "string",
+      "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
+    },
     "button_url": {
       "type": "string",
       "description": "A url, button_label links to this"
@@ -24,10 +28,22 @@
       "type": "string",
       "description": "Text for a button next to main snippet text that links to button_url. Requires button_url."
     },
+    "button_color": {
+      "type": "string",
+      "description": "The text color of the button. Valid CSS color."
+    },
+    "button_background_color": {
+      "type": "string",
+      "description": "The background color of the button. Valid CSS color."
+    },
     "button_type": {
       "type": "string",
       "enum": ["anchor", "button"],
       "description": "(**temporary**, until we get html support in text field Bug 1457233) Style for button, either a regular button or a text link."
+    },
+    "tall": {
+      "type": "boolean",
+      "description": "To be used by fundraising only, increases height to roughly 120px. Defaults to false."
     },
     "links": {
       "additionalProperties": {
@@ -43,6 +59,8 @@
   "dependencies": {
     "button_url": ["button_label"],
     "button_label": ["button_url"],
-    "button_type": ["button_url"]
+    "button_type": ["button_url"],
+    "button_color": ["button_url"],
+    "button_background_color": ["button_url"]
   }
 }

--- a/system-addon/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/system-addon/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -1,8 +1,23 @@
 .SimpleSnippet {
+  &.tall {
+    padding: 27px 0;
+  }
+
   .title {
     display: inline;
     font-size: inherit;
     margin: 0;
+  }
+
+  .titleIcon {
+    background-repeat: no-repeat;
+    background-size: 14px;
+    height: 16px;
+    width: 16px;
+    margin-top: 2px;
+    margin-inline-end: 2px;
+    display: inline-block;
+    vertical-align: top;
   }
 
   .body {
@@ -15,6 +30,9 @@
     width: 42px;
     margin-inline-end: 12px;
     flex-shrink: 0;
+  }
+  &.tall .icon {
+    margin-inline-end: 20px;
   }
 
   .ASRouterAnchor {


### PR DESCRIPTION
This adds some new variables and therefore bumps the SimpleSnippet template version to 0.2.0

To test:
1. Set `browser.newtabpage.activity-stream.asrouter.snippetsUrl` to `https://gist.github.com/k88hudson/f56034f9b2c7ff30ff79859d9af47372/raw` in about:config
2. Restart the browser
3. Check that the small title icon appears, the button is blue with red text, and the snippet looks taller