### PR TITLE
Bug 1467814 - Invalid email field has custom styling and message.

### DIFF
--- a/content-src/components/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/components/StartupOverlay/StartupOverlay.jsx
@@ -11,6 +11,7 @@ export class _StartupOverlay extends React.PureComponent {
     this.clickSkip = this.clickSkip.bind(this);
     this.initScene = this.initScene.bind(this);
     this.removeOverlay = this.removeOverlay.bind(this);
+    this.onInputInvalid = this.onInputInvalid.bind(this);
 
     this.state = {emailInput: ""};
     this.initScene();
@@ -34,7 +35,10 @@ export class _StartupOverlay extends React.PureComponent {
   }
 
   onInputChange(e) {
+    let error = e.target.previousSibling;
     this.setState({emailInput: e.target.value});
+    error.classList.remove("active");
+    e.target.classList.remove("invalid");
   }
 
   onSubmit() {
@@ -45,6 +49,13 @@ export class _StartupOverlay extends React.PureComponent {
   clickSkip() {
     this.props.dispatch(ac.UserEvent({event: "SKIPPED_SIGNIN"}));
     this.removeOverlay();
+  }
+
+  onInputInvalid(e) {
+    let error = e.target.previousSibling;
+    error.classList.add("active");
+    e.target.classList.add("invalid");
+    e.preventDefault(); // Override built-in form validation popup
   }
 
   render() {
@@ -69,7 +80,8 @@ export class _StartupOverlay extends React.PureComponent {
                 <input name="entrypoint" type="hidden" value="activity-stream-firstrun" />
                 <input name="utm_source" type="hidden" value="activity-stream" />
                 <input name="utm_campaign" type="hidden" value="firstrun" />
-                <input className="email-input" name="email" type="email" required="true" placeholder={this.props.intl.formatMessage({id: "firstrun_email_input_placeholder"})} onChange={this.onInputChange} />
+                <span className="error">{this.props.intl.formatMessage({id: "firstrun_invalid_input"})}</span>
+                <input className="email-input" name="email" type="email" required="true" onInvalid={this.onInputInvalid} placeholder={this.props.intl.formatMessage({id: "firstrun_email_input_placeholder"})} onChange={this.onInputChange} />
                 <div className="extra-links">
                   <FormattedMessage
                     id="firstrun_extra_legal_links"

--- a/content-src/components/StartupOverlay/_StartupOverlay.scss
+++ b/content-src/components/StartupOverlay/_StartupOverlay.scss
@@ -93,6 +93,10 @@
   text-align: center;
   padding: 10px;
 
+  form {
+    position: relative;
+  }
+
   .extra-links {
     font-size: 12px;
     max-width: 340px;
@@ -132,6 +136,14 @@
     &:focus {
       border-color: $blue-50;
       box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.3);
+    }
+
+    &.invalid {
+      border-color: $red-60;
+    }
+
+    &.invalid:focus {
+      box-shadow: 0 0 0 3px rgba(215, 0, 34, 0.3);
     }
   }
 
@@ -283,4 +295,58 @@
 .firstrun-link {
   opacity: 0;
   transform: translateY(-5px);
+}
+
+.error {
+  display: none;
+}
+
+html[dir="rtl"] .error{
+  right: 50px;
+  left: auto;
+  
+  &::before {
+    right: 12px;
+    left: auto;
+  }
+}
+
+.error.active {
+  display: block;
+  padding: 5px 12px;
+  animation: fade-down 450ms;
+  font-size: 12px;
+  font-weight: 500;
+  color: white;
+  background-color: $red-60;
+  position: absolute;
+  left: 50px;
+  top: -28px;
+  border-radius: 2px;
+
+  &::before {
+    left: 12px;
+    background: $red-60;
+    bottom: -8px;
+    content: '.';
+    height: 16px;
+    position: absolute;
+    text-indent: -999px;
+    transform: rotate(45deg);
+    white-space: nowrap;
+    width: 16px;
+    z-index: -1;
+  }
+}
+
+@keyframes fade-down {
+  0% {
+    opacity: 0;
+    transform: translateY(-15px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/locales/en-US/strings.properties
+++ b/locales/en-US/strings.properties
@@ -190,6 +190,7 @@ firstrun_form_header=Enter your email
 firstrun_form_sub_header=to continue to Firefox Sync
 
 firstrun_email_input_placeholder=Email
+firstrun_invalid_input=Valid email required
 
 # LOCALIZATION NOTE (firstrun_extra_legal_links): {terms} is equal to firstrun_terms_of_service, and
 # {privacy} is equal to firstrun_privacy_notice. {terms} and {privacy} are clickable links.


### PR DESCRIPTION
r? @sarracini 

This creates a flag that appears on submitting an incorrectly formatted email, or empty field, and suppresses the default flag. This now matches closely the current moz.org firstrun experience.

Tested for rtl as well.

Do not merge until next cycle, to allow new string to be translated.

