### PR TITLE
Fix Bug 1490241 - CFR fluent and string overrides should both have attributes

### DIFF
--- a/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
+++ b/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
@@ -44,8 +44,20 @@
         "label": {
           "oneOf": [
             {
-              "type": "string",
-              "description": "Text for button tooltip used to provide information about the doorhanger."
+              "type": "object",
+              "properties": {
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "tooltiptext": {
+                      "type": "string",
+                      "description": "Text for button tooltip used to provide information about the doorhanger."
+                    }
+                  },
+                  "required": ["tooltiptext"]
+                }
+              },
+              "required": ["attributes"]
             },
             {
               "type": "object",

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -185,10 +185,15 @@ class PageAction {
   async getStrings(string, subAttribute = "") {
     if (!string.string_id) {
       if (subAttribute) {
-        return string.attributes[subAttribute];
+        if (string.attributes) {
+          return string.attributes[subAttribute];
+        }
+
+        Cu.reportError(`String ${string.value} does not contain any attributes`);
+        return subAttribute;
       }
 
-      if (string.attributes) {
+      if (typeof string.value === "string") {
         const stringWithAttributes = new String(string.value); // eslint-disable-line no-new-wrappers
         stringWithAttributes.attributes = string.attributes;
         return stringWithAttributes;

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -184,6 +184,16 @@ class PageAction {
    */
   async getStrings(string, subAttribute = "") {
     if (!string.string_id) {
+      if (subAttribute) {
+        return string.attributes[subAttribute];
+      }
+
+      if (string.attributes) {
+        const stringWithAttributes = new String(string.value); // eslint-disable-line no-new-wrappers
+        stringWithAttributes.attributes = string.attributes;
+        return stringWithAttributes;
+      }
+
       return string;
     }
 

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -10,7 +10,7 @@ function trigger_cfr_panel(browser, trigger, cb) {
         notification_text: "Mochitest",
         heading_text: "Mochitest",
         info_icon: {
-          label: "Why am I seeing this",
+          label: {attributes: {tooltiptext: "Why am I seeing this"}},
           sumo_path: "extensionrecommendations"
         },
         addon: {

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -319,6 +319,7 @@ describe("CFRPageActions", () => {
     });
 
     describe("#getStrings", () => {
+      let formatMessagesStub;
       const localeStrings = [{
         value: "你好世界",
         attributes: [
@@ -330,9 +331,10 @@ describe("CFRPageActions", () => {
 
       beforeEach(() => {
         getStringsStub.restore();
-        global.Localization.prototype.formatMessages = sandbox.stub()
+        formatMessagesStub = sandbox.stub()
           .withArgs({id: "hello_world"})
           .resolves(localeStrings);
+        global.Localization.prototype.formatMessages = formatMessagesStub;
       });
 
       it("should return the argument if a string_id is not defined", async () => {
@@ -344,6 +346,38 @@ describe("CFRPageActions", () => {
       });
       it("should return the right sub-attribute if specified", async () => {
         assert.equal(await pageAction.getStrings({string_id: "hello_world"}, "second_attr"), "some string");
+      });
+      it("should attach attributes to string overrides", async () => {
+        const fromJson = {value: "Add Now", attributes: {accesskey: "A"}};
+
+        const result = await pageAction.getStrings(fromJson);
+
+        assert.equal(result, fromJson.value);
+        assert.propertyVal(result.attributes, "accesskey", "A");
+      });
+      it("should return subAttributes when doing string overrides", async () => {
+        const fromJson = {value: "Add Now", attributes: {accesskey: "A"}};
+
+        const result = await pageAction.getStrings(fromJson, "accesskey");
+
+        assert.equal(result, "A");
+      });
+      it("should resolve ftl strings and attach subAttributes", async () => {
+        const fromFtl = {string_id: "cfr-doorhanger-extension-ok-button"};
+        formatMessagesStub.resolves([{value: "Add Now", attributes: [{name: "accesskey", value: "A"}]}]);
+
+        const result = await pageAction.getStrings(fromFtl);
+
+        assert.equal(result, "Add Now");
+        assert.propertyVal(result.attributes, "accesskey", "A");
+      });
+      it("should return subAttributes from ftl ids", async () => {
+        const fromFtl = {string_id: "cfr-doorhanger-extension-ok-button"};
+        formatMessagesStub.resolves([{value: "Add Now", attributes: [{name: "accesskey", value: "A"}]}]);
+
+        const result = await pageAction.getStrings(fromFtl, "accesskey");
+
+        assert.equal(result, "A");
       });
     });
 

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -379,6 +379,15 @@ describe("CFRPageActions", () => {
 
         assert.equal(result, "A");
       });
+      it("should report an error when no attributes are present but subAttribute is requested", async () => {
+        const fromJson = {value: "Foo"};
+        const stub = sandbox.stub(global.Cu, "reportError");
+
+        await pageAction.getStrings(fromJson, "accesskey");
+
+        assert.calledOnce(stub);
+        stub.restore();
+      });
     });
 
     describe("#_handleClick", () => {

--- a/test/unit/asrouter/templates/ExtensionDoorhanger.test.jsx
+++ b/test/unit/asrouter/templates/ExtensionDoorhanger.test.jsx
@@ -6,7 +6,7 @@ const DEFAULT_CONTENT = {
   "notification_text": "Recommendation",
   "heading_text": "Recommended Extension",
   "info_icon": {
-    "label": "Why am I seeing this",
+    "label": {"attributes": {"tooltiptext": "Why am I seeing this"}},
     "sumo_path": "extensionrecommendations"
   },
   "addon": {


### PR DESCRIPTION
Turned the usage examples from https://github.com/mozilla/activity-stream/commit/21268904be632c4d74f1fa981e852412a94794ef#r30406394 into unit tests.