### PR TITLE
Fix bug in manually pinned site appearing as a search shortcut

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -359,9 +359,9 @@ this.TopSitesFeed = class TopSitesFeed {
   topSiteToSearchTopSite(site) {
     if (isSearchProvider(shortURL(site))) {
       return {
+        ...site,
         searchTopSite: true,
-        label: `@${shortURL(site)}`,
-        ...site
+        label: `@${shortURL(site)}`
       };
     }
 


### PR DESCRIPTION
I noticed a bug where if I manually pinned a new site with the url "amazon.co.uk" and a custom label (e.g. "amazon uk"), then it would get transformed into a broken search shortcut. When clicking on the site the url bar would get focused and instead of inserting "@amazon" it inserted the custom label. This is a simple problem with the ordering of the properties in topSiteToSearchTopSite.