### PR TITLE
Bug 1448359 - Enable CSP for Activity Stream

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -190,7 +190,7 @@ function templateHTML(options, html) {
 <html lang="${options.locale}" dir="${options.direction}">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'; img-src http: https: data: blob:; style-src 'unsafe-inline'; child-src 'none'; object-src 'none'; report-uri https://tiles.services.mozilla.com/v4/links/activity-stream/csp">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' resource: chrome:; connect-src https:; img-src https: data: blob:; style-src 'unsafe-inline';">
     <title>${options.strings.newtab_page_title}</title>
     <link rel="icon" type="image/png" href="chrome://branding/content/icon32.png"/>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />


### PR DESCRIPTION
Alright, I think this should cover what we want. I changed a few things:
* images no longer allow `http` (I think that's OK? I don't think we use any external images right now anyway)
*  I added `default-src none` which should cover frames, object-src, etc.
* `connect-src` is `https` only (i.e. fetching). This is only used for snippets as far as I can think of right now.

The only thing I am a bit worried about is if the (legacy) snippets url is OK as `https` only – @glogiotatidis @pmac do you see this as being an issue possibly?