### PR TITLE
Fix Bug 1471351: Add openURL trigger to ASRouter

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -191,7 +191,7 @@ export class ASRouterUISurface extends React.PureComponent {
 
     // If we are loading about:welcome we want to trigger the onboarding messages
     if (this.props.document.location.href === "about:welcome") {
-      ASRouterUtils.sendMessage({type: "TRIGGER", data: {trigger: "firstRun"}});
+      ASRouterUtils.sendMessage({type: "TRIGGER", data: {trigger: {id: "firstRun"}}});
     } else {
       ASRouterUtils.sendMessage({type: "CONNECT_UI_REQUEST", data: {endpoint}});
     }

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -45,7 +45,7 @@
               "id": {
                 "type": "string",
                 "description": "A string identifying the trigger action",
-                "enum": ["firstRun"]
+                "enum": ["firstRun", "openURL"]
               },
               "params": {
                 "type": "array",

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -36,11 +36,27 @@
           },
           "targeting": {
             "type": "string",
-            "description": "a JEXL expression representing targeting information"
+            "description": "A JEXL expression representing targeting information"
           },
           "trigger": {
-            "type": "string",
-            "description": "A string representing what the trigger to show this message is."
+            "type": "object",
+            "description": "An action to trigger potentially showing the message",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "A string identifying the trigger action",
+                "enum": ["firstRun"]
+              },
+              "params": {
+                "type": "array",
+                "description": "An optional array of string parameters for the trigger action",
+                "items": {
+                  "type": "string",
+                  "description": "A parameter for the trigger action"
+                }
+              }
+            },
+            "required": ["id"]
           },
           "frequency": {
             "type": "object",

--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -140,7 +140,8 @@ module.exports = function(config) {
             exclude: [
               path.resolve("test"),
               path.resolve("vendor"),
-              path.resolve("lib/ASRouterTargeting.jsm")
+              path.resolve("lib/ASRouterTargeting.jsm"),
+              path.resolve("lib/ASRouterTriggerListeners.jsm")
             ]
           }
         ]

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -145,6 +145,15 @@ this.ASRouterTargeting = {
     return FilterExpressions.eval(filterExpression, context);
   },
 
