### PR TITLE
Fix Bug 1482246 - Correctly report mochitest failures

### DIFF
--- a/mochitest.sh
+++ b/mochitest.sh
@@ -15,9 +15,9 @@ cd /activity-stream && npm install . && npm run buildmc
 cd /mozilla-central && ./mach build \
   && ./mach test browser_parsable_css \
   && ./mach lint -l codespell browser/components/newtab \
-  && ./mach test browser/components/newtab/test/browser --headless \
+  && ./mach test browser/components/newtab/test/browser \
   && ./mach test browser/components/newtab/test/xpcshell \
-  && ./mach test browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js --headless \
-  && ./mach test browser/components/preferences/in-content/tests/browser_newtab_menu.js --headless \
-  && ./mach test browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js --headless \
-  && ./mach test browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js --headless
+  && ./mach test browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
+  && ./mach test browser/components/preferences/in-content/tests/browser_newtab_menu.js \
+  && ./mach test browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
+  && ./mach test browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js

--- a/mochitest.sh
+++ b/mochitest.sh
@@ -13,19 +13,12 @@ cd /activity-stream && npm install . && npm run buildmc
 
 # Build latest m-c with Activity Stream changes
 cd /mozilla-central && ./mach build \
-  && ./mach test browser_parsable_css \
   && ./mach lint -l codespell browser/components/newtab \
-  && ./mach test browser/components/newtab/test/browser \
-  browser/components/newtab/test/xpcshell \
+  && ./mach test --log-tbpl test_run_log \
+  browser_parsable_css \
+  browser/components/newtab \
   browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
   browser/components/preferences/in-content/tests/browser_newtab_menu.js \
   browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
-  browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js --log-tbpl test_run_log
-
-# Check test log for any error reports
-if [ $(cat test_run_log | grep "TEST-UNEXPECTED" | wc -l) -gt 0 ]
-then
-	false
-else
-	true
-fi
+  browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js \
+  && ! grep -q TEST-UNEXPECTED test_run_log

--- a/mochitest.sh
+++ b/mochitest.sh
@@ -16,8 +16,16 @@ cd /mozilla-central && ./mach build \
   && ./mach test browser_parsable_css \
   && ./mach lint -l codespell browser/components/newtab \
   && ./mach test browser/components/newtab/test/browser \
-  && ./mach test browser/components/newtab/test/xpcshell \
-  && ./mach test browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
-  && ./mach test browser/components/preferences/in-content/tests/browser_newtab_menu.js \
-  && ./mach test browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
-  && ./mach test browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js
+  browser/components/newtab/test/xpcshell \
+  browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
+  browser/components/preferences/in-content/tests/browser_newtab_menu.js \
+  browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
+  browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js --log-tbpl test_run_log
+
+# Check test log for any error reports
+if [ $(cat test_run_log | grep "TEST-UNEXPECTED" | wc -l) -gt 0 ]
+then
+	false
+else
+	true
+fi


### PR DESCRIPTION
I'm not sure if this is a bug or not but running `./mach test` or `./mach mochitest` seems to return 0 regardless of the success/failure of the actual test.
The only workaround I've found is outputing the logs in a file and grepping for the `TEST-UNEXPECTED` string, funny enough this method is also mentioned in a bug [about returning the correct status code from mochitests](https://bugzilla.mozilla.org/show_bug.cgi?id=875382#c3)
f? @Mardak 