### PR TITLE
Bug 1479021: support url params in provider endpoints

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -27,6 +27,7 @@ const DEFAULT_WHITELIST_HOSTS = {
 const SNIPPETS_ENDPOINT_WHITELIST = "browser.newtab.activity-stream.asrouter.whitelistHosts";
 
 const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider};
+const STARTPAGE_VERSION = "0.1.0";
 
 const MessageLoaderUtils = {
   /**
@@ -179,6 +180,10 @@ class _ASRouter {
         // Get the messages from the local message provider
         const localProvider = this._localProviders[provider.localProvider];
         provider.messages = localProvider ? localProvider.getMessages() : [];
+      }
+      if (provider.type === "remote" && provider.url) {
+        provider.url = provider.url.replace(/%STARTPAGE_VERSION%/g, STARTPAGE_VERSION);
+        provider.url = Services.urlFormatter.formatURL(provider.url);
       }
       // Reset provider update timestamp to force message refresh
       provider.lastUpdated = undefined;


### PR DESCRIPTION
The previous snippets implementation calls `Services.urlFormatter.formatURL`, passing in the snippets endpoint URL, to replace params such as %OS_VERSION%, %LOCALE%, etc. with correct values to help target snippets. It also manually supports an additional param %STARTPAGE_VERSION%. You can see the existing url param support [here](https://github.com/mozilla/activity-stream/blob/7e544945fbe0cba46eba9387e4c593e98d8f9f55/lib/SnippetsFeed.jsm#L43).

This patch extends the same behaviour to ASRouter, applying the same replacement to all remote endpoint URLs. For the %STARTPAGE_VERSION% Kate and I agreed to use the `version` property of the provider-response.schema.json. There is an included test case to ensure that the two values agree.

I don't know whether or not you want to restrict the param support to just the snippets provider? At the moment it works for any remote endpoint.