### PR TITLE
Bug 1478930 - ja-JP-mac builds incorrectly use ja strings

### DIFF
--- a/aboutNewTabService.js
+++ b/aboutNewTabService.js
@@ -20,7 +20,7 @@ const TOPIC_CONTENT_DOCUMENT_INTERACTIVE = "content-document-interactive";
 
 // Automated tests ensure packaged locales are in this list. Copied output of:
 // https://github.com/mozilla/activity-stream/blob/master/bin/render-activity-stream-html.js
-const ACTIVITY_STREAM_LOCALES = "en-US ach an ar ast az be bg bn-BD bn-IN br bs ca cak crh cs cy da de dsb el en-CA en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hu hy-AM ia id it ja ja-JP-mac ka kab kk km kn ko lij lo lt ltg lv mai mk ml mr ms my nb-NO ne-NP nl nn-NO oc pa-IN pl pt-BR pt-PT rm ro ru si sk sl sq sr sv-SE ta te th tl tr uk ur uz vi zh-CN zh-TW".split(" ");
+const ACTIVITY_STREAM_BCP47 = "en-US ach an ar ast az be bg bn-BD bn-IN br bs ca cak crh cs cy da de dsb el en-CA en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hu hy-AM ia id it ja ja-JP-macos ka kab kk km kn ko lij lo lt ltg lv mai mk ml mr ms my nb-NO ne-NP nl nn-NO oc pa-IN pl pt-BR pt-PT rm ro ru si sk sl sq sr sv-SE ta te th tl tr uk ur uz vi zh-CN zh-TW".split(" ");
 
 const ABOUT_URL = "about:newtab";
 const BASE_URL = "resource://activity-stream/";
@@ -309,11 +309,14 @@ AboutNewTabService.prototype = {
   get activityStreamLocale() {
     // Pick the best available locale to match the app locales
     return Services.locale.negotiateLanguages(
-      Services.locale.getAppLocalesAsLangTags(),
-      ACTIVITY_STREAM_LOCALES,
+      Services.locale.getAppLocalesAsBCP47(),
+      ACTIVITY_STREAM_BCP47,
       // defaultLocale's strings aren't necessarily packaged, but en-US' are
-      "en-US"
-    )[0];
+      "en-US",
+      Services.locale.langNegStrategyLookup
+    // Convert the BCP47 to lang tag, which is what is used in our paths, as a
+    // workaround for bug 1478930 negotiating incorrectly with lang tags
+    )[0].replace(/^(ja-JP-mac)os$/, "$1");
   },
 
   resetNewTabURL() {

--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -245,8 +245,11 @@ function main() { // eslint-disable-line max-statements
     console.log("\x1b[33m", `Skipped the following locales because they are not in CENTRAL_LOCALES: ${extraLocales.join(", ")}`, "\x1b[0m");
   }
 
+  // Convert ja-JP-mac lang tag to ja-JP-macos bcp47 to work around bug 1478930
+  const bcp47String = localizedLocales.join(" ").replace(/(ja-JP-mac)/, "$1os");
+
   // Provide some help to copy/paste locales if tests are failing
-  console.log(`\nIf aboutNewTabService tests are failing for unexpected locales, make sure its list is updated:\nconst ACTIVITY_STREAM_LOCALES = "${localizedLocales.join(" ")}".split(" ");`);
+  console.log(`\nIf aboutNewTabService tests are failing for unexpected locales, make sure its list is updated:\nconst ACTIVITY_STREAM_BCP47 = "${bcp47String}".split(" ");`);
 }
 
 main();

--- a/test/browser/browser_packaged_as_locales.js
+++ b/test/browser/browser_packaged_as_locales.js
@@ -59,7 +59,7 @@ add_task(async function test_all_packaged_locales() {
       const locale = file.replace("/", "");
       if (locale !== "static") {
         const url = await getUrlForLocale(locale);
-        Assert[locale === "en-US" ? "equal" : "notEqual"](url, DEFAULT_URL, `can reference "${locale}" files`);
+        Assert.equal(url, DEFAULT_URL.replace("en-US", locale), `can reference "${locale}" files`);
 
         // Specially remember if we saw an ID locale packaged as it can be
         // easily ignored by source control, e.g., .gitignore


### PR DESCRIPTION
r?@sarracini Use BCP47 instead of lang tags for negotiation and switch back to lang tags for paths. As suggested in https://bugzilla.mozilla.org/show_bug.cgi?id=1478930#c7

(Not "Fix"-ing as looks like the bug will be kept open for fixing the underlying negotiate issue.)