### PR TITLE
Bug 1479478 - Exclude default search URLs from topsites

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -153,6 +153,10 @@ const PREFS_CONFIG = new Map([
     title: "The rendering order for the sections",
     value: "topsites,topstories,highlights"
   }],
+  ["improvesearch.noDefaultSearchTile", {
+    title: "Experiment to remove tiles that are the same as the default search",
+    value: false
+  }],
   ["asrouterExperimentEnabled", {
     title: "Is the message center experiment on?",
     value: false


### PR DESCRIPTION
This patch removes `google.*` and `amazon.*` from top sites if google or amazon are set to the default search engine respectively.

To manually test this, please do the following: 
1. On a new profile with this patch applied, do a few google searches such that you organically have google in your top sites as well as the default amazon top site tile. 
2. With google as your default search, set `browser.newtabpage.activity-stream.improvesearch.noDefaultSearchTile` to true in about:config. Confirm that the google no longer appears in your top sites.
3. Restart the browser to ensure that on a first load, google is still not in your top sites.
4. Set your default search to amazon in `about:preferences#search`. Confirm that google is now visible in your top sites and the default amazon tile is gone.
5. Set `browser.newtabpage.activity-stream.improvesearch.noDefaultSearchTile` to `false`. Confirm that both google and amazon now appear in your top sites.