### PR TITLE
Fix Bug 1482859 - Block snippet messages after CTA was clicked

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -153,6 +153,9 @@ export class ASRouterUISurface extends React.PureComponent {
       id: "NEWTAB_FOOTER_BAR_CONTENT"
     };
     this.sendUserActionTelemetry({event: "CLICK_BUTTON", ...metric});
+    if (!this.state.message.content.do_not_autoblock) {
+      ASRouterUtils.blockById(this.state.message.id);
+    }
   }
 
   onBlockById(id) {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -14,6 +14,9 @@ export class SimpleSnippet extends React.PureComponent {
   onButtonClick() {
     this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", id: this.props.UISurface});
     this.props.onAction(this.props.content.button_action);
+    if (!this.props.content.do_not_autoblock) {
+      this.props.onBlock();
+    }
   }
 
   renderTitle() {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -75,6 +75,10 @@
       "type": "boolean",
       "description": "To be used by fundraising only, increases height to roughly 120px. Defaults to false."
     },
+    "do_not_autoblock": {
+      "type": "boolean",
+      "description": "Used to prevent blocking the snippet after the CTA (link or button) has been clicked"
+    },
     "links": {
       "additionalProperties": {
         "url": {

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -132,6 +132,23 @@ describe("ASRouterUISurface", () => {
       fakeDocument.visibilityState = value;
     }
 
+    it("should call blockById after CTA link is clicked", () => {
+      wrapper.setState({message: FAKE_MESSAGE});
+      sandbox.stub(ASRouterUtils, "blockById");
+      wrapper.instance().sendClick({target: {dataset: {metric: ""}}});
+
+      assert.calledOnce(ASRouterUtils.blockById);
+      assert.calledWithExactly(ASRouterUtils.blockById, FAKE_MESSAGE.id);
+    });
+
+    it("should not call blockById if do_not_autoblock is true", () => {
+      wrapper.setState({message: {...FAKE_MESSAGE, ...{content: {...FAKE_MESSAGE.content, do_not_autoblock: true}}}});
+      sandbox.stub(ASRouterUtils, "blockById");
+      wrapper.instance().sendClick({target: {dataset: {metric: ""}}});
+
+      assert.notCalled(ASRouterUtils.blockById);
+    });
+
     it("should not send an impression if no message exists", () => {
       simulateVisibilityChange("visible");
 

--- a/test/unit/asrouter/templates/SimpleSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SimpleSnippet.test.jsx
@@ -5,19 +5,36 @@ import {SimpleSnippet} from "content-src/asrouter/templates/SimpleSnippet/Simple
 
 const DEFAULT_CONTENT = {text: "foo"};
 
-/**
- * mountAndCheckProps - Mounts a SimpleSnippet with DEFAULT_CONTENT extended with any props
- *                      passed in the content param and validates props against the schema.
- * @param {obj} content Object containing custom message content (e.g. {text, icon, title})
- * @returns enzyme wrapper for SimpleSnippet
- */
-function mountAndCheckProps(content = {}) {
-  const props = {content: Object.assign({}, DEFAULT_CONTENT, content)};
-  assert.jsonSchema(props.content, schema);
-  return mount(<SimpleSnippet {...props} />);
-}
-
 describe("SimpleSnippet", () => {
+  let sandbox;
+  let onBlockStub;
+
+  /**
+   * mountAndCheckProps - Mounts a SimpleSnippet with DEFAULT_CONTENT extended with any props
+   *                      passed in the content param and validates props against the schema.
+   * @param {obj} content Object containing custom message content (e.g. {text, icon, title})
+   * @returns enzyme wrapper for SimpleSnippet
+   */
+  function mountAndCheckProps(content = {}) {
+    const props = {
+      content: Object.assign({}, DEFAULT_CONTENT, content),
+      onBlock: onBlockStub,
+      sendUserActionTelemetry: sandbox.stub(),
+      onAction: sandbox.stub()
+    };
+    assert.jsonSchema(props.content, schema);
+    return mount(<SimpleSnippet {...props} />);
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    onBlockStub = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it("should render .text", () => {
     const wrapper = mountAndCheckProps({text: "bar"});
     assert.equal(wrapper.find(".body").text(), "bar");
@@ -43,5 +60,20 @@ describe("SimpleSnippet", () => {
     const button = wrapper.find("button.ASRouterButton");
     assert.equal(button.text(), "Click here");
     assert.equal(button.prop("className"), "ASRouterButton");
+  });
+  it("should call props.onBlock when CTA button is clicked", () => {
+    const wrapper = mountAndCheckProps({text: "bar"});
+
+    wrapper.instance().onButtonClick();
+
+    assert.calledOnce(onBlockStub);
+  });
+
+  it("should not call props.onBlock if do_not_autoblock is true", () => {
+    const wrapper = mountAndCheckProps({text: "bar", do_not_autoblock: true});
+
+    wrapper.instance().onButtonClick();
+
+    assert.notCalled(onBlockStub);
   });
 });


### PR DESCRIPTION
This fixes the issue for `SimpleSnippet` but I would keep the bug open until we land all templates (video, newsletter etc) because they all require this feature.