### PR TITLE
Fix Bug 1477766 - Display Simplified Onboarding Tour Cards in specific order

### DIFF
--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -7,6 +7,8 @@ Field name | Type     | Required | Description | Example / Note
 `publish_start` | `date` | No | When to start showing the message | `1524474850876`
 `publish_end` | `date` | No | When to stop showing the message | `1524474850876`
 `content` | `object` | Yes | An object containing all variables/props to be rendered in the template. Subset of allowed tags detailed below. | [See example below](#html-subset)
+`bundled` | `integer` | No | The number of messages of the same template this one should be shown with | [See example below](#a-bundled-message-example)
+`order` | `integer` | No | If bundled with other messages of the same template, which order should this one be placed in? Defaults to 0 if no order is desired | [See example below](#a-bundled-message-example)
 `campaign` | `string` | No | Campaign id that the message belongs to | `RustWebAssembly`
 `targeting` | `string` `JEXL` | No | A [JEXL expression](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#jexl-basics) with all targeting information needed in order to decide if the message is shown | Not yet implemented, [Examples](#targeting-attributes)
 `trigger` | `string` | No | An event or condition upon which the message will be immediately shown. This can be combined with `targeting`. Messages that define a trigger will not be shown during non-trigger-based passive message rotation.
@@ -28,6 +30,35 @@ Field name | Type     | Required | Description | Example / Note
     lifetime: 20,
     custom: [{period: "daily", cap: 5}, {period: 3600000, cap: 1}]
   }
+}
+```
+
+### A Bundled Message example
+The following 2 messages have a `bundled` property, indicating that they should be shown together, since they have the same template. The number `2` indicates that this message should be shown in a bundle of 2 messages of the same template. The order property defines that ONBOARDING_2 should be shown after ONBOARDING_3 in the bundle.
+```javascript
+{
+  id: "ONBOARDING_2",
+  template: "onboarding",
+  bundled: 2,
+  order: 2,
+  content: {
+    title: "Private Browsing",
+    body: "Browse by yourself. Private Browsing with Tracking Protection blocks online trackers that follow you around the web."
+  },
+  targeting: "",
+  trigger: "firstRun"
+}
+{
+  id: "ONBOARDING_3",
+  template: "onboarding",
+  bundled: 2,
+  order: 1,
+  content: {
+    title: "Find it faster",
+    body: "Access all of your favorite search engines with a click. Search the whole Web or just one website from the search box."
+  },
+  targeting: "",
+  trigger: "firstRun"
 }
 ```
 

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -21,6 +21,15 @@
             "description": "An id matching an existing Activity Stream Router template",
             "enum": ["simple_snippet"]
           },
+          "bundled": {
+            "type": "integer",
+            "description": "The number of messages of the same template this one should be shown with (optional)"
+          },
+          "order": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "If bundled with other messages of the same template, which order should this one be placed in? (optional - defaults to 0)"
+          },
           "content": {
             "type": "object",
             "description": "An object containing all variables/props to be rendered in the template. See individual template schemas for details."

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -283,8 +283,12 @@ class _ASRouter {
     return message;
   }
 
+  _orderBundle(bundle) {
+    return bundle.sort((a, b) => a.order - b.order);
+  }
+
   async _getBundledMessages(originalMessage, target, data, force = false) {
-    let result = [{content: originalMessage.content, id: originalMessage.id}];
+    let result = [{content: originalMessage.content, id: originalMessage.id, order: originalMessage.order || 0}];
 
     // First, find all messages of same template. These are potential matching targeting candidates
     let bundledMessagesOfSameTemplate = this._getUnblockedMessages()
@@ -309,7 +313,7 @@ class _ASRouter {
         }
         // Only copy the content of the message (that's what the UI cares about)
         // Also delete the message we picked so we don't pick it again
-        result.push({content: message.content, id: message.id});
+        result.push({content: message.content, id: message.id, order: message.order || 0});
         bundledMessagesOfSameTemplate.splice(bundledMessagesOfSameTemplate.findIndex(msg => msg.id === message.id), 1);
         // Stop once we have enough messages to fill a bundle
         if (result.length === originalMessage.bundled) {
@@ -322,7 +326,8 @@ class _ASRouter {
     if (result.length < originalMessage.bundled) {
       return null;
     }
-    return {bundle: result, provider: originalMessage.provider, template: originalMessage.template};
+
+    return {bundle: this._orderBundle(result), provider: originalMessage.provider, template: originalMessage.template};
   }
 
   _getUnblockedMessages() {

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -8,6 +8,7 @@ const ONBOARDING_MESSAGES = [
     id: "ONBOARDING_1",
     template: "onboarding",
     bundled: 3,
+    order: 2,
     content: {
       title: "Private Browsing",
       text: "Browse by yourself. Private Browsing with Tracking Protection blocks online trackers that follow you around the web.",
@@ -21,6 +22,7 @@ const ONBOARDING_MESSAGES = [
     id: "ONBOARDING_2",
     template: "onboarding",
     bundled: 3,
+    order: 3,
     content: {
       title: "Screenshots",
       text: "Take, save and share screenshots - without leaving Firefox. Capture a region or an entire page as you browse. Then save to the web for easy access and sharing.",
@@ -35,6 +37,7 @@ const ONBOARDING_MESSAGES = [
     id: "ONBOARDING_3",
     template: "onboarding",
     bundled: 3,
+    order: 1,
     content: {
       title: "Add-ons",
       text: "Add even more features that make Firefox work harder for you. Compare prices, check the weather or express your personality with a custom theme.",
@@ -50,11 +53,12 @@ const ONBOARDING_MESSAGES = [
     id: "ONBOARDING_4",
     template: "onboarding",
     bundled: 3,
+    order: 1,
     content: {
-      title: "Extensions",
-      text: "Make browsing faster, smarter, or safer with browser apps. Protect passwords, find deals, download videos, and much more. You can even block annoying ads with extensions like Ghostery.",
+      title: "Block Ads with Ghostery",
+      text: "Browse faster, smarter, or safer with extensions like Ghostery, which lets you block annoying ads.",
       icon: "gift",
-      button_label: "Get Ghostery",
+      button_label: "Try It Now",
       button_action: "OPEN_URL",
       button_action_params: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/"
     },

--- a/test/unit/asrouter/constants.js
+++ b/test/unit/asrouter/constants.js
@@ -4,8 +4,8 @@ export const EXPERIMENT_PREF = "asrouterExperimentEnabled";
 
 export const FAKE_LOCAL_MESSAGES = [
   {id: "foo", template: "simple_template", content: {title: "Foo", body: "Foo123"}},
-  {id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}},
-  {id: "foo2", template: "simple_template", bundled: 2, content: {title: "Foo2", body: "Foo123-2"}},
+  {id: "foo1", template: "simple_template", bundled: 2, order: 1, content: {title: "Foo1", body: "Foo123-1"}},
+  {id: "foo2", template: "simple_template", bundled: 2, order: 2, content: {title: "Foo2", body: "Foo123-2"}},
   {id: "bar", template: "fancy_template", content: {title: "Foo", body: "Foo123"}},
   {id: "baz", content: {title: "Foo", body: "Foo123"}}
 ];


### PR DESCRIPTION
Adds an order property to the message, and sorts on that order. Defaults to 0 if no order provided - meaning this bundle doesn't care about this order