### PR TITLE
Bug 1480513: Add telemetry for search shortcut

### DIFF
--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -208,6 +208,12 @@ export class TopSite extends React.PureComponent {
     if (this.props.link.isPinned) {
       value.card_type = "pinned";
     }
+    if (this.props.link.searchTopSite) {
+      // Set the card_type as "search" regardless of its pinning status
+      value.card_type = "search";
+      // Extract search vendor from the label, i.e. "@search_vendor" => "search_vendor"
+      value.search_vendor = this.props.link.label.slice(1);
+    }
     return {value};
   }
 

--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -211,8 +211,7 @@ export class TopSite extends React.PureComponent {
     if (this.props.link.searchTopSite) {
       // Set the card_type as "search" regardless of its pinning status
       value.card_type = "search";
-      // Extract search vendor from the label, i.e. "@search_vendor" => "search_vendor"
-      value.search_vendor = this.props.link.label.slice(1);
+      value.search_vendor = this.props.link.hostname;
     }
     return {value};
   }

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -184,7 +184,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `addon_version` | [Required] Firefox build ID, i.e. `Services.appinfo.appBuildID`. | :one:
 | `client_id` | [Required] An identifier for this client. | :one:
 | `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search") | :one:
-| `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon") | :one:
+| `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon", "wikipedia", "duckduckgo", "bing", etc.). This field only exists when `card_type = "search"` | :one:
 | `date` | [Auto populated by Onyx] The date in YYYY-MM-DD format. | :three:
 | `experiment_id` | [Optional] The unique identifier for a specific experiment. | :one:
 | `event_id` | [Required] An identifier shared by multiple performance pings that describe ane entire request flow. | :one:

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -184,7 +184,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `addon_version` | [Required] Firefox build ID, i.e. `Services.appinfo.appBuildID`. | :one:
 | `client_id` | [Required] An identifier for this client. | :one:
 | `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search") | :one:
-| `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon", "baidu", "yandex") | :one:
+| `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon") | :one:
 | `date` | [Auto populated by Onyx] The date in YYYY-MM-DD format. | :three:
 | `experiment_id` | [Optional] The unique identifier for a specific experiment. | :one:
 | `event_id` | [Required] An identifier shared by multiple performance pings that describe ane entire request flow. | :one:

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -183,7 +183,8 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `action` | [Required] Either `activity_stream_event`, `activity_stream_session`, or `activity_stream_performance`. | :one:
 | `addon_version` | [Required] Firefox build ID, i.e. `Services.appinfo.appBuildID`. | :one:
 | `client_id` | [Required] An identifier for this client. | :one:
