### PR TITLE
fix(topsites) - TopSitesFeed would fail if it got more pinned sites than slots

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -173,8 +173,9 @@ this.TopSitesFeed = class TopSitesFeed {
       // The plainPinnedSites array is populated with pinned sites at their
       // respective indices, and null everywhere else, but is not always the
       // right length
+      const emptySlots = numberOfSlots > plainPinnedSites.length ? numberOfSlots - plainPinnedSites.length : 0;
       const pinnedSites = [...plainPinnedSites].concat(
-        Array(numberOfSlots - plainPinnedSites.length).fill(null)
+        Array(emptySlots).fill(null)
       );
 
       await new Promise(resolve => Services.search.init(resolve));


### PR DESCRIPTION
This resulted in AS not loading in Nightly on first run after update.
The issue happened because I had 19 pinned sites and 16 slots available. This might be a likely scenario if you sync your profile across two different devices one getting wide layout and one getting small layout with fewer topsite slots.
<img width="1112" alt="screen shot 2018-08-10 at 14 58 53" src="https://user-images.githubusercontent.com/810040/43959668-1acb8e74-9c9f-11e8-81c0-cacf69361257.png">
