### PR TITLE
Bug 1476381 - Fix outstanding sass lint warnings

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,11 +1,12 @@
 options:
   merge-default-rules: true
+  max-warnings: 0
 
 files:
   include: 'content-src/**/*.scss'
 
 rules:
-  class-name-format: [{convention: ["hyphenatedlowercase", "camelcase"]}]
+  class-name-format: 0
   extends-before-declarations: 2
   extends-before-mixins: 2
   force-element-nesting: 0

--- a/content-src/components/Base/_Base.scss
+++ b/content-src/components/Base/_Base.scss
@@ -15,10 +15,6 @@
 }
 
 main {
-  .hide-main & {
-    visibility: hidden;
-  }
-
   margin: auto;
   // Offset the snippets container so things at the bottom of the page are still
   // visible when snippets / onboarding are visible. Adjust for other spacing.
@@ -45,6 +41,11 @@ main {
     margin-bottom: $section-spacing;
     position: relative;
   }
+
+  .hide-main & {
+    visibility: hidden;
+  }
+
 }
 
 .base-content-fallback {

--- a/content-src/components/StartupOverlay/_StartupOverlay.scss
+++ b/content-src/components/StartupOverlay/_StartupOverlay.scss
@@ -72,11 +72,11 @@
 }
 
 .background,
