### PR TITLE
Fix Bug 1476959 - Cut off tail letters in New Tab page (Highlights section)

### DIFF
--- a/content-src/components/Card/_Card.scss
+++ b/content-src/components/Card/_Card.scss
@@ -247,8 +247,9 @@
       &:not(.no-description) .card-title {
         font-size: $card-title-font-size;
         line-height: $card-title-font-size + 1;
-        max-height: $card-title-font-size + 1;
+        max-height: $card-title-font-size + 5;
         overflow: hidden;
+        padding: 0 0 4px;
         text-overflow: ellipsis;
         white-space: nowrap;
       }


### PR DESCRIPTION
I was actually able to reproduce this on Mac. I gave it a whole extra 4 pixels to be safe.

r? @ncloudioj 

Before:
![before](https://user-images.githubusercontent.com/36629/43154918-e53c298e-8f43-11e8-83e8-6372d37e0d77.png)

After:
![after](https://user-images.githubusercontent.com/36629/43154932-e9de021e-8f43-11e8-96bc-911e84cdbd4e.png)

