### PR TITLE
Fix Bug 1473848 - Stop exporting locales not explicitly in CENTRAL_LOCALES, e.g., "mix"

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -309,7 +309,7 @@ function main() { // eslint-disable-line max-statements
   // Process the default locale first then all the ones from mozilla-central
   const localizedLocales = [];
   const skippedLocales = [];
-  for (const locale of [DEFAULT_LOCALE, ...CENTRAL_LOCALES, ...extraLocales]) {
+  for (const locale of [DEFAULT_LOCALE, ...CENTRAL_LOCALES]) {
     // Skip the locale if it would have resulted in duplicate packaged files
     const strings = getStrings(locale, allStrings);
     if (isSubset(strings, defaultStrings) || isSubset(strings, langStrings)) {
@@ -352,7 +352,7 @@ function main() { // eslint-disable-line max-statements
     console.log("\x1b[33m", `Skipped the following locales because they use the same strings as ${DEFAULT_LOCALE} or its language locale: ${skippedLocales.join(", ")}`, "\x1b[0m");
   }
   if (extraLocales.length) {
-    console.log("\x1b[31m", `✗ These locales were not in CENTRAL_LOCALES, but probably should be: ${extraLocales.join(", ")}`, "\x1b[0m");
+    console.log("\x1b[33m", `Skipped the following locales because they are not in CENTRAL_LOCALES: ${extraLocales.join(", ")}`, "\x1b[0m");
   }
 
   // Provide some help to copy/paste locales if tests are failing


### PR DESCRIPTION
r?@k88hudson Skips the extra and makes the message yellow instead of red.