### PR TITLE
Fix Bug 1470211 - Dismissing a Bookmarked highlight also dismissed a Saved To Pocket highlight of the same content - Part 2

### DIFF
--- a/content-src/lib/link-menu-options.js
+++ b/content-src/lib/link-menu-options.js
@@ -67,7 +67,7 @@ export const LinkMenuOptions = {
     icon: "dismiss",
     action: ac.AlsoToMain({
       type: at.BLOCK_URL,
-      data: {url: site.url, pocket_id: site.pocket_id}
+      data: {url: site.open_url || site.url, pocket_id: site.pocket_id}
     }),
     impression: ac.ImpressionStats({
       source: eventSource,


### PR DESCRIPTION
This needs part 1 to land in order to actually work. See attachment on bug 1470211 for part 1
https://reviewboard.mozilla.org/r/260524/diff/1#index_header

STR:
1. go to a page and  pocket it, then bookmark it
2. open a new tab, see that there is both a pocket card and a bookmark card for that page (lets call this site 1)
3. go to a different page and pocket it, then bookmark it
4. open a new tab, see that there is both a pocket card and a bookmark card for that page (lets call this site 2)
_Note: At this point you should have 4 highlights from 2 different sites - 2 bookmarks and 2 pocket items_
5. dismiss **pocket** card from site 1 - see that the corresponding bookmark card of site 1 is still there
6. dismiss the **bookmark** card from site 2 - see that the corresponding pocket card of site 2 is still there