### PR TITLE
Fix Bug 1482579 - Wait on Search services to intialize before using it

### DIFF
--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -185,7 +185,13 @@ const TEST_GLOBAL = {
     appinfo: {appBuildID: "20180710100040"}
   },
   XPCOMUtils: {
-    defineLazyGetter(_1, _2, f) { f(); },
+    defineLazyGetter(object, name, f) {
+      if (object && name) {
+        object[name] = f();
+      } else {
+        f();
+      }
+    },
     defineLazyGlobalGetters() {},
     defineLazyModuleGetter() {},
     defineLazyServiceGetter() {},


### PR DESCRIPTION
Ideally I would like to refactor all the accesses to search services into one (maybe move all to init) because the pattern to await for `search.init` seems to repeat itself several time in the feed.
I can follow up with another PR but for now this will fix the sync access and [Mike's comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1482579#c7) seemed pretty serious I wanted to have a fix ready.