### PR TITLE
Bug 1483562 - Use object for button_action in ASR

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -28,9 +28,9 @@ export const ASRouterUtils = {
   blockBundle(bundle) {
     ASRouterUtils.sendMessage({type: "BLOCK_BUNDLE", data: {bundle}});
   },
-  executeAction({button_action, button_action_params}) {
-    if (button_action in ra) {
-      ASRouterUtils.sendMessage({type: button_action, data: {button_action_params}});
+  executeAction(button_action) {
+    if (button_action.type in ra) {
+      ASRouterUtils.sendMessage(button_action);
     }
   },
   unblockById(id) {

--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -10,7 +10,7 @@ class OnboardingCard extends React.PureComponent {
   onClick() {
     const {props} = this;
     props.sendUserActionTelemetry({event: "CLICK_BUTTON", message_id: props.id, id: props.UISurface});
-    props.onAction(props.content);
+    props.onAction(props.content.button_action);
   }
 
   render() {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -613,10 +613,10 @@ class _ASRouter {
         target.browser.ownerGlobal.OpenBrowserWindow({private: true});
         break;
       case ra.OPEN_URL:
-        this.openLinkIn(action.data.button_action_params, target, {isPrivate: false, where: "tabshifted"});
+        this.openLinkIn(action.data.url, target, {isPrivate: false, where: "tabshifted"});
         break;
       case ra.OPEN_ABOUT_PAGE:
-        this.openLinkIn(`about:${action.data.button_action_params}`, target, {isPrivate: false, trusted: true, where: "tab"});
+        this.openLinkIn(`about:${action.data.page}`, target, {isPrivate: false, trusted: true, where: "tab"});
         break;
       case "BLOCK_MESSAGE_BY_ID":
         await this.blockById(action.data.id);

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -14,7 +14,7 @@ const ONBOARDING_MESSAGES = [
       text: "Browse by yourself. Private Browsing with Tracking Protection blocks online trackers that follow you around the web.",
       icon: "privatebrowsing",
       button_label: "Try It Now",
-      button_action: "OPEN_PRIVATE_BROWSER_WINDOW"
+      button_action: {type: "OPEN_PRIVATE_BROWSER_WINDOW"}
     },
     trigger: {id: "firstRun"}
   },
@@ -28,8 +28,10 @@ const ONBOARDING_MESSAGES = [
       text: "Take, save and share screenshots - without leaving Firefox. Capture a region or an entire page as you browse. Then save to the web for easy access and sharing.",
       icon: "screenshots",
       button_label: "Try It Now",
-      button_action: "OPEN_URL",
-      button_action_params: "https://screenshots.firefox.com/#tour"
+      button_action: {
+        type: "OPEN_URL",
+        data: {url: "https://screenshots.firefox.com/#tour"}
+      }
     },
     trigger: {id: "firstRun"}
   },
@@ -43,8 +45,7 @@ const ONBOARDING_MESSAGES = [
       text: "Add even more features that make Firefox work harder for you. Compare prices, check the weather or express your personality with a custom theme.",
       icon: "addons",
       button_label: "Try It Now",
-      button_action: "OPEN_ABOUT_PAGE",
-      button_action_params: "addons"
+      button_action: {type: "OPEN_ABOUT_PAGE", data: {page: "addons"}}
     },
     targeting: "isInExperimentCohort == 1",
     trigger: {id: "firstRun"}
@@ -59,8 +60,7 @@ const ONBOARDING_MESSAGES = [
       text: "Browse faster, smarter, or safer with extensions like Ghostery, which lets you block annoying ads.",
       icon: "gift",
       button_label: "Try It Now",
-      button_action: "OPEN_URL",
-      button_action_params: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/"
+      button_action: {type: "OPEN_URL", data: {url: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/"}}
     },
     targeting: "isInExperimentCohort == 2",
     trigger: {id: "firstRun"}

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -597,21 +597,21 @@ describe("ASRouter", () => {
     it("should call openLinkIn with the correct params on OPEN_URL", async () => {
       sinon.spy(Router, "openLinkIn");
       let [testMessage] = Router.state.messages;
-      testMessage.button_action_params = "some/url.com";
-      const msg = fakeAsyncMessage({type: "OPEN_URL", data: testMessage});
+      testMessage.button_action = {type: "OPEN_URL", data: {url: "some/url.com"}};
+      const msg = fakeAsyncMessage(testMessage.button_action);
       await Router.onMessage(msg);
 
-      assert.calledWith(Router.openLinkIn, testMessage.button_action_params, msg.target, {isPrivate: false, where: "tabshifted"});
+      assert.calledWith(Router.openLinkIn, "some/url.com", msg.target, {isPrivate: false, where: "tabshifted"});
       assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
     });
     it("should call openLinkIn with the correct params on OPEN_ABOUT_PAGE", async () => {
       sinon.spy(Router, "openLinkIn");
       let [testMessage] = Router.state.messages;
-      testMessage.button_action_params = "something";
-      const msg = fakeAsyncMessage({type: "OPEN_ABOUT_PAGE", data: testMessage});
+      testMessage.button_action = {type: "OPEN_ABOUT_PAGE", data: {page: "something"}};
+      const msg = fakeAsyncMessage(testMessage.button_action);
       await Router.onMessage(msg);
 
-      assert.calledWith(Router.openLinkIn, `about:${testMessage.button_action_params}`, msg.target, {isPrivate: false, trusted: true, where: "tab"});
+      assert.calledWith(Router.openLinkIn, `about:something`, msg.target, {isPrivate: false, trusted: true, where: "tab"});
       assert.calledOnce(msg.target.browser.ownerGlobal.openTrustedLinkIn);
     });
   });


### PR DESCRIPTION
To test this, just open the onboarding panels via `about:newtab#asrouter` and make sure the buttons still work.

Changes `button_action` and `button_params` to be a single `button_action`