### PR TITLE
Fix Bug 1477631: Allow setting whitelist hosts via prefs

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -484,7 +484,7 @@ class _ASRouter {
 
   _loadSnippetsWhitelistHosts() {
     let additionalHosts = [];
-    const whitelistPrefValue = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_WHITELIST);
+    const whitelistPrefValue = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_WHITELIST, "");
     try {
       additionalHosts = JSON.parse(whitelistPrefValue);
     } catch (e) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -18,10 +18,11 @@ const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 const SNIPPETS_ENDPOINT_PREF = "browser.newtabpage.activity-stream.asrouter.snippetsUrl";
 // List of hosts for endpoints that serve router messages.
 // Key is allowed host, value is a name for the endpoint host.
-const WHITELIST_HOSTS = {
+const DEFAULT_WHITELIST_HOSTS = {
   "activity-stream-icons.services.mozilla.com": "production",
   "snippets-admin.mozilla.org": "preview"
 };
+const SNIPPETS_ENDPOINT_WHITELIST = "browser.newtab.activity-stream.asrouter.whitelistHosts";
 
 const MessageLoaderUtils = {
   /**
@@ -229,6 +230,7 @@ class _ASRouter {
     this.messageChannel.addMessageListener(INCOMING_MESSAGE_NAME, this.onMessage);
     this._addASRouterPrefListener();
     this._storage = storage;
+    this.WHITELIST_HOSTS = this._loadSnippetsWhitelistHosts();
 
     const blockList = await this._storage.get("blockList") || [];
     const impressions = await this._storage.get("impressions") || {};
@@ -468,16 +470,35 @@ class _ASRouter {
   _validPreviewEndpoint(url) {
     try {
       const endpoint = new URL(url);
-      if (!WHITELIST_HOSTS[endpoint.host]) {
+      if (!this.WHITELIST_HOSTS[endpoint.host]) {
         Cu.reportError(`The preview URL host ${endpoint.host} is not in the whitelist.`);
       }
       if (endpoint.protocol !== "https:") {
         Cu.reportError("The URL protocol is not https.");
       }
-      return (endpoint.protocol === "https:" && WHITELIST_HOSTS[endpoint.host]);
+      return (endpoint.protocol === "https:" && this.WHITELIST_HOSTS[endpoint.host]);
     } catch (e) {
       return false;
     }
+  }
+
+  _loadSnippetsWhitelistHosts() {
+    let additionalHosts = [];
+    try {
+      additionalHosts = JSON.parse(Services.prefs.getStringPref(SNIPPETS_ENDPOINT_WHITELIST));
+    } catch (e) {}
+
+    if (!additionalHosts.length) {
+      return DEFAULT_WHITELIST_HOSTS;
+    }
+
+    // If there are additional hosts we want to whitelist, add them as
+    // `preview` so that the updateCycle is 0
+    return additionalHosts.reduce((whitelist_hosts, host) => {
+      whitelist_hosts[host] = "preview";
+      Services.console.logStringMessage(`Adding ${host} to whitelist hosts.`);
+      return whitelist_hosts;
+    }, {...DEFAULT_WHITELIST_HOSTS});
   }
 
   async _addPreviewEndpoint(url) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -484,9 +484,14 @@ class _ASRouter {
 
   _loadSnippetsWhitelistHosts() {
     let additionalHosts = [];
+    const whitelistPrefValue = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_WHITELIST);
     try {
-      additionalHosts = JSON.parse(Services.prefs.getStringPref(SNIPPETS_ENDPOINT_WHITELIST));
-    } catch (e) {}
+      additionalHosts = JSON.parse(whitelistPrefValue);
+    } catch (e) {
+      if (whitelistPrefValue) {
+        Cu.reportError(`Pref ${SNIPPETS_ENDPOINT_WHITELIST} value is not valid JSON`);
+      }
+    }
 
     if (!additionalHosts.length) {
       return DEFAULT_WHITELIST_HOSTS;

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -128,6 +128,22 @@ describe("ASRouter", () => {
       assert.lengthOf(Router.state.providers, length);
       assert.isDefined(provider);
     });
+    it("should load additional whitelisted hosts", async () => {
+      getStringPrefStub.returns("[\"whitelist.com\"]");
+      await createRouterAndInit();
+
+      assert.propertyVal(Router.WHITELIST_HOSTS, "whitelist.com", "preview");
+      // Should still include the defaults
+      assert.lengthOf(Object.keys(Router.WHITELIST_HOSTS), 3);
+    });
+    it("should fallback to defaults if pref parsing fails", async () => {
+      getStringPrefStub.returns("err");
+      await createRouterAndInit();
+
+      assert.lengthOf(Object.keys(Router.WHITELIST_HOSTS), 2);
+      assert.propertyVal(Router.WHITELIST_HOSTS, "snippets-admin.mozilla.org", "preview");
+      assert.propertyVal(Router.WHITELIST_HOSTS, "activity-stream-icons.services.mozilla.com", "production");
+    });
   });
 
   describe("#loadMessagesFromAllProviders", () => {
@@ -143,8 +159,10 @@ describe("ASRouter", () => {
       getStringPrefStub.returns("example.com");
       await createRouterAndInit();
 
-      assert.calledOnce(getStringPrefStub);
+      // Get snippets endpoint url, get the whitelisted hosts for endpoints
+      assert.calledTwice(getStringPrefStub);
       assert.calledWithExactly(getStringPrefStub, "remotePref", "");
+      assert.calledWithExactly(getStringPrefStub, "browser.newtab.activity-stream.asrouter.whitelistHosts");
       assert.isDefined(Router.state.providers.find(p => p.url === "example.com"));
     });
     it("should not trigger an update if not enough time has passed for a provider", async () => {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -162,7 +162,7 @@ describe("ASRouter", () => {
       // Get snippets endpoint url, get the whitelisted hosts for endpoints
       assert.calledTwice(getStringPrefStub);
       assert.calledWithExactly(getStringPrefStub, "remotePref", "");
-      assert.calledWithExactly(getStringPrefStub, "browser.newtab.activity-stream.asrouter.whitelistHosts");
+      assert.calledWithExactly(getStringPrefStub, "browser.newtab.activity-stream.asrouter.whitelistHosts", "");
       assert.isDefined(Router.state.providers.find(p => p.url === "example.com"));
     });
     it("should not trigger an update if not enough time has passed for a provider", async () => {


### PR DESCRIPTION
With this PR you can add additional whitelist hosts via the pref `browser.newtab.activity-stream.asrouter.whitelistHosts`. They are added in addition to the already existing list.

Because this is used for development only the pref **does not come with a default value** (does not exist in about:config), it will have to be added manually. Example value `["gist.github.com", "gist.githubusercontent.com"]`
You also need to restart the Router by flipping `browser.newtabpage.activity-stream.asrouterExperimentEnabled` which I think is acceptable since it's used for development.
Every host added will be of type preview: when adding an endpoint its`updateCycle` will be 0 so that it refreshes on every page load.

If you are trying to add an endpoint that is not in the list you will get an error
<img width="831" alt="screen shot 2018-07-23 at 16 30 10" src="https://user-images.githubusercontent.com/810040/43088397-9424a13c-8e91-11e8-8ef6-9f50e07f4174.png">

There's a confirmation message on success
<img width="838" alt="screen shot 2018-07-23 at 16 30 16" src="https://user-images.githubusercontent.com/810040/43088398-944481f0-8e91-11e8-921c-ffe6f29b8172.png">

Then you will be able to add new endpoints which will show up in the ASRouter admin
<img width="841" alt="screen shot 2018-07-23 at 16 31 12" src="https://user-images.githubusercontent.com/810040/43088400-94600fba-8e91-11e8-8a74-01d2f95b2eee.png">
