### PR TITLE
Fix Bug 1480535 - Make in-content search box more prominent

### DIFF
--- a/content-src/components/Search/_Search.scss
+++ b/content-src/components/Search/_Search.scss
@@ -1,10 +1,9 @@
 .search-wrapper {
-  $search-height: 35px;
+  $search-height: 48px;
   $search-icon-size: 18px;
-  $search-icon-padding: 8px;
+  $search-icon-padding: 15px;
   $search-icon-width: 2 * $search-icon-padding + $search-icon-size;
-  $search-input-left-label-width: 35px;
-  $search-button-width: 36px;
+  $search-button-width: 48px;
   $glyph-forward: url('chrome://browser/skin/forward.svg');
 
   cursor: default;
@@ -149,5 +148,11 @@
         color: var(--newtab-text-primary-color);
       }
     }
+  }
+
+  .contentSearchHeaderRow > td > img,
+  .contentSearchSuggestionRow > td > .historyIcon {
+    margin-inline-start: 7px;
+    margin-inline-end: 15px;
   }
 }


### PR DESCRIPTION
In addition to the height change, I (under the supervision of @aaronrbenson) adjusted the padding around the icons to give them some extra horizontal breathing room and make it look better.

Before:
<img width="1020" alt="screen shot 2018-08-03 at 3 51 47 pm" src="https://user-images.githubusercontent.com/36629/43662858-52174dc4-9735-11e8-94ea-a019b9b2ad2a.png">

After:
<img width="1021" alt="screen shot 2018-08-03 at 3 49 26 pm" src="https://user-images.githubusercontent.com/36629/43662862-58729dfe-9735-11e8-9c20-2b19024c18b6.png">

