### PR TITLE
Fix Bug 1482412 - Don't change the status of existing pinned sites

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -277,7 +277,8 @@ this.TopSitesFeed = class TopSitesFeed {
         {},
         frecentSite || {isDefault: !!notBlockedDefaultSites.find(finder)},
         link,
-        {hostname: shortURL(link)}
+        {hostname: shortURL(link)},
+        {searchTopSite: link.searchTopSite}
       );
 
       // Add in favicons if we don't already have it

--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -278,7 +278,7 @@ this.TopSitesFeed = class TopSitesFeed {
         frecentSite || {isDefault: !!notBlockedDefaultSites.find(finder)},
         link,
         {hostname: shortURL(link)},
-        {searchTopSite: link.searchTopSite}
+        {searchTopSite: !!link.searchTopSite}
       );
 
       // Add in favicons if we don't already have it

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -363,6 +363,16 @@ describe("Top Sites Feed", () => {
 
         assert.equal(result[0].screenshot, "bar");
       });
+      it("should not set searchTopSite from frecent site", async () => {
+        links = [{url: "https://foo.com/", searchTopSite: true, screenshot: "screenshot"}];
+        fakeNewTabUtils.pinnedLinks.links = [{url: "https://foo.com/"}];
+
+        const result = await feed.getLinksWithDefaults();
+
+        assert.propertyVal(result[0], "searchTopSite", false);
+        // But it should copy over other properties
+        assert.propertyVal(result[0], "screenshot", "screenshot");
+      });
       describe("concurrency", () => {
         let resolvers;
         beforeEach(() => {


### PR DESCRIPTION
When we add existing information from frecent sites we accidentaly copy over the `searchTopSite` label to existing pinned sites.