### PR TITLE
Followup Bug 1464548 - Restore eslint no-undef by upgrading to eslint-plugin-mozilla 0.14.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,8 +33,6 @@ module.exports = {
     }
   }],
   "rules": {
-    "no-undef": 1, // Override eslint-plugin-mozilla until 0.13.1+ is available
-
     "promise/catch-or-return": 2,
     "promise/param-names": 2,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2948,11 +2948,12 @@
       }
     },
     "eslint-plugin-mozilla": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.11.0.tgz",
-      "integrity": "sha512-O/02mzydm2KqjGb0gSAz+qJQSwZAmWsKaxRRkqkM1Tv4+/spn2aeYLorZKzcCZb+I27oQHOej151TCPXofix9w==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.14.0.tgz",
+      "integrity": "sha512-H0hb49FJP4qKFgT2l89tlm7QYIsBpKC0cXvFY+mT9Or+7lqlovsYexYtzl9qfT2PFKg37ay7TB2C0U3N7rlp1Q==",
       "dev": true,
       "requires": {
+        "htmlparser2": "3.9.2",
         "ini-parser": "0.0.2",
         "sax": "1.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "4.19.1",
     "eslint-plugin-import": "2.11.0",
     "eslint-plugin-json": "1.2.0",
-    "eslint-plugin-mozilla": "0.11.0",
+    "eslint-plugin-mozilla": "0.14.0",
     "eslint-plugin-no-unsanitized": "3.0.0",
     "eslint-plugin-promise": "3.7.0",
     "eslint-plugin-react": "7.7.0",


### PR DESCRIPTION
r?@sarracini Makes the warnings go away!