### PR TITLE
Fix Bug 1484207 - Add geo and firefox version targeting getters

### DIFF
--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -100,6 +100,8 @@ Name | Type | Example value | Description
 `providerCohorts` | `Object` | `{onboarding: "hello"}` | Cohorts defined for all providers
 `previousSessionEnd` | `Number` | `1536325802800` | Timestamp in milliseconds of previously closed session
 `totalBookmarksCount` | `Number` | `8` | Total number of bookmarks
+`firefoxVersion` | `Number` | `64` | Firefox version number rounded down
+`geoCountry` | `String` | `US` | Country code retrieved from `location.services.mozilla.com` can be `""` if request did not finish, encountered an error
 #### addonsInfo Example
 
 ```javascript

--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -100,8 +100,8 @@ Name | Type | Example value | Description
 `providerCohorts` | `Object` | `{onboarding: "hello"}` | Cohorts defined for all providers
 `previousSessionEnd` | `Number` | `1536325802800` | Timestamp in milliseconds of previously closed session
 `totalBookmarksCount` | `Number` | `8` | Total number of bookmarks
-`firefoxVersion` | `Number` | `64` | Firefox version number rounded down
-`geoCountry` | `String` | `US` | Country code retrieved from `location.services.mozilla.com` can be `""` if request did not finish, encountered an error
+`firefoxVersion` | `Number` | `64` | The major Firefox version of the browser 
+`region` | `String` | `US` | Country code retrieved from `location.services.mozilla.com` can be `""` if request did not finish, encountered an error
 #### addonsInfo Example
 
 ```javascript

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -2,7 +2,7 @@
   "title": "ProviderResponse",
   "description": "A response object for remote providers of AS Router",
   "type": "object",
