### PR TITLE
Bug 1432674	- Add support for frequency caps for AS Router

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -137,6 +137,7 @@ export class ASRouterUISurface extends React.PureComponent {
   }
 
   sendImpression(extraProps) {
+    ASRouterUtils.sendMessage({type: "IMPRESSION", data: this.state.message});
     this.sendUserActionTelemetry({event: "IMPRESSION", ...extraProps});
   }
 

--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -10,6 +10,9 @@ Field name | Type     | Required | Description | Example / Note
 `campaign` | `string` | No | Campaign id that the message belongs to | `RustWebAssembly`
 `targeting` | `string` `JEXL` | No | A [JEXL expression](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#jexl-basics) with all targeting information needed in order to decide if the message is shown | Not yet implemented, [Examples](#targeting-attributes)
 `trigger` | `string` | No | An event or condition upon which the message will be immediately shown. This can be combined with `targeting`. Messages that define a trigger will not be shown during non-trigger-based passive message rotation.
+`frequency` | `object` | No | A definition for frequency cap information for the message
+`frequency.lifetime` | `integer` | No | The maximum number of lifetime impressions for the message.
+`frequency.custom` | `array` | No | An array of frequency cap definition objects including `period`, a time period in milliseconds, and `cap`, a max number of impressions for that period.
 
 ### Message example
 ```javascript
@@ -19,6 +22,11 @@ Field name | Type     | Required | Description | Example / Note
   content: {
     title: "Find it faster",
     body: "Access all of your favorite search engines with a click. Search the whole Web or just one website from the search box."
+  },
+  targeting: "hasFxAccount && !addonsInfo.addons['activity-stream@mozilla.org']",
+  frequency: {
+    lifetime: 20,
+    custom: [{period: "daily", cap: 5}, {period: 3600000, cap: 1}]
   }
 }
 ```

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -2,6 +2,7 @@
   "title": "ProviderResponse",
   "description": "A response object for remote providers of AS Router",
   "type": "object",
+  "version": "0.1.0",
   "properties": {
     "messages": {
       "type": "array",
@@ -31,6 +32,49 @@
           "trigger": {
             "type": "string",
             "description": "A string representing what the trigger to show this message is."
+          },
+          "frequency": {
+            "type": "object",
+            "description": "An object containing frequency cap information for a message.",
+            "properties": {
+              "lifetime": {
+                "type": "integer",
+                "description": "The maximum lifetime impressions for a message.",
+                "minimum": 1,
+                "maximum": 100
+              },
+              "custom": {
+                "type": "array",
+                "description": "An array of custom frequency cap definitions.",
+                "items": {
+                  "description": "A frequency cap definition containing time and max impression information",
+                  "type": "object",
+                  "properties": {
+                    "period": {
+                      "oneOf": [
+                        {
+                          "type": "integer",
+                          "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                        },
+                        {
+                          "type": "string",
+                          "description": "One of a preset list of short forms for period of time (e.g. 'daily' for one day)",
+                          "enum": ["daily"]
+                        }
+                      ]
+
+                    },
+                    "cap": {
+                      "type": "integer",
+                      "description": "The maximum impressions for the message within the defined period.",
+                      "minimum": 1,
+                      "maximum": 100
+                    }
+                  },
+                  "required": ["period", "cap"]
+                }
+              }
+            }
           }
         },
         "required": ["id", "template", "content"]

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -54,16 +54,18 @@ export class ASRouterAdmin extends React.PureComponent {
   renderMessageItem(msg) {
     const isCurrent = msg.id === this.state.lastMessageId;
     const isBlocked = this.state.blockList.includes(msg.id);
+    const impressions = this.state.impressions[msg.id] ? this.state.impressions[msg.id].length : 0;
 
     let itemClassName = "message-item";
     if (isCurrent) { itemClassName += " current"; }
     if (isBlocked) { itemClassName += " blocked"; }
 
     return (<tr className={itemClassName} key={msg.id}>
-      <td className="message-id"><span>{msg.id}</span></td>
+      <td className="message-id"><span>{msg.id} <br /></span></td>
       <td>
         <button className={`button ${(isBlocked ? "" : " primary")}`} onClick={isBlocked ? this.handleUnblock(msg) : this.handleBlock(msg)}>{isBlocked ? "Unblock" : "Block"}</button>
        {isBlocked ? null : <button className="button" onClick={this.handleOverride(msg.id)}>Show</button>}
+       <br />({impressions} impressions)
       </td>
       <td className="message-summary">
         <pre>{JSON.stringify(msg, null, 2)}</pre>

--- a/test/functional/mochitest/browser_asrouter_targeting.js
+++ b/test/functional/mochitest/browser_asrouter_targeting.js
@@ -28,7 +28,7 @@ add_task(async function find_matching_message() {
   ];
   const context = {FOO: true};
 
-  const match = await ASRouterTargeting.findMatchingMessage(messages, {}, context);
+  const match = await ASRouterTargeting.findMatchingMessage({messages, target: {}, context});
 
   is(match, messages[0], "should match and return the correct message");
 });
@@ -37,7 +37,7 @@ add_task(async function return_nothing_for_no_matching_message() {
   const messages = [{id: "bar", targeting: "!FOO"}];
   const context = {FOO: true};
 
-  const match = await ASRouterTargeting.findMatchingMessage(messages, {}, context);
+  const match = await ASRouterTargeting.findMatchingMessage({messages, target: {}, context});
 
   is(match, undefined, "should return nothing since no matching message exists");
 });
@@ -49,7 +49,7 @@ add_task(async function checkProfileAgeCreated() {
     "should return correct profile age creation date");
 
   const message = {id: "foo", targeting: `profileAgeCreated > ${await profileAccessor.created - 100}`};
-  is(await ASRouterTargeting.findMatchingMessage([message], {}), message,
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message], target: {}, context}), message,
     "should select correct item by profile age created");
 });
 
@@ -59,7 +59,7 @@ add_task(async function checkProfileAgeReset() {
     "should return correct profile age reset");
 
   const message = {id: "foo", targeting: `profileAgeReset == ${await profileAccessor.reset}`};
-  is(await ASRouterTargeting.findMatchingMessage([message], {}), message,
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message], target: {}}), message,
     "should select correct item by profile age reset");
 });
 
