### PR TITLE
Bug 1482519 - Separate custom search shortcut options from organic ones

### DIFF
--- a/content-src/components/TopSites/SearchShortcutsForm.jsx
+++ b/content-src/components/TopSites/SearchShortcutsForm.jsx
@@ -38,7 +38,10 @@ export class SearchShortcutsForm extends React.PureComponent {
     const shortcuts = [];
     const {rows, searchShortcuts} = props.TopSites;
     searchShortcuts.forEach(shortcut => {
-      shortcuts.push(Object.assign({}, shortcut, {isSelected: !!rows.find(({isPinned, searchTopSite, label}) => isPinned && searchTopSite && label === shortcut.keyword)}));
+      shortcuts.push({
+        ...shortcut,
+        isSelected: !!rows.find(row => row && row.isPinned && row.searchTopSite && row.label === shortcut.keyword)
+      });
     });
     this.state = {shortcuts};
   }
@@ -67,7 +70,7 @@ export class SearchShortcutsForm extends React.PureComponent {
     const pinQueue = [];
     const unpinQueue = [];
     this.state.shortcuts.forEach(shortcut => {
-      const alreadyPinned = rows.find(({isPinned, searchTopSite, label}) => isPinned && searchTopSite && label === shortcut.keyword);
+      const alreadyPinned = rows.find(row => row && row.isPinned && row.searchTopSite && row.label === shortcut.keyword);
       if (shortcut.isSelected && !alreadyPinned) {
         pinQueue.push(this._searchTopSite(shortcut));
       } else if (!shortcut.isSelected && alreadyPinned) {
@@ -80,8 +83,8 @@ export class SearchShortcutsForm extends React.PureComponent {
       // First find the available slots. A slot is available if it isn't pinned
       // or if it's a pinned shortcut that we are about to unpin.
       const availableSlots = [];
-      rows.forEach(({isPinned, searchTopSite, url}, index) => {
-        if (!isPinned || (searchTopSite && unpinQueue.find(site => url === site.url))) {
+      rows.forEach((row, index) => {
+        if (!row || !row.isPinned || (row.searchTopSite && unpinQueue.find(site => row.url === site.url))) {
           availableSlots.push(index);
         }
       });

--- a/lib/SearchShortcuts.jsm
+++ b/lib/SearchShortcuts.jsm
@@ -8,15 +8,20 @@
 const SEARCH_SHORTCUTS = [
   {keyword: "@amazon", shortURL: "amazon", url: "https://amazon.com", searchIdentifier: /^amazon/},
   {keyword: "@baidu", shortURL: "baidu", url: "https://baidu.com", searchIdentifier: /^baidu/},
-  {keyword: "@bing", shortURL: "bing", url: "https://bing.com", searchIdentifier: /^bing/},
-  {keyword: "@duckduckgo", shortURL: "duckduckgo", url: "https://duckduckgo.com", searchIdentifier: /^ddg/},
-  {keyword: "@ebay", shortURL: "ebay", url: "https://ebay.com", searchIdentifier: /^ebay/},
   {keyword: "@google", shortURL: "google", url: "https://google.com", searchIdentifier: /^google/},
-  {keyword: "@twitter", shortURL: "twitter", url: "https://twitter.com", searchIdentifier: /^twitter/},
-  {keyword: "@wikipedia", shortURL: "wikipedia", url: "https://wikipedia.org", searchIdentifier: /^wikipedia/},
   {keyword: "@yandex", shortURL: "yandex", url: "https://yandex.com", searchIdentifier: /^yandex/}
 ];
 this.SEARCH_SHORTCUTS = SEARCH_SHORTCUTS;
+
+// These can be added via the editor but will not be added organically
+this.CUSTOM_SEARCH_SHORTCUTS = [
+  ...SEARCH_SHORTCUTS,
+  {keyword: "@bing", shortURL: "bing", url: "https://bing.com", searchIdentifier: /^bing/},
+  {keyword: "@duckduckgo", shortURL: "duckduckgo", url: "https://duckduckgo.com", searchIdentifier: /^ddg/},
+  {keyword: "@ebay", shortURL: "ebay", url: "https://ebay.com", searchIdentifier: /^ebay/},
+  {keyword: "@twitter", shortURL: "twitter", url: "https://twitter.com", searchIdentifier: /^twitter/},
+  {keyword: "@wikipedia", shortURL: "wikipedia", url: "https://wikipedia.org", searchIdentifier: /^wikipedia/}
+];
 
 // Note: you must add the activity stream branch to the beginning of this if using outside activity stream
 this.SEARCH_SHORTCUTS_EXPERIMENT = "improvesearch.topSiteSearchShortcuts";
@@ -28,5 +33,5 @@ function getSearchProvider(candidateShortURL) {
 }
 this.getSearchProvider = getSearchProvider;
 
-const EXPORTED_SYMBOLS = ["getSearchProvider", "SEARCH_SHORTCUTS", "SEARCH_SHORTCUTS_EXPERIMENT",
+const EXPORTED_SYMBOLS = ["getSearchProvider", "SEARCH_SHORTCUTS", "CUSTOM_SEARCH_SHORTCUTS", "SEARCH_SHORTCUTS_EXPERIMENT",
   "SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF", "SEARCH_SHORTCUTS_HAVE_PINNED_PREF"];

--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -12,7 +12,7 @@ const {Dedupe} = ChromeUtils.import("resource://activity-stream/common/Dedupe.js
 const {shortURL} = ChromeUtils.import("resource://activity-stream/lib/ShortURL.jsm", {});
 const {getDefaultOptions} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamStorage.jsm", {});
 const {
-  SEARCH_SHORTCUTS,
+  CUSTOM_SEARCH_SHORTCUTS,
   SEARCH_SHORTCUTS_EXPERIMENT,
   SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF,
   SEARCH_SHORTCUTS_HAVE_PINNED_PREF,
@@ -364,7 +364,7 @@ this.TopSitesFeed = class TopSitesFeed {
     }
   }
 
-  async updateSearchShortcuts() {
+  async updateCustomSearchShortcuts() {
     if (!this.store.getState().Prefs.values[SEARCH_SHORTCUTS_EXPERIMENT]) {
       return;
     }
@@ -377,7 +377,7 @@ this.TopSitesFeed = class TopSitesFeed {
     await new Promise(resolve => Services.search.init(resolve));
     const searchShortcuts = Services.search.getDefaultEngines().reduce((result, engine) => {
       if (engine.identifier) {
-        const shortcut = SEARCH_SHORTCUTS.find(s => engine.identifier.match(s.searchIdentifier));
+        const shortcut = CUSTOM_SEARCH_SHORTCUTS.find(s => engine.identifier.match(s.searchIdentifier));
         if (shortcut) {
           result.push(this._tippyTopProvider.processSite({...shortcut}));
         }
@@ -617,7 +617,7 @@ this.TopSitesFeed = class TopSitesFeed {
     switch (action.type) {
       case at.INIT:
         this.init();
-        this.updateSearchShortcuts();
+        this.updateCustomSearchShortcuts();
         break;
       case at.SYSTEM_TICK:
         this.refresh({broadcast: false});

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -1287,9 +1287,9 @@ describe("Top Sites Feed", () => {
       const defaultSearchTopsite = urlsReturned.find(s => s.url === "google.com");
       assert.isTrue(defaultSearchTopsite.searchTopSite);
     });
-    it("should dispatch UPDATE_SEARCH_SHORTCUTS on updateSearchShortcuts", async () => {
+    it("should dispatch UPDATE_SEARCH_SHORTCUTS on updateCustomSearchShortcuts", async () => {
       feed.store.state.Prefs.values["improvesearch.noDefaultSearchTile"] = true;
-      await feed.updateSearchShortcuts();
+      await feed.updateCustomSearchShortcuts();
       assert.calledOnce(feed.store.dispatch);
       assert.calledWith(feed.store.dispatch, {
         data: {


### PR DESCRIPTION
Also fixed a small bug where null top sites were crashing the add search
shortcuts editor.