### PR TITLE
chore(telemetry): Remove the redundant flag in CFR telemetry

### DIFF
--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -157,13 +157,9 @@ class PageAction {
   }
 
   _sendTelemetry(ping) {
-    // Note `useClientID` is set to true to tell TelemetryFeed to use client_id
-    // instead of `impression_id`. TelemetryFeed is also responsible for deciding
-    // whether to use `message_id` or `bucket_id` based on the release channel and
-    // shield study setup.
     this._dispatchToASRouter({
       type: "DOORHANGER_TELEMETRY",
-      data: {useClientID: true, action: "cfr_user_event", source: "CFR", ...ping}
+      data: {action: "cfr_user_event", source: "CFR", ...ping}
     });
   }
 

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -159,7 +159,6 @@ describe("CFRPageActions", () => {
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
           data: {
-            useClientID: true,
             action: "cfr_user_event",
             source: "CFR",
             message_id: fakeRecommendation.id,
@@ -303,7 +302,7 @@ describe("CFRPageActions", () => {
         pageAction._sendTelemetry(fakePing);
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
-          data: {useClientID: true, action: "cfr_user_event", source: "CFR", message_id: 42}
+          data: {action: "cfr_user_event", source: "CFR", message_id: 42}
         });
       });
     });
@@ -409,7 +408,6 @@ describe("CFRPageActions", () => {
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
           data: {
-            useClientID: true,
             action: "cfr_user_event",
             source: "CFR",
             message_id: fakeRecommendation.id,
@@ -441,7 +439,6 @@ describe("CFRPageActions", () => {
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
           data: {
-            useClientID: true,
             action: "cfr_user_event",
             source: "CFR",
             message_id: fakeRecommendation.id,
@@ -465,7 +462,6 @@ describe("CFRPageActions", () => {
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
           data: {
-            useClientID: true,
             action: "cfr_user_event",
             source: "CFR",
             message_id: fakeRecommendation.id,


### PR DESCRIPTION
The `useClientID` flag is redundant for CFR telemetry, since using `client_id` or `impression_id` is fully controlled by `TelemetryFeed.applyCFRPolicy()`. 