### PR TITLE
Fix Bug 1475921 - remove text-transform usage on localized strings (section headers)

### DIFF
--- a/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -8,7 +8,6 @@
     font-size: $section-title-font-size;
     font-weight: bold;
     margin: 0;
-    text-transform: uppercase;
 
     span {
       color: var(--newtab-section-header-text-color);

--- a/content-src/components/TopSites/_TopSites.scss
+++ b/content-src/components/TopSites/_TopSites.scss
@@ -299,7 +299,6 @@ $half-base-gutter: $base-gutter / 2;
     }
 
     .section-title {
-      text-transform: none;
       font-size: 16px;
       margin: 0 0 16px;
     }


### PR DESCRIPTION
There are two more instances of `text-transform: uppercase;` but they are on strings that aren't localized (domain letter fallback and domain names). We can take care of those with `/* eslint-disable */` or possibly `.toUpperCase()` when we add the eslint rule in https://bugzilla.mozilla.org/show_bug.cgi?id=1476450

r? @k88hudson 