### PR TITLE
Fix Bug 1457233 - Use custom metric attributes for links

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -76,10 +76,10 @@ const ALLOWED_TAGS = {
  * Transform an object (tag name: {url}) into (tag name: anchor) where the url
  * is used as href, in order to render links inside a Fluent.Localized component.
  */
-function convertLinks(links) {
+export function convertLinks(links, sendClick) {
   if (links) {
     return Object.keys(links).reduce((acc, linkTag) => {
-      acc[linkTag] = <a href={safeURI(links[linkTag].url)} />;
+      acc[linkTag] = <a href={safeURI(links[linkTag].url)} data-metric={links[linkTag].metric} onClick={sendClick} />;
       return acc;
     }, {});
   }
@@ -92,7 +92,7 @@ function convertLinks(links) {
  */
 function RichText(props) {
   return (
-    <Localized id="RichTextSnippet" {...ALLOWED_TAGS} {...convertLinks(props.links)}>
+    <Localized id="RichTextSnippet" {...ALLOWED_TAGS} {...convertLinks(props.links, props.sendClick)}>
       <span>{props.text}</span>
     </Localized>
   );
@@ -102,6 +102,7 @@ export class ASRouterUISurface extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onMessageFromParent = this.onMessageFromParent.bind(this);
+    this.sendClick = this.sendClick.bind(this);
     this.sendImpression = this.sendImpression.bind(this);
     this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
     this.state = {message: {}, bundle: {}};
@@ -123,6 +124,14 @@ export class ASRouterUISurface extends React.PureComponent {
 
   sendImpression(extraProps) {
     this.sendUserActionTelemetry({event: "IMPRESSION", ...extraProps});
+  }
+
+  // If link has a `metric` data attribute send it as part of the `value`
+  // telemetry field which can have arbitrary values.
+  // Used for router messages with links as part of the content.
+  sendClick(event) {
+    const metric = {value: event.target.dataset.metric};
+    this.sendUserActionTelemetry({event: "CLICK_BUTTON", ...metric});
   }
 
   onBlockById(id) {
@@ -177,7 +186,9 @@ export class ASRouterUISurface extends React.PureComponent {
           <LocalizationProvider messages={generateMessages(this.state.message.content.text)}>
             <SimpleSnippet
               {...this.state.message}
-              richText={<RichText text={this.state.message.content.text} links={this.state.message.content.links} />}
+              richText={<RichText text={this.state.message.content.text}
+                                  links={this.state.message.content.links}
+                                  sendClick={this.sendClick} />}
               UISurface="NEWTAB_FOOTER_BAR"
               getNextMessage={ASRouterUtils.getNextMessage}
               onBlock={this.onBlockById(this.state.message.id)}

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -132,8 +132,8 @@ export class ASRouterUISurface extends React.PureComponent {
   sendClick(event) {
     const metric = {
       value: event.target.dataset.metric,
-      // The will the the `source` of the event. Needed to differentiate
-      // from other snippet or onboarding events that may occur
+      // Used for the `source` of the event. Needed to differentiate
+      // from other snippet or onboarding events that may occur.
       id: "NEWTAB_FOOTER_BAR_CONTENT"
     };
     this.sendUserActionTelemetry({event: "CLICK_BUTTON", ...metric});

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -130,7 +130,12 @@ export class ASRouterUISurface extends React.PureComponent {
   // telemetry field which can have arbitrary values.
   // Used for router messages with links as part of the content.
   sendClick(event) {
-    const metric = {value: event.target.dataset.metric};
+    const metric = {
+      value: event.target.dataset.metric,
+      // The will the the `source` of the event. Needed to differentiate
+      // from other snippet or onboarding events that may occur
+      id: "NEWTAB_FOOTER_BAR_CONTENT"
+    };
     this.sendUserActionTelemetry({event: "CLICK_BUTTON", ...metric});
   }
 

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "SimpleSnippet",
   "description": "A simple template with an icon, text, and optional button.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "object",
   "properties": {
     "title": {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -50,6 +50,10 @@
         "url": {
           "type": "string",
           "description": "The url where the link points to."
+        },
+        "metric": {
+          "type": "string",
+          "description": "Custom event name sent with telemetry event."
         }
       }
     }

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "SimpleSnippet",
   "description": "A simple template with an icon, text, and optional button.",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "type": "object",
   "properties": {
     "title": {

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -1,4 +1,4 @@
-import {ASRouterUISurface, ASRouterUtils} from "content-src/asrouter/asrouter-content";
+import {ASRouterUISurface, ASRouterUtils, convertLinks} from "content-src/asrouter/asrouter-content";
 import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
 import {FAKE_LOCAL_MESSAGES} from "./constants";
 import {GlobalOverrider} from "test/unit/utils";
@@ -105,6 +105,23 @@ describe("ASRouterUISurface", () => {
       wrapper.find(".blockButton").simulate("click");
       assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "event", "BLOCK");
       assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "source", "NEWTAB_FOOTER_BAR");
+    });
+  });
+
+  describe("convertLinks", () => {
+    it("should return an object with anchor elements", () => {
+      const cta = {
+        url: "https://foo.com",
+        metric: "foo"
+      };
+      const stub = sandbox.stub();
+      const result = convertLinks({cta}, stub);
+
+      assert.property(result, "cta");
+      assert.propertyVal(result.cta, "type", "a");
+      assert.propertyVal(result.cta.props, "href", cta.url);
+      assert.propertyVal(result.cta.props, "data-metric", cta.metric);
+      assert.propertyVal(result.cta.props, "onClick", stub);
     });
   });
 


### PR DESCRIPTION
This is based on the work in #4162 so only the very last commit should be reviewed https://github.com/mozilla/activity-stream/pull/4196/commits/c2f696b6df5e6a7b44fcf8d77c9f4db9b1d82080

Follow up work for https://bugzilla.mozilla.org/show_bug.cgi?id=1457233