### PR TITLE
Fix Bug 1471375 - Catch IndexedDB permafail

### DIFF
--- a/lib/Store.jsm
+++ b/lib/Store.jsm
@@ -124,7 +124,11 @@ this.Store = class Store {
       this.initFeed(telemetryKey);
     }
 
-    await this._initIndexedDB(telemetryKey);
+    try {
+      await this._initIndexedDB(telemetryKey);
+    } catch (e) {
+      this.dbStorage.telemetry = null;
+    }
 
     for (const pref of feedFactories.keys()) {
       if (pref !== telemetryKey && this._prefs.get(pref)) {

--- a/lib/Store.jsm
+++ b/lib/Store.jsm
@@ -127,6 +127,7 @@ this.Store = class Store {
     try {
       await this._initIndexedDB(telemetryKey);
     } catch (e) {
+      /* istanbul ignore next */
       this.dbStorage.telemetry = null;
     }
 

--- a/lib/Store.jsm
+++ b/lib/Store.jsm
@@ -124,12 +124,7 @@ this.Store = class Store {
       this.initFeed(telemetryKey);
     }
 
-    try {
-      await this._initIndexedDB(telemetryKey);
-    } catch (e) {
-      /* istanbul ignore next */
-      this.dbStorage.telemetry = null;
-    }
+    await this._initIndexedDB(telemetryKey);
 
     for (const pref of feedFactories.keys()) {
       if (pref !== telemetryKey && this._prefs.get(pref)) {
@@ -157,7 +152,11 @@ this.Store = class Store {
     // Accessing the db causes the object stores to be created / migrated.
     // This needs to happen before other instances try to access the db, which
     // would update only a subset of the stores to the latest version.
-    await this.dbStorage.db; // eslint-disable-line no-unused-expressions
+    try {
+      await this.dbStorage.db; // eslint-disable-line no-unused-expressions
+    } catch (e) {
+      this.dbStorage.telemetry = null;
+    }
   }
 
   /**

--- a/test/unit/lib/Store.test.js
+++ b/test/unit/lib/Store.test.js
@@ -159,6 +159,16 @@ describe("Store", () => {
 
       assert.calledOnce(dbStub);
     });
+    it("should reset ASStorage telemetry if opening the db fails", async () => {
+      store._initIndexedDB.restore();
+      // Force an IndexedDB error
+      dbStub.rejects();
+
+      await store.init(new Map());
+
+      assert.calledOnce(dbStub);
+      assert.isNull(store.dbStorage.telemetry);
+    });
     it("should not initialize the feed if the Pref is set to false", async () => {
       sinon.stub(store, "initFeed");
       store._prefs.set("foo", false);

--- a/test/unit/lib/Store.test.js
+++ b/test/unit/lib/Store.test.js
@@ -159,7 +159,7 @@ describe("Store", () => {
 
       assert.calledOnce(dbStub);
     });
-    it("should reset ASStorage telemetry if opening the db fails", async () => {
+    it("should reset ActivityStreamStorage telemetry if opening the db fails", async () => {
       store._initIndexedDB.restore();
       // Force an IndexedDB error
       dbStub.rejects();


### PR DESCRIPTION
This is the only "small" change I could think of to prevent a lot of `TRANSACTION_FAILED` events.
This solution will still log the `INDEXEDDB_OPEN_FAILED` event.