### PR TITLE
Bug 1476309 - use RemoteSettings for Tippy Top

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -150,10 +150,6 @@ const PREFS_CONFIG = new Map([
     title: "Number of rows of Top Stories to display",
     value: 1
   }],
-  ["tippyTop.service.endpoint", {
-    title: "Tippy Top service manifest url",
-    value: "https://activity-stream-icons.services.mozilla.com/v1/icons.json.br"
-  }],
   ["sectionOrder", {
     title: "The rendering order for the sections",
     value: "topsites,topstories,highlights"

--- a/test/unit/lib/FaviconFeed.test.js
+++ b/test/unit/lib/FaviconFeed.test.js
@@ -33,19 +33,6 @@ describe("FaviconFeed", () => {
     siteIconsPref = true;
     sandbox.stub(global.Services.prefs, "getBoolPref")
       .withArgs("browser.chrome.site_icons").callsFake(() => siteIconsPref);
-    let fetchStub = globals.sandbox.stub();
-    globals.set("fetch", fetchStub);
-    fetchStub.resolves({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve([{
-        "domains": ["facebook.com"],
-        "image_url": "https://www.facebook.com/icon.png"
-      }, {
-        "domains": ["gmail.com", "mail.google.com"],
-        "image_url": "https://iconserver.com/gmail.png"
-      }])
-    });
 
     feed = new FaviconFeed();
     feed.store = {
@@ -63,151 +50,13 @@ describe("FaviconFeed", () => {
     assert.instanceOf(feed, FaviconFeed);
   });
 
-  describe("#getSitesByDomain", () => {
-    it("should loadCachedData and maybeRefresh if _sitesByDomain isn't set", async () => {
-      feed.loadCachedData = sinon.spy(() => ([]));
-      feed.maybeRefresh = sinon.spy(() => {
-        feed._sitesByDomain = {"mozilla.org": {"image_url": "https://mozilla.org/icon.png"}};
-        return [];
-      });
-      await feed.getSitesByDomain();
-      assert.calledOnce(feed.loadCachedData);
-      assert.calledOnce(feed.maybeRefresh);
-    });
-    it("should NOT loadCachedData and maybeRefresh if _sitesByDomain is already set", async () => {
-      feed._sitesByDomain = {"mozilla.org": {"image_url": "https://mozilla.org/icon.png"}};
-      feed.loadCachedData = sinon.spy(() => ([]));
-      feed.maybeRefresh = sinon.spy(() => ([]));
-      await feed.getSitesByDomain();
-      assert.notCalled(feed.loadCachedData);
-      assert.notCalled(feed.maybeRefresh);
-    });
-    it("should resolve to empty object if there is no cache and fetch fails", async () => {
-      feed.loadCachedData = sinon.spy(() => ([]));
-      feed.maybeRefresh = sinon.spy(() => ([]));
-      await feed.getSitesByDomain();
-      assert.deepEqual(feed._sitesByDomain, {});
-    });
-  });
-
-  describe("#loadCachedData", () => {
-    it("should set _sitesByDomain if there is cached data", async () => {
-      const cachedData = {
-        "mozilla.org": {"image_url": "https://mozilla.org/icon.png"},
-        "_timestamp": Date.now(),
-        "_etag": "foobaretag1234567890"
-      };
-      feed.cache.get = () => cachedData;
-      await feed.loadCachedData();
-      assert.deepEqual(feed._sitesByDomain, cachedData);
-      assert.equal(feed.tippyTopNextUpdate, cachedData._timestamp + 24 * 60 * 60 * 1000);
-      assert.equal(feed._sitesByDomain._etag, cachedData._etag);
-    });
-    it("should NOT set _sitesByDomain if there is no cached data", async () => {
-      feed.cache.get = () => ({});
-      await feed.loadCachedData();
-      assert.isNull(feed._sitesByDomain);
-    });
-  });
-
-  describe("#maybeRefresh", () => {
-    it("should refresh if next update is due", () => {
-      feed.refresh = sinon.spy();
-      feed.tippyTopNextUpdate = Date.now();
-      feed.maybeRefresh();
-      assert.calledOnce(feed.refresh);
-    });
-    it("should NOT refresh if next update is in future", () => {
-      feed.refresh = sinon.spy();
-      feed.tippyTopNextUpdate = Date.now() + 6000;
-      feed.maybeRefresh();
-      assert.notCalled(feed.refresh);
-    });
-  });
-
-  describe("#refresh", () => {
-    it("should loadFromURL with the right URL from prefs", async () => {
-      feed.loadFromURL = sinon.spy(() => ({data: []}));
-      await feed.refresh();
-      assert.calledOnce(feed.loadFromURL);
-      assert.calledWith(feed.loadFromURL, FAKE_ENDPOINT);
-    });
-    it("should set _sitesByDomain if new sites are returned from loadFromURL", async () => {
-      const data = {
-        data: [
-          {"domains": ["mozilla.org"], "image_url": "https://mozilla.org/icon.png"},
-          {"domains": ["facebook.com"], "image_url": "https://facebook.com/icon.png"}
-        ],
-        etag: "etag1234567890",
-        status: 200
-      };
-      const expectedData = {
-        "facebook.com": {"image_url": "https://facebook.com/icon.png"},
-        "mozilla.org": {"image_url": "https://mozilla.org/icon.png"},
-        "_etag": "etag1234567890",
-        "_timestamp": Date.now()
-      };
-      feed.loadFromURL = sinon.spy(url => data);
-      feed.cache.set = sinon.spy();
-      await feed.refresh();
-      assert.equal(feed._sitesByDomain._etag, data.etag);
-      assert.deepEqual(feed._sitesByDomain, expectedData);
-      assert.calledOnce(feed.cache.set);
-      assert.calledWith(feed.cache.set, "sites", expectedData);
-    });
-    it("should pass If-None-Match if we have a last known etag", async () => {
-      feed.loadFromURL = sinon.spy(url => ({data: [], status: 304}));
-      feed._sitesByDomain = {};
-      feed._sitesByDomain._etag = "etag1234567890";
-      await feed.refresh();
-      const [, headers] = feed.loadFromURL.getCall(0).args;
-      assert.equal(headers.get("If-None-Match"), feed._sitesByDomain._etag);
-    });
-    it("should not set _sitesByDomain if the remote manifest is not modified since last fetch", async () => {
-      const data = {"mozilla.org": {"image_url": "https://mozilla.org/icon.png"}};
-      feed._sitesByDomain = data;
-      feed._sitesByDomain._timestamp = Date.now() - 1000;
-      feed.loadFromURL = sinon.spy(url => ({data: [], status: 304}));
-      feed.cache.set = sinon.spy();
-      await feed.refresh();
-      assert.deepEqual(feed._sitesByDomain, data);
-      assert.calledOnce(feed.cache.set);
-      assert.calledWith(feed.cache.set, "sites", Object.assign({_timestamp: Date.now()}, data));
-    });
-    it("should handle server errors by retrying with exponential backoff", async () => {
-      const expectedDelay = 5 * 60 * 1000;
-      feed.loadFromURL = sinon.spy(url => ({data: [], status: 500}));
-      await feed.refresh();
-      assert.equal(1, feed.numRetries);
-      assert.equal(expectedDelay, feed.tippyTopNextUpdate);
-      await feed.refresh();
-      assert.equal(2, feed.numRetries);
-      assert.equal(2 * expectedDelay, feed.tippyTopNextUpdate);
-      await feed.refresh();
-      assert.equal(3, feed.numRetries);
-      assert.equal(2 * 2 * expectedDelay, feed.tippyTopNextUpdate);
-      await feed.refresh();
-      assert.equal(4, feed.numRetries);
-      assert.equal(2 * 2 * 2 * expectedDelay, feed.tippyTopNextUpdate);
-      // Verify the delay maxes out at 24 hours.
-      feed.numRetries = 100;
-      await feed.refresh();
-      assert.equal(24 * 60 * 60 * 1000, feed.tippyTopNextUpdate);
-      // Verify the numRetries gets reset on a successful fetch.
-      feed.loadFromURL = sinon.spy(url => ({data: [], status: 200}));
-      await feed.refresh();
-      assert.equal(0, feed.numRetries);
-      assert.equal(24 * 60 * 60 * 1000, feed.tippyTopNextUpdate);
-    });
-  });
-
   describe("#fetchIcon", () => {
     let domain;
     let url;
     beforeEach(() => {
       domain = "mozilla.org";
       url = `https://${domain}/`;
-      feed._sitesByDomain = {[domain]: {url, image_url: `${url}/icon.png`}};
+      feed.getSite = sandbox.stub().returns(Promise.resolve({domain, image_url: `${url}/icon.png`}));
       feed._queryForRedirects.clear();
     });
 
@@ -230,19 +79,14 @@ describe("FaviconFeed", () => {
 
       assert.notCalled(global.PlacesUtils.favicons.setAndFetchFaviconForPage);
     });
-    it("should NOT setAndFetchFaviconForPage if the endpoint is empty", async () => {
-      feed.store.state.Prefs.values["tippyTop.service.endpoint"] = "";
-
-      await feed.fetchIcon(url);
-
-      assert.notCalled(global.PlacesUtils.favicons.setAndFetchFaviconForPage);
-    });
     it("should NOT setAndFetchFaviconForPage if the url is NOT in the TippyTop data", async () => {
+      feed.getSite = sandbox.stub().returns(Promise.resolve(null));
       await feed.fetchIcon("https://example.com");
 
       assert.notCalled(global.PlacesUtils.favicons.setAndFetchFaviconForPage);
     });
     it("should issue a fetchIconFromRedirects if the url is NOT in the TippyTop data", async () => {
+      feed.getSite = sandbox.stub().returns(Promise.resolve(null));
       sandbox.spy(global.Services.tm, "idleDispatchToMainThread");
 
       await feed.fetchIcon("https://example.com");
@@ -250,6 +94,7 @@ describe("FaviconFeed", () => {
       assert.calledOnce(global.Services.tm.idleDispatchToMainThread);
     });
     it("should only issue fetchIconFromRedirects once on the same url", async () => {
+      feed.getSite = sandbox.stub().returns(Promise.resolve(null));
       sandbox.spy(global.Services.tm, "idleDispatchToMainThread");
 
       await feed.fetchIcon("https://example.com");
@@ -258,6 +103,7 @@ describe("FaviconFeed", () => {
       assert.calledOnce(global.Services.tm.idleDispatchToMainThread);
     });
     it("should issue fetchIconFromRedirects twice on two different urls", async () => {
+      feed.getSite = sandbox.stub().returns(Promise.resolve(null));
       sandbox.spy(global.Services.tm, "idleDispatchToMainThread");
 
       await feed.fetchIcon("https://example.com");
@@ -265,28 +111,29 @@ describe("FaviconFeed", () => {
 
       assert.calledTwice(global.Services.tm.idleDispatchToMainThread);
     });
-    it("should cause sites to initialize with fetched sites if no sites", async () => {
-      delete feed._sitesByDomain;
+  });
 
-      await feed.fetchIcon(url);
-
-      assert.containsAllKeys(feed._sitesByDomain, ["facebook.com", "gmail.com", "mail.google.com"]);
+  describe("#getSite", () => {
+    it("should return site data if RemoteSettings has an entry for the domain", async () => {
+      const get = () => Promise.resolve([{domain: "example.com", image_url: "foo.img"}]);
+      feed._tippyTop = {get};
+      const site = await feed.getSite("example.com");
+      assert.equal(site.domain, "example.com");
+    });
+    it("should return null if RemoteSettings doesn't have an entry for the domain", async () => {
+      const get = () => Promise.resolve([]);
+      feed._tippyTop = {get};
+      const site = await feed.getSite("example.com");
+      assert.isNull(site);
+    });
+    it("should lazy init _tippyTop", async () => {
+      assert.isUndefined(feed._tippyTop);
+      await feed.getSite("example.com");
+      assert.ok(feed._tippyTop);
     });
   });
 
   describe("#onAction", () => {
-    it("should maybeRefresh on SYSTEM_TICK if initialized", async () => {
-      feed._sitesByDomain = {"mozilla.org": {}};
-      feed.maybeRefresh = sinon.spy();
-      feed.onAction({type: at.SYSTEM_TICK});
-      assert.calledOnce(feed.maybeRefresh);
-    });
-    it("should NOT maybeRefresh on SYSTEM_TICK if NOT initialized", async () => {
-      feed._sitesByDomain = null;
-      feed.maybeRefresh = sinon.spy();
-      feed.onAction({type: at.SYSTEM_TICK});
-      assert.notCalled(feed.maybeRefresh);
-    });
     it("should fetchIcon on RICH_ICON_MISSING", async () => {
       feed.fetchIcon = sinon.spy();
       const url = "https://mozilla.org";

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -45,7 +45,12 @@ const TEST_GLOBAL = {
   ChromeUtils: {
     defineModuleGetter() {},
     generateQI() { return {}; },
-    import() {}
+    import(str) {
+      if (str === "resource://services-settings/remote-settings.js") {
+        return {RemoteSettings: TEST_GLOBAL.RemoteSettings};
+      }
+      return {};
+    }
   },
   Components: {isSuccessCode: () => true},
   // eslint-disable-next-line object-shorthand
@@ -178,7 +183,8 @@ const TEST_GLOBAL = {
   },
   EventEmitter,
   ShellService: {isDefaultBrowser: () => true},
-  FilterExpressions: {eval() { return Promise.resolve(true); }}
+  FilterExpressions: {eval() { return Promise.resolve(true); }},
+  RemoteSettings() { return {get() { return Promise.resolve([]); }}; }
 };
 overrider.set(TEST_GLOBAL);
 


### PR DESCRIPTION
@ncloudioj to test it out, you need to change the prefs for RS. I just run the following in the browser console:

```
const SERVER_STAGE = "https://settings.stage.mozaws.net/v1";
const HASH_STAGE = "DB:74:CE:58:E4:F9:D0:9E:E0:42:36:BE:6C:C5:C4:F6:6A:E7:74:7D:C0:21:42:7A:03:BC:2F:57:0C:8B:9B:90";
Services.prefs.setCharPref("services.settings.server", SERVER_STAGE);
Services.prefs.setCharPref("security.content.signature.root_hash", HASH_STAGE);
```