### PR TITLE
Fix Bug 1480814 - Add a pref to enable/disable top site search shortcuts on the newtab page

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -159,6 +159,10 @@ const PREFS_CONFIG = new Map([
     title: "Experiment to remove tiles that are the same as the default search",
     value: false
   }],
+  ["improvesearch.topSiteSearchShortcuts", {
+    title: "Experiment to show special top sites that perform keyword searches",
+    value: true
+  }],
   ["asrouterExperimentEnabled", {
     title: "Is the message center experiment on?",
     value: false


### PR DESCRIPTION
Adds pref for top sites search shortcuts experiment