### PR TITLE
bug 1478755 - Ensure spocs load without a flash of rec via a slight r…

### DIFF
--- a/content-src/components/Sections/Sections.jsx
+++ b/content-src/components/Sections/Sections.jsx
@@ -18,6 +18,11 @@ function getFormattedMessage(message) {
 }
 
 export class Section extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {delayThirdCard: props.id === "topstories"};
+  }
+
   get numRows() {
     const {rowsPref, maxRows, Prefs} = this.props;
     return rowsPref ? Prefs.values[rowsPref] : maxRows;
@@ -77,6 +82,12 @@ export class Section extends React.PureComponent {
   }
 
   componentDidMount() {
+    if (this.state.delayThirdCard) {
+      // We delay the third card for 200ms to give time for a spoc to load.
+      setTimeout(() => {
+        this.setState({delayThirdCard: false});
+      }, 200);
+    }
     if (this.props.rows.length && !this.props.pref.collapsed) {
       this.sendImpressionStatsOrAddListener();
     }
@@ -152,7 +163,12 @@ export class Section extends React.PureComponent {
         // On narrow viewports, we only show 3 cards per row. We'll mark the rest as
         // .hide-for-narrow to hide in CSS via @media query.
         const className = (i >= maxCardsOnNarrow) ? "hide-for-narrow" : "";
-        cards.push(link ? (
+        let usePlaceholder = !link;
+        if (this.state.delayThirdCard && i === 2 && !usePlaceholder) {
+          usePlaceholder = this.state.delayThirdCard;
+        }
+
+        cards.push(!usePlaceholder ? (
           <Card key={i}
             index={i}
             className={className}

--- a/test/unit/content-src/components/Sections.test.jsx
+++ b/test/unit/content-src/components/Sections.test.jsx
@@ -194,6 +194,25 @@ describe("<Section>", () => {
 
       assert.lengthOf(wrapper.find(".topic"), 1);
     });
+    it("should delay render of third rec to give time for potential spoc", async () => {
+      TOP_STORIES_SECTION.rows = [
+        {guid: 1, link: "http://localhost"},
+        {guid: 2, link: "http://localhost"},
+        {guid: 3, link: "http://localhost"}
+      ];
+
+      wrapper = shallow(<Section {...TOP_STORIES_SECTION} />);
+      assert.equal(wrapper.state("delayThirdCard"), true);
+      assert.lengthOf(wrapper.find(PlaceholderCard), 1);
+      wrapper.setState({delayThirdCard: false});
+      assert.equal(wrapper.state("delayThirdCard"), false);
+      assert.lengthOf(wrapper.find(PlaceholderCard), 0);
+
+      TOP_STORIES_SECTION.id = "topsites";
+      wrapper = shallow(<Section {...TOP_STORIES_SECTION} />);
+      assert.lengthOf(wrapper.find(PlaceholderCard), 0);
+      assert.equal(!!wrapper.state("delayThirdCard"), false);
+    });
   });
 
   describe("impression stats", () => {


### PR DESCRIPTION
Steps to test:

1. Open the browser with the Profile manager.
2. Create a new Profile, but DO NOT open it.
3. Navigate to the Profile's location on the computer.
(Win - C:\Users\<username>\AppData\Roaming\Mozilla\Firefox\Profiles\
Mac - Users/<username>/Library/Application Support/Firefox/Profiles/
Linux - /home/<username>/.mozilla/firefox)
Create a file named user.js and open it with a text editor.
Write :
```
user_pref("browser.newtabpage.activity-stream.feeds.section.topstories.options", '{"api_key_pref":"extensions.pocket.oAuthConsumerKey","hidden":false,"provider_icon":"pocket","provider_name":"Pocket","read_more_endpoint":"https://getpocket.com/explore/trending?src=fx_new_tab","stories_endpoint":"file:///home/scott/spoc.json","stories_referrer":"https://getpocket.com/recommendations","topics_endpoint":"https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=en-US","show_spocs":true,"personalized":true}');
```
4. Start the browser with the newly created profile.

That's the steps for the original bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=1478755

What's actually causing the flash is the fact that `NEW_TAB_REHYDRATED` is happening after render of sections.

I'm not a fan of this solution, tbh, but it was approved by Nick Chapman, and much much easier than a refactor (which I believe is doable with a bit more work)

Thoughts?
