### PR TITLE
Fix Bug 1471350: add topFrecentSites to ASRouterTargeting

### DIFF
--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -86,6 +86,7 @@ const TEST_GLOBAL = {
   fetch() {},
   // eslint-disable-next-line object-shorthand
   Image: function() {}, // NB: This is a function/constructor
+  NewTabUtils: {activityStreamProvider: {getTopFrecentSites: () => []}},
   PlacesUtils: {
     get bookmarks() {
       return TEST_GLOBAL.Cc["@mozilla.org/browser/nav-bookmarks-service;1"];


### PR DESCRIPTION
Relies on some minor changes to FilterExpressions.jsm in order to work effectively (and in order for the added mochitests to pass).