### PR TITLE
Fix Bug 1469823 - Listen for PLACES_LINK_DELETED actions and update Topsites

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -395,6 +395,7 @@ this.TopSitesFeed = class TopSitesFeed {
       // All these actions mean we need new top sites
       case at.MIGRATION_COMPLETED:
       case at.PLACES_HISTORY_CLEARED:
+      case at.PLACES_LINK_DELETED:
         this.frecentCache.expire();
         this.refresh({broadcast: true});
         break;

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -763,6 +763,14 @@ describe("Top Sites Feed", () => {
       assert.calledOnce(feed.refresh);
       assert.calledWithExactly(feed.refresh, {broadcast: true});
     });
+    it("should call refresh without a target if we remove a Topsite from history", () => {
+      sandbox.stub(feed, "refresh");
+
+      feed.onAction({type: at.PLACES_LINK_DELETED});
+
+      assert.calledOnce(feed.refresh);
+      assert.calledWithExactly(feed.refresh, {broadcast: true});
+    });
     it("should still dispatch an action even if there's no target provided", async () => {
       sandbox.stub(feed, "_fetchIcon");
       await feed.refresh({broadcast: true});


### PR DESCRIPTION
Looking back at the [discussion in the PR](https://github.com/mozilla/activity-stream/pull/4184#discussion_r191934937) the original change so that we don't fetch `4 * TOP_SITES_MAX_SITES_PER_ROW` unnecessarily, but I didn't see this usecase (when the user removes a topsites) being discussed. 
This would fetch an extra 4 items to be used in case a hole needs to be filled in.
It also seems like Highlights deduping uses all the `TopSites.rows` in the store (not just the ones being displayed) so this would also need to be fixed. 

f? @Mardak 