### PR TITLE
Fix Bug 1482854 - Middle clicking an @search Top Site wrongly triggers autoscroll

### DIFF
--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -54,6 +54,10 @@ export class TopSiteLink extends React.PureComponent {
         }
         break;
       case "mousedown":
+        // Block the scroll wheel from appearing for middle clicks on search top sites
+        if (event.button === 1 && this.props.link.searchTopSite) {
+          event.preventDefault();
+        }
         // Reset at the first mouse event of a potential drag
         this.dragged = false;
         break;


### PR DESCRIPTION
No more middle clicks for search top sites