### PR TITLE
Fix Bug 1471243: stop AS showing before first run overlay

### DIFF
--- a/content-src/components/Base/Base.jsx
+++ b/content-src/components/Base/Base.jsx
@@ -30,7 +30,7 @@ export class _Base extends React.PureComponent {
     this.sendNewTabRehydrated(App);
     addLocaleDataForReactIntl(locale);
     if (this.props.isFirstrun) {
-      global.document.body.classList.add("welcome");
+      global.document.body.classList.add("welcome", "hide-main");
     }
   }
 
@@ -56,9 +56,10 @@ export class _Base extends React.PureComponent {
   updateTheme() {
     const bodyClassName = [
       "activity-stream",
-      // If we skipped the about:welcome overlay and removed the CSS class
-      // we don't want to add it back to the Activity Stream view
-      document.body.classList.contains("welcome") ? "welcome" : ""
+      // If we skipped the about:welcome overlay and removed the CSS classes
+      // we don't want to add them back to the Activity Stream view
+      document.body.classList.contains("welcome") ? "welcome" : "",
+      document.body.classList.contains("hide-main") ? "hide-main" : ""
     ].filter(v => v).join(" ");
     global.document.body.className = bodyClassName;
   }

--- a/content-src/components/Base/_Base.scss
+++ b/content-src/components/Base/_Base.scss
@@ -15,6 +15,10 @@
 }
 
 main {
+  .hide-main & {
+    visibility: hidden;
+  }
+
   margin: auto;
   // Offset the snippets container so things at the bottom of the page are still
   // visible when snippets / onboarding are visible. Adjust for other spacing.

--- a/content-src/components/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/components/StartupOverlay/StartupOverlay.jsx
@@ -30,6 +30,7 @@ export class _StartupOverlay extends React.PureComponent {
 
   removeOverlay() {
     window.removeEventListener("visibilitychange", this.removeOverlay);
+    document.body.classList.remove("hide-main");
     this.setState({show: false});
     setTimeout(() => {
       // Allow scrolling and fully remove overlay after animation finishes.
@@ -73,7 +74,7 @@ export class _StartupOverlay extends React.PureComponent {
     let termsLink = (<a href="https://accounts.firefox.com/legal/terms" target="_blank" rel="noopener noreferrer"><FormattedMessage id="firstrun_terms_of_service" /></a>);
     let privacyLink = (<a href="https://accounts.firefox.com/legal/privacy" target="_blank" rel="noopener noreferrer"><FormattedMessage id="firstrun_privacy_notice" /></a>);
     return (
-      <div className={`overlay-wrapper ${this.state.show ? "show " : ""}`}>
+      <div className={`overlay-wrapper ${this.state.show ? "show" : ""}`}>
         <div className="background" />
         <div className="firstrun-scene">
           <div className="fxaccounts-container">

--- a/content-src/components/StartupOverlay/_StartupOverlay.scss
+++ b/content-src/components/StartupOverlay/_StartupOverlay.scss
@@ -13,6 +13,7 @@
 .overlay-wrapper {
   position: absolute;
   top: 0;
+  left: 0;
   width: 100vw;
   height: 100vh;
   z-index: 21000;
@@ -70,7 +71,7 @@
   }
 }
 
-.background {
+.background, body.hide-main {
   width: 100%;
   height: 100%;
   display: block;
@@ -236,7 +237,7 @@
   padding-bottom: 210px;
 }
 
-.firstrun-link {
+a.firstrun-link {
   color: $white;
   display: block;
   text-decoration: underline;

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -18,8 +18,12 @@ body {
   font-size: 16px;
   overflow-y: scroll;
 
-  &.hide-onboarding > #onboarding-overlay-button {
+  &.hide-onboarding, &.hide-main > #onboarding-overlay-button {
     display: none !important;
+  }
+
+  &.hide-main > #onboarding-notification-bar {
+    display: none;
   }
 }
 


### PR DESCRIPTION
These CSS changes will stop AS flashing before the startup overlay renders, but only if prerendering is disabled for the about:welcome load. With prerendering you'll still see the prerendered page flash before the overlay.

I have a patch to AboutRedirector and aboutNewTabService to disable prerendering on about:welcome; I'm not sure if there's a way to do that within AS that would be easier?

Kate and I talked about the possibility of having separate prerendered about:welcome files; [timing measurements](https://gist.github.com/AdamHillier/c32db37b66570f0e0d7f08a31b1849f6) suggest that these CSS changes should be sufficient by themselves.