### PR TITLE
Backport chanages from Bug 1474410

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -40,7 +40,6 @@ const DEFAULT_SITES = new Map([
   ["FR", "https://www.youtube.com/,https://www.facebook.com/,https://www.wikipedia.org/,https://www.amazon.fr/,https://www.leboncoin.fr/,https://twitter.com/"]
 ]);
 const GEO_PREF = "browser.search.region";
-const REASON_ADDON_UNINSTALL = 6;
 const SPOCS_GEOS = ["US"];
 
 // Determine if spocs should be shown for a geo/locale
@@ -316,15 +315,6 @@ this.ActivityStream = class ActivityStream {
 
     this.store.uninit();
     this.initialized = false;
-  }
-
-  uninstall(reason) {
-    if (reason === REASON_ADDON_UNINSTALL) {
-      // This resets all prefs in the config to their default values,
-      // so we DON'T want to do this on an upgrade/downgrade, only on a
-      // real uninstall
-      this._defaultPrefs.reset();
-    }
   }
 
   _updateDynamicPrefs() {

--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -1,8 +1,6 @@
 import {CONTENT_MESSAGE_TYPE} from "common/Actions.jsm";
 import injector from "inject!lib/ActivityStream.jsm";
 
-const REASON_ADDON_UNINSTALL = 6;
-
 describe("ActivityStream", () => {
   let sandbox;
   let as;
@@ -79,16 +77,6 @@ describe("ActivityStream", () => {
     });
     it("should call .store.uninit", () => {
       assert.calledOnce(as.store.uninit);
-    });
-  });
-  describe("#uninstall", () => {
-    it("should reset default prefs if the reason is REASON_ADDON_UNINSTALL", () => {
-      as.uninstall(REASON_ADDON_UNINSTALL);
-      assert.calledOnce(as._defaultPrefs.reset);
-    });
-    it("should not reset default prefs if the reason is something else", () => {
-      as.uninstall("foo");
-      assert.notCalled(as._defaultPrefs.reset);
     });
   });
   describe("feeds", () => {


### PR DESCRIPTION
Backport changes which move activity stream init/uninit from boostrap.js to AboutNewTab.jsm in m-c. Also while here, deleting the now unused `uninstall` function in ActivityStream.jsm.

This needs to wait until changes in bug 1474410 land in mozilla central before landing