### PR TITLE
Fix Bug 1478569 - New Action: Show AppMenu

### DIFF
--- a/common/Actions.jsm
+++ b/common/Actions.jsm
@@ -124,6 +124,7 @@ for (const type of [
 const ASRouterActions = {};
 for (const type of [
   "INSTALL_ADDON_FROM_URL",
+  "OPEN_APPLICATIONS_MENU",
   "OPEN_PRIVATE_BROWSER_WINDOW",
   "OPEN_URL",
   "OPEN_ABOUT_PAGE"

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -20,16 +20,19 @@ export const ASRouterUtils = {
     global.RPMRemoveMessageListener(INCOMING_MESSAGE_NAME, listener);
   },
   sendMessage(action) {
-    global.RPMSendAsyncMessage(OUTGOING_MESSAGE_NAME, {
-      type: "USER_ACTION",
-      data: action
-    });
+    global.RPMSendAsyncMessage(OUTGOING_MESSAGE_NAME, action);
   },
   blockById(id) {
     ASRouterUtils.sendMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id}});
   },
   blockBundle(bundle) {
     ASRouterUtils.sendMessage({type: "BLOCK_BUNDLE", data: {bundle}});
+  },
+  executeAction(button_action) {
+    ASRouterUtils.sendMessage({
+      type: "USER_ACTION",
+      data: button_action
+    });
   },
   unblockById(id) {
     ASRouterUtils.sendMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id}});
@@ -217,7 +220,7 @@ export class ASRouterUISurface extends React.PureComponent {
               UISurface="NEWTAB_FOOTER_BAR"
               getNextMessage={ASRouterUtils.getNextMessage}
               onBlock={this.onBlockById(this.state.message.id)}
-              onAction={ASRouterUtils.sendMessage}
+              onAction={ASRouterUtils.executeAction}
               sendUserActionTelemetry={this.sendUserActionTelemetry} />
           </LocalizationProvider>
       </ImpressionsWrapper>);
@@ -228,7 +231,7 @@ export class ASRouterUISurface extends React.PureComponent {
       <OnboardingMessage
         {...this.state.bundle}
         UISurface="NEWTAB_OVERLAY"
-        onAction={ASRouterUtils.sendMessage}
+        onAction={ASRouterUtils.executeAction}
         onDoneButton={this.clearBundle(this.state.bundle.bundle)}
         getNextMessage={ASRouterUtils.getNextMessage}
         sendUserActionTelemetry={this.sendUserActionTelemetry} />);

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -1,5 +1,5 @@
-import {actionCreators as ac, ASRouterActions as ra} from "common/Actions.jsm";
 import {LocalizationProvider, Localized} from "fluent-react";
+import {actionCreators as ac} from "common/Actions.jsm";
 import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
 import {ImpressionsWrapper} from "./components/ImpressionsWrapper/ImpressionsWrapper";
 import {MessageContext} from "fluent";
@@ -20,18 +20,16 @@ export const ASRouterUtils = {
     global.RPMRemoveMessageListener(INCOMING_MESSAGE_NAME, listener);
   },
   sendMessage(action) {
-    global.RPMSendAsyncMessage(OUTGOING_MESSAGE_NAME, action);
+    global.RPMSendAsyncMessage(OUTGOING_MESSAGE_NAME, {
+      type: "USER_ACTION",
+      data: action
+    });
   },
   blockById(id) {
     ASRouterUtils.sendMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id}});
   },
   blockBundle(bundle) {
     ASRouterUtils.sendMessage({type: "BLOCK_BUNDLE", data: {bundle}});
-  },
-  executeAction(button_action) {
-    if (button_action.type in ra) {
-      ASRouterUtils.sendMessage(button_action);
-    }
   },
   unblockById(id) {
     ASRouterUtils.sendMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id}});
@@ -229,7 +227,7 @@ export class ASRouterUISurface extends React.PureComponent {
       <OnboardingMessage
         {...this.state.bundle}
         UISurface="NEWTAB_OVERLAY"
-        onAction={ASRouterUtils.executeAction}
+        onAction={ASRouterUtils.sendMessage}
         onDoneButton={this.clearBundle(this.state.bundle.bundle)}
         getNextMessage={ASRouterUtils.getNextMessage}
         sendUserActionTelemetry={this.sendUserActionTelemetry} />);

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -217,6 +217,7 @@ export class ASRouterUISurface extends React.PureComponent {
               UISurface="NEWTAB_FOOTER_BAR"
               getNextMessage={ASRouterUtils.getNextMessage}
               onBlock={this.onBlockById(this.state.message.id)}
+              onAction={ASRouterUtils.sendMessage}
               sendUserActionTelemetry={this.sendUserActionTelemetry} />
           </LocalizationProvider>
       </ImpressionsWrapper>);

