### PR TITLE
Fix Bug 1470170 - Implement priority system for AS Router messages

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -187,7 +187,13 @@ export class ASRouterUISurface extends React.PureComponent {
   componentWillMount() {
     const endpoint = ASRouterUtils.getEndpoint();
     ASRouterUtils.addListener(this.onMessageFromParent);
-    ASRouterUtils.sendMessage({type: "CONNECT_UI_REQUEST", data: {endpoint}});
+
+    // If we are loading about:welcome we want to trigger the onboarding messages
+    if (this.props.document.location.href === "about:welcome") {
+      ASRouterUtils.sendMessage({type: "TRIGGER", data: {trigger: "firstRun"}});
+    } else {
+      ASRouterUtils.sendMessage({type: "CONNECT_UI_REQUEST", data: {endpoint}});
+    }
   }
 
   componentWillUnmount() {

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -27,6 +27,10 @@
           "targeting": {
             "type": "string",
             "description": "a JEXL expression representing targeting information"
+          },
+          "trigger": {
+            "type": "string",
+            "description": "A string representing what the trigger to show this message is."
           }
         },
         "required": ["id", "template", "content"]

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -33,15 +33,11 @@ const TargetingGetters = {
   }
 };
 
-function EnvironmentTargeting(target) {
-  return {isFirstRun: target.url === "about:welcome"};
-}
-
 this.ASRouterTargeting = {
   Environment: TargetingGetters,
 
   isMatch(filterExpression, target, context = this.Environment) {
-    return FilterExpressions.eval(filterExpression, {...context, ...EnvironmentTargeting(target)});
+    return FilterExpressions.eval(filterExpression, context);
   },
 
   /**
@@ -58,7 +54,20 @@ this.ASRouterTargeting = {
     let candidate;
     while (!match && arrayOfItems.length) {
       candidate = removeRandomItemFromArray(arrayOfItems);
-      if (candidate && (!candidate.targeting || await this.isMatch(candidate.targeting, target, context))) {
+      if (candidate && !candidate.trigger && (!candidate.targeting || await this.isMatch(candidate.targeting, target, context))) {
+        match = candidate;
+      }
+    }
+    return match;
+  },
+
+  async findMatchingMessageWithTrigger(messages, target, trigger, context) {
+    const arrayOfItems = [...messages];
+    let match;
+    let candidate;
+    while (!match && arrayOfItems.length) {
+      candidate = removeRandomItemFromArray(arrayOfItems);
+      if (candidate && candidate.trigger === trigger && (!candidate.targeting || await this.isMatch(candidate.targeting, target, context))) {
         match = candidate;
       }
     }

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -15,7 +15,7 @@ const ONBOARDING_MESSAGES = [
       button_label: "Try It Now",
       button_action: "OPEN_PRIVATE_BROWSER_WINDOW"
     },
-    targeting: "isFirstRun"
+    trigger: "firstRun"
   },
   {
     id: "ONBOARDING_2",
@@ -29,7 +29,7 @@ const ONBOARDING_MESSAGES = [
       button_action: "OPEN_URL",
       button_action_params: "https://screenshots.firefox.com/#tour"
     },
-    targeting: "isFirstRun"
+    trigger: "firstRun"
   },
   {
     id: "ONBOARDING_3",
@@ -43,7 +43,8 @@ const ONBOARDING_MESSAGES = [
       button_action: "OPEN_ABOUT_PAGE",
       button_action_params: "addons"
     },
-    targeting: "isFirstRun && isInExperimentCohort == 1"
+    targeting: "isInExperimentCohort == 1",
+    trigger: "firstRun"
   },
   {
     id: "ONBOARDING_4",
@@ -57,7 +58,8 @@ const ONBOARDING_MESSAGES = [
       button_action: "OPEN_URL",
       button_action_params: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/"
     },
-    targeting: "isFirstRun && isInExperimentCohort == 2"
+    targeting: "isInExperimentCohort == 2",
+    trigger: "firstRun"
   }
 ];
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -145,7 +145,7 @@ describe("ASRouter", () => {
       await Router.setState(() => ({blockList: ALL_MESSAGE_IDS.slice(1)}));
       const targetStub = {sendAsyncMessage: sandbox.stub()};
 
-      await Router.sendNextMessage(targetStub, null);
+      await Router.sendNextMessage(targetStub);
 
       assert.calledOnce(targetStub.sendAsyncMessage);
       assert.equal(Router.state.lastMessageId, ALL_MESSAGE_IDS[0]);
@@ -154,7 +154,7 @@ describe("ASRouter", () => {
       await Router.setState(() => ({blockList: ALL_MESSAGE_IDS}));
       const targetStub = {sendAsyncMessage: sandbox.stub()};
 
-      await Router.sendNextMessage(targetStub, null);
+      await Router.sendNextMessage(targetStub);
 
       assert.calledOnce(targetStub.sendAsyncMessage);
       assert.equal(Router.state.lastMessageId, null);
@@ -331,7 +331,7 @@ describe("ASRouter", () => {
       await Router.onMessage(msg);
 
       assert.calledOnce(Router.sendNextMessage);
-      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager));
+      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {type: "CONNECT_UI_REQUEST"});
     });
     it("should call sendNextMessage on GET_NEXT_MESSAGE", async () => {
       sandbox.stub(Router, "sendNextMessage").resolves();
@@ -340,7 +340,7 @@ describe("ASRouter", () => {
       await Router.onMessage(msg);
 
       assert.calledOnce(Router.sendNextMessage);
-      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager));
+      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {type: "GET_NEXT_MESSAGE"});
     });
     it("should return the preview message if that's available", async () => {
       const expectedObj = {provider: "preview"};
@@ -395,6 +395,39 @@ describe("ASRouter", () => {
       msg.bundled = 2; // force this message to want to be bundled
       await Router.onMessage(msg);
       assert.calledOnce(Router.sendNextMessage);
+    });
+  });
+
+  describe("#onMessage: TRIGGER", () => {
+    it("should pass the trigger to ASRouterTargeting on TRIGGER message", async () => {
+      sandbox.stub(Router, "_findMessage").resolves();
+      const msg = fakeAsyncMessage({type: "TRIGGER", data: {trigger: "firstRun"}});
+      await Router.onMessage(msg);
+
+      assert.calledOnce(Router._findMessage);
+      assert.deepEqual(Router._findMessage.firstCall.args[2], {trigger: "firstRun"});
+    });
+    it("consider the trigger when picking a message", async () => {
+      let messages = [
+        {id: "foo1", template: "simple_template", bundled: 1, trigger: "foo", content: {title: "Foo1", body: "Foo123-1"}}
+      ];
+
+      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: "foo"}});
+      let message = await Router._findMessage(messages, target, data.data);
+      assert.equal(message, messages[0]);
+    });
+    it("should pick a message with the right targeting and trigger", async () => {
+      let messages = [
+        {id: "foo1", template: "simple_template", bundled: 2, trigger: "foo", content: {title: "Foo1", body: "Foo123-1"}},
+        {id: "foo2", template: "simple_template", bundled: 2, trigger: "bar", content: {title: "Foo2", body: "Foo123-2"}},
+        {id: "foo3", template: "simple_template", bundled: 2, trigger: "foo", content: {title: "Foo3", body: "Foo123-3"}}
+      ];
+      await Router.setState({messages});
+      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: "foo"}});
+      let {bundle} = await Router._getBundledMessages(messages[0], target, data.data);
+      assert.equal(bundle.length, 2);
+      // it should have picked foo1 and foo3 only
+      assert.isTrue(bundle.every(elem => elem.id === "foo1" || elem.id === "foo3"));
     });
   });
 

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -43,6 +43,7 @@ describe("ASRouterUISurface", () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     fakeDocument = {
+      location: {href: ""},
       _listeners: new Set(),
       _visibilityState: "hidden",
       get visibilityState() {


### PR DESCRIPTION
This PR allows for a notion of "triggers" which act as a way to have priority in AS Router. This means that messages can be both targeted, for things that are long lasting (e.g locale, list of addons, prefs etc) but they can also be shown when a trigger happens - a one time event (e.g first new tab on a fresh profile, new addon installed, etc). Basically the content requests that a trigger message be shown under some condition (in this case we check the url to be about:welcome, indicating we are in a first run case) and then AS Router searches for messages that should be shown on a 'firstRun' trigger. Picks those, and shows them.

New method  `findMatchingMessageWithTrigger` called when content sends data 'trigger', and then fall back to the original `findMatchingMessage` if no messages with the trigger are found