### PR TITLE
Bug 1479458 - Fixing broadcast of updated data from cache.

### DIFF
--- a/lib/TopStoriesFeed.jsm
+++ b/lib/TopStoriesFeed.jsm
@@ -40,8 +40,6 @@ this.TopStoriesFeed = class TopStoriesFeed {
     try {
       const {options} = SectionsManager.sections.get(SECTION_ID);
       const apiKey = this.getApiKeyFromPref(options.api_key_pref);
-      // Set this to true if we're not loading from cache.
-      let shouldBroadcast = false;
       this.stories_endpoint = this.produceFinalEndpointUrl(options.stories_endpoint, apiKey);
       this.topics_endpoint = this.produceFinalEndpointUrl(options.topics_endpoint, apiKey);
       this.read_more_endpoint = options.read_more_endpoint;
@@ -57,17 +55,14 @@ this.TopStoriesFeed = class TopStoriesFeed {
       // Cache is used for new page loads, which shouldn't have changed data.
       // If we have changed data, cache should be cleared,
       // and last updated should be 0, and we can fetch.
-      // Think there is a bug here.
       await this.loadCachedData();
       if (this.storiesLastUpdated === 0) {
-        shouldBroadcast = true;
         await this.fetchStories();
       }
       if (this.topicsLastUpdated === 0) {
-        shouldBroadcast = true;
         await this.fetchTopics();
       }
-      this.doContentUpdate(shouldBroadcast);
+      this.doContentUpdate(true);
       this.storiesLoaded = true;
 
       // This is filtered so an update function can return true to retry on the next run

--- a/test/unit/lib/TopStoriesFeed.test.js
+++ b/test/unit/lib/TopStoriesFeed.test.js
@@ -1007,6 +1007,17 @@ describe("Top Stories Feed", () => {
       await instance.loadCachedData();
       assert.notCalled(sectionsManagerStub.updateSection);
     });
+    it("should broadcast in doContentUpdate when updating from cache", async () => {
+      sectionsManagerStub.sections.set("topstories", {options: {stories_referrer: "referrer"}});
+      globals.set("NewTabUtils", {blockedLinks: {isBlocked: () => {}}});
+      const stories = {"recommendations": [{}]};
+      const topics = {"topics": [{}]};
+      sinon.spy(instance, "doContentUpdate");
+      instance.cache.get = () => ({stories, topics});
+      await instance.onInit();
+      assert.calledOnce(instance.doContentUpdate);
+      assert.calledWith(instance.doContentUpdate, true);
+    });
     it("should initialize user domain affinity provider from cache if personalization is preffed on", async () => {
       const domainAffinities = {
         "parameterSets": {


### PR DESCRIPTION
To test.

1. Checkout aab3771a50215d97ed4f34c7056f46a0f943a822 which is the pr before the patch that caused the bug.

2. Open about:home enough to generate some spocs and a preload and a cache.

3. Checkout my branch.

4. Go to about:home

5. Should see rec.

If you want to see the initial bug reproduced, instead of checking out my branch on step 3, checkout  be0ccddd3e6f7d7adffa55b0440f8a1104286ca5 and do everything else the same, and then on 5 should see no recs.