-  "version": "6",
+  "version": "6.1.0",
   "properties": {
     "messages": {
       "type": "array",

--- a/content-src/asrouter/schemas/provider-response.schema.json
+++ b/content-src/asrouter/schemas/provider-response.schema.json
@@ -2,7 +2,7 @@
   "title": "ProviderResponse",
   "description": "A response object for remote providers of AS Router",
   "type": "object",
-  "version": "0.1.0",
+  "version": "6",
   "properties": {
     "messages": {
       "type": "array",

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -38,7 +38,7 @@ const SNIPPETS_ENDPOINT_WHITELIST = "browser.newtab.activity-stream.asrouter.whi
 const MAX_MESSAGE_LIFETIME_CAP = 100;
 
 const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider, CFRMessageProvider};
-const STARTPAGE_VERSION = "0.1.0";
+const STARTPAGE_VERSION = "6";
 
 const MessageLoaderUtils = {
   /**

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -181,9 +181,9 @@ const TargetingGetters = {
     return TotalBookmarksCountCache.getTotalBookmarksCount;
   },
   get firefoxVersion() {
-    return parseInt(AppConstants.MOZ_APP_VERSION, 10);
+    return parseInt(AppConstants.MOZ_APP_VERSION.match(/\d+/), 10);
   },
-  get geoCountry() {
+  get region() {
     return Services.prefs.getStringPref(SEARCH_REGION_PREF, "");
   }
 };

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -184,7 +184,7 @@ const TargetingGetters = {
     return parseInt(AppConstants.MOZ_APP_VERSION, 10);
   },
   get geoCountry() {
-    return Services.prefs.getStringPref(SEARCH_REGION_PREF);
+    return Services.prefs.getStringPref(SEARCH_REGION_PREF, "");
   }
 };
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -13,8 +13,11 @@ ChromeUtils.defineModuleGetter(this, "ShellService",
   "resource:///modules/ShellService.jsm");
 ChromeUtils.defineModuleGetter(this, "TelemetryEnvironment",
   "resource://gre/modules/TelemetryEnvironment.jsm");
+ChromeUtils.defineModuleGetter(this, "AppConstants",
+  "resource://gre/modules/AppConstants.jsm");
 
 const FXA_USERNAME_PREF = "services.sync.username";
+const SEARCH_REGION_PREF = "browser.search.region";
 const MOZ_JEXL_FILEPATH = "mozjexl";
 
 const {activityStreamProvider: asProvider} = NewTabUtils;
@@ -176,6 +179,12 @@ const TargetingGetters = {
   },
   get totalBookmarksCount() {
     return TotalBookmarksCountCache.getTotalBookmarksCount;
+  },
+  get firefoxVersion() {
+    return parseInt(AppConstants.MOZ_APP_VERSION, 10);
+  },
+  get geoCountry() {
+    return Services.prefs.getStringPref(SEARCH_REGION_PREF);
   }
 };
 

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -215,7 +215,7 @@ const PREFS_CONFIG = new Map([
     }, {
       id: "snippets",
       type: "remote",
-      url: "https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json",
+      url: "https://snippets.cdn.mozilla.net/%STARTPAGE_VERSION%/%NAME%/%VERSION%/%APPBUILDID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/",
       updateCycleInMs: ONE_HOUR_IN_MS * 4,
       enabled: false
     }, {

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -314,10 +314,10 @@ add_task(async function check_firefox_version() {
     "should select correct item when filtering by firefox version");
 });
 
-add_task(async function check_geoCountry() {
+add_task(async function check_region() {
   await SpecialPowers.pushPrefEnv({"set": [["browser.search.region", "DE"]]});
 
-  const message = {id: "foo", targeting: "geoCountry in ['DE']"};
+  const message = {id: "foo", targeting: "region in ['DE']"};
   is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
     "should select correct item when filtering by firefox geo");
 });

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -315,7 +315,9 @@ add_task(async function check_firefox_version() {
 });
 
 add_task(async function check_geoCountry() {
-  const message = {id: "foo", targeting: "geoCountry in ['US']"};
+  await SpecialPowers.pushPrefEnv({"set": [["browser.search.region", "DE"]]});
+
+  const message = {id: "foo", targeting: "geoCountry in ['DE']"};
   is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
     "should select correct item when filtering by firefox geo");
 });

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -308,6 +308,18 @@ add_task(async function checkFrecentSites() {
   TopFrecentSitesCache.expire();
 });
 
+add_task(async function check_firefox_version() {
+  const message = {id: "foo", targeting: "firefoxVersion > 0"};
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
+    "should select correct item when filtering by firefox version");
+});
+
+add_task(async function check_geoCountry() {
+  const message = {id: "foo", targeting: "geoCountry in ['US']"};
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
+    "should select correct item when filtering by firefox geo");
+});
+
 add_task(async function check_browserSettings() {
   is(await ASRouterTargeting.Environment.browserSettings.attribution, TelemetryEnvironment.currentEnvironment.settings.attribution,
     "should return correct attribution info");

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -339,7 +339,7 @@ describe("ASRouter", () => {
       const provider = {id: "foo", enabled: true, type: "remote", url: "https://www.mozilla.org/%STARTPAGE_VERSION%/"};
       setMessageProviderPref([provider]);
       Router._updateMessageProviders();
-      assert.equal(Router.state.providers[0].url, `https://www.mozilla.org/${expectedStartpageVersion}/`);
+      assert.equal(Router.state.providers[0].url, `https://www.mozilla.org/${parseInt(expectedStartpageVersion, 10)}/`);
     });
     it("should replace other params in remote provider urls by calling Services.urlFormater.formatURL", () => {
       const url = "https://www.example.com/";

--- a/test/unit/asrouter/ASRouterTargeting.test.js
+++ b/test/unit/asrouter/ASRouterTargeting.test.js
@@ -30,7 +30,15 @@ describe("ASRouterTargeting#isInExperimentCohort", () => {
     assert.equal(result, 0);
   });
   it("should combine customContext and TargetingGetters", async () => {
-    assert.isTrue(await ASRouterTargeting.isMatch("foo == true && currentDate == 0", {foo: true}));
+    sandbox.stub(global.FilterExpressions, "eval");
+
+    await ASRouterTargeting.isMatch("true == true", {foo: true});
+
+    assert.calledOnce(global.FilterExpressions.eval);
+    const [, context] = global.FilterExpressions.eval.firstCall.args;
+    // Assert direct properties instead of inherited
+    assert.equal(context.foo, true);
+    assert.match(context.currentDate, sinon.match.date);
   });
 });
 

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -200,7 +200,7 @@ const TEST_GLOBAL = {
   },
   EventEmitter,
   ShellService: {isDefaultBrowser: () => true},
-  FilterExpressions: {eval() { return Promise.resolve(true); }},
+  FilterExpressions: {eval() { return Promise.resolve(false); }},
   RemoteSettings() { return {get() { return Promise.resolve([]); }}; }
 };
 overrider.set(TEST_GLOBAL);


### PR DESCRIPTION
Some more insights: This is needed because previously Snippets could execute code in the browser and it was done to get [user country](https://github.com/mozmeao/snippets-service/blob/2f84e39574bd496921a3defc496888c8ff8c66d0/snippets/base/templates/base/includes/snippet_as.js#L484) and [useragent](https://github.com/mozmeao/snippets-service/blob/2f84e39574bd496921a3defc496888c8ff8c66d0/snippets/base/templates/base/includes/snippet_as.js#L234). Now we need to provide that information.

Using `browser.search.region` is equivalent because Search services calls the same endpoint to get country code [0] [1].

I also updated the remote snippets url, previously it was poiting to a static bundle.

[0] https://searchfox.org/mozilla-central/rev/9e7995b3c384945740985107a4de601b27904718/toolkit/components/search/nsSearchService.js#561
[1] https://searchfox.org/mozilla-central/rev/9e7995b3c384945740985107a4de601b27904718/modules/libpref/init/all.js#5664