### PR TITLE
Fix Bug 1479458 - Spocs updating when pref changes from a shield study

### DIFF
--- a/content-src/components/Base/Base.jsx
+++ b/content-src/components/Base/Base.jsx
@@ -48,9 +48,29 @@ export class _Base extends React.PureComponent {
     this.updateTheme();
   }
 
-  componentWillUpdate({App}) {
+  hasTopStoriesSectionChanged(nextProps) {
+    const nPropsSections = nextProps.Sections.find(section => section.id === "topstories");
+    const tPropsSections = this.props.Sections.find(section => section.id === "topstories");
+    if (nPropsSections && nPropsSections.options) {
+      if (!tPropsSections || !tPropsSections.options) {
+        return true;
+      }
+      if (nPropsSections.options.show_spocs !== tPropsSections.options.show_spocs) {
+        return true;
+      }
+      if (nPropsSections.options.stories_endpoint !== tPropsSections.options.stories_endpoint) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  componentWillUpdate(nextProps) {
     this.updateTheme();
-    this.sendNewTabRehydrated(App);
+    if (this.hasTopStoriesSectionChanged(nextProps)) {
+      this.renderNotified = false;
+    }
+    this.sendNewTabRehydrated(nextProps.App);
   }
 
   updateTheme() {
@@ -154,4 +174,4 @@ export class BaseContent extends React.PureComponent {
   }
 }
 
-export const Base = connect(state => ({App: state.App, Prefs: state.Prefs}))(_Base);
+export const Base = connect(state => ({App: state.App, Prefs: state.Prefs, Sections: state.Sections}))(_Base);

--- a/lib/SectionsManager.jsm
+++ b/lib/SectionsManager.jsm
@@ -422,7 +422,7 @@ class SectionsFeed {
     this.store.dispatch(ac.SetPref("sectionOrder", orderedSections.join(",")));
   }
 
-  onAction(action) {
+  async onAction(action) {
     switch (action.type) {
       case at.INIT:
         SectionsManager.onceInitialized(this.init);
@@ -435,7 +435,7 @@ class SectionsFeed {
         if (action.data) {
           const matched = action.data.name.match(/^(feeds.section.(\S+)).options$/i);
           if (matched) {
-            SectionsManager.addBuiltInSection(matched[1], action.data.value);
+            await SectionsManager.addBuiltInSection(matched[1], action.data.value);
             this.store.dispatch({type: at.SECTION_OPTIONS_CHANGED, data: matched[2]});
           }
         }

--- a/lib/TopStoriesFeed.jsm
+++ b/lib/TopStoriesFeed.jsm
@@ -35,33 +35,52 @@ this.TopStoriesFeed = class TopStoriesFeed {
     this._prefs = new Prefs();
   }
 
-  init() {
-    const initFeed = () => {
-      SectionsManager.enableSection(SECTION_ID);
-      try {
-        const {options} = SectionsManager.sections.get(SECTION_ID);
-        const apiKey = this.getApiKeyFromPref(options.api_key_pref);
-        this.stories_endpoint = this.produceFinalEndpointUrl(options.stories_endpoint, apiKey);
-        this.topics_endpoint = this.produceFinalEndpointUrl(options.topics_endpoint, apiKey);
-        this.read_more_endpoint = options.read_more_endpoint;
-        this.stories_referrer = options.stories_referrer;
-        this.personalized = options.personalized;
-        this.show_spocs = options.show_spocs;
-        this.maxHistoryQueryResults = options.maxHistoryQueryResults;
-        this.storiesLastUpdated = 0;
-        this.topicsLastUpdated = 0;
-        this.domainAffinitiesLastUpdated = 0;
+  async onInit() {
+    SectionsManager.enableSection(SECTION_ID);
+    try {
+      const {options} = SectionsManager.sections.get(SECTION_ID);
+      const apiKey = this.getApiKeyFromPref(options.api_key_pref);
+      // Set this to true if we're not loading from cache.
+      let shouldBroadcast = false;
+      this.stories_endpoint = this.produceFinalEndpointUrl(options.stories_endpoint, apiKey);
+      this.topics_endpoint = this.produceFinalEndpointUrl(options.topics_endpoint, apiKey);
+      this.read_more_endpoint = options.read_more_endpoint;
+      this.stories_referrer = options.stories_referrer;
+      this.personalized = options.personalized;
+      this.show_spocs = options.show_spocs;
+      this.maxHistoryQueryResults = options.maxHistoryQueryResults;
+      this.storiesLastUpdated = 0;
+      this.topicsLastUpdated = 0;
+      this.storiesLoaded = false;
+      this.domainAffinitiesLastUpdated = 0;
 
-        this.loadCachedData();
-        this.fetchStories();
-        this.fetchTopics();
-
-        Services.obs.addObserver(this, "idle-daily");
-      } catch (e) {
-        Cu.reportError(`Problem initializing top stories feed: ${e.message}`);
+      // Cache is used for new page loads, which shouldn't have changed data.
+      // If we have changed data, cache should be cleared,
+      // and last updated should be 0, and we can fetch.
+      // Think there is a bug here.
+      await this.loadCachedData();
+      if (this.storiesLastUpdated === 0) {
+        shouldBroadcast = true;
+        await this.fetchStories();
       }
-    };
-    SectionsManager.onceInitialized(initFeed);
+      if (this.topicsLastUpdated === 0) {
+        shouldBroadcast = true;
+        await this.fetchTopics();
+      }
+      this.doContentUpdate(shouldBroadcast);
+      this.storiesLoaded = true;
+
+      // This is filtered so an update function can return true to retry on the next run
+      this.contentUpdateQueue = this.contentUpdateQueue.filter(update => update());
+
+      Services.obs.addObserver(this, "idle-daily");
+    } catch (e) {
+      Cu.reportError(`Problem initializing top stories feed: ${e.message}`);
+    }
+  }
+
+  init() {
+    SectionsManager.onceInitialized(this.onInit.bind(this));
   }
 
   observe(subject, topic, data) {
@@ -73,8 +92,24 @@ this.TopStoriesFeed = class TopStoriesFeed {
   }
 
   uninit() {
+    this.storiesLoaded = false;
+    this.cache.set("stories", {});
+    this.cache.set("topics", {});
     Services.obs.removeObserver(this, "idle-daily");
     SectionsManager.disableSection(SECTION_ID);
+  }
+
+  doContentUpdate(shouldBroadcast) {
+    let updateProps = {};
+    if (this.stories) {
+      updateProps.rows = this.stories;
+    }
+    if (this.topics) {
+      Object.assign(updateProps, {topics: this.topics, read_more_endpoint: this.read_more_endpoint});
+    }
+
+    // We should only be calling this once per init.
+    this.dispatchUpdateEvent(shouldBroadcast, updateProps);
   }
 
   async fetchStories() {
@@ -97,13 +132,8 @@ this.TopStoriesFeed = class TopStoriesFeed {
         this.spocs = this.transform(body.spocs).filter(s => s.score >= s.min_score);
         this.cleanUpCampaignImpressionPref();
       }
-
-      this.dispatchUpdateEvent(this.storiesLastUpdated, {rows: this.stories});
       this.storiesLastUpdated = Date.now();
       body._timestamp = this.storiesLastUpdated;
-      // This is filtered so an update function can return true to retry on the next run
-      this.contentUpdateQueue = this.contentUpdateQueue.filter(update => update());
-
       this.cache.set("stories", body);
     } catch (error) {
       Cu.reportError(`Failed to fetch content: ${error.message}`);
@@ -123,11 +153,11 @@ this.TopStoriesFeed = class TopStoriesFeed {
     if (stories && stories.length > 0 && this.storiesLastUpdated === 0) {
       this.updateSettings(data.stories.settings);
       const rows = this.transform(stories);
-      this.dispatchUpdateEvent(this.storiesLastUpdated, {rows});
+      this.stories = rows;
       this.storiesLastUpdated = data.stories._timestamp;
     }
     if (topics && topics.length > 0 && this.topicsLastUpdated === 0) {
-      this.dispatchUpdateEvent(this.topicsLastUpdated, {topics, read_more_endpoint: this.read_more_endpoint});
+      this.topics = topics;
       this.topicsLastUpdated = data.topics._timestamp;
     }
   }
@@ -169,7 +199,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
       const body = await response.json();
       const {topics} = body;
       if (topics) {
-        this.dispatchUpdateEvent(this.topicsLastUpdated, {topics, read_more_endpoint: this.read_more_endpoint});
+        this.topics = topics;
         this.topicsLastUpdated = Date.now();
         body._timestamp = this.topicsLastUpdated;
         this.cache.set("topics", body);
@@ -179,8 +209,8 @@ this.TopStoriesFeed = class TopStoriesFeed {
     }
   }
 
-  dispatchUpdateEvent(lastUpdated, data) {
-    SectionsManager.updateSection(SECTION_ID, data, lastUpdated === 0);
+  dispatchUpdateEvent(shouldBroadcast, data) {
+    SectionsManager.updateSection(SECTION_ID, data, shouldBroadcast);
   }
 
   compareScore(a, b) {
@@ -320,7 +350,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
       return false;
     };
 
-    if (this.stories) {
+    if (this.storiesLoaded) {
       updateContent();
     } else {
       // Delay updating tab content until initial data has been fetched
@@ -448,18 +478,20 @@ this.TopStoriesFeed = class TopStoriesFeed {
     this.init();
   }
 
-  onAction(action) {
+  async onAction(action) {
     switch (action.type) {
       case at.INIT:
         this.init();
         break;
       case at.SYSTEM_TICK:
         if (Date.now() - this.storiesLastUpdated >= STORIES_UPDATE_TIME) {
-          this.fetchStories();
+          await this.fetchStories();
         }
         if (Date.now() - this.topicsLastUpdated >= TOPICS_UPDATE_TIME) {
-          this.fetchTopics();
+          await this.fetchTopics();
         }
+
+        this.doContentUpdate(false);
         break;
       case at.UNINIT:
         this.uninit();

--- a/test/unit/content-src/components/Base.test.jsx
+++ b/test/unit/content-src/components/Base.test.jsx
@@ -27,6 +27,30 @@ describe("<Base>", () => {
     assert.equal("NEW_TAB_REHYDRATED", action.type);
   });
 
+  it("should also fire NEW_TAB_REHYDRATED event when a section changes", () => {
+    const dispatch = sinon.spy();
+    const wrapper = shallow(<Base {...Object.assign({}, DEFAULT_PROPS, {
+      dispatch,
+      Sections: [{id: "topstories", options: {show_spocs: false}}]
+    })} />);
+
+    sinon.spy(wrapper.instance(), "hasTopStoriesSectionChanged");
+    wrapper.setProps(Object.assign({}, DEFAULT_PROPS, {
+      Sections: [{
+        id: "topstories",
+        options: {
+          show_spocs: true,
+          stories_endpoint: "https://foo.json"
+        }
+      }]
+    }));
+
+    assert.calledOnce(wrapper.instance().hasTopStoriesSectionChanged);
+    assert.calledTwice(dispatch);
+    const [action] = dispatch.firstCall.args;
+    assert.equal("NEW_TAB_REHYDRATED", action.type);
+  });
+
   it("should render an ErrorBoundary with class base-content-fallback", () => {
     const wrapper = shallow(<Base {...DEFAULT_PROPS} />);
 

--- a/test/unit/lib/SectionsManager.test.js
+++ b/test/unit/lib/SectionsManager.test.js
@@ -570,8 +570,8 @@ describe("SectionsFeed", () => {
       assert.calledOnce(SectionsManager.addBuiltInSection);
       assert.calledWith(SectionsManager.addBuiltInSection, "feeds.section.topstories", "foo");
     });
-    it("should fire SECTION_OPTIONS_UPDATED on suitable PREF_CHANGED events", () => {
-      feed.onAction({type: "PREF_CHANGED", data: {name: "feeds.section.topstories.options", value: "foo"}});
+    it("should fire SECTION_OPTIONS_UPDATED on suitable PREF_CHANGED events", async () => {
+      await feed.onAction({type: "PREF_CHANGED", data: {name: "feeds.section.topstories.options", value: "foo"}});
       assert.calledOnce(feed.store.dispatch);
       const [action] = feed.store.dispatch.firstCall.args;
       assert.equal(action.type, "SECTION_OPTIONS_CHANGED");

--- a/test/unit/lib/TopStoriesFeed.test.js
+++ b/test/unit/lib/TopStoriesFeed.test.js
@@ -90,8 +90,8 @@ describe("Top Stories Feed", () => {
       instance.onAction({type: at.INIT});
       assert.calledOnce(sectionsManagerStub.onceInitialized);
     });
-    it("should initialize endpoints based on options", () => {
-      instance.onAction({type: at.INIT});
+    it("should initialize endpoints based on options", async () => {
+      await instance.onInit();
       assert.equal("https://somedomain.org/stories?key=test-api-key", instance.stories_endpoint);
       assert.equal("https://somedomain.org/referrer", instance.stories_referrer);
       assert.equal("https://somedomain.org/topics?key=test-api-key", instance.topics_endpoint);
@@ -101,16 +101,19 @@ describe("Top Stories Feed", () => {
       assert.calledOnce(sectionsManagerStub.enableSection);
       assert.calledWith(sectionsManagerStub.enableSection, SECTION_ID);
     });
-    it("should fetch stories on init", () => {
-      instance.fetchStories = sinon.spy();
-      instance.fetchTopics = sinon.spy();
+    it("init should fire onInit", () => {
+      instance.onInit = sinon.spy();
       instance.onAction({type: at.INIT});
+      assert.calledOnce(instance.onInit);
+    });
+    it("should fetch stories on init", async () => {
+      instance.fetchStories = sinon.spy();
+      await instance.onInit();
       assert.calledOnce(instance.fetchStories);
     });
-    it("should fetch topics on init", () => {
-      instance.fetchStories = sinon.spy();
+    it("should fetch topics on init", async () => {
       instance.fetchTopics = sinon.spy();
-      instance.onAction({type: at.INIT});
+      await instance.onInit();
       assert.calledOnce(instance.fetchTopics);
     });
     it("should not fetch if endpoint not configured", () => {
@@ -139,9 +142,9 @@ describe("Top Stories Feed", () => {
 
       assert.called(Cu.reportError);
     });
-    it("should load data from cache on init", () => {
+    it("should load data from cache on init", async () => {
       instance.loadCachedData = sinon.spy();
-      instance.onAction({type: at.INIT});
+      await instance.onInit();
       assert.calledOnce(instance.loadCachedData);
     });
   });
@@ -151,10 +154,21 @@ describe("Top Stories Feed", () => {
       assert.calledOnce(sectionsManagerStub.disableSection);
       assert.calledWith(sectionsManagerStub.disableSection, SECTION_ID);
     });
+    it("should unload stories", () => {
+      instance.storiesLoaded = true;
+      instance.onAction({type: at.UNINIT});
+      assert.equal(instance.storiesLoaded, false);
+    });
   });
   describe("#fetch", () => {
     it("should fetch stories, send event and cache results", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          stories_endpoint: "stories-endpoint",
+          stories_referrer: "referrer"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -186,11 +200,9 @@ describe("Top Stories Feed", () => {
         "spoc_meta": {}
       }];
 
-      instance.stories_endpoint = "stories-endpoint";
-      instance.stories_referrer = "referrer";
       instance.cache.set = sinon.spy();
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       assert.calledOnce(fetchStub);
       assert.calledOnce(shortURLStub);
@@ -202,6 +214,12 @@ describe("Top Stories Feed", () => {
     });
     it("should use domain as hostname, if present", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          stories_endpoint: "stories-endpoint",
+          stories_referrer: "referrer"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -234,11 +252,9 @@ describe("Top Stories Feed", () => {
         "spoc_meta": {}
       }];
 
-      instance.stories_endpoint = "stories-endpoint";
-      instance.stories_referrer = "referrer";
       instance.cache.set = sinon.spy();
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       assert.calledOnce(fetchStub);
       assert.notCalled(shortURLStub);
@@ -250,34 +266,37 @@ describe("Top Stories Feed", () => {
     });
     it("should report error for unexpected stories response", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {options: {stories_endpoint: "stories-endpoint"}});
       globals.set("fetch", fetchStub);
       globals.sandbox.spy(global.Cu, "reportError");
 
-      instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: false, status: 400});
-      await instance.fetchStories();
+      await instance.onInit();
 
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, instance.stories_endpoint);
-      assert.notCalled(sectionsManagerStub.updateSection);
+      assert.equal(instance.storiesLastUpdated, 0);
       assert.called(Cu.reportError);
     });
     it("should exclude blocked (dismissed) URLs", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {options: {stories_endpoint: "stories-endpoint"}});
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: site => site.url === "blocked"}});
 
       const response = {"recommendations": [{"url": "blocked"}, {"url": "not_blocked"}]};
-      instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
+      // Issue!
+      // Should actually be fixed when cache is fixed.
       assert.calledOnce(sectionsManagerStub.updateSection);
       assert.equal(sectionsManagerStub.updateSection.firstCall.args[1].rows.length, 1);
       assert.equal(sectionsManagerStub.updateSection.firstCall.args[1].rows[0].url, "not_blocked");
     });
     it("should mark stories as new", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {options: {stories_endpoint: "stories-endpoint"}});
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
       clock.restore();
@@ -289,10 +308,9 @@ describe("Top Stories Feed", () => {
         ]
       };
 
-      instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
 
-      await instance.fetchStories();
+      await instance.onInit();
       assert.calledOnce(sectionsManagerStub.updateSection);
       assert.equal(sectionsManagerStub.updateSection.firstCall.args[1].rows.length, 3);
       assert.equal(sectionsManagerStub.updateSection.firstCall.args[1].rows[0].type, "now");
@@ -301,6 +319,7 @@ describe("Top Stories Feed", () => {
     });
     it("should fetch topics, send event and cache results", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {options: {topics_endpoint: "topics-endpoint"}});
       globals.set("fetch", fetchStub);
 
       const response = {"topics": [{"name": "topic1", "url": "url-topic1"}, {"name": "topic2", "url": "url-topic2"}]};
@@ -312,10 +331,9 @@ describe("Top Stories Feed", () => {
         "url": "url-topic2"
       }];
 
-      instance.topics_endpoint = "topics-endpoint";
       instance.cache.set = sinon.spy();
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchTopics();
+      await instance.onInit();
 
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, instance.topics_endpoint);
@@ -465,7 +483,7 @@ describe("Top Stories Feed", () => {
       assert.calledWith(instance._prefs.set.firstCall, REC_IMPRESSION_TRACKING_PREF, JSON.stringify({3: 1}));
     });
   });
-  describe("#spocs", () => {
+  describe("#spocs", async () => {
     it("should insert spoc with provided probability", async () => {
       let fetchStub = globals.sandbox.stub();
       globals.set("fetch", fetchStub);
@@ -480,6 +498,7 @@ describe("Top Stories Feed", () => {
       instance.personalized = true;
       instance.show_spocs = true;
       instance.stories_endpoint = "stories-endpoint";
+      instance.storiesLoaded = true;
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
       await instance.fetchStories();
 
@@ -517,6 +536,13 @@ describe("Top Stories Feed", () => {
     });
     it("should delay inserting spoc if stories haven't been fetched", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: true,
+          personalized: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
       globals.set("Math", {random: () => 0.4});
@@ -531,14 +557,11 @@ describe("Top Stories Feed", () => {
       assert.notCalled(instance.store.dispatch);
       assert.equal(instance.contentUpdateQueue.length, 1);
 
-      instance.personalized = true;
-      instance.show_spocs = true;
       instance.spocsPerNewTabs = 0.5;
-      instance.stories_endpoint = "stories-endpoint";
       instance.store.getState = () => ({Sections: [{id: "topstories", rows: response.recommendations}], Prefs: {values: {showSponsored: true}}});
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
 
-      await instance.fetchStories();
+      await instance.onInit();
       assert.equal(instance.contentUpdateQueue.length, 0);
       assert.calledOnce(instance.store.dispatch);
       let [action] = instance.store.dispatch.firstCall.args;
@@ -546,6 +569,13 @@ describe("Top Stories Feed", () => {
     });
     it("should not insert spoc if preffed off", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: false,
+          personalized: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -553,18 +583,26 @@ describe("Top Stories Feed", () => {
         "settings": {"spocsPerNewTabs": 0.5},
         "spocs": [{"id": "spoc1"}, {"id": "spoc2"}]
       };
+      sinon.spy(instance, "maybeAddSpoc");
+      sinon.spy(instance, "shouldShowSpocs");
 
-      instance.personalized = true;
-      instance.show_spocs = false;
-      instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
+      assert.calledOnce(instance.maybeAddSpoc);
+      assert.calledOnce(instance.shouldShowSpocs);
       assert.notCalled(instance.store.dispatch);
     });
     it("should not insert spoc if user opted out", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: true,
+          personalized: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -573,18 +611,22 @@ describe("Top Stories Feed", () => {
         "spocs": [{"id": "spoc1"}, {"id": "spoc2"}]
       };
 
-      instance.personalized = true;
-      instance.show_spocs = true;
-      instance.stories_endpoint = "stories-endpoint";
       instance.store.getState = () => ({Sections: [{id: "topstories", rows: response.recommendations}], Prefs: {values: {showSponsored: false}}});
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
       assert.notCalled(instance.store.dispatch);
     });
     it("should not fail if there is no spoc", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: true,
+          personalized: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
       globals.set("Math", {random: () => 0.4});
@@ -594,11 +636,8 @@ describe("Top Stories Feed", () => {
         "recommendations": [{"id": "rec1"}, {"id": "rec2"}, {"id": "rec3"}]
       };
 
-      instance.personalized = true;
-      instance.show_spocs = true;
-      instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
       assert.notCalled(instance.store.dispatch);
@@ -637,6 +676,12 @@ describe("Top Stories Feed", () => {
     });
     it("should not record spoc/campaign impressions for non-view impressions", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -646,10 +691,8 @@ describe("Top Stories Feed", () => {
       };
 
       instance._prefs = {get: pref => undefined, set: sinon.spy()};
-      instance.show_spocs = true;
-      instance.stories_endpoint = "stories-endpoint";
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       instance.onAction({type: at.TELEMETRY_IMPRESSION_STATS, data: {click: 0, tiles: [{id: 1}]}});
       assert.notCalled(instance._prefs.set);
@@ -698,6 +741,13 @@ describe("Top Stories Feed", () => {
     });
     it("should maintain frequency caps when inserting spocs", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: true,
+          personalized: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -710,12 +760,9 @@ describe("Top Stories Feed", () => {
         ]
       };
 
-      instance.personalized = true;
-      instance.show_spocs = true;
-      instance.stories_endpoint = "stories-endpoint";
       instance.store.getState = () => ({Sections: [{id: "topstories", rows: response.recommendations}], Prefs: {values: {showSponsored: true}}});
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
       instance.spocsPerNewTabs = 1;
 
       clock.tick();
@@ -758,6 +805,13 @@ describe("Top Stories Feed", () => {
     });
     it("should maintain client-side MAX_LIFETIME_CAP", async () => {
       let fetchStub = globals.sandbox.stub();
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+          show_spocs: true,
+          personalized: true,
+          stories_endpoint: "stories-endpoint"
+        }
+      });
       globals.set("fetch", fetchStub);
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
@@ -769,12 +823,9 @@ describe("Top Stories Feed", () => {
         ]
       };
 
-      instance.personalized = true;
-      instance.show_spocs = true;
-      instance.stories_endpoint = "stories-endpoint";
       instance.store.getState = () => ({Sections: [{id: "topstories", rows: response.recommendations}], Prefs: {values: {showSponsored: true}}});
       fetchStub.resolves({ok: true, status: 200, json: () => Promise.resolve(response)});
-      await instance.fetchStories();
+      await instance.onInit();
 
       instance._prefs.get = pref => JSON.stringify({1: [...Array(100).keys()]});
       instance.onAction({type: at.NEW_TAB_REHYDRATED, meta: {fromTarget: {}}});
@@ -782,25 +833,44 @@ describe("Top Stories Feed", () => {
     });
   });
   describe("#update", () => {
-    it("should fetch stories after update interval", () => {
-      instance.init();
-      instance.fetchStories = sinon.spy();
-      instance.onAction({type: at.SYSTEM_TICK});
+    it("should fetch stories after update interval", async () => {
+      await instance.onInit();
+      sinon.spy(instance, "fetchStories");
+      await instance.onAction({type: at.SYSTEM_TICK});
       assert.notCalled(instance.fetchStories);
 
       clock.tick(STORIES_UPDATE_TIME);
-      instance.onAction({type: at.SYSTEM_TICK});
+      await instance.onAction({type: at.SYSTEM_TICK});
       assert.calledOnce(instance.fetchStories);
     });
-    it("should fetch topics after update interval", () => {
-      instance.init();
-      instance.fetchTopics = sinon.spy();
-      instance.onAction({type: at.SYSTEM_TICK});
+    it("should fetch topics after update interval", async () => {
+      await instance.onInit();
+      sinon.spy(instance, "fetchTopics");
+      await instance.onAction({type: at.SYSTEM_TICK});
       assert.notCalled(instance.fetchTopics);
 
       clock.tick(TOPICS_UPDATE_TIME);
-      instance.onAction({type: at.SYSTEM_TICK});
+      await instance.onAction({type: at.SYSTEM_TICK});
       assert.calledOnce(instance.fetchTopics);
+    });
+    it("should return updated stories and topics on system tick", async () => {
+      await instance.onInit();
+      sinon.spy(instance, "dispatchUpdateEvent");
+      instance.stories = [{"guid": "rec1"}, {"guid": "rec2"}, {"guid": "rec3"}];
+      instance.topics = {
+        "_timestamp": 123,
+        "topics": [{"name": "topic1", "url": "url-topic1"}, {"name": "topic2", "url": "url-topic2"}]
+      };
+      await instance.onAction({type: at.SYSTEM_TICK});
+      assert.calledOnce(instance.dispatchUpdateEvent);
+      assert.calledWith(instance.dispatchUpdateEvent, false, {
+        rows: [{"guid": "rec1"}, {"guid": "rec2"}, {"guid": "rec3"}],
+        topics: {
+          _timestamp: 123,
+          topics: [{"name": "topic1", "url": "url-topic1"}, {"name": "topic2", "url": "url-topic2"}]
+        },
+        read_more_endpoint: undefined
+      });
     });
     it("should update domain affinities on idle-daily, if personalization preffed on", () => {
       instance.init();
@@ -843,25 +913,35 @@ describe("Top Stories Feed", () => {
       assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
       assert.equal(action.data.event, "topstories.domain.affinity.calculation.ms");
     });
-    it("should re-init on options change", () => {
-      instance.storiesLastUpdated = 1;
-      instance.topicsLastUpdated = 1;
-
+    it("should not call init and uninit if data doesn't match on options change ", () => {
+      sinon.spy(instance, "init");
+      sinon.spy(instance, "uninit");
       instance.onAction({type: at.SECTION_OPTIONS_CHANGED, data: "foo"});
       assert.notCalled(sectionsManagerStub.disableSection);
       assert.notCalled(sectionsManagerStub.enableSection);
-      assert.equal(instance.storiesLastUpdated, 1);
-      assert.equal(instance.topicsLastUpdated, 1);
-
+      assert.notCalled(instance.init);
+      assert.notCalled(instance.uninit);
+    });
+    it("should call init and uninit on options change", () => {
+      sinon.spy(instance, "init");
+      sinon.spy(instance, "uninit");
       instance.onAction({type: at.SECTION_OPTIONS_CHANGED, data: "topstories"});
       assert.calledOnce(sectionsManagerStub.disableSection);
       assert.calledOnce(sectionsManagerStub.enableSection);
+      assert.calledOnce(instance.init);
+      assert.calledOnce(instance.uninit);
+    });
+    it("should set LastUpdated to 0 on init", async () => {
+      instance.storiesLastUpdated = 1;
+      instance.topicsLastUpdated = 1;
+
+      await instance.onInit();
       assert.equal(instance.storiesLastUpdated, 0);
       assert.equal(instance.topicsLastUpdated, 0);
     });
-    it("should filter spocs when link is blocked", () => {
+    it("should filter spocs when link is blocked", async () => {
       instance.spocs = [{"url": "not_blocked"}, {"url": "blocked"}];
-      instance.onAction({type: at.PLACES_LINK_BLOCKED, data: {url: "blocked"}});
+      await instance.onAction({type: at.PLACES_LINK_BLOCKED, data: {url: "blocked"}});
 
       assert.deepEqual(instance.spocs, [{"url": "not_blocked"}]);
     });
@@ -880,6 +960,7 @@ describe("Top Stories Feed", () => {
   });
   describe("#loadCachedData", () => {
     it("should update section with cached stories and topics if available", async () => {
+      sectionsManagerStub.sections.set("topstories", {options: {stories_referrer: "referrer"}});
       const stories = {
         "_timestamp": 123,
         "recommendations": [{
@@ -914,13 +995,11 @@ describe("Top Stories Feed", () => {
         "topics": [{"name": "topic1", "url": "url-topic1"}, {"name": "topic2", "url": "url-topic2"}]
       };
       instance.cache.get = () => ({stories, topics});
-      instance.stories_referrer = "referrer";
       globals.set("NewTabUtils", {blockedLinks: {isBlocked: globals.sandbox.spy()}});
 
-      await instance.loadCachedData();
-      assert.calledTwice(sectionsManagerStub.updateSection);
-      assert.calledWith(sectionsManagerStub.updateSection, SECTION_ID, {topics: topics.topics, read_more_endpoint: undefined});
-      assert.calledWith(sectionsManagerStub.updateSection, SECTION_ID, {rows: transformedStories});
+      await instance.onInit();
+      assert.calledOnce(sectionsManagerStub.updateSection);
+      assert.calledWith(sectionsManagerStub.updateSection, SECTION_ID, {rows: transformedStories, topics: topics.topics, read_more_endpoint: undefined});
     });
     it("should NOT update section if there is no cached data", async () => {
       instance.cache.get = () => ({});


### PR DESCRIPTION
To test:

1. Set the pref "browser.newtabpage.activity-stream.feeds.section.topstories.options" to default.

2. load about:home take not of the third rec. This ensures that we have a preloaded tab generated with default recs. You can keep this tab open, or close it, both are viable and shouldn't matter.

3. Update "browser.newtabpage.activity-stream.feeds.section.topstories.options" pref to:
```
{"api_key_pref":"extensions.pocket.oAuthConsumerKey","hidden":false,"provider_icon":"pocket","provider_name":"Pocket","read_more_endpoint":"https://getpocket.com/explore/trending?src=fx_new_tab","stories_endpoint":"file:///home/scott/spoc.json","stories_referrer":"https://getpocket.com/recommendations","topics_endpoint":"https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=en-US","show_spocs":true,"personalized":true}
```

You'll also need a file saved on your local system and to update the stories_endpoint with the file. i used this file: https://bug1479458.bmoattachments.org/attachment.cgi?id=8997024

4. open about:home again (or another one).

5. Ensure the new tab updates the third rec with something from theringer.com titled "The Kawhi-DeRozan Trade Is a Win for Both the Spurs and Raptors" If you kept the initial tab open from step 2, that should also be updated.

This basically simulates shield updating the pref.