### PR TITLE
(nobug) Remove the popupnotification to stop undesired chiclet collapse

### DIFF
--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -158,6 +158,8 @@ class PageAction {
   _popupStateChange(state) {
     if (["dismissed", "removed"].includes(state)) {
       this._collapse();
+      // This is safe even if this.currentNotification is invalid/undefined
+      this.window.PopupNotifications.remove(this.currentNotification);
     }
   }
 


### PR DESCRIPTION
Remove the popupnotification so that a "removed" event isn't triggered for a subsequent popupnotification in the same tab, causing the chiclet to collapse.