-body.hide-main {
+body.hide-main { // sass-lint:disable-line no-qualifying-elements
   width: 100%;
   height: 100%;
   display: block;
-  background-image: url('#{$image-path}fox-tail.png'), linear-gradient(to bottom, $blue-70 40%, #004EC2 60%, $blue-60 80%, #0080FF 90%, #00C7FF 100%);
+  background-image: url('#{$image-path}fox-tail.png'), $about-welcome-gradient;
   background-position-x: center;
   background-position-y: -200px, top;
   background-repeat: no-repeat;
@@ -104,7 +104,7 @@ body.hide-main {
     font-size: 12px;
     max-width: 340px;
     margin: 17px 50px;
-    color: #676F7E;
+    color: $about-welcome-extra-links;
     cursor: default;
 
     a {
@@ -239,7 +239,7 @@ body.hide-main {
   padding-bottom: 210px;
 }
 
-a.firstrun-link {
+a.firstrun-link { // sass-lint:disable-line no-qualifying-elements
   color: $white;
   display: block;
   text-decoration: underline;

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -18,12 +18,12 @@ body {
   font-size: 16px;
   overflow-y: scroll;
 
-  &.hide-onboarding > #onboarding-overlay-button,
-  &.hide-main > #onboarding-overlay-button {
-    display: none !important;
+  &.hide-onboarding > #onboarding-overlay-button, // sass-lint:disable-line no-ids
+  &.hide-main > #onboarding-overlay-button { // sass-lint:disable-line no-ids
+    display: none !important; // sass-lint:disable-line no-important
   }
 
-  &.hide-main > #onboarding-notification-bar {
+  &.hide-main > #onboarding-notification-bar { // sass-lint:disable-line no-ids
     display: none;
   }
 }

--- a/content-src/styles/_theme.scss
+++ b/content-src/styles/_theme.scss
@@ -74,62 +74,61 @@ body {
   // Snippets
   --newtab-snippets-background-color: $white;
   --newtab-snippets-hairline-color: transparent;
-}
 
-// Dark theme
-body[lwt-newtab-brighttext] {
-  // General styles
-  --newtab-background-color: $grey-80;
-  --newtab-border-primary-color: $grey-10-80;
-  --newtab-border-secondary-color: $grey-10-10;
-  --newtab-button-primary-color: $blue-60;
-  --newtab-button-secondary-color: $grey-70;
-  --newtab-element-active-color: $grey-10-20;
-  --newtab-element-hover-color: $grey-10-10;
-  --newtab-icon-primary-color: $grey-10-80;
-  --newtab-icon-secondary-color: $grey-10-40;
-  --newtab-icon-tertiary-color: $grey-10-40;
-  --newtab-inner-box-shadow-color: $grey-10-20;
-  --newtab-link-primary-color: $blue-40;
-  --newtab-link-secondary-color: $pocket-teal;
-  --newtab-text-conditional-color: $grey-10;
-  --newtab-text-primary-color: $grey-10;
-  --newtab-text-secondary-color: $grey-10-80;
-  --newtab-textbox-background-color: $grey-70;
-  --newtab-textbox-border: $grey-10-20;
-  @include textbox-focus($blue-40); // sass-lint:disable-line mixins-before-declarations
+  &[lwt-newtab-brighttext] {
+    // General styles
+    --newtab-background-color: $grey-80;
+    --newtab-border-primary-color: $grey-10-80;
+    --newtab-border-secondary-color: $grey-10-10;
+    --newtab-button-primary-color: $blue-60;
+    --newtab-button-secondary-color: $grey-70;
+    --newtab-element-active-color: $grey-10-20;
+    --newtab-element-hover-color: $grey-10-10;
+    --newtab-icon-primary-color: $grey-10-80;
+    --newtab-icon-secondary-color: $grey-10-40;
+    --newtab-icon-tertiary-color: $grey-10-40;
+    --newtab-inner-box-shadow-color: $grey-10-20;
+    --newtab-link-primary-color: $blue-40;
+    --newtab-link-secondary-color: $pocket-teal;
+    --newtab-text-conditional-color: $grey-10;
+    --newtab-text-primary-color: $grey-10;
+    --newtab-text-secondary-color: $grey-10-80;
+    --newtab-textbox-background-color: $grey-70;
+    --newtab-textbox-border: $grey-10-20;
+    @include textbox-focus($blue-40); // sass-lint:disable-line mixins-before-declarations
 
-  // Context menu
-  --newtab-contextmenu-background-color: $grey-60;
-  --newtab-contextmenu-button-color: $grey-80;
+    // Context menu
+    --newtab-contextmenu-background-color: $grey-60;
+    --newtab-contextmenu-button-color: $grey-80;
 
-  // Modal + overlay
-  --newtab-modal-color: $grey-80;
-  --newtab-overlay-color: $grey-90-80;
+    // Modal + overlay
+    --newtab-modal-color: $grey-80;
+    --newtab-overlay-color: $grey-90-80;
 
-  // Sections
-  --newtab-section-header-text-color: $grey-10-80;
-  --newtab-section-navigation-text-color: $grey-10-80;
-  --newtab-section-active-contextmenu-color: $white;
+    // Sections
+    --newtab-section-header-text-color: $grey-10-80;
+    --newtab-section-navigation-text-color: $grey-10-80;
+    --newtab-section-active-contextmenu-color: $white;
 
-  // Search
-  --newtab-search-border-color: $grey-10-20;
-  --newtab-search-dropdown-color: $grey-70;
-  --newtab-search-dropdown-header-color: $grey-60;
-  --newtab-search-icon-color: $grey-10-60;
+    // Search
+    --newtab-search-border-color: $grey-10-20;
+    --newtab-search-dropdown-color: $grey-70;
+    --newtab-search-dropdown-header-color: $grey-60;
+    --newtab-search-icon-color: $grey-10-60;
 
-  // Top Sites
-  --newtab-topsites-background-color: $grey-70;
-  --newtab-topsites-icon-shadow: none;
-  --newtab-topsites-label-color: $grey-10-80;
+    // Top Sites
+    --newtab-topsites-background-color: $grey-70;
+    --newtab-topsites-icon-shadow: none;
+    --newtab-topsites-label-color: $grey-10-80;
 
-  // Cards
-  --newtab-card-active-outline-color: $grey-60;
-  --newtab-card-background-color: $grey-70;
-  --newtab-card-hairline-color: $grey-10-10;
-  --newtab-card-shadow: 0 1px 8px 0 $grey-90-20;
+    // Cards
+    --newtab-card-active-outline-color: $grey-60;
+    --newtab-card-background-color: $grey-70;
+    --newtab-card-hairline-color: $grey-10-10;
+    --newtab-card-shadow: 0 1px 8px 0 $grey-90-20;
 
-  // Snippets
-  --newtab-snippets-background-color: $grey-70;
-  --newtab-snippets-hairline-color: $white-10;
+    // Snippets
+    --newtab-snippets-background-color: $grey-70;
+    --newtab-snippets-hairline-color: $white-10;
+  }
 }

--- a/content-src/styles/_variables.scss
+++ b/content-src/styles/_variables.scss
@@ -53,6 +53,11 @@ $download-icon-fill: #12BC00;
 $pocket-icon-fill: #D70022;
 $email-input-focus: rgba($blue-50, 0.3);
 $email-input-invalid: rgba($red-60, 0.3);
+$aw-extra-blue-1: #004EC2;
+$aw-extra-blue-2: #0080FF;
+$aw-extra-blue-3: #00C7FF;
+$about-welcome-gradient: linear-gradient(to bottom, $blue-70 40%, $aw-extra-blue-1 60%, $blue-60 80%, $aw-extra-blue-2 90%, $aw-extra-blue-3 100%);
+$about-welcome-extra-links: #676F7E;
 
 // Photon transitions from http://design.firefox.com/photon/motion/duration-and-easing.html
 $photon-easing: cubic-bezier(0.07, 0.95, 0, 1);


### PR DESCRIPTION
Woohoo, no more warnings!

To test:
- run `npm run lint:sasslint` and ensure no warnings are produced.
- please check `about:welcome` and dark theme since almost all changes involve those files.

Notes:
- I don't think there's actually a way to allow for more than 1 `class-name-format` convention, so I just removed the rule. Personally I don't particularly think it matters if people use camel case or hyphens anyway
- these changes should not result in any significant changes in the output and definitely not in the design