### PR TITLE
Fix Bug 1485626 - Tab_Index reaches elements inside collapsed menus in activity stream

### DIFF
--- a/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -69,7 +69,7 @@ export class _CollapsibleSection extends React.PureComponent {
     // Get the current height of the body so max-height transitions can work
     this.setState({
       isAnimating: true,
-      maxHeight: `${this.sectionBody.scrollHeight}px`,
+      maxHeight: `${this._getSectionBodyHeight()}px`,
     });
     const {action, userEvent} = SectionMenuOptions.CheckCollapsed(this.props);
     this.props.dispatch(action);
@@ -77,6 +77,18 @@ export class _CollapsibleSection extends React.PureComponent {
       event: userEvent,
       source: this.props.source,
     }));
+  }
+
+  _getSectionBodyHeight() {
+    const div = this.sectionBody;
+    if (div.style.display === "none") {
+      // If the div isn't displayed, we can't get it's height. So we display it
+      // with a 0px height to get the height. We don't undo this because we are about
+      // to expand the section anyway;
+      div.style.maxHeight = "0px";
+      div.style.display = "block";
+    }
+    return div.scrollHeight;
   }
 
   onTransitionEnd(event) {
@@ -116,6 +128,12 @@ export class _CollapsibleSection extends React.PureComponent {
     const {enableAnimation, isAnimating, maxHeight, menuButtonHover, showContextMenu} = this.state;
     const {id, eventSource, collapsed, learnMore, title, extraMenuOptions, showPrefName, privacyNoticeURL, dispatch, isFirst, isLast, isWebExtension} = this.props;
     const active = menuButtonHover || showContextMenu;
+    let bodyStyle;
+    if (isAnimating && !collapsed) {
+      bodyStyle = {maxHeight};
+    } else if (!isAnimating && collapsed) {
+      bodyStyle = {display: "none"};
+    }
     return (
       <section
         className={`collapsible-section ${this.props.className}${enableAnimation ? " animation-enabled" : ""}${collapsed ? " collapsed" : ""}${active ? " active" : ""}`}
@@ -173,7 +191,7 @@ export class _CollapsibleSection extends React.PureComponent {
             className={`section-body${isAnimating ? " animating" : ""}`}
             onTransitionEnd={this.onTransitionEnd}
             ref={this.onBodyMount}
-            style={isAnimating && !collapsed ? {maxHeight} : null}>
+            style={bodyStyle}>
             {this.props.children}
           </div>
         </ErrorBoundary>

--- a/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -83,9 +83,8 @@ export class _CollapsibleSection extends React.PureComponent {
     const div = this.sectionBody;
     if (div.style.display === "none") {
       // If the div isn't displayed, we can't get it's height. So we display it
-      // with a 0px height to get the height. We don't undo this because we are about
-      // to expand the section anyway;
-      div.style.maxHeight = "0px";
+      // to get the height (it doesn't show up because max-height is set to 0px
+      // in CSS). We don't undo this because we are about to expand the section.
       div.style.display = "block";
     }
     return div.scrollHeight;


### PR DESCRIPTION
To verify:
* Make sure collapsing and expanding still works
* Make sure you can't tab through top sites, for example, while they are collapsed