### PR TITLE
Bug 1483653 - Sites filtered out by improvesearch.noDefaultSearchTiles are replaced by default sites

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -217,7 +217,8 @@ this.TopSitesFeed = class TopSitesFeed {
 
     // Get all frecent sites from history
     const frecent = (await this.frecentCache.request({
-      numItems,
+      // We need to overquery due to the top 5 alexa search + default search possibly being removed
+      numItems: numItems + SEARCH_FILTERS.length + 1,
       topsiteFrecency: FRECENCY_THRESHOLD
     }))
     .reduce((validLinks, link) => {


### PR DESCRIPTION
If you'd like to test this, you can paste this in [NewTabUtils at line 1159](https://searchfox.org/mozilla-central/source/toolkit/modules/NewTabUtils.jsm#1159) to override your top sites query:

https://gist.github.com/k88hudson/e69eea7e89342e5fcb294ad45d8d403a

Prefs:
 - 1 row of top sites
- `improvesearch.noDefaultSearchTiles` set to `true`

The incorrect behavior on master is that with you should see the last two positions be filled with default tiles (youtube, facebook) rather than organic tiles.

With my patch applied, you should see organic tiles (slack, github).