### PR TITLE
Fix Bug 1467449 - ASRouter sets bundle to null

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -253,16 +253,13 @@ class _ASRouter {
     return state.messages.filter(item => !state.blockList.includes(item.id));
   }
 
-  async sendNextMessage(target) {
+  _sendMessageToTarget(message, target) {
     let bundledMessages;
-    const msgs = this._getUnblockedMessages();
-    let message = await ASRouterTargeting.findMatchingMessage(msgs);
-    await this.setState({lastMessageId: message ? message.id : null});
-
     // If this message needs to be bundled with other messages of the same template, find them and bundle them together
     if (message && message.bundled) {
       bundledMessages = this._getBundledMessages(message);
     }
+
     if (message && !message.bundled) {
       // If we only need to send 1 message, send the message
       target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "SET_MESSAGE", data: message});
@@ -274,18 +271,19 @@ class _ASRouter {
     }
   }
 
+  async sendNextMessage(target) {
+    const msgs = this._getUnblockedMessages();
+    let message = await ASRouterTargeting.findMatchingMessage(msgs);
+    await this.setState({lastMessageId: message ? message.id : null});
+
+    this._sendMessageToTarget(message, target);
+  }
+
   async setMessageById(id) {
     await this.setState({lastMessageId: id});
     const newMessage = this.getMessageById(id);
-    if (newMessage) {
-      // If this message needs to be bundled with other messages of the same template, find them and bundle them together
-      if (newMessage.bundled) {
-        let bundledMessages = this._getBundledMessages(newMessage);
-        this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "SET_BUNDLED_MESSAGES", data: bundledMessages});
-      } else {
-        this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "SET_MESSAGE", data: newMessage});
-      }
-    }
+
+    this._sendMessageToTarget(newMessage, this.messageChannel);
   }
 
   async blockById(idOrIds) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -259,7 +259,6 @@ class _ASRouter {
     if (message && message.bundled) {
       bundledMessages = this._getBundledMessages(message);
     }
-
     if (message && !message.bundled) {
       // If we only need to send 1 message, send the message
       target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "SET_MESSAGE", data: message});

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -348,6 +348,13 @@ describe("ASRouter", () => {
 
       assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: testMessage});
     });
+
+    it("should broadcast CLEAR_ALL if provided id did not resolve to a message", async () => {
+      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: -1}});
+      await Router.onMessage(msg);
+
+      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
+    });
   });
 
   describe("#onMessage: Onboarding actions", () => {


### PR DESCRIPTION
[Bugzilla description](https://bugzilla.mozilla.org/show_bug.cgi?id=1467449) shows how to reproduce.
The issue here is that `setMessageById` and `sendNextMessage` have very similar flows (get the message to the target) but `sendNextMessage` has more safeguards against `null` messages so I just refactored that code into a common method that both can use.

https://github.com/mozilla/activity-stream/blob/7e544945fbe0cba46eba9387e4c593e98d8f9f55/lib/ASRouter.jsm#L256-L289