### PR TITLE
Bug 1466888 - Empty scrollbar on blank page

### DIFF
--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -21,7 +21,6 @@ body {
   background-color: var(--newtab-background-color);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Ubuntu', 'Helvetica Neue', sans-serif;
   font-size: 16px;
-  overflow-y: auto;
 }
 
 .no-scroll {

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -21,7 +21,7 @@ body {
   background-color: var(--newtab-background-color);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Ubuntu', 'Helvetica Neue', sans-serif;
   font-size: 16px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .no-scroll {


### PR DESCRIPTION
Well, guys, I ve found a problem:
If you open New Tab, and open it's source code, you will see this line:
resource://activity-stream/css/activity-stream.css
In that file you will see this line under body element properories:
overflow-y: scroll;
To prevent the behavior, noticed in this bug, you should change it to auto.