### PR TITLE
gSnippetsMap parity in ASRouter

### DIFF
--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -50,11 +50,12 @@ For a more in-depth explanation of JEXL syntax you can read the [Normady project
 Currently we expose the following targeting attributes that can be used by messages:
 
 Name | Type | Example value | Description
----  | ---  | ---           | ---      
+---  | ---  | ---           | ---
+`addonsInfo` | `Object` | [example below](#addonsinfo-example) | Information about the addons the user has installed
+`hasFxAccount` | `Boolean` | `true` | Does the user have a firefox account
 `profileAgeCreated` | Number | `1522843725924` | Profile creation timestamp
 `profileAgeReset` | `Number` or `undefined` | `1522843725924` | When (if) the profile was reset
-`hasFxAccount` | `Boolean` | `true` | Does the user have a firefox account
-`addonsInfo` | `Object` | [example below](#addonsinfo-example) | Information about the addons the user has installed
+`searchEngines` | `Object` | [example below](#searchengines-example) | Information about the current and available search engines
 
 #### addonsInfo Example
 
@@ -73,6 +74,17 @@ Name | Type | Example value | Description
     }
   },
   "isFullData": true
+}
+```
+
+#### searchEngines Example
+
+```javascript
+{
+  "searchEngines": {
+    "current": "google",
+    "installed": ["google", "amazondotcom", "duckduckgo"]
+  }
 }
 ```
 

--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -52,6 +52,7 @@ Currently we expose the following targeting attributes that can be used by messa
 Name | Type | Example value | Description
 ---  | ---  | ---           | ---
 `addonsInfo` | `Object` | [example below](#addonsinfo-example) | Information about the addons the user has installed
+`devToolsOpenedCount` | `Integer` | Number of usages of the web console or scratchpad
 `hasFxAccount` | `Boolean` | `true` | Does the user have a firefox account
 `isDefaultBrowser` | `Boolean` or `null` | Is Firefox the user's default browser? If we could not determine the default browser, this value is `null`
 `profileAgeCreated` | Number | `1522843725924` | Profile creation timestamp

--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -53,6 +53,7 @@ Name | Type | Example value | Description
 ---  | ---  | ---           | ---
 `addonsInfo` | `Object` | [example below](#addonsinfo-example) | Information about the addons the user has installed
 `hasFxAccount` | `Boolean` | `true` | Does the user have a firefox account
+`isDefaultBrowser` | `Boolean` or `null` | Is Firefox the user's default browser? If we could not determine the default browser, this value is `null`
 `profileAgeCreated` | Number | `1522843725924` | Profile creation timestamp
 `profileAgeReset` | `Number` or `undefined` | `1522843725924` | When (if) the profile was reset
 `searchEngines` | `Object` | [example below](#searchengines-example) | Information about the current and available search engines

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -51,6 +51,26 @@ const TargetingGetters = {
         return {addons: info, isFullData: fullData};
       });
   },
+
+  get searchEngines() {
+    return new Promise(resolve => {
+      // Note: calling init ensures this code is only executed after Search has been initialized
+      Services.search.init(rv => {
+        if (Components.isSuccessCode(rv)) {
+          let engines = Services.search.getVisibleEngines();
+          resolve({
+            current: Services.search.defaultEngine.identifier,
+            installed: engines
+              .map(engine => engine.identifier)
+              .filter(engine => engine)
+          });
+        } else {
+          resolve({installed: [], current: ""});
+        }
+      });
+    });
+  },
+
   // Temporary targeting function for the purposes of running the simplified onboarding experience
   get isInExperimentCohort() {
     return Services.prefs.getIntPref(ONBOARDING_EXPERIMENT_PREF, 0);

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -5,6 +5,8 @@ ChromeUtils.defineModuleGetter(this, "AddonManager",
 ChromeUtils.defineModuleGetter(this, "ProfileAge",
   "resource://gre/modules/ProfileAge.jsm");
 ChromeUtils.import("resource://gre/modules/Console.jsm");
+ChromeUtils.defineModuleGetter(this, "ShellService",
+  "resource:///modules/ShellService.jsm");
 
 const FXA_USERNAME_PREF = "services.sync.username";
 const ONBOARDING_EXPERIMENT_PREF = "browser.newtabpage.activity-stream.asrouterOnboardingCohort";
@@ -69,6 +71,13 @@ const TargetingGetters = {
         }
       });
     });
+  },
+
+  get isDefaultBrowser() {
+    try {
+      return ShellService.isDefaultBrowser();
+    } catch (e) {}
+    return null;
   },
 
   // Temporary targeting function for the purposes of running the simplified onboarding experience

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -80,6 +80,10 @@ const TargetingGetters = {
     return null;
   },
 
+  get devToolsOpenedCount() {
+    return Services.prefs.getIntPref("devtools.selfxss.count");
+  },
+
   // Temporary targeting function for the purposes of running the simplified onboarding experience
   get isInExperimentCohort() {
     return Services.prefs.getIntPref(ONBOARDING_EXPERIMENT_PREF, 0);

--- a/test/functional/mochitest/browser_asrouter_targeting.js
+++ b/test/functional/mochitest/browser_asrouter_targeting.js
@@ -109,6 +109,15 @@ add_task(async function checkisDefaultBrowser() {
     "should select correct item by isDefaultBrowser");
 });
 
+add_task(async function checkdevToolsOpenedCount() {
+  await pushPrefs(["devtools.selfxss.count", 5]);
+  is(ASRouterTargeting.Environment.devToolsOpenedCount, 5,
+    "devToolsOpenedCount should be equal to devtools.selfxss.count pref value");
+  const message = {id: "foo", targeting: "devToolsOpenedCount >= 5"};
+  is(await ASRouterTargeting.findMatchingMessage([message], {}), message,
+    "should select correct item by devToolsOpenedCount");
+});
+
 AddonTestUtils.initMochitest(this);
 
 add_task(async function checkAddonsInfo() {

--- a/test/functional/mochitest/browser_asrouter_targeting.js
+++ b/test/functional/mochitest/browser_asrouter_targeting.js
@@ -4,6 +4,8 @@ ChromeUtils.defineModuleGetter(this, "ProfileAge",
   "resource://gre/modules/ProfileAge.jsm");
 ChromeUtils.defineModuleGetter(this, "AddonManager",
   "resource://gre/modules/AddonManager.jsm");
+ChromeUtils.defineModuleGetter(this, "ShellService",
+  "resource:///modules/ShellService.jsm");
 
 const {AddonTestUtils} = ChromeUtils.import("resource://testing-common/AddonTestUtils.jsm", {});
 
@@ -93,6 +95,18 @@ add_task(async function checksearchEngines() {
   const message2 = {id: "foo", targeting: `searchEngines[${Services.search.getVisibleEngines()[0].identifier} in .installed]`};
   is(await ASRouterTargeting.findMatchingMessage([message2], {}), message2,
     "should select correct item by searchEngines.installed");
+});
+
+add_task(async function checkisDefaultBrowser() {
+  const expected = ShellService.isDefaultBrowser();
+  const result = ASRouterTargeting.Environment.isDefaultBrowser;
+  is(typeof result, "boolean",
+    "isDefaultBrowser should be a boolean value");
+  is(result, expected,
+    "isDefaultBrowser should be equal to ShellService.isDefaultBrowser()");
+  const message = {id: "foo", targeting: `isDefaultBrowser == ${expected.toString()}`};
+  is(await ASRouterTargeting.findMatchingMessage([message], {}), message,
+    "should select correct item by isDefaultBrowser");
 });
 
 AddonTestUtils.initMochitest(this);

--- a/test/functional/mochitest/browser_asrouter_targeting.js
+++ b/test/functional/mochitest/browser_asrouter_targeting.js
@@ -71,6 +71,30 @@ add_task(async function checkhasFxAccount() {
     "should select correct item by hasFxAccount");
 });
 
+add_task(async function checksearchEngines() {
+  const result = await ASRouterTargeting.Environment.searchEngines;
+  const expectedInstalled = Services.search.getVisibleEngines()
+    .map(engine => engine.identifier)
+    .sort()
+    .join(",");
+  ok(result.installed.length,
+    "searchEngines.installed should be a non-empty array");
+  is(result.installed.sort().join(","), expectedInstalled,
+    "searchEngines.installed should be an array of visible search engines");
+  ok(result.current && typeof result.current === "string",
+    "searchEngines.current should be a truthy string");
+  is(result.current, Services.search.currentEngine.identifier,
+    "searchEngines.current should be the current engine name");
+
+  const message = {id: "foo", targeting: `searchEngines[.current == ${Services.search.currentEngine.identifier}]`};
+  is(await ASRouterTargeting.findMatchingMessage([message], {}), message,
+    "should select correct item by searchEngines.current");
+
+  const message2 = {id: "foo", targeting: `searchEngines[${Services.search.getVisibleEngines()[0].identifier} in .installed]`};
+  is(await ASRouterTargeting.findMatchingMessage([message2], {}), message2,
+    "should select correct item by searchEngines.installed");
+});
+
 AddonTestUtils.initMochitest(this);
 
 add_task(async function checkAddonsInfo() {


### PR DESCRIPTION
Adds additional targeting properties to achieve parity with existing snippets targeting fields.

To test:
- Please ensure mochi tests pass by running `./mach test browser/extensions/activity-stream/test/functional/mochitest/browser_asrouter_targeting.js`. See tests and docs for examples and JEXL