### PR TITLE
Bug 1485528 - Ensure proper cache load when browser shutsdown and res…

### DIFF
--- a/lib/PersistentCache.jsm
+++ b/lib/PersistentCache.jsm
@@ -35,7 +35,7 @@ this.PersistentCache = class PersistentCache {
   async set(key, value) {
     const data = await this._load();
     data[key] = value;
-    this._persist(data);
+    await this._persist(data);
   }
 
   /**
@@ -75,7 +75,7 @@ this.PersistentCache = class PersistentCache {
    */
   _persist(data) {
     const filepath = OS.Path.join(OS.Constants.Path.localProfileDir, this._filename);
-    OS.File.writeAtomic(filepath, JSON.stringify(data), {tmpPath: `${filepath}.tmp`});
+    return OS.File.writeAtomic(filepath, JSON.stringify(data), {tmpPath: `${filepath}.tmp`});
   }
 };
 

--- a/test/unit/lib/PersistentCache.test.js
+++ b/test/unit/lib/PersistentCache.test.js
@@ -15,7 +15,7 @@ describe("PersistentCache", () => {
       File: {
         exists: async () => true,
         read: async () => ({}),
-        writeAtomic: sinon.spy()
+        writeAtomic: sinon.stub().returns(Promise.resolve())
       },
       Path: {join: () => filename}
     };


### PR DESCRIPTION
To test:

1. Open about:config
2. Find config browser.newtabpage.activity-stream.feeds.section.topstories.spoc.impressions
3. Set it to
```
{"api_key_pref":"extensions.pocket.oAuthConsumerKey","hidden":false,"provider_icon":"pocket","provider_name":"Pocket","read_more_endpoint":"https://getpocket.com/explore/trending?src=fx_new_tab","stories_endpoint":"https://gist.githubusercontent.com/ScottDowne/164995d9535b4203846048bdee29d169/raw/9531da1c81fa4d15f8048567245141ef6948583f/spoc.json","stories_referrer":"https://getpocket.com/recommendations","topics_endpoint":"https://getpocket.cdn.mozilla.net/v3/firefox/trending-topics?version=2&consumer_key=$apiKey&locale_lang=en-US","show_spocs":true,"personalized":true}
```
4. Load about:home
5. Ensure the third rec is from theringer.com
6. close and open or restart the browser.
7. Expected: theringer.com still in third spot.