### PR TITLE
Fix Bug 1481503 - Use pocket outline for save action and solid pocket for saved

### DIFF
--- a/content-src/lib/link-menu-options.js
+++ b/content-src/lib/link-menu-options.js
@@ -169,7 +169,7 @@ export const LinkMenuOptions = {
   }),
   SaveToPocket: (site, index, eventSource) => ({
     id: "menu_action_save_to_pocket",
-    icon: "pocket",
+    icon: "pocket-save",
     action: ac.AlsoToMain({
       type: at.SAVE_TO_POCKET,
       data: {site: {url: site.url, title: site.title}}

--- a/content-src/styles/_icons.scss
+++ b/content-src/styles/_icons.scss
@@ -89,6 +89,10 @@
     background-image: url('#{$image-path}glyph-pocket-16.svg');
   }
 
+  &.icon-pocket-save {
+    background-image: url('#{$image-path}glyph-pocket-save-16.svg');
+  }
+
   &.icon-history-item {
     background-image: url('chrome://browser/skin/history.svg');
   }

--- a/data/content/assets/glyph-pocket-save-16.svg
+++ b/data/content/assets/glyph-pocket-save-16.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="context-fill" fill-opacity="context-fill-opacity" d="M14.5.932h-13A1.509 1.509 0 0 0 0 2.435v4.5a8 8 0 0 0 16 0v-4.5A1.508 1.508 0 0 0 14.5.932zm-.5 6a6 6 0 0 1-12 0v-4h12zm-6.7 3.477a1 1 0 0 0 1.422 0l3.343-3.39a1 1 0 1 0-1.423-1.406L8.01 8.283 5.38 5.614a1 1 0 0 0-1.425 1.405zm.711.3z"/></svg>


### PR DESCRIPTION
r?@AdamHillier   Ports https://hg.mozilla.org/mozilla-central/rev/d2dfd67e6fc8 by adding the outline as a separate icon.

Before bug 1462790:
![screen shot 2018-08-07 at 10 39 59 am](https://user-images.githubusercontent.com/438537/43793866-96e106ee-9a31-11e8-8da0-bee3a123cf64.png)

After bug 1462790:
![screen shot 2018-08-07 at 10 42 49 am](https://user-images.githubusercontent.com/438537/43793871-9a174170-9a31-11e8-9642-0b90da470d27.png)

After this fix:
![screen shot 2018-08-07 at 10 53 33 am](https://user-images.githubusercontent.com/438537/43793878-9e2aefaa-9a31-11e8-8a21-e3d435d7b4d8.png)
