### PR TITLE
Fix Bug 1474372: Run mochitests on taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,6 +8,7 @@ tasks:
           - pull_request.opened
           - pull_request.reopened
           - pull_request.synchronize
+          - push
     payload:
       maxRunTime: 7200
       image: piatra/asmochitests
@@ -17,7 +18,7 @@ tasks:
         - '-c'
         - >-
           git clone {{event.head.repo.url}} /activity-stream && cd /activity-stream &&
-          git checkout {{event.head.sha}} && npm install . && bash ./mochitest.sh
+          git checkout {{event.head.sha}} && bash ./mochitest.sh
     metadata:
       name: activitystream
       description: run mochitests for PRs

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,30 @@
+version: 0
+tasks:
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events:
+          - pull_request.opened
+          - pull_request.reopened
+          - pull_request.synchronize
+    payload:
+      maxRunTime: 7200
+      image: piatra/asmochitests
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - >-
+          git clone {{event.head.repo.url}} /activity-stream && cd /activity-stream &&
+          git checkout {{event.head.sha}} && npm install . && npm run buildmc &&
+          export SHELL=/bin/bash && cd /mozilla-central &&
+          wget https://gist.githubusercontent.com/piatra/3e14b97ab54f9bc1c2ba2146a7367270/raw/e7bd33e9f6315b20ea65a3cf40f8429b84890cf8/mozconfig &&
+          ./mach build && cd /activity-stream && npm run mochitest
+    metadata:
+      name: activitystream
+      description: run mochitests for PRs
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'
+allowPullRequests: public
+

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,10 +17,7 @@ tasks:
         - '-c'
         - >-
           git clone {{event.head.repo.url}} /activity-stream && cd /activity-stream &&
-          git checkout {{event.head.sha}} && npm install . && npm run buildmc &&
-          export SHELL=/bin/bash && cd /mozilla-central &&
-          wget https://gist.githubusercontent.com/piatra/3e14b97ab54f9bc1c2ba2146a7367270/raw/e7bd33e9f6315b20ea65a3cf40f8429b84890cf8/mozconfig &&
-          ./mach build && cd /activity-stream && npm run mochitest
+          git checkout {{event.head.sha}} && npm install . && bash ./mochitest.sh
     metadata:
       name: activitystream
       description: run mochitests for PRs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # activity-stream
 
