### PR TITLE
Fix Bug 1482190: don't convert manually pinned sites to search shortcuts

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -271,7 +271,7 @@ this.TopSitesFeed = class TopSitesFeed {
       const copy = Object.assign(
         {},
         frecentSite || {isDefault: !!notBlockedDefaultSites.find(finder)},
-        searchShortcutsExperiment ? this.topSiteToSearchTopSite(link) : link,
+        link,
         {hostname: shortURL(link)}
       );
 


### PR DESCRIPTION
Oops was caused by my patch. Solution is straightforward.