### PR TITLE
Add utm params to initial fetch call.

### DIFF
--- a/content-src/components/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/components/StartupOverlay/StartupOverlay.jsx
@@ -26,7 +26,8 @@ export class _StartupOverlay extends React.PureComponent {
     if (this.props.fxa_endpoint && !this.didFetch) {
       try {
         this.didFetch = true;
-        const response = await fetch(`${this.props.fxa_endpoint}/metrics-flow`);
+        const response = await fetch(`${this.props.fxa_endpoint}/metrics-flow?entrypoint=
+          activity-stream-firstrun&utm_source=activity-stream&utm_campaign=firstrun&form_type=email`);
         if (response.status === 200) {
           const {flowId, flowBeginTime} = await response.json();
           this.setState({flowId, flowBeginTime});


### PR DESCRIPTION
utm params are added to the initial fetch call to give more information to FxA
as described in https://bugzilla.mozilla.org/show_bug.cgi?id=1478649#c5

fixes: Bug 1478649