+[![Task Status](https://github.taskcluster.net/v1/repository/mozilla/activity-stream/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla/activity-stream/master/latest)
+
 This system add-on replaces the new tab page in Firefox with a new design and
 functionality as part of the Activity Stream project.
 

--- a/mochitest.sh
+++ b/mochitest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export SHELL=/bin/bash
+
+# Pull latest m-c and update tip
+cd /mozilla-central && hg pull && hg update -C
+
+# Build Activity Stream and copy the output to m-c
+cd /activity-stream && npm run buildmc
+
+# Build latest m-c with Activity Stream changes
+cd /mozilla-central && ./mach build  
+
+# Run the mochitests
+cd /activity-stream && npm run mochitest

--- a/mochitest.sh
+++ b/mochitest.sh
@@ -6,10 +6,15 @@ export SHELL=/bin/bash
 cd /mozilla-central && hg pull && hg update -C
 
 # Build Activity Stream and copy the output to m-c
-cd /activity-stream && npm run buildmc
+cd /activity-stream && npm install . && npm run buildmc
 
 # Build latest m-c with Activity Stream changes
-cd /mozilla-central && ./mach build  
-
-# Run the mochitests
-cd /activity-stream && npm run mochitest
+cd /mozilla-central && ./mach build \
+  && ./mach lint -l eslint -l codespell browser/extensions/activity-stream \
+  && ./mach test browser/extensions/activity-stream --headless \
+  && ./mach test browser/components/newtab/tests/browser --headless \
+  && ./mach test browser/components/newtab/tests/xpcshell \
+  && ./mach test browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js --headless \
+  && ./mach test browser/components/preferences/in-content/tests/browser_newtab_menu.js --headless \
+  && ./mach test browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js --headless \
+  && ./mach test browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js --headless

--- a/mochitest.sh
+++ b/mochitest.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 export SHELL=/bin/bash
+# Display required for `browser_parsable_css` tests
+export DISPLAY=:99.0
+/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR
 
 # Pull latest m-c and update tip
 cd /mozilla-central && hg pull && hg update -C
@@ -10,6 +13,7 @@ cd /activity-stream && npm install . && npm run buildmc
 
 # Build latest m-c with Activity Stream changes
 cd /mozilla-central && ./mach build \
+  && ./mach test browser_parsable_css \
   && ./mach lint -l eslint -l codespell browser/extensions/activity-stream \
   && ./mach test browser/extensions/activity-stream --headless \
   && ./mach test browser/components/newtab/tests/browser --headless \

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "mc_dir": "../mozilla-central"
   },
   "scripts": {
-    "mochitest": "(cd $npm_package_config_mc_dir && ./mach mochitest browser/extensions/activity-stream/test/functional/mochitest )",
+    "mochitest": "(cd $npm_package_config_mc_dir && ./mach mochitest browser/extensions/activity-stream/test/functional/mochitest --headless )",
     "mochitest-debug": "(cd $npm_package_config_mc_dir && ./mach mochitest --jsdebugger browser/extensions/activity-stream/test/functional/mochitest)",
     "bundle": "npm-run-all bundle:*",
     "bundle:locales": "pontoon-to-json --src locales --dest data",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "mc_dir": "../mozilla-central"
   },
   "scripts": {
-    "mochitest": "(cd $npm_package_config_mc_dir && ./mach mochitest browser/extensions/activity-stream/test/functional/mochitest --headless )",
+    "mochitest": "(cd $npm_package_config_mc_dir && ./mach mochitest browser/extensions/activity-stream/test/functional/mochitest --headless)",
     "mochitest-debug": "(cd $npm_package_config_mc_dir && ./mach mochitest --jsdebugger browser/extensions/activity-stream/test/functional/mochitest)",
     "bundle": "npm-run-all bundle:*",
     "bundle:locales": "pontoon-to-json --src locales --dest data",

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -5,7 +5,7 @@
 
 scripts:
   # Run the activity-stream mochitests
-  mochitest: (cd $npm_package_config_mc_dir && ./mach mochitest browser/extensions/activity-stream/test/functional/mochitest )
+  mochitest: (cd $npm_package_config_mc_dir && ./mach mochitest browser/extensions/activity-stream/test/functional/mochitest --headless)
 
   # Run the activity-stream mochitests with the browser toolbox debugger.
   # Often handy in combination with adding a "debugger" statement in your


### PR DESCRIPTION
<img width="526" alt="screen shot 2018-07-19 at 16 44 12" src="https://user-images.githubusercontent.com/810040/42949893-23ca5eb6-8b73-11e8-8c15-98db609081ad.png">
Not sure where that request actually goes. It's needed so that taskcluster actually registers our repository.

Here are the logs of the mochitests running on my fork of AS https://tools.taskcluster.net/groups/FZ0dHWLVTq6q0sbQj2JEig/tasks/FZ0dHWLVTq6q0sbQj2JEig/runs/0/logs/public%2Flogs%2Flive.log#L1753

Some more info about the task steps include:
* pulling the image
* updating m-c 
* pulling the PR we want to test
* building AS and m-c (artifact)
* running the tests

Took 17 minutes. To achieve this the docker image `piatra/asmochitests` (specified in .taskcluster.yml) is built to include m-c repo + an artifact built before publishing in an attempt to speed things up.
As a follow up I am planning to set up a cron job on my machine that will rebuild + publish a new version of the image weekly to keep up with code changes. This does not mean the m-c is not updated (there is a `hg pull` step when running the tests) but it helps to have the image as up to date as possible.