### PR TITLE
Fix Bug 1484206 - Add previousSessionEnd to targeting context

### DIFF
--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -98,6 +98,7 @@ Name | Type | Example value | Description
 `searchEngines` | `Object` | [example below](#searchengines-example) | Information about the current and available search engines
 `browserSettings.attribution` | `Object` or `undefined` | [example below](#attribution-example) | Attribution for the source of of where the browser was downloaded.
 `providerCohorts` | `Object` | `{onboarding: "hello"}` | Cohorts defined for all providers
+`previousSessionEnd` | `Number` | `1536325802800` | Timestamp in milliseconds of previously closed session
 #### addonsInfo Example
 
 ```javascript

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -179,12 +179,8 @@ this.ASRouterTargeting = {
     OTHER_ERROR: "OTHER_ERROR"
   },
 
-  isMatch(filterExpression, context = this.Environment) {
-    // Combine any provided context with the default getters
-    if (context !== this.Environment) {
-      return FilterExpressions.eval(filterExpression, {...this.Environment, ...context});
-    }
-    return FilterExpressions.eval(filterExpression, context);
+  isMatch(filterExpression, context) {
+    return FilterExpressions.eval(filterExpression, Object.assign({}, this.Environment, context));
   },
 
   isTriggerMatch(trigger = {}, candidateMessageTrigger = {}) {

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -180,6 +180,10 @@ this.ASRouterTargeting = {
   },
 
   isMatch(filterExpression, context = this.Environment) {
+    // Combine any provided context with the default getters
+    if (context !== this.Environment) {
+      return FilterExpressions.eval(filterExpression, {...this.Environment, ...context});
+    }
     return FilterExpressions.eval(filterExpression, context);
   },
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -180,7 +180,12 @@ this.ASRouterTargeting = {
   },
 
   isMatch(filterExpression, context) {
-    return FilterExpressions.eval(filterExpression, Object.assign({}, this.Environment, context));
+    if (context) {
+      // If we passed in a value for `context` we want to merge that with `Environment`
+      // Object.create will do this without evaluating/calling any of the getters defined in `Environment`
+      context.prototype = Object.create({}, Object.getOwnPropertyDescriptors(this.Environment));
+    }
+    return FilterExpressions.eval(filterExpression, context || this.Environment);
   },
 
   isTriggerMatch(trigger = {}, candidateMessageTrigger = {}) {

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -251,7 +251,6 @@ add_task(async function checkFrecentSites() {
   }
 
   await PlacesTestUtils.addVisits(visits);
-  TopFrecentSitesCache.expire();
 
   let message = {id: "foo", targeting: "'mozilla3.com' in topFrecentSites|mapToProperty('host')"};
   is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -251,6 +251,7 @@ add_task(async function checkFrecentSites() {
   }
 
   await PlacesTestUtils.addVisits(visits);
+  TopFrecentSitesCache.expire();
 
   let message = {id: "foo", targeting: "'mozilla3.com' in topFrecentSites|mapToProperty('host')"};
   is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,


### PR DESCRIPTION
This PR has unit tests instead of our usual mochitests for targeting because targeting parameter was added to `ASRouter` and that's more complicated to set up for mochitesting than our (stateless) `ASRouterTargeting.jsm`

Fetches and updates the timestamp in the router, passes it down to targeting through the context parameter. Targeting will merge the provided context and default one. `ASRouterFeed` calls `Router.uninit` on shutdown and that's when we update the timestamp.