### PR TITLE
Fix Bug 1484290 - remove hairline/border from searchy icon

### DIFF
--- a/content-src/components/TopSites/_TopSites.scss
+++ b/content-src/components/TopSites/_TopSites.scss
@@ -205,7 +205,7 @@ $half-base-gutter: $base-gutter / 2;
     border-radius: 42px;
     -moz-context-properties: fill;
     fill: $white;
-    box-shadow: inset 0 0 0 1px var(--newtab-inner-box-shadow-color), var(--newtab-card-shadow);
+    box-shadow: var(--newtab-card-shadow);
   }
 
   // We want all search shortcuts to have a white background in case they have transparency.


### PR DESCRIPTION
Before:
<img width="249" alt="screen shot 2018-08-24 at 11 43 36 am" src="https://user-images.githubusercontent.com/36629/44594242-9795ad00-a793-11e8-85e7-f414deb7318d.png">

After:
<img width="256" alt="screen shot 2018-08-24 at 11 44 39 am" src="https://user-images.githubusercontent.com/36629/44594245-9bc1ca80-a793-11e8-856e-d51965d7c951.png">

(It's even more noticeable in dark theme).
