### PR TITLE
Bug 1485345 - Add timestamp targeting

### DIFF
--- a/content-src/asrouter/README.md
+++ b/content-src/asrouter/README.md
@@ -5,7 +5,25 @@
 Name | Used for | Type | Example value
 ---  | ---      | ---  | ---
 `whitelistHosts` | Whitelist a host in order to fetch messages from its endpoint | `[String]` |  `["gist.github.com", "gist.githubusercontent.com", "localhost:8000"]`
-`snippetsUrl` | The main remote endpoint that serves all snippet messages | `String` | `https://activity-stream-icons.services.mozilla.com/v1/messages.json.br`
+`messageProviders` | Message provider options | `Object` | [see below](#message-providers)
+
+### Message providers
+
+```json
+[
+   {
+      "id" : "onboarding",
+      "type" : "local",
+      "localProvider" : "OnboardingMessageProvider"
+   },
+   {
+      "type" : "remote",
+      "url" : "https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json",
+      "updateCycleInMs" : 14400000,
+      "id" : "snippets"
+   }
+]
+```
 
 ## Admin Interface
 

--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -94,7 +94,7 @@ Name | Type | Example value | Description
 `isDefaultBrowser` | `Boolean` or `null` | Is Firefox the user's default browser? If we could not determine the default browser, this value is `null`
 `profileAgeCreated` | Number | `1522843725924` | Profile creation timestamp
 `profileAgeReset` | `Number` or `undefined` | `1522843725924` | When (if) the profile was reset
-`currentTimestamp` | `Date` | `Date 2018-08-22T15:48:04.100Z` | Date object of current time in UTC
+`currentDate` | `Date` | `Date 2018-08-22T15:48:04.100Z` | Date object of current time in UTC
 `searchEngines` | `Object` | [example below](#searchengines-example) | Information about the current and available search engines
 `browserSettings.attribution` | `Object` or `undefined` | [example below](#attribution-example) | Attribution for the source of of where the browser was downloaded.
 
@@ -174,6 +174,6 @@ Examples:
   "id": "7866",
   "content": {...},
   // targeting based on time
-  "targeting": "currentTimestamp > '2018-08-08'|date"
+  "targeting": "currentDate > '2018-08-08'|date"
 }
 ```

--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -4,8 +4,6 @@ Field name | Type     | Required | Description | Example / Note
 ---        | ---      | ---      | ---         | ---
 `id`       | `string` | Yes | A unique identifier for the message that should not conflict with any other previous message | `ONBOARDING_1`
 `template` | `string` | Yes | An id matching an existing Activity Stream Router template | [See example](https://github.com/mozilla/activity-stream/blob/33669c67c2269078a6d3d6d324fb48175d98f634/system-addon/content-src/message-center/templates/SimpleSnippet.jsx)
-`publish_start` | `date` | No | When to start showing the message | `1524474850876`
-`publish_end` | `date` | No | When to stop showing the message | `1524474850876`
 `content` | `object` | Yes | An object containing all variables/props to be rendered in the template. Subset of allowed tags detailed below. | [See example below](#html-subset)
 `bundled` | `integer` | No | The number of messages of the same template this one should be shown with | [See example below](#a-bundled-message-example)
 `order` | `integer` | No | If bundled with other messages of the same template, which order should this one be placed in? Defaults to 0 if no order is desired | [See example below](#a-bundled-message-example)
@@ -96,6 +94,7 @@ Name | Type | Example value | Description
 `isDefaultBrowser` | `Boolean` or `null` | Is Firefox the user's default browser? If we could not determine the default browser, this value is `null`
 `profileAgeCreated` | Number | `1522843725924` | Profile creation timestamp
 `profileAgeReset` | `Number` or `undefined` | `1522843725924` | When (if) the profile was reset
+`currentTimestamp` | `Date` | `Date 2018-08-22T15:48:04.100Z` | Date object of current time in UTC
 `searchEngines` | `Object` | [example below](#searchengines-example) | Information about the current and available search engines
 `browserSettings.attribution` | `Object` or `undefined` | [example below](#attribution-example) | Attribution for the source of of where the browser was downloaded.
 
@@ -169,5 +168,12 @@ Examples:
   "content": {...},
   // targeting addon information
   "targeting": "addonsInfo.addons['activity-stream@mozilla.org'].name == 'Activity Stream'"
+}
+
+{
+  "id": "7866",
+  "content": {...},
+  // targeting based on time
+  "targeting": "currentTimestamp > '2018-08-08'|date"
 }
 ```

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -67,6 +67,9 @@ const TargetingGetters = {
       update: settings.update
     };
   },
+  get timestamp() {
+    return new Date(new Date().getTime());
+  },
   get profileAgeCreated() {
     return new ProfileAge(null, null).created;
   },

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -67,7 +67,7 @@ const TargetingGetters = {
       update: settings.update
     };
   },
