### PR TITLE
(styles) Fix Bug 1472819: adjust position of Pocket disclaimer button

### DIFF
--- a/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -89,12 +89,12 @@
 
     color: var(--newtab-text-conditional-color);
     font-size: 13px;
-    margin-bottom: 16px;
+    margin-bottom: 26px;
     position: relative;
+    display: flex;
 
     .section-disclaimer-text {
       display: inline-block;
-      min-height: $min-button-height;
       width: calc(100% - #{$max-button-width});
 
       @media (max-width: $break-point-medium) {
@@ -113,10 +113,10 @@
       border: 1px solid $grey-40;
       border-radius: 4px;
       cursor: pointer;
-      margin-top: 2px;
       max-width: $max-button-width;
       min-height: $min-button-height;
       inset-inline-end: 0;
+      align-self: center;
 
       &:hover:not(.dismiss) {
         box-shadow: $shadow-primary;


### PR DESCRIPTION
Before:

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/7688302/42248202-3332fbc0-7ed9-11e8-95ca-424ef5e745a9.png">

After:

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/7688302/42248135-fb637ac6-7ed8-11e8-8eb2-f81066026e3b.png">