### PR TITLE
Port Bug 1369466 - Change consumers to the new location of RemotePageManager. r=mossop

### DIFF
--- a/lib/ActivityStreamMessageChannel.jsm
+++ b/lib/ActivityStreamMessageChannel.jsm
@@ -5,7 +5,8 @@
 "use strict";
 
 ChromeUtils.import("resource:///modules/AboutNewTab.jsm");
-ChromeUtils.import("resource://gre/modules/RemotePageManager.jsm");
+/* globals RemotePages */ // Remove when updating eslint-plugin-mozilla 0.14.0+
+ChromeUtils.import("resource://gre/modules/remotepagemanager/RemotePageManagerParent.jsm");
 
 const {actionCreators: ac, actionTypes: at, actionUtils: au} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 


### PR DESCRIPTION
r?@piatra  Manually add RemotePages global until eslint-plugin-mozilla is updated.

Simple port of https://hg.mozilla.org/mozilla-central/rev/6aa03eee1597 but needs some fixes until eslint-plugin-mozilla gets the changes from https://hg.mozilla.org/mozilla-central/rev/df67254b8e79 (for modules.json)