@@ -69,7 +69,7 @@ add_task(async function checkhasFxAccount() {
     "should return true if a fx account is set");
 
   const message = {id: "foo", targeting: "hasFxAccount"};
-  is(await ASRouterTargeting.findMatchingMessage([message], {}), message,
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message], target: {}}), message,
     "should select correct item by hasFxAccount");
 });
 

--- a/test/unit/asrouter/ASRouterTargeting.test.js
+++ b/test/unit/asrouter/ASRouterTargeting.test.js
@@ -1,0 +1,100 @@
+import {ASRouterTargeting} from "lib/ASRouterTargeting.jsm";
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+// Note that tests for the ASRouterTargeting environment can be found in
+// test/functional/mochitest/browser_asrouter_targeting.js
+
+describe("ASRouterTargeting#isBelowFrequencyCap", () => {
+  describe("lifetime frequency caps", () => {
+    it("should return true if .frequency is not defined on the message", () => {
+      const message = {id: "msg1"};
+      const impressions = [0, 1];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isTrue(result);
+    });
+    it("should return true if there are no impressions", () => {
+      const message = {id: "msg1", frequency: {lifetime: 10, custom: [{period: ONE_DAY, cap: 2}]}};
+      const impressions = [];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isTrue(result);
+    });
+    it("should return true if the # of impressions is less than .frequency.lifetime", () => {
+      const message = {id: "msg1", frequency: {lifetime: 3}};
+      const impressions = [0, 1];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isTrue(result);
+    });
+    it("should return false if the # of impressions is equal to .frequency.lifetime", () => {
+      const message = {id: "msg1", frequency: {lifetime: 2}};
+      const impressions = [0, 1];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isFalse(result);
+    });
+    it("should return false if the # of impressions is greater than .frequency.lifetime", () => {
+      const message = {id: "msg1", frequency: {lifetime: 2}};
+      const impressions = [0, 1, 2];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isFalse(result);
+    });
+  });
+  describe("custom frequency caps", () => {
+    let sandbox;
+    let clock;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      clock = sandbox.useFakeTimers();
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+    it("should return true if impressions in the time period < the cap and total impressions < the lifetime cap", () => {
+      clock.tick(ONE_DAY + 10);
+      const message = {id: "msg1", frequency: {custom: [{period: ONE_DAY, cap: 2}], lifetime: 3}};
+      const impressions = [0, ONE_DAY + 1];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isTrue(result);
+    });
+    it("should return false if impressions in the time period > the cap and total impressions < the lifetime cap", () => {
+      clock.tick(200);
+      const message = {id: "msg1", frequency: {custom: [{period: 100, cap: 2}], lifetime: 3}};
+      const impressions = [0, 160, 161];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isFalse(result);
+    });
+    it("should return false if impressions in one of the time periods > the cap and total impressions < the lifetime cap", () => {
+      clock.tick(ONE_DAY + 200);
+      const messageTrue = {id: "msg2", frequency: {custom: [{period: 100, cap: 2}]}};
+      const messageFalse = {id: "msg1", frequency: {custom: [{period: 100, cap: 2}, {period: ONE_DAY, cap: 3}]}};
+      const impressions = [0, ONE_DAY + 160, ONE_DAY - 100, ONE_DAY - 200];
+      assert.isTrue(ASRouterTargeting.isBelowFrequencyCap(messageTrue, impressions));
+      assert.isFalse(ASRouterTargeting.isBelowFrequencyCap(messageFalse, impressions));
+    });
+    it("should return false if impressions in the time period < the cap and total impressions > the lifetime cap", () => {
+      clock.tick(ONE_DAY + 10);
+      const message = {id: "msg1", frequency: {custom: [{period: ONE_DAY, cap: 2}], lifetime: 3}};
+      const impressions = [0, 1, 2, 3, ONE_DAY + 1];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isFalse(result);
+    });
+    it("should return true if daily impressions < the daily cap and there is no lifetime cap", () => {
+      clock.tick(ONE_DAY + 10);
+      const message = {id: "msg1", frequency: {custom: [{period: ONE_DAY, cap: 2}]}};
+      const impressions = [0, 1, 2, 3, ONE_DAY + 1];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isTrue(result);
+    });
+    it("should return false if daily impressions > the daily cap and there is no lifetime cap", () => {
+      clock.tick(ONE_DAY + 10);
+      const message = {id: "msg1", frequency: {custom: [{period: ONE_DAY, cap: 2}]}};
+      const impressions = [0, 1, 2, 3, ONE_DAY + 1, ONE_DAY + 2, ONE_DAY + 3];
+      const result = ASRouterTargeting.isBelowFrequencyCap(message, impressions);
+      assert.isFalse(result);
+    });
+    it("should allow the 'daily' alias for period", () => {
+      clock.tick(ONE_DAY + 10);
+      const message = {id: "msg1", frequency: {custom: [{period: "daily", cap: 2}]}};
+      assert.isFalse(ASRouterTargeting.isBelowFrequencyCap(message, [0, 1, 2, 3, ONE_DAY + 1, ONE_DAY + 2, ONE_DAY + 3]));
+      assert.isTrue(ASRouterTargeting.isBelowFrequencyCap(message, [0, 1, 2, 3, ONE_DAY + 1]));
+    });
+  });
+});


### PR DESCRIPTION
This patch allows messages to define lifetime and custom period frequency caps for impressions. 
For example, this message allows 50 impressions in total, 5 within a day and only 1 within a minute.

```json
{
      "id": "MSG123",
      "caps": {
        "lifetime": 50,
        "custom": [{"period": "daily", "cap": 5}, {"period": 60000, "cap": 1}]
      }
}
```
The current behaviour for cleaning up the impression list is that impressions for messages that are not found in the currently loaded list of messages get removed. Perhaps this is too aggressive?

Testing setup:
1. ensure `browser.newtabpage.activity-stream.asrouterExperimentEnabled` is `true`
2. set `browser.newtabpage.activity-stream.asrouter.snippetsUrl` to `https://gist.githubusercontent.com/k88hudson/bab3cf6e9035d5d0392311ca928480fd/raw` (this will give you some snippets with frequency cap settings)
3. go to `about:newtab#asrouter` to ensure messages are unblocked and impressions are at 0;
4. ensure that messages stop showing up randomly once the impression caps have been met (for FREQ_TEST_1 this should be 2 impressions within a minute, and 5 within a day; for FREQ_TEST_2 this should be 5 max impressions regardless of time)