### PR TITLE
Fix Bug 1481901: include additional search shortcut providers

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -163,6 +163,27 @@ const PREFS_CONFIG = new Map([
     title: "Experiment to show special top sites that perform keyword searches",
     value: true
   }],
+  ["improvesearch.topSiteSearchShortcuts.searchEngines", {
+    title: "An ordered, comma-delimited list of search shortcuts that we should try and pin",
+    // This pref is dynamic as the shortcuts vary depending on the region
+    getValue: ({geo}) => {
+      if (!geo) {
+        return "";
+      }
+      const searchShortcuts = [];
+      if (geo === "CN") {
+        searchShortcuts.push("baidu");
+      } else if (["BY", "KZ", "RU", "TR"].includes(geo)) {
+        searchShortcuts.push("yandex");
+      } else {
+        searchShortcuts.push("google");
+      }
+      // Always include Amazon - we will only be able to actually pin it if it
+      // is available as a default search engine in that region
+      searchShortcuts.push("amazon");
+      return searchShortcuts.join(",");
+    }
+  }],
   ["improvesearch.topSiteSearchShortcuts.havePinned", {
     title: "A comma-delimited list of search shortcuts that have previously been pinned",
     value: ""

--- a/lib/SearchShortcuts.jsm
+++ b/lib/SearchShortcuts.jsm
@@ -7,16 +7,21 @@
 // that should be converted to search Topsites
 const SEARCH_SHORTCUTS = [
   {keyword: "@google", shortURL: "google", url: "https://google.com", searchIdentifier: /^google/},
+  {keyword: "@baidu", shortURL: "baidu", url: "https://baidu.com", searchIdentifier: /^baidu/},
+  {keyword: "@yandex", shortURL: "yandex", url: "https://yandex.com", searchIdentifier: /^yandex/},
   {keyword: "@amazon", shortURL: "amazon", url: "https://amazon.com", searchIdentifier: /^amazon/}
 ];
 this.SEARCH_SHORTCUTS = SEARCH_SHORTCUTS;
 
 // Note: you must add the activity stream branch to the beginning of this if using outside activity stream
 this.SEARCH_SHORTCUTS_EXPERIMENT = "improvesearch.topSiteSearchShortcuts";
+this.SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF = "improvesearch.topSiteSearchShortcuts.searchEngines";
+this.SEARCH_SHORTCUTS_HAVE_PINNED_PREF = "improvesearch.topSiteSearchShortcuts.havePinned";
 
 function getSearchProvider(candidateShortURL) {
   return SEARCH_SHORTCUTS.filter(match => candidateShortURL === match.shortURL)[0] || null;
 }
 this.getSearchProvider = getSearchProvider;
 
-const EXPORTED_SYMBOLS = ["getSearchProvider", "SEARCH_SHORTCUTS", "SEARCH_SHORTCUTS_EXPERIMENT"];
+const EXPORTED_SYMBOLS = ["getSearchProvider", "SEARCH_SHORTCUTS", "SEARCH_SHORTCUTS_EXPERIMENT",
+  "SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF", "SEARCH_SHORTCUTS_HAVE_PINNED_PREF"];

--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -12,8 +12,9 @@ const {Dedupe} = ChromeUtils.import("resource://activity-stream/common/Dedupe.js
 const {shortURL} = ChromeUtils.import("resource://activity-stream/lib/ShortURL.jsm", {});
 const {getDefaultOptions} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamStorage.jsm", {});
 const {
-  SEARCH_SHORTCUTS,
   SEARCH_SHORTCUTS_EXPERIMENT,
+  SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF,
+  SEARCH_SHORTCUTS_HAVE_PINNED_PREF,
   getSearchProvider
 } = ChromeUtils.import("resource://activity-stream/lib/SearchShortcuts.jsm", {});
 
@@ -38,7 +39,6 @@ const SECTION_ID = "topsites";
 const ROWS_PREF = "topSitesRows";
 
 // Search experiment stuff
-const SEARCH_SHORTCUTS_HAVE_PINNED_PREF = "improvesearch.topSiteSearchShortcuts.havePinned";
 const NO_DEFAULT_SEARCH_TILE_EXP_PREF = "improvesearch.noDefaultSearchTile";
 const SEARCH_FILTERS = [
   "google",
@@ -158,8 +158,13 @@ this.TopSitesFeed = class TopSitesFeed {
         .split(",").filter(s => s); // Filter out empty strings
       const newInsertedShortcuts = [];
 
+      const shouldPin = this.store.getState().Prefs.values[SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF]
+        .split(",")
+        .map(getSearchProvider)
+        .filter(s => s);
+
       // If we've previously inserted all search shortcuts return early
-      if (SEARCH_SHORTCUTS.every(shortcut => prevInsertedShortcuts.includes(shortcut.shortURL))) {
+      if (shouldPin.every(shortcut => prevInsertedShortcuts.includes(shortcut.shortURL))) {
         return false;
       }
 
@@ -192,7 +197,7 @@ this.TopSitesFeed = class TopSitesFeed {
         }
       };
 
-      SEARCH_SHORTCUTS.forEach(shortcut => tryToInsertSearchShortcut(shortcut));
+      shouldPin.forEach(shortcut => tryToInsertSearchShortcut(shortcut));
 
       if (newInsertedShortcuts.length) {
         this.store.dispatch(ac.SetPref(SEARCH_SHORTCUTS_HAVE_PINNED_PREF, prevInsertedShortcuts.concat(newInsertedShortcuts).join(",")));

--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -329,4 +329,44 @@ describe("ActivityStream", () => {
       assert.calledOnce(telemetry.handleUndesiredEvent);
     });
   });
+
+  describe("searchs shortcuts shouldPin pref", () => {
+    const SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF = "improvesearch.topSiteSearchShortcuts.searchEngines";
+    let stub;
+
+    beforeEach(() => {
+      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
+      stub = sandbox.stub(global.Services.prefs, "getStringPref");
+    });
+
+    it("should be an empty string when no geo is available", () => {
+      as._updateDynamicPrefs();
+      assert.equal(PREFS_CONFIG.get(SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF).value, "");
+    });
+
+    it("should be 'baidu,amazon' in China", () => {
+      stub.returns("CN");
+      as._updateDynamicPrefs();
+      assert.equal(PREFS_CONFIG.get(SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF).value, "baidu,amazon");
+    });
+
+    it("should be 'yandex,amazon' in Russia, Belarus, Kazakhstan, and Turkey", () => {
+      const geos = ["BY", "KZ", "RU", "TR"];
+      for (const geo of geos) {
+        stub.returns(geo);
+        as._updateDynamicPrefs();
+        assert.equal(PREFS_CONFIG.get(SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF).value, "yandex,amazon");
+      }
+    });
+
+    it("should be 'google,amazon' elsewhere", () => {
+      // A selection of other geos
+      const geos = ["CA", "DE", "GB", "ID", "IN", "US"];
+      for (const geo of geos) {
+        stub.returns(geo);
+        as._updateDynamicPrefs();
+        assert.equal(PREFS_CONFIG.get(SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF).value, "google,amazon");
+      }
+    });
+  });
 });

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -16,6 +16,7 @@ const FAKE_LINKS = new Array(2 * TOP_SITES_MAX_SITES_PER_ROW).fill(null).map((v,
 }));
 const FAKE_SCREENSHOT = "data123";
 const SEARCH_SHORTCUTS_EXPERIMENT_PREF = "improvesearch.topSiteSearchShortcuts";
+const SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF = "improvesearch.topSiteSearchShortcuts.searchEngines";
 const SEARCH_SHORTCUTS_HAVE_PINNED_PREF = "improvesearch.topSiteSearchShortcuts.havePinned";
 
 function FakeTippyTopProvider() {}
@@ -471,51 +472,6 @@ describe("Top Sites Feed", () => {
       await feed.getLinksWithDefaults();
 
       assert.calledWith(feed._fetchScreenshot, sinon.match.object, "custom");
-    });
-    describe("#improvesearch.topSiteSearchShortcuts", () => {
-      beforeEach(() => {
-        feed.store.state.Prefs.values["improvesearch.topSiteSearchShortcuts"] = true;
-      });
-      it("should update frecent search topsite icon", async () => {
-        feed._tippyTopProvider.processSite = site => {
-          site.tippyTopIcon = "icon.png";
-          site.backgroundColor = "#fff";
-          return site;
-        };
-        links = [{url: "google.com"}];
-
-        const urlsReturned = await feed.getLinksWithDefaults();
-
-        const defaultSearchTopsite = urlsReturned.find(s => s.url === "google.com");
-        assert.propertyVal(defaultSearchTopsite, "searchTopSite", true);
-        assert.equal(defaultSearchTopsite.tippyTopIcon, "icon.png");
-        assert.equal(defaultSearchTopsite.backgroundColor, "#fff");
-      });
-      it("should update default search topsite icon", async () => {
-        feed._tippyTopProvider.processSite = site => {
-          site.tippyTopIcon = "icon.png";
-          site.backgroundColor = "#fff";
-          return site;
-        };
-        links = [{url: "foo.com"}];
-        feed.onAction({type: at.PREFS_INITIAL_VALUES, data: {"default.sites": "google.com,amazon.com"}});
-
-        const urlsReturned = await feed.getLinksWithDefaults();
-
-        const defaultSearchTopsite = urlsReturned.find(s => s.url === "amazon.com");
-        assert.propertyVal(defaultSearchTopsite, "searchTopSite", true);
-        assert.equal(defaultSearchTopsite.tippyTopIcon, "icon.png");
-        assert.equal(defaultSearchTopsite.backgroundColor, "#fff");
-      });
-      it("should not overlap with improvesearch.noDefaultSearchTile and still provide search tiles", async () => {
-        feed.store.state.Prefs.values["improvesearch.noDefaultSearchTile"] = true;
-        links = [{url: "google.com"}];
-
-        const urlsReturned = await feed.getLinksWithDefaults();
-
-        const defaultSearchTopsite = urlsReturned.find(s => s.url === "google.com");
-        assert.isTrue(defaultSearchTopsite.searchTopSite);
-      });
     });
   });
   describe("#init", () => {
@@ -1214,6 +1170,7 @@ describe("Top Sites Feed", () => {
   describe("improvesearch.topSitesSearchShortcuts", () => {
     beforeEach(() => {
       feed.store.state.Prefs.values[SEARCH_SHORTCUTS_EXPERIMENT_PREF] = true;
+      feed.store.state.Prefs.values[SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF] = "google,amazon";
       feed.store.state.Prefs.values[SEARCH_SHORTCUTS_HAVE_PINNED_PREF] = "";
       global.Services.search.getEngines = () => [
         {identifier: "google"},
@@ -1231,10 +1188,46 @@ describe("Top Sites Feed", () => {
       const urlsReturned = (await feed.getLinksWithDefaults()).map(link => link.url);
       assert.notInclude(urlsReturned, "https://amazon.ca");
     });
-    it("_maybeInsertSearchShortcuts should be called on getLinksWithDefaults", async () => {
-      sandbox.spy(feed, "_maybeInsertSearchShortcuts");
-      await feed.getLinksWithDefaults();
-      assert.calledOnce(feed._maybeInsertSearchShortcuts);
+
+    it("should update frecent search topsite icon", async () => {
+      feed._tippyTopProvider.processSite = site => {
+        site.tippyTopIcon = "icon.png";
+        site.backgroundColor = "#fff";
+        return site;
+      };
+      links = [{url: "google.com"}];
+
+      const urlsReturned = await feed.getLinksWithDefaults();
+
+      const defaultSearchTopsite = urlsReturned.find(s => s.url === "google.com");
+      assert.propertyVal(defaultSearchTopsite, "searchTopSite", true);
+      assert.equal(defaultSearchTopsite.tippyTopIcon, "icon.png");
+      assert.equal(defaultSearchTopsite.backgroundColor, "#fff");
+    });
+    it("should update default search topsite icon", async () => {
+      feed._tippyTopProvider.processSite = site => {
+        site.tippyTopIcon = "icon.png";
+        site.backgroundColor = "#fff";
+        return site;
+      };
+      links = [{url: "foo.com"}];
+      feed.onAction({type: at.PREFS_INITIAL_VALUES, data: {"default.sites": "google.com,amazon.com"}});
+
+      const urlsReturned = await feed.getLinksWithDefaults();
+
+      const defaultSearchTopsite = urlsReturned.find(s => s.url === "amazon.com");
+      assert.propertyVal(defaultSearchTopsite, "searchTopSite", true);
+      assert.equal(defaultSearchTopsite.tippyTopIcon, "icon.png");
+      assert.equal(defaultSearchTopsite.backgroundColor, "#fff");
+    });
+    it("should not overlap with improvesearch.noDefaultSearchTile and still provide search tiles", async () => {
+      feed.store.state.Prefs.values["improvesearch.noDefaultSearchTile"] = true;
+      links = [{url: "google.com"}];
+
+      const urlsReturned = await feed.getLinksWithDefaults();
+
+      const defaultSearchTopsite = urlsReturned.find(s => s.url === "google.com");
+      assert.isTrue(defaultSearchTopsite.searchTopSite);
     });
 
     describe("_maybeInsertSearchShortcuts", () => {
@@ -1245,30 +1238,34 @@ describe("Top Sites Feed", () => {
         fakeNewTabUtils.pinnedLinks.links = [{url: ""}, {url: ""}, {url: ""}, null, {url: ""}, {url: ""}, null, {url: ""}];
       });
 
+      it("should be called on getLinksWithDefaults", async () => {
+        sandbox.spy(feed, "_maybeInsertSearchShortcuts");
+        await feed.getLinksWithDefaults();
+        assert.calledOnce(feed._maybeInsertSearchShortcuts);
+      });
+
       it("should do nothing and return false if the experiment is disabled", async () => {
         feed.store.state.Prefs.values[SEARCH_SHORTCUTS_EXPERIMENT_PREF] = false;
         assert.isFalse(await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links));
         assert.notCalled(fakeNewTabUtils.pinnedLinks.pin);
       });
 
-      it("should pin Google in the first available slot", async () => {
+      it("should pin shortcuts in the correct order, into the available unpinned slots", async () => {
         await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);
+        // The shouldPin pref is "google,amazon" so expect the shortcuts in that order
         assert.deepEqual(fakeNewTabUtils.pinnedLinks.links[3], {url: "https://google.com", searchTopSite: true, label: "@google"});
-      });
-
-      it("should pin Amazon in the second available slot", async () => {
-        await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);
         assert.deepEqual(fakeNewTabUtils.pinnedLinks.links[6], {url: "https://amazon.com", searchTopSite: true, label: "@amazon"});
       });
 
-      it("should only pin Google if there's only one available slot", async () => {
+      it("should only pin the first shortcut if there's only one available slot", async () => {
         fakeNewTabUtils.pinnedLinks.links[3] = {url: ""};
         await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);
+        // The first item in the shouldPin pref is "google" so expect only Google to be pinned
         assert.ok(fakeNewTabUtils.pinnedLinks.links.find(s => s && s.url === "https://google.com"));
         assert.notOk(fakeNewTabUtils.pinnedLinks.links.find(s => s && s.url === "https://amazon.com"));
       });
 
-      it("should pin neither if there's no available slot", async () => {
+      it("should pin none if there's no available slot", async () => {
         fakeNewTabUtils.pinnedLinks.links[3] = {url: ""};
         fakeNewTabUtils.pinnedLinks.links[6] = {url: ""};
         await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);
@@ -1276,7 +1273,8 @@ describe("Top Sites Feed", () => {
         assert.notOk(fakeNewTabUtils.pinnedLinks.links.find(s => s && s.url === "https://amazon.com"));
       });
 
-      it("should not pin Amazon if Amazon is not available as a search engine", async () => {
+      it("should not pin a shortcut if the corresponding search engine is not available", async () => {
+        // Make Amazon search engine unavailable
         global.Services.search.getEngines = () => [{identifier: "google"}];
         fakeNewTabUtils.pinnedLinks.links.fill(null);
         await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);


### PR DESCRIPTION
Uses Romanised names for the @... search labels for now, can be corrected if needed in a follow-up. Also moves some of the search shortcut tests so that they're all in the same place.