### PR TITLE
Bug 1480888 - Implement blocking system for special search shortcut top sites - Part 1

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -226,9 +226,14 @@ this.TopSitesFeed = class TopSitesFeed {
     // Remove any defaults that have been blocked
     const notBlockedDefaultSites = DEFAULT_TOP_SITES
       .reduce((topsites, link) => {
+        const searchProvider = getSearchProvider(shortURL(link));
         if (NewTabUtils.blockedLinks.isBlocked({url: link.url})) {
           return topsites;
         } else if (this.isExperimentOnAndLinkFilteredSearch(link.hostname)) {
+          return topsites;
+          // If we've previously blocked a search shortcut, remove the default top site
+          // that matches the hostname
+        } else if (searchProvider && NewTabUtils.blockedLinks.isBlocked({url: searchProvider.url})) {
           return topsites;
         }
         return [

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -68,7 +68,7 @@ describe("Top Sites Feed", () => {
       _shouldGetScreenshots: sinon.stub().returns(true)
     };
     filterAdultStub = sinon.stub().returns([]);
-    shortURLStub = sinon.stub().callsFake(site => site.url.replace(".com", "").replace("https://", ""));
+    shortURLStub = sinon.stub().callsFake(site => site.url.replace(/(.com|.ca)/, "").replace("https://", ""));
     const fakeDedupe = function() {};
     fakePageThumbs = {
       addExpirationFilter: sinon.stub(),
@@ -1224,6 +1224,13 @@ describe("Top Sites Feed", () => {
       });
     });
 
+    it("should filter out default top sites that match a hostname of a search shortcut if previously blocked", async () => {
+      feed.refreshDefaults("https://amazon.ca");
+      fakeNewTabUtils.blockedLinks.links = [{url: "https://amazon.com"}];
+      fakeNewTabUtils.blockedLinks.isBlocked = site => (fakeNewTabUtils.blockedLinks.links[0].url === site.url);
+      const urlsReturned = (await feed.getLinksWithDefaults()).map(link => link.url);
+      assert.notInclude(urlsReturned, "https://amazon.ca");
+    });
     it("_maybeInsertSearchShortcuts should be called on getLinksWithDefaults", async () => {
       sandbox.spy(feed, "_maybeInsertSearchShortcuts");
       await feed.getLinksWithDefaults();


### PR DESCRIPTION
Check that if we've blocked a search shortcut, then we should also filter out the matching default site. See https://phabricator.services.mozilla.com/D2970 for Part 2