+  isTriggerMatch(trigger = {}, candidateMessageTrigger = {}) {
+    if (trigger.id !== candidateMessageTrigger.id) {
+      return false;
+    } else if (!candidateMessageTrigger.params) {
+      return true;
+    }
+    return candidateMessageTrigger.params.includes(trigger.param);
+  },
+
   isBelowFrequencyCap(message, impressionsForMessage) {
     if (!message.frequency || !impressionsForMessage || !impressionsForMessage.length) {
       return true;
@@ -202,6 +211,9 @@ this.ASRouterTargeting = {
   },
 
   async findMatchingMessageWithTrigger({messages, impressions = {}, target, trigger, context}) {
+    if (!trigger) {
+      return null;
+    }
     const arrayOfItems = [...messages];
     let match;
     let candidate;
@@ -209,8 +221,8 @@ this.ASRouterTargeting = {
       candidate = removeRandomItemFromArray(arrayOfItems);
       if (
         candidate &&
+        this.isTriggerMatch(trigger, candidate.trigger) &&
         this.isBelowFrequencyCap(candidate, impressions[candidate.id]) &&
-        candidate.trigger === trigger &&
         (!candidate.targeting || await this.isMatch(candidate.targeting, target, context))
       ) {
         match = candidate;

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+ChromeUtils.defineModuleGetter(this, "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm");
+
+/**
+ * A Map from trigger IDs to singleton trigger listeners. Each listener must
+ * have idempotent `init` and `uninit` methods.
+ */
+this.ASRouterTriggerListeners = new Map([
+
+  /**
+   * Attach listeners to every browser window to detect location changes, and
+   * notify the trigger handler whenever we navigate to a URL with a hostname
+   * we're looking for.
+   */
+  ["openURL", {
+    _initialized: false,
+    _triggerHandler: null,
+    _hosts: null,
+
+    /*
+     * If the listener is already initialised, `init` will replace the trigger
+     * handler and add any new hosts to `this._hosts`.
+     */
+    init(triggerHandler, hosts = []) {
+      if (!this._initialized) {
+        this.onLocationChange = this.onLocationChange.bind(this);
+
+        // Listen for new windows being opened
+        Services.ww.registerNotification(this);
+
+        // Add listeners to all existing browser windows
+        const winEnum = Services.wm.getEnumerator("navigator:browser");
+        while (winEnum.hasMoreElements()) {
+          let win = winEnum.getNext();
+          if (win.closed || PrivateBrowsingUtils.isWindowPrivate(win)) {
+            continue;
+          }
+          win.gBrowser.addTabsProgressListener(this);
+        }
+
+        this._initialized = true;
+      }
+      this._triggerHandler = triggerHandler;
+      if (this._hosts) {
+        hosts.forEach(h => this._hosts.add(h));
+      } else {
+        this._hosts = new Set(hosts); // Clone the hosts to avoid unexpected behaviour
+      }
+    },
+
+    uninit() {
+      if (this._initialized) {
+        Services.ww.unregisterNotification(this);
+
+        const winEnum = Services.wm.getEnumerator("navigator:browser");
+        while (winEnum.hasMoreElements()) {
+          let win = winEnum.getNext();
+          if (win.closed || PrivateBrowsingUtils.isWindowPrivate(win)) {
+            continue;
+          }
+
+          win.gBrowser.removeTabsProgressListener(this);
+        }
+
+        this._initialized = false;
+        this._triggerHandler = null;
+        this._hosts = null;
+      }
+    },
+
+    onLocationChange(aBrowser, aWebProgress, aRequest, aLocationURI, aFlags) {
+      const location = aLocationURI ? aLocationURI.spec : "";
+      if (location && aWebProgress.isTopLevel) {
+        try {
+          const host = (new URL(location)).hostname;
+          if (this._hosts.has(host)) {
+            this._triggerHandler(aBrowser.messageManager, {id: "openURL", param: host});
+          }
+        } catch (e) {} // Couldn't parse location URL
+      }
+    },
+
+    observe(win, topic, data) {
+      let onLoad;
+
+      switch (topic) {
+        case "domwindowopened":
+          if (!(win instanceof Ci.nsIDOMWindow) || win.closed || PrivateBrowsingUtils.isWindowPrivate(win)) {
+            break;
+          }
+          onLoad = () => {
+            // Ignore non-browser windows.
+            if (win.document.documentElement.getAttribute("windowtype") === "navigator:browser") {
+              win.gBrowser.addTabsProgressListener(this);
+            }
+          };
+          win.addEventListener("load", onLoad, {once: true});
+          break;
+
+        case "domwindowclosed":
+          if ((win instanceof Ci.nsIDOMWindow) &&
+              win.document.documentElement.getAttribute("windowtype") === "navigator:browser") {
+            win.gBrowser.removeTabsProgressListener(this);
+          }
+          break;
+      }
+    }
+  }]
+]);
+
+const EXPORTED_SYMBOLS = ["ASRouterTriggerListeners"];

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -16,7 +16,7 @@ const ONBOARDING_MESSAGES = [
       button_label: "Try It Now",
       button_action: "OPEN_PRIVATE_BROWSER_WINDOW"
     },
-    trigger: "firstRun"
+    trigger: {id: "firstRun"}
   },
   {
     id: "ONBOARDING_2",
@@ -31,7 +31,7 @@ const ONBOARDING_MESSAGES = [
       button_action: "OPEN_URL",
       button_action_params: "https://screenshots.firefox.com/#tour"
     },
-    trigger: "firstRun"
+    trigger: {id: "firstRun"}
   },
   {
     id: "ONBOARDING_3",
@@ -47,7 +47,7 @@ const ONBOARDING_MESSAGES = [
       button_action_params: "addons"
     },
     targeting: "isInExperimentCohort == 1",
-    trigger: "firstRun"
+    trigger: {id: "firstRun"}
   },
   {
     id: "ONBOARDING_4",
@@ -63,7 +63,7 @@ const ONBOARDING_MESSAGES = [
       button_action_params: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/"
     },
     targeting: "isInExperimentCohort == 2",
-    trigger: "firstRun"
+    trigger: {id: "firstRun"}
   }
 ];
 

--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -9,6 +9,7 @@ prefs =
 [browser_as_load_location.js]
 [browser_as_render.js]
 [browser_asrouter_targeting.js]
+[browser_asrouter_trigger_listeners.js]
 [browser_enabled_newtabpage.js]
 [browser_highlights_section.js]
 [browser_getScreenshots.js]

--- a/test/browser/browser_asrouter_trigger_listeners.js
+++ b/test/browser/browser_asrouter_trigger_listeners.js
@@ -1,0 +1,58 @@
+ChromeUtils.defineModuleGetter(this, "ASRouterTriggerListeners",
+  "resource://activity-stream/lib/ASRouterTriggerListeners.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.defineModuleGetter(this, "TestUtils",
+  "resource://testing-common/TestUtils.jsm");
+ChromeUtils.defineModuleGetter(this, "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm");
+
+async function openURLInWindow(window, url) {
+  const {selectedBrowser} = window.gBrowser;
+  await BrowserTestUtils.loadURI(selectedBrowser, url);
+  await BrowserTestUtils.browserLoaded(selectedBrowser);
+}
+
+add_task(async function check_openURL_listener() {
+  const TEST_URL = "https://example.com/browser/browser/components/newtab/test/browser/blue_page.html";
+
+  let urlVisitCount = 0;
+  const triggerHandler = () => urlVisitCount++;
+
+  const normalWindow = await BrowserTestUtils.openNewBrowserWindow();
+  const privateWindow = await BrowserTestUtils.openNewBrowserWindow({private: true});
+
+  // Initialise listener
+  const openURLListener = ASRouterTriggerListeners.get("openURL");
+  openURLListener.init(triggerHandler, ["example.com"]);
+
+  await openURLInWindow(normalWindow, TEST_URL);
+  is(urlVisitCount, 1, "should receive page visits from existing windows");
+
+  await openURLInWindow(normalWindow, "http://www.example.com/abc");
+  is(urlVisitCount, 1, "should not receive page visits for different domains");
+
+  await openURLInWindow(privateWindow, TEST_URL);
+  is(urlVisitCount, 1, "should not receive page visits from existing private windows");
+
+  const secondNormalWindow = await BrowserTestUtils.openNewBrowserWindow();
+  await openURLInWindow(secondNormalWindow, TEST_URL);
+  is(urlVisitCount, 2, "should receive page visits from newly opened windows");
+
+  const secondPrivateWindow = await BrowserTestUtils.openNewBrowserWindow({private: true});
+  await openURLInWindow(secondPrivateWindow, TEST_URL);
+  is(urlVisitCount, 2, "should not receive page visits from newly opened private windows");
+
+  // Uninitialise listener
+  openURLListener.uninit();
+
+  await openURLInWindow(normalWindow, TEST_URL);
+  is(urlVisitCount, 2, "should now not receive page visits from existing windows");
+
+  const thirdNormalWindow = await BrowserTestUtils.openNewBrowserWindow();
+  await openURLInWindow(thirdNormalWindow, TEST_URL);
+  is(urlVisitCount, 2, "should now not receive page visits from newly opened windows");
+
+  // Cleanup
+  const windows = [normalWindow, privateWindow, secondNormalWindow, secondPrivateWindow, thirdNormalWindow];
+  await Promise.all(windows.map(win => BrowserTestUtils.closeWindow(win)));
+});

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -410,7 +410,7 @@ describe("ASRouter", () => {
       await Router.onMessage(msg);
 
       assert.calledOnce(Router.sendNextMessage);
-      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {type: "CONNECT_UI_REQUEST"});
+      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {});
     });
     it("should call sendNextMessage on GET_NEXT_MESSAGE", async () => {
       sandbox.stub(Router, "sendNextMessage").resolves();
@@ -419,7 +419,7 @@ describe("ASRouter", () => {
       await Router.onMessage(msg);
 
       assert.calledOnce(Router.sendNextMessage);
-      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {type: "GET_NEXT_MESSAGE"});
+      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {});
     });
     it("should return the preview message if that's available", async () => {
       const expectedObj = {provider: "preview"};
@@ -480,30 +480,30 @@ describe("ASRouter", () => {
   describe("#onMessage: TRIGGER", () => {
     it("should pass the trigger to ASRouterTargeting on TRIGGER message", async () => {
       sandbox.stub(Router, "_findMessage").resolves();
-      const msg = fakeAsyncMessage({type: "TRIGGER", data: {trigger: "firstRun"}});
+      const msg = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "firstRun"}}});
       await Router.onMessage(msg);
 
       assert.calledOnce(Router._findMessage);
-      assert.deepEqual(Router._findMessage.firstCall.args[2], {trigger: "firstRun"});
+      assert.deepEqual(Router._findMessage.firstCall.args[2], {id: "firstRun"});
     });
     it("consider the trigger when picking a message", async () => {
       let messages = [
-        {id: "foo1", template: "simple_template", bundled: 1, trigger: "foo", content: {title: "Foo1", body: "Foo123-1"}}
+        {id: "foo1", template: "simple_template", bundled: 1, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}}
       ];
 
-      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: "foo"}});
-      let message = await Router._findMessage(messages, target, data.data);
+      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
+      let message = await Router._findMessage(messages, target, data.data.trigger);
       assert.equal(message, messages[0]);
     });
     it("should pick a message with the right targeting and trigger", async () => {
       let messages = [
-        {id: "foo1", template: "simple_template", bundled: 2, trigger: "foo", content: {title: "Foo1", body: "Foo123-1"}},
-        {id: "foo2", template: "simple_template", bundled: 2, trigger: "bar", content: {title: "Foo2", body: "Foo123-2"}},
-        {id: "foo3", template: "simple_template", bundled: 2, trigger: "foo", content: {title: "Foo3", body: "Foo123-3"}}
+        {id: "foo1", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}},
+        {id: "foo2", template: "simple_template", bundled: 2, trigger: {id: "bar"}, content: {title: "Foo2", body: "Foo123-2"}},
+        {id: "foo3", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo3", body: "Foo123-3"}}
       ];
       await Router.setState({messages});
-      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: "foo"}});
-      let {bundle} = await Router._getBundledMessages(messages[0], target, data.data);
+      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
+      let {bundle} = await Router._getBundledMessages(messages[0], target, data.data.trigger);
       assert.equal(bundle.length, 2);
       // it should have picked foo1 and foo3 only
       assert.isTrue(bundle.every(elem => elem.id === "foo1" || elem.id === "foo3"));

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -1,0 +1,133 @@
+import {ASRouterTriggerListeners} from "lib/ASRouterTriggerListeners.jsm";
+
+describe("ASRouterTriggerListeners", () => {
+  let sandbox;
+  let registerWindowNotificationStub;
+  let unregisterWindoNotificationStub;
+  let windowEnumeratorStub;
+  let existingWindow;
+  const triggerHandler = () => {};
+  const openURLListener = ASRouterTriggerListeners.get("openURL");
+  const hosts = ["www.mozilla.com", "www.mozilla.org"];
+
+  function resetEnumeratorStub(windows) {
+    windowEnumeratorStub
+      .withArgs("navigator:browser")
+      .returns({
+        _count: -1,
+        hasMoreElements() { this._count++; return this._count < windows.length; },
+        getNext() { return windows[this._count]; }
+      });
+  }
+
+  beforeEach(async () => {
+    sandbox = sinon.sandbox.create();
+    registerWindowNotificationStub = sandbox.stub(global.Services.ww, "registerNotification");
+    unregisterWindoNotificationStub = sandbox.stub(global.Services.ww, "unregisterNotification");
+    existingWindow = {gBrowser: {addTabsProgressListener: sandbox.stub(), removeTabsProgressListener: sandbox.stub()}};
+    windowEnumeratorStub = sandbox.stub(global.Services.wm, "getEnumerator");
+    resetEnumeratorStub([existingWindow]);
+    sandbox.spy(openURLListener, "init");
+    sandbox.spy(openURLListener, "uninit");
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("openURL listener", () => {
+    it("should exist and initially be uninitialised", () => {
+      assert.ok(openURLListener);
+      assert.notOk(openURLListener._initialized);
+    });
+
+    describe("#init", () => {
+      beforeEach(() => {
+        openURLListener.init(triggerHandler, hosts);
+      });
+      afterEach(() => {
+        openURLListener.uninit();
+      });
+
+      it("should set ._initialized to true and save the triggerHandler and hosts", () => {
+        assert.ok(openURLListener._initialized);
+        assert.deepEqual(openURLListener._hosts, new Set(hosts));
+        assert.equal(openURLListener._triggerHandler, triggerHandler);
+      });
+
+      it("should register an open-window notification", () => {
+        assert.calledOnce(registerWindowNotificationStub);
+        assert.calledWith(registerWindowNotificationStub, openURLListener);
+      });
+
+      it("should add tab progress listeners to all existing browser windows", () => {
+        assert.calledOnce(existingWindow.gBrowser.addTabsProgressListener);
+        assert.calledWithExactly(existingWindow.gBrowser.addTabsProgressListener, openURLListener);
+      });
+
+      it("if already initialised, should only update the trigger handler and add the new hosts", () => {
+        const newHosts = ["www.example.com"];
+        const newTriggerHandler = () => {};
+        resetEnumeratorStub([existingWindow]);
+        registerWindowNotificationStub.reset();
+        existingWindow.gBrowser.addTabsProgressListener.reset();
+
+        openURLListener.init(newTriggerHandler, newHosts);
+        assert.ok(openURLListener._initialized);
+        assert.deepEqual(openURLListener._hosts, new Set([...hosts, ...newHosts]));
+        assert.equal(openURLListener._triggerHandler, newTriggerHandler);
+        assert.notCalled(registerWindowNotificationStub);
+        assert.notCalled(existingWindow.gBrowser.addTabsProgressListener);
+      });
+    });
+
+    describe("#uninit", () => {
+      beforeEach(() => {
+        openURLListener.init(triggerHandler, hosts);
+        // Ensure that the window enumerator will return the existing window for uninit as well
+        resetEnumeratorStub([existingWindow]);
+        openURLListener.uninit();
+      });
+
+      it("should set ._initialized to false and clear the triggerHandler and hosts", () => {
+        assert.notOk(openURLListener._initialized);
+        assert.equal(openURLListener._hosts, null);
+        assert.equal(openURLListener._triggerHandler, null);
+      });
+
+      it("should remove an open-window notification", () => {
+        assert.calledOnce(unregisterWindoNotificationStub);
+        assert.calledWith(unregisterWindoNotificationStub, openURLListener);
+      });
+
+      it("should remove tab progress listeners from all existing browser windows", () => {
+        assert.calledOnce(existingWindow.gBrowser.removeTabsProgressListener);
+        assert.calledWithExactly(existingWindow.gBrowser.removeTabsProgressListener, openURLListener);
+      });
+
+      it("should do nothing if already uninitialised", () => {
+        unregisterWindoNotificationStub.reset();
+        existingWindow.gBrowser.removeTabsProgressListener.reset();
+        resetEnumeratorStub([existingWindow]);
+
+        openURLListener.uninit();
+        assert.notOk(openURLListener._initialized);
+        assert.notCalled(unregisterWindoNotificationStub);
+        assert.notCalled(existingWindow.gBrowser.removeTabsProgressListener);
+      });
+    });
+
+    describe("#onLocationChange", () => {
+      it("should call the ._triggerHandler with the right arguments", () => {
+        const newTriggerHandler = sinon.stub();
+        openURLListener.init(newTriggerHandler, hosts);
+
+        const browser = {messageManager: {}};
+        const webProgress = {isTopLevel: true};
+        const location = "https://www.mozilla.org/something";
+        openURLListener.onLocationChange(browser, webProgress, undefined, {spec: location});
+        assert.calledOnce(newTriggerHandler);
+        assert.calledWithExactly(newTriggerHandler, browser.messageManager, {id: "openURL", param: "www.mozilla.org"});
+      });
+    });
+  });
+});

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -102,6 +102,7 @@ const TEST_GLOBAL = {
   },
   PluralForm: {get() {}},
   Preferences: FakePrefs,
+  PrivateBrowsingUtils: {isWindowPrivate: () => false},
   DownloadsViewUI: {DownloadElementShell},
   Services: {
     locale: {
@@ -178,7 +179,8 @@ const TEST_GLOBAL = {
       createNullPrincipal() {},
       getSystemPrincipal() {}
     },
-    wm: {getMostRecentWindow: () => window},
+    wm: {getMostRecentWindow: () => window, getEnumerator: () => ({hasMoreElements: () => false})},
+    ww: {registerNotification() {}, unregisterNotification() {}},
     appinfo: {appBuildID: "20180710100040"}
   },
   XPCOMUtils: {


### PR DESCRIPTION
In order to support an `openURL` trigger, triggers become (instead of being just strings) objects with an `id` and an optional `param` (in this case the url host name).

`ASRouterTriggerListeners.jsm` has a map of singleton listeners which are initialised or not depending on whether ASRouter has messages that have that particular trigger. Every time ASRouter updates its messages, it checks their triggers to do this un/initialisation of the trigger listeners.

At the moment the only listener is for `openURL`, which listens for webpages being opened with specific host names, but it's set up in a way that allows listeners for new triggers to be added very easily.

You can manually test that the patch works by adding a test message to `OnboardingMessageProvider` such as:
```js
{
  id: "TEST",
  trigger: {
    id: "openURL",
    params: ["www.amazon.com", "www.amazon.co.uk"]
  }
}
```
After putting a breakpoint in the `TRIGGER` case of ASRouter#onMessage in the browser debugger, and then navigating to www.amazon.com or www.amazon.co.uk you should be able to inspect the trigger message that gets sent.