### PR TITLE
Fix Bug 1472038: Use app build ID for telemetry addon_version

### DIFF
--- a/common/Reducers.jsm
+++ b/common/Reducers.jsm
@@ -14,9 +14,7 @@ const dedupe = new Dedupe(site => site && site.url);
 const INITIAL_STATE = {
   App: {
     // Have we received real data from the app yet?
-    initialized: false,
-    // The version of the system-addon
-    version: null
+    initialized: false
   },
   Snippets: {initialized: false},
   TopSites: {

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -14,7 +14,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 
 ```js
 {
-  "addon_version": "1.0.0",
+  "addon_version": "20180710100040",
   "client_id": "374dc4d8-0cb2-4ac5-a3cf-c5a9bc3c602e",
   "locale": "en-US",
   "version": "62.0a1",
@@ -36,7 +36,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 {
   // These fields are sent from the client
   "action": "activity_stream_session",
-  "addon_version": "1.0.0",
+  "addon_version": "20180710100040",
   "client_id": "374dc4d8-0cb2-4ac5-a3cf-c5a9bc3c602e",
   "locale": "en-US",
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
@@ -60,7 +60,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 {
   "action": "activity_stream_user_event",
   "action_position": "3",
-  "addon_version": "1.0.0",
+  "addon_version": "20180710100040",
   "client_id": "374dc4d8-0cb2-4ac5-a3cf-c5a9bc3c602e",
   "event": "click or scroll or search or delete",
   "locale": "en-US",
@@ -84,7 +84,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 ```js
 {
   "action": "activity_stream_performance_event",
-  "addon_version": "1.0.0",
+  "addon_version": "20180710100040",
   "client_id": "374dc4d8-0cb2-4ac5-a3cf-c5a9bc3c602e",
   "event": "previewCacheHit",
   "event_id": "45f1912165ca4dfdb5c1c2337dbdc58f",
@@ -108,7 +108,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 ```js
 {
   "action": "activity_stream_undesired_event",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "event": "MISSING_IMAGE",
   "locale": "en-US",
@@ -132,7 +132,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "client_id": "n/a",
   "session_id": "n/a",
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "source": "pocket",
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"]
@@ -147,7 +147,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "client_id": "n/a",
   "session_id": "n/a",
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "source": "pocket",
   "page": "unknown",
@@ -169,7 +169,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "action": ["snippets_user_event" | "onboarding_user_event"],
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
   "source": "pocket",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "source": "NEWTAB_FOOTER_BAR",
   "message_id": "some_snippet_id",
@@ -181,7 +181,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 |-----|-------------|:-----:|
 | `action_position` | [Optional] The index of the element in the `source` that was clicked. | :one:
 | `action` | [Required] Either `activity_stream_event`, `activity_stream_session`, or `activity_stream_performance`. | :one:
-| `addon_version` | [Required] The version of the Activity Stream addon. | :one:
+| `addon_version` | [Required] Firefox build ID, i.e. `Services.appinfo.appBuildID`. | :one:
 | `client_id` | [Required] An identifier for this client. | :one:
 | `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned") | :one:
 | `date` | [Auto populated by Onyx] The date in YYYY-MM-DD format. | :three:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -56,7 +56,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown" ],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "action": "activity_stream_event",
   "user_prefs": 7
@@ -76,7 +76,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -99,7 +99,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -122,7 +122,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -145,7 +145,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -167,7 +167,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -189,7 +189,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -212,7 +212,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -235,7 +235,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -252,7 +252,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -269,7 +269,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -287,7 +287,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7
 }
@@ -327,7 +327,7 @@ All `"activity_stream_session"` pings have the following basic shape. Some field
   "action": "activity_stream_session",
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
   "session_duration": 4199,
@@ -426,7 +426,7 @@ This reports all the Pocket recommended articles (a list of `id`s) when the user
   "client_id": "n/a",
   "session_id": "n/a",
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "source": "pocket",
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
@@ -447,7 +447,7 @@ This reports the user's interaction with those Pocket tiles.
   "client_id": "n/a",
   "session_id": "n/a",
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "source": "pocket",
   "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
@@ -473,7 +473,7 @@ This reports the duration of the domain affinity calculation in milliseconds.
 {
   "action": "activity_stream_performance_event",
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7,
   "event": "topstories.domain.affinity.calculation.ms",
@@ -493,7 +493,7 @@ This reports when the addon fails to initialize
 {
   "action": "activity_stream_undesired_event",
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "user_prefs": 7,
   "event": "ADDON_INIT_FAILED",
@@ -514,7 +514,7 @@ This reports the impression of Activity Stream Router.
   "action": ["snippets_user_event" | "onboarding_user_event"],
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
   "source": "pocket",
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "locale": "en-US",
   "source": "NEWTAB_FOOTER_BAR",
   "message_id": "some_snippet_id",
@@ -531,7 +531,7 @@ This reports the user's interaction with Activity Stream Router.
 {
   "client_id": "n/a",
   "action": ["snippets_user_event" | "onboarding_user_event"],
-  "addon_version": "1.0.12",
+  "addon_version": "20180710100040",
   "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
   "locale": "en-US",
   "source": "NEWTAB_FOOTER_BAR",

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -278,15 +278,9 @@ for (const config of FEEDS_DATA) {
 this.ActivityStream = class ActivityStream {
   /**
    * constructor - Initializes an instance of ActivityStream
-   *
-   * @param  {object} options Options for the ActivityStream instance
-   * @param  {string} options.id Add-on ID. e.g. "activity-stream@mozilla.org".
-   * @param  {string} options.version Version of the add-on. e.g. "0.1.0"
-   * @param  {string} options.newTabURL URL of New Tab page on which A.S. is displayed. e.g. "about:newtab"
    */
-  constructor(options = {}) {
+  constructor() {
     this.initialized = false;
-    this.options = options;
     this.store = new Store();
     this.feeds = FEEDS_CONFIG;
     this._defaultPrefs = new DefaultPrefs(PREFS_CONFIG);
@@ -300,7 +294,7 @@ this.ActivityStream = class ActivityStream {
       // Hook up the store and let all feeds and pages initialize
       this.store.init(this.feeds, ac.BroadcastToContent({
         type: at.INIT,
-        data: {version: this.options.version}
+        data: {}
       }), {type: at.UNINIT});
 
       this.initialized = true;

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -288,9 +288,8 @@ this.TelemetryFeed = class TelemetryFeed {
    * @return {obj}    A telemetry ping
    */
   createPing(portID) {
-    const appInfo = this.store.getState().App;
     const ping = {
-      addon_version: appInfo.version,
+      addon_version: Services.appinfo.appBuildID,
       locale: Services.locale.getAppLocaleAsLangTag(),
       user_prefs: this.userPreferences
     };
@@ -366,10 +365,9 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   createASRouterEvent(action) {
-    const appInfo = this.store.getState().App;
     const ping = {
       client_id: "n/a",
-      addon_version: appInfo.version,
+      addon_version: Services.appinfo.appBuildID,
       locale: Services.locale.getAppLocaleAsLangTag(),
       impression_id: this._impressionId
     };

--- a/test/unit/common/Reducers.test.js
+++ b/test/unit/common/Reducers.test.js
@@ -13,13 +13,6 @@ describe("Reducers", () => {
 
       assert.propertyVal(nextState, "initialized", true);
     });
-    it("should set initialized and version on INIT", () => {
-      const action = {type: "INIT", data: {version: "1.2.3"}};
-
-      const nextState = App(undefined, action);
-
-      assert.propertyVal(nextState, "version", "1.2.3");
-    });
   });
   describe("TopSites", () => {
     it("should return the initial state", () => {

--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -56,16 +56,6 @@ describe("ActivityStream", () => {
     it("should call .store.init", () => {
       assert.calledOnce(as.store.init);
     });
-    it("should pass to Store an INIT event with the right version", () => {
-      as = new ActivityStream({version: "1.2.3"});
-      sandbox.stub(as.store, "init");
-      sandbox.stub(as._defaultPrefs, "init");
-
-      as.init();
-
-      const [, action] = as.store.init.firstCall.args;
-      assert.propertyVal(action.data, "version", "1.2.3");
-    });
     it("should pass to Store an INIT event for content", () => {
       as.init();
 

--- a/test/unit/lib/TelemetryFeed.test.js
+++ b/test/unit/lib/TelemetryFeed.test.js
@@ -19,10 +19,6 @@ describe("TelemetryFeed", () => {
   let sandbox;
   let expectedUserPrefs;
   let browser = {getAttribute() { return "true"; }};
-  let store = {
-    dispatch() {},
-    getState() { return {App: {version: "1.0.0"}}; }
-  };
   let instance;
   let clock;
   class PingCentre {sendPing() {} uninit() {}}
@@ -54,7 +50,6 @@ describe("TelemetryFeed", () => {
     globals.set("PingCentre", PingCentre);
     globals.set("UTEventReporting", UTEventReporting);
     instance = new TelemetryFeed();
-    instance.store = store;
   });
   afterEach(() => {
     clock.restore();
@@ -743,7 +738,6 @@ describe("TelemetryFeed", () => {
       FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
       FakePrefs.prototype.prefs[EVENTS_TELEMETRY_PREF] = true;
       instance = new TelemetryFeed();
-      instance.store = store;
 
       const eventHandler = sandbox.spy(instance, "handleASRouterUserEvent");
       const action = {type: at.AS_ROUTER_TELEMETRY_USER_EVENT, data: {event: "CLICK"}};

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -166,7 +166,8 @@ const TEST_GLOBAL = {
       createNullPrincipal() {},
       getSystemPrincipal() {}
     },
-    wm: {getMostRecentWindow: () => window}
+    wm: {getMostRecentWindow: () => window},
+    appinfo: {appBuildID: "20180710100040"}
   },
   XPCOMUtils: {
     defineLazyGetter(_1, _2, f) { f(); },


### PR DESCRIPTION
This fixes bug 1472038.

It also simplifies the ActivityStream by
* Getting rid of the `option` argument of constructor
* Getting rid of the `reason` argument of `init()`