### PR TITLE
Fix Bug 1482865 - fix searchy overlap when resizing window

### DIFF
--- a/content-src/components/TopSites/_TopSites.scss
+++ b/content-src/components/TopSites/_TopSites.scss
@@ -318,13 +318,13 @@ $half-base-gutter: $base-gutter / 2;
     margin: 0 auto;
     padding: $form-spacing;
 
+    > div {
+      margin-inline-end: -39px;
+    }
+
     .top-site-outer {
       margin-inline-start: 0;
       margin-inline-end: 39px;
-
-      &:nth-child(5n) {
-        margin-inline-end: 0;
-      }
     }
   }
 


### PR DESCRIPTION
before:
<img width="568" alt="screen shot 2018-08-13 at 11 34 25 am" src="https://user-images.githubusercontent.com/36629/44041882-dff9a9de-9eec-11e8-84fd-1719a3ae8c60.png">

after:
<img width="604" alt="screen shot 2018-08-13 at 11 33 23 am" src="https://user-images.githubusercontent.com/36629/44041885-e2f6f362-9eec-11e8-9e68-c74103a928e4.png">