-| `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned") | :one:
+| `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search") | :one:
+| `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon", "baidu", "yandex") | :one:
 | `date` | [Auto populated by Onyx] The date in YYYY-MM-DD format. | :three:
 | `experiment_id` | [Optional] The unique identifier for a specific experiment. | :one:
 | `event_id` | [Required] An identifier shared by multiple performance pings that describe ane entire request flow. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -90,8 +90,53 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "source": "TOP_SITES",
   "action_position": 2,
   "value": {
-    "card_type": "pinned",
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"]
+    "card_type": ["pinned" | "search"],
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
+    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
+  }
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7
+}
+```
+
+#### Adding a search shortcut
+```js
+{
+  "event": "ADD_SEARCH_SHORTCUT",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  "value": {
+    "card_type": "search",
+    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
+  }
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7
+}
+```
+
+#### Editing a search shortcut
+```js
+{
+  "event": "EDIT_SEARCH_SHORTCUT",
+  "source": "TOP_SITES",
+  "action_position": 2,
+  "value": {
+    "card_type": "search",
+    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
   }
 
   // Basic metadata
@@ -136,8 +181,9 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "source": "TOP_SITES",
   "action_position": 2,
   "value": {
-    "card_type": "pinned",
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"]
+    "card_type": ["pinned" | "search"],
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
+    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
   }
 
   // Basic metadata

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -92,7 +92,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "value": {
     "card_type": ["pinned" | "search"],
     "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
-    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
+    "search_vendor": ["google" | "amazon"]
   }
 
   // Basic metadata
@@ -114,7 +114,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "search",
-    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
+    "search_vendor": ["google" | "amazon"]
   }
 
   // Basic metadata
@@ -136,7 +136,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "search",
-    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
+    "search_vendor": ["google" | "amazon"]
   }
 
   // Basic metadata
@@ -183,7 +183,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "value": {
     "card_type": ["pinned" | "search"],
     "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
-    "search_vendor": ["google" | "amazon" | "baidu" | "yandex"]
+    "search_vendor": ["google" | "amazon"]
   }
 
   // Basic metadata

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -92,7 +92,8 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "value": {
     "card_type": ["pinned" | "search"],
     "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
-    "search_vendor": ["google" | "amazon"]
+    // only exists if its card_type = "search"
+    "search_vendor": "google"
   }
 
   // Basic metadata
@@ -114,7 +115,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "search",
-    "search_vendor": ["google" | "amazon"]
+    "search_vendor": "google"
   }
 
   // Basic metadata
@@ -136,7 +137,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "search",
-    "search_vendor": ["google" | "amazon"]
+    "search_vendor": "google"
   }
 
   // Basic metadata
@@ -183,7 +184,8 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "value": {
     "card_type": ["pinned" | "search"],
     "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
-    "search_vendor": ["google" | "amazon"]
+    // only exists if its card_type = "search"
+    "search_vendor": "google"
   }
 
   // Basic metadata

--- a/test/schemas/pings.js
+++ b/test/schemas/pings.js
@@ -97,7 +97,8 @@ export const UserEventAction = Joi.object().keys({
     action_position: Joi.number().integer(),
     value: Joi.object().keys({
       icon_type: Joi.valid(["tippytop", "rich_icon", "screenshot_with_icon", "screenshot", "no_image"]),
-      card_type: Joi.valid(["bookmark", "trending", "pinned", "pocket"])
+      card_type: Joi.valid(["bookmark", "trending", "pinned", "pocket", "search"]),
+      search_vendor: Joi.valid(["google", "amazon", "baidu", "yandex"])
     })
   }).required(),
   meta: Joi.object().keys({

--- a/test/schemas/pings.js
+++ b/test/schemas/pings.js
@@ -98,7 +98,7 @@ export const UserEventAction = Joi.object().keys({
     value: Joi.object().keys({
       icon_type: Joi.valid(["tippytop", "rich_icon", "screenshot_with_icon", "screenshot", "no_image"]),
       card_type: Joi.valid(["bookmark", "trending", "pinned", "pocket", "search"]),
-      search_vendor: Joi.valid(["google", "amazon", "baidu", "yandex"])
+      search_vendor: Joi.valid(["google", "amazon"])
     })
   }).required(),
   meta: Joi.object().keys({

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -587,6 +587,28 @@ describe("<TopSite>", () => {
       assert.propertyVal(action.data.value, "card_type", "pinned");
       assert.propertyVal(action.data.value, "icon_type", "rich_icon");
     });
+    it("should dispatch a UserEventAction with the right data for search top site", () => {
+      const dispatch = sinon.stub();
+      const siteInfo = {
+        iconType: "tippytop",
+        isPinned: true,
+        searchTopSite: true,
+        label: "@google"
+      };
+      const wrapper = shallow(<TopSite link={Object.assign({}, link, siteInfo)} index={3} dispatch={dispatch} />);
+
+      wrapper.find(TopSiteLink).simulate("click", {preventDefault() {}});
+
+      const [action] = dispatch.firstCall.args;
+      assert.isUserEventAction(action);
+
+      assert.propertyVal(action.data, "event", "CLICK");
+      assert.propertyVal(action.data, "source", "TOP_SITES");
+      assert.propertyVal(action.data, "action_position", 3);
+      assert.propertyVal(action.data.value, "card_type", "search");
+      assert.propertyVal(action.data.value, "icon_type", "tippytop");
+      assert.propertyVal(action.data.value, "search_vendor", "google");
+    });
     it("should dispatch OPEN_LINK with the right data", () => {
       const dispatch = sinon.stub();
       const wrapper = shallow(<TopSite link={Object.assign({}, link, {typedBonus: true})} index={3} dispatch={dispatch} />);

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -593,6 +593,7 @@ describe("<TopSite>", () => {
         iconType: "tippytop",
         isPinned: true,
         searchTopSite: true,
+        hostname: "google",
         label: "@google"
       };
       const wrapper = shallow(<TopSite link={Object.assign({}, link, siteInfo)} index={3} dispatch={dispatch} />);


### PR DESCRIPTION
This documents the telemetry part for [search shortcuts](https://bugzilla.mozilla.org/show_bug.cgi?id=1479806) in Top Sites of Activity Stream.

@fmarier Could you take a look at this please? The data review request was attached at [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1480513#c2)