### PR TITLE
Fix Bug 1491944 - Run all_files_referenced on taskcluster

### DIFF
--- a/mochitest.sh
+++ b/mochitest.sh
@@ -22,4 +22,5 @@ cd /mozilla-central && ./mach build \
   browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
   browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js \
   browser/extensions/onboarding/test/browser \
-  && ! grep -q TEST-UNEXPECTED test_run_log
+  && ! grep -q TEST-UNEXPECTED test_run_log \
+  && ! ./mach test all_files_referenced | grep activity-stream


### PR DESCRIPTION
Finish the followup from https://github.com/mozilla/activity-stream/pull/4254#issuecomment-407041386 and fix broken tests introduced by the new files from #4294