### PR TITLE
Followup to Bug 1463381 - fix history icon fill color (compact cards)

### DIFF
--- a/content-src/components/Card/_Card.scss
+++ b/content-src/components/Card/_Card.scss
@@ -292,10 +292,6 @@
           fill: $download-icon-fill;
         }
 
-        &.icon-history-item {
-          fill: $history-icon-fill;
-        }
-
         &.icon-pocket {
           fill: $pocket-icon-fill;
         }

--- a/content-src/styles/_variables.scss
+++ b/content-src/styles/_variables.scss
@@ -50,7 +50,6 @@ $white-10: rgba($white, 0.1);
 $pocket-teal: #50BCB6;
 $bookmark-icon-fill: #0A84FF;
 $download-icon-fill: #12BC00;
-$history-icon-fill: #B1B1B3;
 $pocket-icon-fill: #D70022;
 
 // Photon transitions from http://design.firefox.com/photon/motion/duration-and-easing.html


### PR DESCRIPTION
@bryanbell says the history icon color should match the trending icon color from pocket. So we just remove the color override.

Before:
<img width="281" alt="screen shot 2018-06-08 at 11 32 29 am" src="https://user-images.githubusercontent.com/36629/41167035-cdb10166-6b0f-11e8-99b7-7313833b77d3.png">
<img width="261" alt="screen shot 2018-06-08 at 11 33 03 am" src="https://user-images.githubusercontent.com/36629/41167042-d02ce86a-6b0f-11e8-8db8-42f48fbf8c24.png">

After:
<img width="274" alt="screen shot 2018-06-08 at 11 32 39 am" src="https://user-images.githubusercontent.com/36629/41167052-d3b69d96-6b0f-11e8-9417-4512c93e4c00.png">
<img width="237" alt="screen shot 2018-06-08 at 11 33 14 am" src="https://user-images.githubusercontent.com/36629/41167054-d53b5008-6b0f-11e8-8730-a409f74df74d.png">
