### PR TITLE
Bug 1476055 - Add telemetry for JEXL and other targeting errors

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -539,3 +539,20 @@ This reports the user's interaction with Activity Stream Router.
   "event": ["CLICK_BUTTION" | "BLOCK"]
 }
 ```
+
+### Targeting error pings
+
+This reports when an error has occurred when parsing/evaluating a JEXL targeting string in a message.
+
+```js
+{
+  "client_id": "n/a",
+  "action": "asrouter_undesired_event",
+  "addon_version": "20180710100040",
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "locale": "en-US",
+  "message_id": "some_message_id",
+  "event": "TARGETING_EXPRESSION_ERROR",
+  "value": ["MALFORMED_EXPRESSION" | "OTHER_ERROR"]
+}
+```

--- a/lib/ASRouterFeed.jsm
+++ b/lib/ASRouterFeed.jsm
@@ -14,8 +14,11 @@ class ASRouterFeed {
   }
 
   async enable() {
-    await this.router.init(this.store._messageChannel.channel,
-      this.store.dbStorage.getDbTable("snippets"));
+    await this.router.init(
+      this.store._messageChannel.channel,
+      this.store.dbStorage.getDbTable("snippets"),
+      this.store.dispatch
+    );
     // Disable onboarding
     Services.prefs.setBoolPref(ONBOARDING_FINISHED_PREF, true);
   }

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -11,6 +11,8 @@ ChromeUtils.defineModuleGetter(this, "ShellService",
 
 const FXA_USERNAME_PREF = "services.sync.username";
 const ONBOARDING_EXPERIMENT_PREF = "browser.newtabpage.activity-stream.asrouterOnboardingCohort";
+const MOZ_JEXL_FILEPATH = "mozjexl";
+
 // Max possible cap for any message
 const MAX_LIFETIME_CAP = 100;
 const ONE_DAY = 24 * 60 * 60 * 1000;
@@ -141,7 +143,12 @@ const TargetingGetters = {
 this.ASRouterTargeting = {
   Environment: TargetingGetters,
 
-  isMatch(filterExpression, target, context = this.Environment) {
+  ERROR_TYPES: {
+    MALFORMED_EXPRESSION: "MALFORMED_EXPRESSION",
+    OTHER_ERROR: "OTHER_ERROR"
+  },
+
+  isMatch(filterExpression, context = this.Environment) {
     return FilterExpressions.eval(filterExpression, context);
   },
 
@@ -184,46 +191,57 @@ this.ASRouterTargeting = {
   },
 
   /**
+   * checkMessageTargeting - Checks is a message's targeting parameters are satisfied
+   *
+   * @param {*} message An AS router message
+   * @param {obj} context A FilterExpression context
+   * @param {func} onError A function to handle errors (takes two params; error, message)
+   * @returns
+   */
+  async checkMessageTargeting(message, context, onError) {
+    // If no targeting is specified,
+    if (!message.targeting) {
+      return true;
+    }
+    let result;
+    try {
+      result = await this.isMatch(message.targeting, context);
+    } catch (error) {
+      Cu.reportError(error);
+      if (onError) {
+        const type = error.fileName.includes(MOZ_JEXL_FILEPATH) ? this.ERROR_TYPES.MALFORMED_EXPRESSION : this.ERROR_TYPES.OTHER_ERROR;
+        onError(type, error, message);
+      }
+      result = false;
+    }
+    return result;
+  },
+
+  /**
    * findMatchingMessage - Given an array of messages, returns one message
    *                       whos targeting expression evaluates to true
    *
    * @param {Array} messages An array of AS router messages
+   * @param {obj} impressions An object containing impressions, where keys are message ids
+   * @param {trigger} string A trigger expression if a message for that trigger is desired
    * @param {obj|null} context A FilterExpression context. Defaults to TargetingGetters above.
    * @returns {obj} an AS router message
    */
-  async findMatchingMessage({messages, impressions = {}, target, context}) {
+  async findMatchingMessage({messages, impressions = {}, trigger, context, onError}) {
     const arrayOfItems = [...messages];
     let match;
     let candidate;
 
     while (!match && arrayOfItems.length) {
       candidate = removeRandomItemFromArray(arrayOfItems);
-      if (
-        candidate &&
-        this.isBelowFrequencyCap(candidate, impressions[candidate.id]) &&
-        !candidate.trigger &&
-        (!candidate.targeting || await this.isMatch(candidate.targeting, target, context))
-      ) {
-        match = candidate;
-      }
-    }
-    return match;
-  },
 
-  async findMatchingMessageWithTrigger({messages, impressions = {}, target, trigger, context}) {
-    if (!trigger) {
-      return null;
-    }
-    const arrayOfItems = [...messages];
-    let match;
-    let candidate;
-    while (!match && arrayOfItems.length) {
-      candidate = removeRandomItemFromArray(arrayOfItems);
       if (
         candidate &&
-        this.isTriggerMatch(trigger, candidate.trigger) &&
+        (trigger ? this.isTriggerMatch(trigger, candidate.trigger) : !candidate.trigger) &&
         this.isBelowFrequencyCap(candidate, impressions[candidate.id]) &&
-        (!candidate.targeting || await this.isMatch(candidate.targeting, target, context))
+        // If a trigger expression was passed to this function, the message should match it.
+        // Otherwise, we should choose a message with no trigger property (i.e. a message that can show up at any time)
+        await this.checkMessageTargeting(candidate, context, onError)
       ) {
         match = candidate;
       }

--- a/test/unit/asrouter/ASRouterFeed.test.js
+++ b/test/unit/asrouter/ASRouterFeed.test.js
@@ -68,7 +68,7 @@ describe("ASRouterFeed", () => {
     });
     it("should not re-initialize the ASRouter if it is already initialized", async () => {
       // Router starts initialized
-      await Router.init(new FakeRemotePageManager(), storage);
+      await Router.init(new FakeRemotePageManager(), storage, () => {});
       sinon.stub(Router, "init");
       prefs[EXPERIMENT_PREF] = true;
 
@@ -81,7 +81,7 @@ describe("ASRouterFeed", () => {
   describe("#onAction: PREF_CHANGE", () => {
     it("should return early if the pref changed does not enable/disable the router", async () => {
       // Router starts initialized
-      await Router.init(new FakeRemotePageManager(), storage);
+      await Router.init(new FakeRemotePageManager(), storage, () => {});
       sinon.stub(Router, "uninit");
       prefs[EXPERIMENT_PREF] = false;
 
@@ -92,7 +92,7 @@ describe("ASRouterFeed", () => {
     });
     it("should uninitialize the ASRouter if it is already initialized and the experiment pref is false", async () => {
       // Router starts initialized
-      await Router.init(new FakeRemotePageManager(), storage);
+      await Router.init(new FakeRemotePageManager(), storage, () => {});
       sinon.stub(Router, "uninit");
       prefs[EXPERIMENT_PREF] = false;
 
@@ -104,7 +104,7 @@ describe("ASRouterFeed", () => {
   });
   describe("#onAction: UNINIT", () => {
     it("should uninitialize the ASRouter and restore onboarding", async () => {
-      await Router.init(new FakeRemotePageManager(), storage);
+      await Router.init(new FakeRemotePageManager(), storage, () => {});
       sinon.stub(Router, "uninit");
 
       feed.onAction({type: at.UNINIT});


### PR DESCRIPTION
This patch adds telemetry for errors that occur in JEXL string or elsewhere in the targeting environment.

If an error is thrown when a jexl string is being parsed/evaluated, a ping in the following format will be sent:

```json
{
  "client_id": "n/a",
  "action": "asrouter_undesired_event",
  "addon_version": "20180710100040",
  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
  "locale": "en-US",
  "message_id": "some_message_id",
  "event": ["MALFORMED_EXPRESSION" | "OTHER_TARGETING_ERROR"],
}
```

To test this, you can:

1. Set the following prefs in about:config

- `browser.newtabpage.activity-stream.asrouter.snippetsUrl` to `https://gist.githubusercontent.com/k88hudson/bab3cf6e9035d5d0392311ca928480fd/raw`
- `browser.newtabpage.activity-stream.asrouterExperimentEnabled` to `true`
- `browser.ping-centre.log` to `true`
- `browser.newtabpage.activity-stream.telemetry` to `true`

2. Open the new tab a few times until you see an error come up the console (you should see `Invalid expression token: =`)
3. Ensure a `asrouter_undesired_event` event is logged