### PR TITLE
Backport Bug 1340498 - Remove onVisits from PlacesFeed

### DIFF
--- a/lib/PlacesFeed.jsm
+++ b/lib/PlacesFeed.jsm
@@ -60,8 +60,6 @@ class HistoryObserver extends Observer {
 
   onEndUpdateBatch() {}
 
-  onVisits() {}
-
   onTitleChanged() {}
 
   onFrecencyChanged() {}

--- a/test/unit/lib/PlacesFeed.test.js
+++ b/test/unit/lib/PlacesFeed.test.js
@@ -313,7 +313,6 @@ describe("PlacesFeed", () => {
       it("should have a various empty functions for xpconnect happiness", () => {
         observer.onBeginUpdateBatch();
         observer.onEndUpdateBatch();
-        observer.onVisits();
         observer.onTitleChanged();
         observer.onFrecencyChanged();
         observer.onManyFrecenciesChanged();


### PR DESCRIPTION
Backport bug 1340498 which landed today: https://hg.mozilla.org/mozilla-central/diff/b6f047709e8e/browser/extensions/activity-stream/lib/PlacesFeed.jsm

and fix the test along with it