### PR TITLE
Fix Bug 1480506 - Top Search Shortcuts should allow user to unpin

### DIFF
--- a/content-src/components/LinkMenu/LinkMenu.jsx
+++ b/content-src/components/LinkMenu/LinkMenu.jsx
@@ -13,7 +13,7 @@ export class _LinkMenu extends React.PureComponent {
     const {site, index, source, isPrivateBrowsingEnabled, siteInfo, platform} = props;
 
     // Handle special case of default site
-    const propOptions = !site.isDefault ? props.options : DEFAULT_SITE_MENU_OPTIONS;
+    const propOptions = (!site.isDefault || site.searchTopSite) ? props.options : DEFAULT_SITE_MENU_OPTIONS;
 
     const options = propOptions.map(o => LinkMenuOptions[o](site, index, source, isPrivateBrowsingEnabled, siteInfo, platform)).map(option => {
       const {action, impression, id, string_id, type, userEvent} = option;

--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -4,6 +4,7 @@ import {
   MIN_CORNER_FAVICON_SIZE,
   MIN_RICH_FAVICON_SIZE,
   TOP_SITES_CONTEXT_MENU_OPTIONS,
+  TOP_SITES_SEARCH_SHORTCUTS_CONTEXT_MENU_OPTIONS,
   TOP_SITES_SOURCE
 } from "./TopSitesConstants";
 import {LinkMenu} from "content-src/components/LinkMenu/LinkMenu";
@@ -266,7 +267,7 @@ export class TopSite extends React.PureComponent {
               dispatch={props.dispatch}
               index={props.index}
               onUpdate={this.onMenuUpdate}
-              options={TOP_SITES_CONTEXT_MENU_OPTIONS}
+              options={link.searchTopSite ? TOP_SITES_SEARCH_SHORTCUTS_CONTEXT_MENU_OPTIONS : TOP_SITES_CONTEXT_MENU_OPTIONS}
               site={link}
               siteInfo={this._getTelemetryInfo()}
               source={TOP_SITES_SOURCE} />

--- a/content-src/components/TopSites/TopSitesConstants.js
+++ b/content-src/components/TopSites/TopSitesConstants.js
@@ -1,6 +1,8 @@
 export const TOP_SITES_SOURCE = "TOP_SITES";
 export const TOP_SITES_CONTEXT_MENU_OPTIONS = ["CheckPinTopSite", "EditTopSite", "Separator",
   "OpenInNewWindow", "OpenInPrivateWindow", "Separator", "BlockUrl", "DeleteUrl"];
+// the special top site for search shortcut experiment can only have the option to unpin (which removes) the topsite
+export const TOP_SITES_SEARCH_SHORTCUTS_CONTEXT_MENU_OPTIONS = ["CheckPinTopSite", "Separator", "BlockUrl"];
 // minimum size necessary to show a rich icon instead of a screenshot
 export const MIN_RICH_FAVICON_SIZE = 96;
 // minimum size necessary to show any icon in the top left corner with a screenshot


### PR DESCRIPTION
Adds a context menu for 'pin/unpin' and 'block' if a site is a search shortcut top site
<img width="262" alt="screen shot 2018-08-07 at 11 39 37 am" src="https://user-images.githubusercontent.com/7219526/43802340-7e456896-9a63-11e8-831d-0c4f0354f9db.png">

a lil baby context menu 👶 