### PR TITLE
(nobug): Switch to lazy loading the modules

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -5,9 +5,11 @@
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
-ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
-ChromeUtils.import("resource:///modules/UITour.jsm");
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
+XPCOMUtils.defineLazyModuleGetters(this, {
+  AddonManager: "resource://gre/modules/AddonManager.jsm",
+  UITour: "resource:///modules/UITour.jsm"
+});
 const {ASRouterActions: ra, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {CFRMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/CFRMessageProvider.jsm", {});
 const {OnboardingMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/OnboardingMessageProvider.jsm", {});

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -194,6 +194,7 @@ const TEST_GLOBAL = {
     },
     defineLazyGlobalGetters() {},
     defineLazyModuleGetter() {},
+    defineLazyModuleGetters() {},
     defineLazyServiceGetter() {},
     generateQI() { return {}; }
   },


### PR DESCRIPTION
This might be the smallest easiest win but ASRouter was showing up in the profiler for no good reason:

<img width="913" alt="screen shot 2018-08-27 at 22 53 27" src="https://user-images.githubusercontent.com/810040/44698760-e2077a00-aa70-11e8-85f3-988e0a44f850.png">

Even though the experiment is disabled we include ASRouter.jsm which includes UITour.jsm which automatically calls `init()` [when the file is loaded](https://searchfox.org/mozilla-central/rev/55da592d85c2baf8d8818010c41d9738c97013d2/browser/components/uitour/UITour.jsm#1732).