--- a/content-src/asrouter/components/Button/Button.jsx
+++ b/content-src/asrouter/components/Button/Button.jsx
@@ -16,9 +16,9 @@ export const Button = props => {
     style.border = "0";
   }
 
-  return (<a onClick={props.onClick}
+  return (<button onClick={props.onClick}
     className={props.className || "ASRouterButton"}
     style={style}>
     {props.children}
-  </a>);
+  </button>);
 };

--- a/content-src/asrouter/components/Button/Button.jsx
+++ b/content-src/asrouter/components/Button/Button.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import {safeURI} from "../../template-utils";
 
 const ALLOWED_STYLE_TAGS = ["color", "backgroundColor"];
 
@@ -19,8 +18,7 @@ export const Button = props => {
 
   return (<a onClick={props.onClick}
     className={props.className || "ASRouterButton"}
-    style={style}
-    {...(props.url && {href: safeURI(props.url)})}>
+    style={style}>
     {props.children}
   </a>);
 };

--- a/content-src/asrouter/components/Button/Button.jsx
+++ b/content-src/asrouter/components/Button/Button.jsx
@@ -17,10 +17,10 @@ export const Button = props => {
     style.border = "0";
   }
 
-  return (<a href={safeURI(props.url)}
-    onClick={props.onClick}
+  return (<a onClick={props.onClick}
     className={props.className || "ASRouterButton"}
-    style={style}>
+    style={style}
+    {...(props.url && {href: safeURI(props.url)})}>
     {props.children}
   </a>);
 };

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -28,18 +28,14 @@ export class SimpleSnippet extends React.PureComponent {
     return titleIcon ? <span className="titleIcon" style={{backgroundImage: `url("${titleIcon}")`}} /> : null;
   }
 
