### PR TITLE
Fix Bug 1488846 - Pocket cta for logged out users flickers a bit before displaying the logged in version (topics) and shifting

### DIFF
--- a/common/Reducers.jsm
+++ b/common/Reducers.jsm
@@ -44,7 +44,7 @@ const INITIAL_STATE = {
   },
   Sections: [],
   Pocket: {
-    isUserLoggedIn: false,
+    isUserLoggedIn: null,
     pocketCta: {},
     waitingForSpoc: true
   }

--- a/content-src/components/Base/_Base.scss
+++ b/content-src/components/Base/_Base.scss
@@ -59,7 +59,7 @@ main {
   $selectors-to-hide: '
     .section-title,
     .sections-list .section:last-of-type,
-    .topic
+    .topics
   ';
 
   #{$selectors-to-hide} {

--- a/content-src/components/Sections/Sections.jsx
+++ b/content-src/components/Sections/Sections.jsx
@@ -155,14 +155,21 @@ export class Section extends React.PureComponent {
     const maxCards = maxCardsPerRow * numRows;
     const maxCardsOnNarrow = CARDS_PER_ROW_DEFAULT * numRows;
 
-    const shouldShowPocketCta = (id === "topstories" &&
-      Pocket.pocketCta.useCta && !Pocket.isUserLoggedIn);
+    const {pocketCta, isUserLoggedIn} = Pocket || {};
+    const {useCta} = pocketCta || {};
 
-    // Show topics only for top stories and if it's not initialized yet (so
-    // content doesn't shift when it is loaded) or has loaded with topics
+    // Don't display anything until we have a definitve result from Pocket,
+    // to avoid a flash of logged out state while we render.
+    const isPocketLoggedInDefined = (isUserLoggedIn === true || isUserLoggedIn === false);
+
+    const shouldShowPocketCta = (id === "topstories" &&
+      useCta && isUserLoggedIn === false);
+
+    // Show topics only for top stories and if it has loaded with topics.
+    // The classs .top-stories-bottom-container ensures content doesn't shift as things load.
     const shouldShowTopics = (id === "topstories" &&
-      (!topics || topics.length > 0) &&
-      !shouldShowPocketCta);
+      (topics && topics.length > 0) &&
+      ((useCta && isUserLoggedIn === true) || (!useCta && isPocketLoggedInDefined)));
 
     const realRows = rows.slice(0, maxCards);
 

--- a/content-src/components/Sections/_Sections.scss
+++ b/content-src/components/Sections/_Sections.scss
@@ -83,6 +83,7 @@
 
   @media (min-width: $break-point-large) {
     line-height: 16px;
+    height: 16px;
   }
 
   // This is a clearfix to for the more-recommendations link which is floating and causes

--- a/test/unit/common/Reducers.test.js
+++ b/test/unit/common/Reducers.test.js
@@ -621,6 +621,9 @@ describe("Reducers", () => {
       const state = Pocket(undefined, {type: at.POCKET_WAITING_FOR_SPOC, data: false});
       assert.isFalse(state.waitingForSpoc);
     });
+    it("should have undefined for initial isUserLoggedIn state", () => {
+      assert.isNull(Pocket(undefined, {type: "some_action"}).isUserLoggedIn);
+    });
     it("should set isUserLoggedIn to false on a POCKET_LOGGED_IN with null", () => {
       const state = Pocket(undefined, {type: at.POCKET_LOGGED_IN, data: null});
       assert.isFalse(state.isUserLoggedIn);

--- a/test/unit/content-src/components/Sections.test.jsx
+++ b/test/unit/content-src/components/Sections.test.jsx
@@ -4,10 +4,12 @@ import {mountWithIntl, shallowWithIntl} from "test/unit/utils";
 import {Section, SectionIntl, _Sections as Sections} from "content-src/components/Sections/Sections";
 import {actionTypes as at} from "common/Actions.jsm";
 import {PlaceholderCard} from "content-src/components/Card/Card";
+import {PocketLoggedInCta} from "content-src/components/PocketLoggedInCta/PocketLoggedInCta";
 import {Provider} from "react-redux";
 import React from "react";
 import {SectionMenu} from "content-src/components/SectionMenu/SectionMenu";
 import {shallow} from "enzyme";
+import {Topics} from "content-src/components/Topics/Topics";
 import {TopSites} from "content-src/components/TopSites/TopSites";
 
 function mountSectionWithProps(props) {
@@ -188,10 +190,10 @@ describe("<Section>", () => {
     });
     it("should render for non-empty topics", () => {
       TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
+      wrapper = shallow(<Section Pocket={{pocketCta: {useCta: true}, isUserLoggedIn: true}} {...TOP_STORIES_SECTION} />);
 
-      wrapper = mountSectionIntlWithProps(TOP_STORIES_SECTION);
-
-      assert.lengthOf(wrapper.find(".topics"), 1);
+      assert.lengthOf(wrapper.find(Topics), 1);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 0);
     });
     it("should delay render of third rec to give time for potential spoc", async () => {
       TOP_STORIES_SECTION.rows = [
@@ -210,12 +212,48 @@ describe("<Section>", () => {
       });
       assert.lengthOf(wrapper.find(PlaceholderCard), 0);
     });
-    it("should render for uninitialized topics", () => {
+    it("should render container for uninitialized topics to ensure content doesn't shift", () => {
       delete TOP_STORIES_SECTION.topics;
 
       wrapper = mountSectionIntlWithProps(TOP_STORIES_SECTION);
 
-      assert.lengthOf(wrapper.find(".topics"), 1);
+      assert.lengthOf(wrapper.find(".top-stories-bottom-container"), 1);
+      assert.lengthOf(wrapper.find(Topics), 0);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 0);
+    });
+
+    it("should render a pocket cta if not logged in and set to display cta", () => {
+      TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
+      wrapper = shallow(<Section Pocket={{pocketCta: {useCta: true}, isUserLoggedIn: false}} {...TOP_STORIES_SECTION} />);
+
+      assert.lengthOf(wrapper.find(Topics), 0);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 1);
+    });
+    it("should render nothing while loading to avoid a flicker of log in state", () => {
+      TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
+      wrapper = shallow(<Section Pocket={{pocketCta: {useCta: false}}} {...TOP_STORIES_SECTION} />);
+
+      assert.lengthOf(wrapper.find(Topics), 0);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 0);
+    });
+    it("should render a topics list if set to not display cta with either logged or out", () => {
+      TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
+      wrapper = shallow(<Section Pocket={{pocketCta: {useCta: false}, isUserLoggedIn: false}} {...TOP_STORIES_SECTION} />);
+
+      assert.lengthOf(wrapper.find(Topics), 1);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 0);
+
+      wrapper = shallow(<Section Pocket={{pocketCta: {useCta: false}, isUserLoggedIn: true}} {...TOP_STORIES_SECTION} />);
+
+      assert.lengthOf(wrapper.find(Topics), 1);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 0);
+    });
+    it("should render nothing if set to display a cta and not logged in or out (waiting for state)", () => {
+      TOP_STORIES_SECTION.topics = [{name: "topic1", url: "topic-url1"}];
+      wrapper = shallow(<Section Pocket={{pocketCta: {useCta: true}}} {...TOP_STORIES_SECTION} />);
+
+      assert.lengthOf(wrapper.find(Topics), 0);
+      assert.lengthOf(wrapper.find(PocketLoggedInCta), 0);
     });
   });
 


### PR DESCRIPTION
@k88hudson 

Two small design related issues noticed in https://bugzilla.mozilla.org/show_bug.cgi?id=1483655, which this fixes.

1. Flicker of logged in/out state while the page loads. Adding a gif below.

2. The height of the cta was actually a few pixels larger than the topics, which potentially causes a slight shift in content as it loads. I made sure on max screen sizes the content doesn't move.