### PR TITLE
Fix Bug 1482255: fix search shortcut pinning race condition

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -614,6 +614,7 @@ this.TopSitesFeed = class TopSitesFeed {
             break;
           case ROWS_PREF:
           case NO_DEFAULT_SEARCH_TILE_EXP_PREF:
+          case SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF:
             this.refresh({broadcast: true});
             break;
           case SEARCH_SHORTCUTS_EXPERIMENT:


### PR DESCRIPTION
Refresh and broadcast the top sites when we get the geo-dependent list of search shortcuts to pin.