### PR TITLE
Bug 1479606 - Content process getAppLocalesAsBCP47 returns "ja-JP-mac"

### DIFF
--- a/aboutNewTabService.js
+++ b/aboutNewTabService.js
@@ -309,7 +309,9 @@ AboutNewTabService.prototype = {
   get activityStreamLocale() {
     // Pick the best available locale to match the app locales
     return Services.locale.negotiateLanguages(
-      Services.locale.getAppLocalesAsBCP47(),
+      // Fix up incorrect BCP47 that are actually lang tags as a workaround for
+      // bug 1479606 returning the wrong values in the content process
+      Services.locale.getAppLocalesAsBCP47().map(l => l.replace(/^(ja-JP-mac)$/, "$1os")),
       ACTIVITY_STREAM_BCP47,
       // defaultLocale's strings aren't necessarily packaged, but en-US' are
       "en-US",


### PR DESCRIPTION
r?@sarracini Manually convert to BCP47 to avoid wrong locale in content process

This is a temporary workaround until https://bugzilla.mozilla.org/show_bug.cgi?id=1479606 is fixed, but the full fix there is unlikely to be uplifted to beta 62, so we'll use this to uplift as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1478183