### PR TITLE
Bug 1492942 - Snippets should respect onboarding, user pref

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -11,6 +11,7 @@ import {SimpleSnippet} from "./templates/SimpleSnippet/SimpleSnippet";
 
 const INCOMING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const OUTGOING_MESSAGE_NAME = "ASRouter:child-to-parent";
+const ASR_CONTAINER_ID = "asr-newtab-container";
 
 export const ASRouterUtils = {
   addListener(listener) {
@@ -40,9 +41,6 @@ export const ASRouterUtils = {
   unblockBundle(bundle) {
     ASRouterUtils.sendMessage({type: "UNBLOCK_BUNDLE", data: {bundle}});
   },
-  getNextMessage() {
-    ASRouterUtils.sendMessage({type: "GET_NEXT_MESSAGE"});
-  },
   overrideMessage(id) {
     ASRouterUtils.sendMessage({type: "OVERRIDE_MESSAGE", data: {id}});
   },
@@ -50,7 +48,7 @@ export const ASRouterUtils = {
     const payload = ac.ASRouterUserEvent(ping);
     global.RPMSendAsyncMessage(AS_GENERAL_OUTGOING_MESSAGE_NAME, payload);
   },
-  getEndpoint() {
+  getPreviewEndpoint() {
     if (window.location.href.includes("endpoint")) {
       const params = new URLSearchParams(window.location.href.slice(window.location.href.indexOf("endpoint")));
       try {
@@ -203,14 +201,14 @@ export class ASRouterUISurface extends React.PureComponent {
   }
 
   componentWillMount() {
-    const endpoint = ASRouterUtils.getEndpoint();
+    const endpoint = ASRouterUtils.getPreviewEndpoint();
     ASRouterUtils.addListener(this.onMessageFromParent);
 
     // If we are loading about:welcome we want to trigger the onboarding messages
     if (this.props.document.location.href === "about:welcome") {
       ASRouterUtils.sendMessage({type: "TRIGGER", data: {trigger: {id: "firstRun"}}});
     } else {
-      ASRouterUtils.sendMessage({type: "CONNECT_UI_REQUEST", data: {endpoint}});
+      ASRouterUtils.sendMessage({type: "SNIPPETS_REQUEST", data: {endpoint}});
     }
   }
 
@@ -234,7 +232,6 @@ export class ASRouterUISurface extends React.PureComponent {
                                   links={this.state.message.content.links}
                                   sendClick={this.sendClick} />}
               UISurface="NEWTAB_FOOTER_BAR"
-              getNextMessage={ASRouterUtils.getNextMessage}
               onBlock={this.onBlockById(this.state.message.id)}
               onAction={ASRouterUtils.executeAction}
               sendUserActionTelemetry={this.sendUserActionTelemetry} />
@@ -249,7 +246,6 @@ export class ASRouterUISurface extends React.PureComponent {
         UISurface="NEWTAB_OVERLAY"
         onAction={ASRouterUtils.executeAction}
         onDoneButton={this.clearBundle(this.state.bundle.bundle)}
-        getNextMessage={ASRouterUtils.getNextMessage}
         sendUserActionTelemetry={this.sendUserActionTelemetry} />);
   }
 
@@ -270,10 +266,10 @@ export class ASRouterUISurface extends React.PureComponent {
     const {message, bundle} = this.state;
     if (!message.id && !bundle.template) { return null; }
     return (
-      <div>
+      <React.Fragment>
         {this.renderPreviewBanner()}
         {bundle.template === "onboarding" ? this.renderOnboarding() : this.renderSnippets()}
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -287,7 +283,14 @@ export class ASRouterContent {
   }
 
   _mount() {
-    this.containerElement = global.document.getElementById("snippets-container");
+    this.containerElement = global.document.getElementById(ASR_CONTAINER_ID);
+    if (!this.containerElement) {
+      this.containerElement = global.document.createElement("div");
+      this.containerElement.id = ASR_CONTAINER_ID;
+      this.containerElement.style.zIndex = 1;
+      global.document.body.appendChild(this.containerElement);
+    }
+
     ReactDOM.render(<ASRouterUISurface />, this.containerElement);
   }
 

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -16,7 +16,7 @@ export class ASRouterAdmin extends React.PureComponent {
   }
 
   componentWillMount() {
-    const endpoint = ASRouterUtils.getEndpoint();
+    const endpoint = ASRouterUtils.getPreviewEndpoint();
     ASRouterUtils.sendMessage({type: "ADMIN_CONNECT_STATE", data: {endpoint}});
     ASRouterUtils.addListener(this.onMessage);
   }
@@ -113,7 +113,6 @@ export class ASRouterAdmin extends React.PureComponent {
   render() {
     return (<div className="asrouter-admin outer-wrapper">
       <h1>AS Router Admin</h1>
-      <button className="button primary" onClick={ASRouterUtils.getNextMessage}>Refresh Current Message</button>
       <h2>Message Providers</h2>
       {this.state.providers ? this.renderProviders() : null}
       <h2>Messages</h2>

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -243,6 +243,17 @@ const MessageLoaderUtils = {
 this.MessageLoaderUtils = MessageLoaderUtils;
 
 /**
+ * hasLegacyOnboardingConflict - Checks if we need to turn off snippets because of
+ *                               legacy onboarding using the same UI space
+ *
+ * @param {Provider} provider
+ * @returns {boolean} Is there a conflict with legacy onboarding?
+ */
+function hasLegacyOnboardingConflict(provider) {
+  return provider.id === "snippets" && !Services.prefs.getBoolPref(ONBOARDING_FINISHED_PREF, false);
+}
+
+/**
  * @class _ASRouter - Keeps track of all messages, UI surfaces, and
  * handles blocking, rotation, etc. Inspecting ASRouter.state will
  * tell you what the current displayed message is in all UI surfaces.
@@ -293,6 +304,14 @@ class _ASRouter {
     }
   }
 
+  // This will be removed when legacy onboarding is removed.
+  async observe(aSubject, aTopic, aPrefName) {
+    if (aPrefName === ONBOARDING_FINISHED_PREF) {
+      this._updateMessageProviders();
+      await this.loadMessagesFromAllProviders();
+    }
+  }
+
   // Update message providers and fetch new messages on pref change
   async onPrefChange() {
     this._updateMessageProviders();
@@ -315,10 +334,17 @@ class _ASRouter {
 
   // Fetch and decode the message provider pref JSON, and update the message providers
   _updateMessageProviders() {
+    const previousProviders =  this.state.providers;
     const providers = [
       // If we have added a `preview` provider, hold onto it
-      ...this.state.providers.filter(p => p.id === "preview"),
-      ...ASRouterPreferences.providers.filter(p => p.enabled),
+      ...previousProviders.filter(p => p.id === "preview"),
+      // The provider should be enabled and not have a user preference set to false
+      ...ASRouterPreferences.providers.filter(p => (
+        p.enabled &&
+        ASRouterPreferences.getUserPreference(p.id) !== false) &&
+        // sorry this is crappy. will remove soon
+        !hasLegacyOnboardingConflict(p)
+      ),
     ].map(_provider => {
       // make a copy so we don't modify the source of the pref
       const provider = {..._provider};
@@ -339,6 +365,14 @@ class _ASRouter {
     });
 
     const providerIDs = providers.map(p => p.id);
+
+    // Clear old messages for providers that are no longer enabled
+    for (const prevProvider of previousProviders) {
+      if (!providerIDs.includes(prevProvider.id)) {
+        this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_PROVIDER", data: {id: prevProvider.id}});
+      }
+    }
+
     this.setState(prevState => ({
       providers,
       // Clear any messages from removed providers
@@ -436,6 +470,8 @@ class _ASRouter {
     this.dispatchToAS = dispatchToAS;
     this.dispatch = this.dispatch.bind(this);
 
+    // For watching legacy onboarding. To be removed when legacy onboarding is gone.
+    Services.prefs.addObserver(ONBOARDING_FINISHED_PREF, this);
     ASRouterPreferences.init();
     ASRouterPreferences.addListener(this.onPrefChange);
 
@@ -467,6 +503,8 @@ class _ASRouter {
 
     this.overrideOrEnableLegacyOnboarding();
 
+    // For watching legacy onboarding. To be removed when legacy onboarding is gone.
+    Services.prefs.removeObserver(ONBOARDING_FINISHED_PREF, this);
     ASRouterPreferences.removeListener(this.onPrefChange);
     ASRouterPreferences.uninit();
 
@@ -494,8 +532,13 @@ class _ASRouter {
 
   _onStateChanged(state) {
     if (ASRouterPreferences.devtoolsEnabled) {
-      this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: this.state});
+      this._updateAdminState();
     }
+  }
+
+  _updateAdminState(target) {
+    const channel = target || this.messageChannel;
+    channel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: this.state});
   }
 
   _handleTargetingError(type, error, message) {
@@ -907,8 +950,7 @@ class _ASRouter {
           await this.handleUserAction({data: action.data, target});
         }
         break;
-      case "CONNECT_UI_REQUEST":
-      case "GET_NEXT_MESSAGE":
+      case "SNIPPETS_REQUEST":
       case "TRIGGER":
         // Wait for our initial message loading to be done before responding to any UI requests
         await this.waitForInitialized;
@@ -965,7 +1007,7 @@ class _ASRouter {
           this._addPreviewEndpoint(action.data.endpoint.url, target.portID);
           await this.loadMessagesFromAllProviders();
         } else {
-          target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: this.state});
+          this._updateAdminState(target);
         }
         break;
       case "IMPRESSION":

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -16,6 +16,8 @@ const DEFAULT_STATE = {
   _devtoolsPref: DEVTOOLS_PREF,
 };
 
+const USER_PREFERENCES = {snippets: "browser.newtabpage.activity-stream.feeds.snippets"};
+
 class _ASRouterPreferences {
   constructor() {
     Object.assign(this, DEFAULT_STATE);
@@ -71,6 +73,13 @@ class _ASRouterPreferences {
     this._callbacks.forEach(cb => cb(aPrefName));
   }
 
+  getUserPreference(providerId) {
+    if (!USER_PREFERENCES[providerId]) {
+      return null;
+    }
+    return Services.prefs.getBoolPref(USER_PREFERENCES[providerId], true);
+  }
+
   addListener(callback) {
     this._callbacks.add(callback);
   }
@@ -85,6 +94,9 @@ class _ASRouterPreferences {
     }
     Services.prefs.addObserver(this._providerPref, this);
     Services.prefs.addObserver(this._devtoolsPref, this);
+    for (const id of Object.keys(USER_PREFERENCES)) {
+      Services.prefs.addObserver(USER_PREFERENCES[id], this);
+    }
     this._initialized = true;
   }
 
@@ -92,6 +104,9 @@ class _ASRouterPreferences {
     if (this._initialized) {
       Services.prefs.removeObserver(this._providerPref, this);
       Services.prefs.removeObserver(this._devtoolsPref, this);
+      for (const id of Object.keys(USER_PREFERENCES)) {
+        Services.prefs.removeObserver(USER_PREFERENCES[id], this);
+      }
     }
     Object.assign(this, DEFAULT_STATE);
     this._callbacks.clear();

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -11,6 +11,8 @@ ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const {actionTypes: at, actionUtils: au} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {Prefs} = ChromeUtils.import("resource://activity-stream/lib/ActivityStreamPrefs.jsm", {});
 
+ChromeUtils.defineModuleGetter(this, "ASRouterPreferences",
+  "resource://activity-stream/lib/ASRouterPreferences.jsm");
 ChromeUtils.defineModuleGetter(this, "perfService",
   "resource://activity-stream/common/PerfService.jsm");
 ChromeUtils.defineModuleGetter(this, "PingCentre",
@@ -41,7 +43,6 @@ const USER_PREFS_ENCODING = {
 const PREF_IMPRESSION_ID = "impressionId";
 const TELEMETRY_PREF = "telemetry";
 const EVENTS_TELEMETRY_PREF = "telemetry.ut.events";
-const ROUTER_MESSAGE_PROVIDER_PREF = "asrouter.messageProviders";
 
 this.TelemetryFeed = class TelemetryFeed {
   constructor(options) {
@@ -55,8 +56,6 @@ this.TelemetryFeed = class TelemetryFeed {
     this._prefs.observe(TELEMETRY_PREF, this._onTelemetryPrefChange);
     this._onEventsTelemetryPrefChange = this._onEventsTelemetryPrefChange.bind(this);
     this._prefs.observe(EVENTS_TELEMETRY_PREF, this._onEventsTelemetryPrefChange);
-    this._onRouterMessageProviderChange = this._onRouterMessageProviderChange.bind(this);
-    this._prefs.observe(ROUTER_MESSAGE_PROVIDER_PREF, this._onRouterMessageProviderChange);
   }
 
   init() {
@@ -120,28 +119,6 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   /**
-   * Check the CFR experiment cohort information by parsing the pref string of
-   * AS router message provider. The experiment cohort can be identified by the
-   * `cohort` field in the "cfr" provider.
-   */
-  _parseCFRCohort(pref) {
-    try {
-      for (let provider of JSON.parse(pref)) {
-        if (provider.id === "cfr" && provider.enabled && provider.cohort) {
-          return true;
-        }
-      }
-    } catch (e) {
-      Cu.reportError("Problem parsing JSON message provider pref for ASRouter");
-    }
-    return false;
-  }
-
-  _onRouterMessageProviderChange(prefVal) {
-    this._isInCFRCohort = this._parseCFRCohort(prefVal);
-  }
-
-  /**
    * Lazily initialize PingCentre for Activity Stream to send pings
    */
   get pingCentre() {
@@ -190,14 +167,15 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   /**
-   * Lazily parse the AS router pref to check if it is in the CFR experiment cohort
+   *  Check if it is in the CFR experiment cohort. ASRouterPreferences lazily parses AS router pref.
    */
   get isInCFRCohort() {
-    if (this._isInCFRCohort === undefined) {
-      const pref = this._prefs.get(ROUTER_MESSAGE_PROVIDER_PREF);
-      this._isInCFRCohort = this._parseCFRCohort(pref);
+    for (let provider of ASRouterPreferences.providers) {
+      if (provider.id === "cfr" && provider.enabled && provider.cohort) {
+        return true;
+      }
     }
-    return this._isInCFRCohort;
+    return false;
   }
 
   /**
@@ -585,7 +563,6 @@ this.TelemetryFeed = class TelemetryFeed {
     try {
       this._prefs.ignore(TELEMETRY_PREF, this._onTelemetryPrefChange);
       this._prefs.ignore(EVENTS_TELEMETRY_PREF, this._onEventsTelemetryPrefChange);
-      this._prefs.ignore(ROUTER_MESSAGE_PROVIDER_PREF, this._onRouterMessageProviderChange);
     } catch (e) {
       Cu.reportError(e);
     }
@@ -599,5 +576,4 @@ const EXPORTED_SYMBOLS = [
   "PREF_IMPRESSION_ID",
   "TELEMETRY_PREF",
   "EVENTS_TELEMETRY_PREF",
-  "ROUTER_MESSAGE_PROVIDER_PREF",
 ];

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -201,6 +201,18 @@ describe("ASRouter", () => {
       assert.lengthOf(Router.state.providers, length);
       assert.isDefined(provider);
     });
+    it("should update the list of providers and load messages on legacy onboarding pref change", async () => {
+      sandbox.spy(Router, "_updateMessageProviders");
+      sandbox.spy(Router, "loadMessagesFromAllProviders");
+      // we do NOT want to set the onboarding pref again and cause an infinite loop
+      sandbox.stub(global.Services.prefs, "setBoolPref");
+
+      await Router.observe(null, null, ONBOARDING_FINISHED_PREF);
+
+      assert.calledOnce(Router._updateMessageProviders);
+      assert.calledOnce(Router.loadMessagesFromAllProviders);
+      assert.notCalled(global.Services.prefs.setBoolPref);
+    });
   });
 
   describe("setState", () => {
@@ -219,7 +231,7 @@ describe("ASRouter", () => {
   });
 
   describe("#overrideOrEnableLegacyOnboarding", () => {
-    it("should set the onboarding finished pref to true if it is true and ASRPreferences.allowLegacyOnboarding is false", async () => {
+    it("should set the onboarding finished pref to true if legacy onboarding is NOT allowed", async () => {
       sandbox.stub(global.Services.prefs, "getBoolPref").withArgs(ONBOARDING_FINISHED_PREF).returns(false);
       sandbox.stub(ASRouterPreferences, "specialConditions").get(() => ({allowLegacyOnboarding: false}));
       const setStub = sandbox.stub(global.Services.prefs, "setBoolPref");
@@ -227,9 +239,15 @@ describe("ASRouter", () => {
       Router.overrideOrEnableLegacyOnboarding();
       assert.calledWith(setStub, ONBOARDING_FINISHED_PREF, true);
     });
-    it("should set the onboarding finished pref to false if it is false and ASRPreferences.allowLegacyOnboarding is true", async () => {
-      sandbox.stub(global.Services.prefs, "getBoolPref").withArgs(ONBOARDING_FINISHED_PREF).returns(true);
-      sandbox.stub(ASRouterPreferences, "specialConditions").get(() => ({allowLegacyOnboarding: true}));
+    it("should set the onboarding finished pref to false if ASRPreferences.allowLegacyOnboarding is true and we previously override onboarding", async () => {
+      // First override the finished pref to be to true so we can reverse the overriding
+      const onboardingPrefStub = sandbox.stub(global.Services.prefs, "getBoolPref").withArgs(ONBOARDING_FINISHED_PREF).returns(false);
+      const specialConditionsStub = sandbox.stub(ASRouterPreferences, "specialConditions").get(() => ({allowLegacyOnboarding: false}));
+      Router.overrideOrEnableLegacyOnboarding();
+
+      // Now reverse it
+      onboardingPrefStub.withArgs(ONBOARDING_FINISHED_PREF).returns(true);
+      specialConditionsStub.get(() => ({allowLegacyOnboarding: true}));
       const setStub = sandbox.stub(global.Services.prefs, "setBoolPref");
 
       Router.overrideOrEnableLegacyOnboarding();
@@ -365,6 +383,15 @@ describe("ASRouter", () => {
       assert.equal(Router.state.providers.length, 1);
       assert.equal(Router.state.providers[0].id, providers[1].id);
     });
+    it("should not add snippets if legacy onboarding is not finished", () => {
+      sandbox.stub(global.Services.prefs, "getBoolPref").withArgs(ONBOARDING_FINISHED_PREF).returns(false);
+      const providers = [
+        {id: "snippets", enabled: true, type: "remote", url: "https://www.foo.com/"},
+      ];
+      setMessageProviderPref(providers);
+      Router._updateMessageProviders();
+      assert.equal(Router.state.providers.length, 0);
+    });
   });
 
   describe("blocking", () => {
@@ -432,16 +459,16 @@ describe("ASRouter", () => {
     });
   });
 
-  describe("#onMessage: CONNECT_UI_REQUEST", () => {
+  describe("#onMessage: SNIPPETS_REQUEST", () => {
     it("should set state.lastMessageId to a message id", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "CONNECT_UI_REQUEST"}));
+      await Router.onMessage(fakeAsyncMessage({type: "SNIPPETS_REQUEST"}));
 
       assert.include(ALL_MESSAGE_IDS, Router.state.lastMessageId);
     });
     it("should send a message back to the to the target", async () => {
       // force the only message to be a regular message so getRandomItemFromArray picks it
       await Router.setState({messages: [{id: "foo", template: "simple_template", content: {title: "Foo", body: "Foo123"}}]});
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       await Router.onMessage(msg);
       const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: currentMessage});
@@ -450,7 +477,7 @@ describe("ASRouter", () => {
       // force the only message to be a bundled message so getRandomItemFromArray picks it
       sandbox.stub(Router, "_findProvider").returns(null);
       await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 1, content: {title: "Foo1", body: "Foo123-1"}}]});
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       await Router.onMessage(msg);
       const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
@@ -463,7 +490,7 @@ describe("ASRouter", () => {
       const firstMessage = {id: "foo2", template: "simple_template", bundled: 2, order: 1, content: {title: "Foo2", body: "Foo123-2"}};
       const secondMessage = {id: "foo1", template: "simple_template", bundled: 2, order: 2, content: {title: "Foo1", body: "Foo123-1"}};
       await Router.setState({messages: [secondMessage, firstMessage]});
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       await Router.onMessage(msg);
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
       assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].type, "SET_BUNDLED_MESSAGES");
@@ -485,20 +512,20 @@ describe("ASRouter", () => {
     it("should send a CLEAR_ALL message if no bundle available", async () => {
       // force the only message to be a bundled message that needs 2 messages in the bundle
       await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       await Router.onMessage(msg);
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
     });
     it("should send a CLEAR_ALL message if no messages are available", async () => {
       await Router.setState({messages: []});
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       await Router.onMessage(msg);
 
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
     });
-    it("should make a request to the provided endpoint on CONNECT_UI_REQUEST", async () => {
+    it("should make a request to the provided endpoint on SNIPPETS_REQUEST", async () => {
       const url = "https://snippets-admin.mozilla.org/foo";
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url}}});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
       await Router.onMessage(msg);
 
       assert.calledWith(global.fetch, url);
@@ -514,21 +541,21 @@ describe("ASRouter", () => {
     });
     it("should dispatch SNIPPETS_PREVIEW_MODE when adding a preview endpoint", async () => {
       const url = "https://snippets-admin.mozilla.org/foo";
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url}}});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
       await Router.onMessage(msg);
 
       assert.calledWithExactly(Router.dispatchToAS, ac.OnlyToOneContent({type: "SNIPPETS_PREVIEW_MODE"}, msg.target.portID));
     });
     it("should not add a url that is not from a whitelisted host", async () => {
       const url = "https://mozilla.org";
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url}}});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
       await Router.onMessage(msg);
 
       assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
     });
     it("should reject bad urls", async () => {
       const url = "foo";
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST", data: {endpoint: {url}}});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
       await Router.onMessage(msg);
 
       assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
@@ -621,15 +648,14 @@ describe("ASRouter", () => {
     it("should send a message containing the whole state", async () => {
       const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE"});
       await Router.onMessage(msg);
-
       assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: Router.state});
     });
   });
 
-  describe("#onMessage: CONNECT_UI_REQUEST", () => {
-    it("should call sendNextMessage on CONNECT_UI_REQUEST", async () => {
+  describe("#onMessage: SNIPPETS_REQUEST", () => {
+    it("should call sendNextMessage on SNIPPETS_REQUEST", async () => {
       sandbox.stub(Router, "sendNextMessage").resolves();
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
 
       await Router.onMessage(msg);
 
@@ -686,7 +712,7 @@ describe("ASRouter", () => {
     });
     it("should get the bundle and send the message if the message has a bundle", async () => {
       sandbox.stub(Router, "sendNextMessage").resolves();
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       msg.bundled = 2; // force this message to want to be bundled
       await Router.onMessage(msg);
       assert.calledOnce(Router.sendNextMessage);
@@ -1139,7 +1165,7 @@ describe("ASRouter", () => {
     it("should dispatch an event when a targeting expression throws an error", async () => {
       sandbox.stub(global.FilterExpressions, "eval").returns(Promise.reject(new Error("fake error")));
       await Router.setState({messages: [{id: "foo", targeting: "foo2.[[("}]});
-      const msg = fakeAsyncMessage({type: "CONNECT_UI_REQUEST"});
+      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
       dispatchStub.reset();
 
       await Router.onMessage(msg);


### PR DESCRIPTION
#### Test snippets user pref

Turn on snippets by running this in the browser:

```js
Services.prefs.setStringPref(
  "browser.newtabpage.activity-stream.asrouter.messageProviders",
  JSON.stringify([{"id":"onboarding","type":"local","localProvider":"OnboardingMessageProvider","enabled":true,"cohort":1},{"id":"snippets","type":"remote","url":"https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json","updateCycleInMs":14400000,"enabled":true},{"id":"cfr","type":"local","localProvider":"CFRMessageProvider","enabled":true,"cohort":0}])
);
```

- Ensure snippets are running on new tab page.
- Turn off the user pref for snippets on about:preferences#home
- Ensure snippets are no longer showing up
- Turn the pref back on
- Ensure snippets are showing up again

#### Test onboarding conflict

Create a new profile (`--temp-profile` is fine).

- Set `browser.onboarding.notification.mute-duration-on-first-session-ms` to `0` to disable onboarding. Ensure the onboarding snippet-like things show up.
- Turn on snippets:

```js
Services.prefs.setStringPref(
  "browser.newtabpage.activity-stream.asrouter.messageProviders",
  JSON.stringify([{"id":"onboarding","type":"local","localProvider":"OnboardingMessageProvider","enabled":true,"cohort":1},{"id":"snippets","type":"remote","url":"https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json","updateCycleInMs":14400000,"enabled":true},{"id":"cfr","type":"local","localProvider":"CFRMessageProvider","enabled":true,"cohort":0}])
);
```
- Ensure that snippets do NOT show up
- Set `browser.onboarding.notification.finished` to `true`
- Ensure the snippets DO show up