-  get currentTimestamp() {
+  get currentDate() {
     return new Date();
   },
   get profileAgeCreated() {

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -67,7 +67,7 @@ const TargetingGetters = {
       update: settings.update
     };
   },
-  get timestamp() {
+  get currentTimestamp() {
     return new Date(new Date().getTime());
   },
   get profileAgeCreated() {

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -68,7 +68,7 @@ const TargetingGetters = {
     };
   },
   get currentTimestamp() {
-    return new Date(new Date().getTime());
+    return new Date();
   },
   get profileAgeCreated() {
     return new ProfileAge(null, null).created;

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -209,7 +209,7 @@ const PREFS_CONFIG = new Map([
     }, {
       id: "snippets",
       type: "remote",
-      url: "https://activity-stream-icons.services.mozilla.com/v1/messages.json.br",
+      url: "https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json",
       updateCycleInMs: ONE_HOUR_IN_MS * 4,
       enabled: false
     }])

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -110,14 +110,14 @@ add_task(async function checkProfileAgeReset() {
     "should select correct item by profile age reset");
 });
 
-add_task(async function checkCurrentTimestamp() {
-  let message = {id: "foo", targeting: `currentTimestamp < '${new Date(new Date().getTime() + 1000)}'|date`};
+add_task(async function checkCurrentDate() {
+  let message = {id: "foo", targeting: `currentDate < '${new Date(Date.now() + 1000)}'|date`};
   is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
-    "should select message based on currentTimestamp");
+    "should select message based on currentDate < timestamp");
 
-  message = {id: "foo", targeting: `currentTimestamp > '${new Date(new Date().getTime() - 1000)}'|date`};
+  message = {id: "foo", targeting: `currentDate > '${new Date(Date.now() - 1000)}'|date`};
   is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
-    "should select message based on currentTimestamp");
+    "should select message based on currentDate > timestamp");
 });
 
 add_task(async function checkhasFxAccount() {

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -110,6 +110,16 @@ add_task(async function checkProfileAgeReset() {
     "should select correct item by profile age reset");
 });
 
+add_task(async function checkCurrentTimestamp() {
+  let message = {id: "foo", targeting: `currentTimestamp < '${new Date(new Date().getTime() + 1000)}'|date`};
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
+    "should select message based on currentTimestamp");
+
+  message = {id: "foo", targeting: `currentTimestamp > '${new Date(new Date().getTime() - 1000)}'|date`};
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
+    "should select message based on currentTimestamp");
+});
+
 add_task(async function checkhasFxAccount() {
   await pushPrefs(["services.sync.username", "someone@foo.com"]);
   is(await ASRouterTargeting.Environment.hasFxAccount, true,


### PR DESCRIPTION
This adds a `currentTimestamp` attribute for targeting. Allows ASRouter messages to filter by time, also allows for more complicated JEXL expressions like "profile age".

I also updated some of the docs `publish_start|end` is not something we support.

And I've moved our remote snippet endpoint to fetch from the snippets cdn. We can now validate the integration of the two services. Also the previous endpoint was using a schema we no longer support (link are now only rendered as part of Fluent).