-  renderButton(className) {
+  renderButton() {
     const {props} = this;
-    const hasLink = props.content.button_url && props.content.button_type === "anchor";
-
-    if (!hasLink && !props.content.button_action) {
+    if (!props.content.button_action) {
       return null;
     }
 
     return (<Button
-      className={className}
       onClick={this.onButtonClick}
-      url={props.content.button_url}
       color={props.content.button_color}
       backgroundColor={props.content.button_background_color}>
       {props.content.button_label}
@@ -48,14 +44,13 @@ export class SimpleSnippet extends React.PureComponent {
 
   render() {
     const {props} = this;
-    const hasButton = props.content.button_url && !props.content.button_type;
     const className = `SimpleSnippet${props.content.tall ? " tall" : ""}`;
     return (<SnippetBase {...props} className={className}>
       <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon" />
       <div>
-        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{props.richText || props.content.text}</p> {this.renderButton("ASRouterAnchor")}
+        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{props.richText || props.content.text}</p>
       </div>
-      {hasButton ? <div>{this.renderButton()}</div> : null}
+      {<div>{this.renderButton()}</div>}
     </SnippetBase>);
   }
 }

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -13,9 +13,7 @@ export class SimpleSnippet extends React.PureComponent {
 
   onButtonClick() {
     this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", id: this.props.UISurface});
-    if (this.props.content.button_action) {
-      this.props.onAction(this.props.content.button_action);
-    }
+    this.props.onAction(this.props.content.button_action);
   }
 
   renderTitle() {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -13,6 +13,9 @@ export class SimpleSnippet extends React.PureComponent {
 
   onButtonClick() {
     this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", id: this.props.UISurface});
+    if (this.props.content.button_action) {
+      this.props.onAction(this.props.content.button_action);
+    }
   }
 
   renderTitle() {
@@ -27,6 +30,12 @@ export class SimpleSnippet extends React.PureComponent {
 
   renderButton(className) {
     const {props} = this;
+    const hasLink = props.content.button_url && props.content.button_type === "anchor";
+
+    if (!hasLink && !props.content.button_action) {
+      return null;
+    }
+
     return (<Button
       className={className}
       onClick={this.onButtonClick}
@@ -39,13 +48,12 @@ export class SimpleSnippet extends React.PureComponent {
 
   render() {
     const {props} = this;
-    const hasLink = props.content.button_url && props.content.button_type === "anchor";
     const hasButton = props.content.button_url && !props.content.button_type;
     const className = `SimpleSnippet${props.content.tall ? " tall" : ""}`;
     return (<SnippetBase {...props} className={className}>
       <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon" />
       <div>
-        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{props.richText || props.content.text}</p> {hasLink ? this.renderButton("ASRouterAnchor") : null}
+        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{props.richText || props.content.text}</p> {this.renderButton("ASRouterAnchor")}
       </div>
       {hasButton ? <div>{this.renderButton()}</div> : null}
     </SnippetBase>);

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -39,6 +39,18 @@
       "type": "string",
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
     },
+    "button_action": {
+      "additionalProperties": {
+        "data": {
+          "additionalProperties": {
+            "target": {
+              "type": "string",
+              "description": "Additional parameters for button action, example which specific menu the button should open"
+            }
+          }
+        }
+      }
+    },
     "button_label": {
       "allOf": [
         {"$ref": "#/definitions/plainText"},
@@ -75,6 +87,7 @@
   "additionalProperties": false,
   "required": ["text"],
   "dependencies": {
+    "button_label": ["button_action"],
     "button_color": ["button_label"],
     "button_background_color": ["button_label"]
   }

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -39,12 +39,6 @@
       "type": "string",
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
     },
-    "button_url": {
-      "allOf": [
-        {"$ref": "#/definitions/link_url"},
-        {"description": "A url, button_label links to this"}
-      ]
-    },
     "button_label": {
       "allOf": [
         {"$ref": "#/definitions/plainText"},
@@ -58,11 +52,6 @@
     "button_background_color": {
       "type": "string",
       "description": "The background color of the button. Valid CSS color."
-    },
-    "button_type": {
-      "type": "string",
-      "enum": ["anchor", "button"],
-      "description": "(**temporary**, until we get html support in text field Bug 1457233) Style for button, either a regular button or a text link."
     },
     "tall": {
       "type": "boolean",
@@ -86,10 +75,7 @@
   "additionalProperties": false,
   "required": ["text"],
   "dependencies": {
-    "button_url": ["button_label"],
-    "button_label": ["button_url"],
-    "button_type": ["button_url"],
-    "button_color": ["button_url"],
-    "button_background_color": ["button_url"]
+    "button_color": ["button_label"],
+    "button_background_color": ["button_label"]
   }
 }

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -40,9 +40,15 @@
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
     },
     "button_action": {
-      "additionalProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["OPEN_APPLICATIONS_MENU"],
+          "description": "The type of action the button should trigger."
+        },
         "data": {
-          "additionalProperties": {
+          "type": "object",
+          "properties": {
             "target": {
               "type": "string",
               "description": "Additional parameters for button action, example which specific menu the button should open"

--- a/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -36,9 +36,7 @@
     margin-inline-end: 20px;
   }
 
-  .ASRouterAnchor {
-    color: inherit;
-    text-decoration: underline;
+  .ASRouterButton {
     cursor: pointer;
   }
 }

--- a/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -39,5 +39,6 @@
   .ASRouterAnchor {
     color: inherit;
     text-decoration: underline;
+    cursor: pointer;
   }
 }

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -6,6 +6,7 @@
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
+ChromeUtils.import("resource:///modules/UITour.jsm");
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 const {ASRouterActions: ra, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {OnboardingMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/OnboardingMessageProvider.jsm", {});
@@ -594,7 +595,7 @@ class _ASRouter {
     }
   }
 
-  async onMessage({data: action, target}) {
+  async handleUserAction({data: action, target}) {
     switch (action.type) {
       case "CONNECT_UI_REQUEST":
       case "GET_NEXT_MESSAGE":
@@ -607,16 +608,6 @@ class _ASRouter {
         // Check if any updates are needed first
         await this.loadMessagesFromAllProviders();
         await this.sendNextMessage(target, (action.data && action.data.trigger) || {});
-        break;
-      case ra.OPEN_PRIVATE_BROWSER_WINDOW:
-        // Forcefully open about:privatebrowsing
-        target.browser.ownerGlobal.OpenBrowserWindow({private: true});
-        break;
-      case ra.OPEN_URL:
-        this.openLinkIn(action.data.url, target, {isPrivate: false, where: "tabshifted"});
-        break;
-      case ra.OPEN_ABOUT_PAGE:
-        this.openLinkIn(`about:${action.data.page}`, target, {isPrivate: false, trusted: true, where: "tab"});
         break;
       case "BLOCK_MESSAGE_BY_ID":
         await this.blockById(action.data.id);
@@ -657,6 +648,31 @@ class _ASRouter {
         break;
       case "IMPRESSION":
         this.addImpression(action.data);
+        break;
+    }
+  }
+
+  async onMessage({data: action, target}) {
+    switch (action.type) {
+      case "USER_ACTION":
+        if (action.data.type in ra) {
+          await this.onMessage({data: action.data, target});
+        } else {
+          await this.handleUserAction({data: action.data, target});
+        }
+        break;
+      case ra.OPEN_PRIVATE_BROWSER_WINDOW:
+        // Forcefully open about:privatebrowsing
+        target.browser.ownerGlobal.OpenBrowserWindow({private: true});
+        break;
+      case ra.OPEN_URL:
+        this.openLinkIn(action.data.url, target, {isPrivate: false, where: "tabshifted"});
+        break;
+      case ra.OPEN_ABOUT_PAGE:
+        this.openLinkIn(`about:${action.data.page}`, target, {isPrivate: false, trusted: true, where: "tab"});
+        break;
+      case ra.OPEN_APPLICATIONS_MENU:
+        UITour.showMenu(target.browser.ownerGlobal, "appMenu");
         break;
       case ra.INSTALL_ADDON_FROM_URL:
         await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -672,7 +672,7 @@ class _ASRouter {
         this.openLinkIn(`about:${action.data.page}`, target, {isPrivate: false, trusted: true, where: "tab"});
         break;
       case ra.OPEN_APPLICATIONS_MENU:
-        UITour.showMenu(target.browser.ownerGlobal, "appMenu");
+        UITour.showMenu(target.browser.ownerGlobal, action.data.target);
         break;
       case ra.INSTALL_ADDON_FROM_URL:
         await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -597,6 +597,32 @@ class _ASRouter {
 
   async handleUserAction({data: action, target}) {
     switch (action.type) {
+      case ra.OPEN_PRIVATE_BROWSER_WINDOW:
+        // Forcefully open about:privatebrowsing
+        target.browser.ownerGlobal.OpenBrowserWindow({private: true});
+        break;
+      case ra.OPEN_URL:
+        this.openLinkIn(action.data.url, target, {isPrivate: false, where: "tabshifted"});
+        break;
+      case ra.OPEN_ABOUT_PAGE:
+        this.openLinkIn(`about:${action.data.page}`, target, {isPrivate: false, trusted: true, where: "tab"});
+        break;
+      case ra.OPEN_APPLICATIONS_MENU:
+        UITour.showMenu(target.browser.ownerGlobal, action.data.target);
+        break;
+      case ra.INSTALL_ADDON_FROM_URL:
+        await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);
+        break;
+    }
+  }
+
+  async onMessage({data: action, target}) {
+    switch (action.type) {
+      case "USER_ACTION":
+        if (action.data.type in ra) {
+          await this.handleUserAction({data: action.data, target});
+        }
+        break;
       case "CONNECT_UI_REQUEST":
       case "GET_NEXT_MESSAGE":
       case "TRIGGER":
@@ -648,34 +674,6 @@ class _ASRouter {
         break;
       case "IMPRESSION":
         this.addImpression(action.data);
-        break;
-    }
-  }
-
-  async onMessage({data: action, target}) {
-    switch (action.type) {
-      case "USER_ACTION":
-        if (action.data.type in ra) {
-          await this.onMessage({data: action.data, target});
-        } else {
-          await this.handleUserAction({data: action.data, target});
-        }
-        break;
-      case ra.OPEN_PRIVATE_BROWSER_WINDOW:
-        // Forcefully open about:privatebrowsing
-        target.browser.ownerGlobal.OpenBrowserWindow({private: true});
-        break;
-      case ra.OPEN_URL:
-        this.openLinkIn(action.data.url, target, {isPrivate: false, where: "tabshifted"});
-        break;
-      case ra.OPEN_ABOUT_PAGE:
-        this.openLinkIn(`about:${action.data.page}`, target, {isPrivate: false, trusted: true, where: "tab"});
-        break;
-      case ra.OPEN_APPLICATIONS_MENU:
-        UITour.showMenu(target.browser.ownerGlobal, action.data.target);
-        break;
-      case ra.INSTALL_ADDON_FROM_URL:
-        await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);
         break;
     }
   }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -22,10 +22,11 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 // Creates a message object that looks like messages returned by
 // RemotePageManager listeners
 function fakeAsyncMessage(action) {
-  return {
-    data: {type: "USER_ACTION", data: action},
-    target: new FakeRemotePageManager()
-  };
+  return {data: action, target: new FakeRemotePageManager()};
+}
+// Create a message that looks like a user action
+function fakeExecuteUserAction(action) {
+  return fakeAsyncMessage({data: action, type: "USER_ACTION"});
 }
 
 describe("ASRouter", () => {
@@ -593,7 +594,7 @@ describe("ASRouter", () => {
   describe("#onMessage: Onboarding actions", () => {
     it("should call OpenBrowserWindow with a private window on OPEN_PRIVATE_BROWSER_WINDOW", async () => {
       let [testMessage] = Router.state.messages;
-      const msg = fakeAsyncMessage({type: "OPEN_PRIVATE_BROWSER_WINDOW", data: testMessage});
+      const msg = fakeExecuteUserAction({type: "OPEN_PRIVATE_BROWSER_WINDOW", data: testMessage});
       await Router.onMessage(msg);
 
       assert.calledWith(msg.target.browser.ownerGlobal.OpenBrowserWindow, {private: true});
@@ -602,7 +603,7 @@ describe("ASRouter", () => {
       sinon.spy(Router, "openLinkIn");
       let [testMessage] = Router.state.messages;
       testMessage.button_action = {type: "OPEN_URL", data: {url: "some/url.com"}};
-      const msg = fakeAsyncMessage(testMessage.button_action);
+      const msg = fakeExecuteUserAction(testMessage.button_action);
       await Router.onMessage(msg);
 
       assert.calledWith(Router.openLinkIn, "some/url.com", msg.target, {isPrivate: false, where: "tabshifted"});
@@ -612,7 +613,7 @@ describe("ASRouter", () => {
       sinon.spy(Router, "openLinkIn");
       let [testMessage] = Router.state.messages;
       testMessage.button_action = {type: "OPEN_ABOUT_PAGE", data: {page: "something"}};
-      const msg = fakeAsyncMessage(testMessage.button_action);
+      const msg = fakeExecuteUserAction(testMessage.button_action);
       await Router.onMessage(msg);
 
       assert.calledWith(Router.openLinkIn, `about:something`, msg.target, {isPrivate: false, trusted: true, where: "tab"});
@@ -623,7 +624,7 @@ describe("ASRouter", () => {
   describe("#onMessage: INSTALL_ADDON_FROM_URL", () => {
     it("should call installAddonFromURL with correct arguments", async () => {
       sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);
-      const msg = fakeAsyncMessage({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com"}});
+      const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com"}});
 
       await Router.onMessage(msg);
 
@@ -652,7 +653,7 @@ describe("ASRouter", () => {
       globals.set("UITour", {showMenu: showMenuStub});
     });
     it("should call UITour.showMenu with the correct params on OPEN_APPLICATIONS_MENU", async () => {
-      const msg = fakeAsyncMessage({type: "OPEN_APPLICATIONS_MENU", data: {target: "appMenu"}});
+      const msg = fakeExecuteUserAction({type: "OPEN_APPLICATIONS_MENU", data: {target: "appMenu"}});
       await Router.onMessage(msg);
 
       assert.calledOnce(showMenuStub);

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -652,7 +652,7 @@ describe("ASRouter", () => {
       globals.set("UITour", {showMenu: showMenuStub});
     });
     it("should call UITour.showMenu with the correct params on OPEN_APPLICATIONS_MENU", async () => {
-      const msg = fakeAsyncMessage({type: "OPEN_APPLICATIONS_MENU"});
+      const msg = fakeAsyncMessage({type: "OPEN_APPLICATIONS_MENU", data: {target: "appMenu"}});
       await Router.onMessage(msg);
 
       assert.calledOnce(showMenuStub);

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -554,8 +554,8 @@ describe("ASRouter", () => {
         {id: "foo1", template: "simple_template", bundled: 1, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}}
       ];
 
-      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
-      let message = await Router._findMessage(messages, target, data.data.data.trigger);
+      const {target} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
+      let message = await Router._findMessage(messages, target, {id: "foo"});
       assert.equal(message, messages[0]);
     });
     it("should pick a message with the right targeting and trigger", async () => {
@@ -565,8 +565,8 @@ describe("ASRouter", () => {
         {id: "foo3", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo3", body: "Foo123-3"}}
       ];
       await Router.setState({messages});
-      const {target, data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
-      let {bundle} = await Router._getBundledMessages(messages[0], target, data.data.data.trigger);
+      const {target} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
+      let {bundle} = await Router._getBundledMessages(messages[0], target, {id: "foo"});
       assert.equal(bundle.length, 2);
       // it should have picked foo1 and foo3 only
       assert.isTrue(bundle.every(elem => elem.id === "foo1" || elem.id === "foo3"));

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -91,15 +91,6 @@ describe("ASRouterUISurface", () => {
   });
 
   describe("snippets", () => {
-    it("should send correct event and source when snippet link is clicked", () => {
-      const content = {button_url: "https://foo.com", button_type: "anchor", button_label: "foo", ...FAKE_MESSAGE.content};
-      const message = Object.assign({}, FAKE_MESSAGE, {content});
-      wrapper.setState({message});
-
-      wrapper.find("a.ASRouterAnchor").simulate("click");
-      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "event", "CLICK_BUTTON");
-      assert.propertyVal(ASRouterUtils.sendTelemetry.firstCall.args[0], "source", "NEWTAB_FOOTER_BAR");
-    });
     it("should send correct event and source when snippet is blocked", () => {
       wrapper.setState({message: FAKE_MESSAGE});
 

--- a/test/unit/asrouter/templates/SimpleSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SimpleSnippet.test.jsx
@@ -37,7 +37,7 @@ describe("SimpleSnippet", () => {
   it("should render .button_label and default className", () => {
     const wrapper = mountAndCheckProps({
       button_label: "Click here",
-      button_action: {type: "foo", data: {target: "bar"}}
+      button_action: {type: "OPEN_APPLICATIONS_MENU", data: {target: "appMenu"}}
     });
 
     const button = wrapper.find("button.ASRouterButton");

--- a/test/unit/asrouter/templates/SimpleSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SimpleSnippet.test.jsx
@@ -34,21 +34,14 @@ describe("SimpleSnippet", () => {
     const wrapper = mountAndCheckProps({icon: "data:image/gif;base64,R0lGODl"});
     assert.equal(wrapper.find(".icon").prop("src"), "data:image/gif;base64,R0lGODl");
   });
-  it("should render .button_url and .button_label", () => {
-    const wrapper = mountAndCheckProps({button_label: "Click here", button_url: "http://foo.com"});
-    const button = wrapper.find("a");
+  it("should render .button_label and default className", () => {
+    const wrapper = mountAndCheckProps({
+      button_label: "Click here",
+      button_action: {type: "foo", data: {target: "bar"}}
+    });
+
+    const button = wrapper.find("button.ASRouterButton");
     assert.equal(button.text(), "Click here");
-    assert.equal(button.prop("href"), "http://foo.com");
-  });
-  it("should render .button_url and .button_label", () => {
-    const wrapper = mountAndCheckProps({button_label: "Click here", button_url: "http://foo.com"});
-    const button = wrapper.find("a");
-    assert.equal(button.text(), "Click here");
-    assert.equal(button.prop("href"), "http://foo.com");
-  });
-  it("should render button with an ASRouterAnchor class if .button_type is anchor", () => {
-    const wrapper = mountAndCheckProps({button_label: "Click here", button_url: "http://foo.com", button_type: "anchor"});
-    const button = wrapper.find("a");
-    assert.equal(button.prop("className"), "ASRouterAnchor");
+    assert.equal(button.prop("className"), "ASRouterButton");
   });
 });


### PR DESCRIPTION
Some steps in order to test this.
1. Whitelist gist.githubusercontent.com
    1. set `browser.newtab.activity-stream.asrouter.whitelistHosts` to `browser.newtab.activity-stream.asrouter.whitelistHosts`
2. Navigate to about:newtab?endpoint=https://gist.githubusercontent.com/piatra/70234f08696c0a0509d7ba5568cd830f/raw/41338334ba7e523020b0ea9a875f872ccb050633/messages.json

The snippet should have a Learn more button that opens the browser menu.

Exposed `sendMessage` method to snippet messages. It can only be triggered if the messages contains a `button_action`. Need to confirm that regular snippet links don't trigger actions but it didn't seem like the case from the examples.

The snippet example served by our endpoint `https://activity-stream-icons.services.mozilla.com/v1/messages.json.br` need to be updated to include the fluent-link-markup. I will follow up on this.

Removed the link option for snippet button and updated the snippet schema for the new payload.