### PR TITLE
Fix Bug 1492086 - Add ASR Snippets Newsletter template

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -33,6 +33,9 @@ export const ASRouterUtils = {
   blockById(id, options) {
     ASRouterUtils.sendMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id, ...options}});
   },
+  dismissById(id) {
+    ASRouterUtils.sendMessage({type: "DISMISS_MESSAGE_BY_ID", data: {id}});
+  },
   blockBundle(bundle) {
     ASRouterUtils.sendMessage({type: "BLOCK_BUNDLE", data: {bundle}});
   },
@@ -176,6 +179,10 @@ export class ASRouterUISurface extends React.PureComponent {
     return options => ASRouterUtils.blockById(id, options);
   }
 
+  onDismissById(id) {
+    return () => ASRouterUtils.dismissById(id);
+  }
+
   clearBundle(bundle) {
     return () => ASRouterUtils.blockBundle(bundle);
   }
@@ -257,6 +264,7 @@ export class ASRouterUISurface extends React.PureComponent {
               privacyNoticeRichText={privacyNoticeRichText}
               UISurface="NEWTAB_FOOTER_BAR"
               onBlock={this.onBlockById(this.state.message.id)}
+              onDismiss={this.onDismissById(this.state.message.id)}
               onAction={ASRouterUtils.executeAction}
               sendUserActionTelemetry={this.sendUserActionTelemetry} />
           </LocalizationProvider>

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -157,17 +157,16 @@ export class ASRouterUISurface extends React.PureComponent {
   // telemetry field which can have arbitrary values.
   // Used for router messages with links as part of the content.
   sendClick(event) {
-    if (this.state.message.provider === "preview") {
-      return;
-    }
-
     const metric = {
       value: event.target.dataset.metric,
       // Used for the `source` of the event. Needed to differentiate
       // from other snippet or onboarding events that may occur.
       id: "NEWTAB_FOOTER_BAR_CONTENT",
     };
-    this.sendUserActionTelemetry({event: "CLICK_BUTTON", ...metric});
+
+    if (this.state.message.provider !== "preview") {
+      this.sendUserActionTelemetry({event: "CLICK_BUTTON", ...metric});
+    }
     if (!this.state.message.content.do_not_autoblock) {
       ASRouterUtils.blockById(this.state.message.id);
     }

--- a/content-src/asrouter/components/Button/_Button.scss
+++ b/content-src/asrouter/components/Button/_Button.scss
@@ -7,8 +7,22 @@
   padding: 8px 15px;
   margin-inline-start: 12px;
   color: inherit;
+  cursor: pointer;
 
   .tall & {
     margin-inline-start: 20px;
+  }
+
+  &.primary {
+    border: 1px solid var(--newtab-border-primary-color);
+    background-color: var(--newtab-button-primary-color);
+    color: $grey-10;
+  }
+
+  &.secondary {
+    background: var(--newtab-button-secondary-color);
+    border: 1px solid var(--newtab-border-primary-color);
+    font-size: 14px;
+    font-weight: 600;
   }
 }

--- a/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -14,6 +14,22 @@ export class SnippetBase extends React.PureComponent {
     this.props.onBlock();
   }
 
+  renderDismissButton() {
+    if (this.props.footerDismiss) {
+      return (
+        <div className="footer">
+          <div className="footer-content">
+            <button className="ASRouterButton secondary" onClick={this.onBlockClicked}>{this.props.content.dismiss_button_label}</button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <button className="blockButton" onClick={this.onBlockClicked} />
+    );
+  }
+
   render() {
     const {props} = this;
 
@@ -23,7 +39,7 @@ export class SnippetBase extends React.PureComponent {
       <div className="innerWrapper">
         {props.children}
       </div>
-      <button className="blockButton" onClick={this.onBlockClicked} />
+      {this.renderDismissButton()}
     </div>);
   }
 }

--- a/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -19,7 +19,7 @@ export class SnippetBase extends React.PureComponent {
       return (
         <div className="footer">
           <div className="footer-content">
-            <button className="ASRouterButton secondary" onClick={this.onBlockClicked}>{this.props.content.dismiss_button_label}</button>
+            <button className="ASRouterButton secondary" onClick={this.props.onDismiss}>{this.props.content.dismiss_button_label}</button>
           </div>
         </div>
       );

--- a/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
+++ b/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
@@ -55,6 +55,13 @@
   &:hover .blockButton {
     display: block;
   }
+
+  .icon {
+    height: 42px;
+    width: 42px;
+    margin-inline-end: 12px;
+    flex-shrink: 0;
+  }
 }
 
 .snippets-preview-banner {

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
@@ -1,4 +1,3 @@
-import {Button} from "../../components/Button/Button";
 import React from "react";
 import {SimpleSnippet} from "../SimpleSnippet/SimpleSnippet";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
@@ -22,6 +22,7 @@ export class NewsletterSnippet extends React.PureComponent {
     };
 
     event.preventDefault();
+    this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", value: "conversion-subscribe-activation", id: "NEWTAB_FOOTER_BAR_CONTENT"});
 
     try {
       const fetchRequest = new Request(this.refs.newsletterForm.action, fetchConfig);
@@ -33,8 +34,10 @@ export class NewsletterSnippet extends React.PureComponent {
     if (json && json.status === "ok") {
       this.setState({signupSuccess: true, signupSubmitted: true});
       this.props.onBlock({preventDismiss: true});
+      this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", value: "subscribe-success", id: "NEWTAB_FOOTER_BAR_CONTENT"});
     } else {
       this.setState({signupSuccess: false, signupSubmitted: true});
+      this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", value: "subscribe-error", id: "NEWTAB_FOOTER_BAR_CONTENT"});
     }
   }
 

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
@@ -72,7 +72,10 @@ export class NewsletterSnippet extends React.PureComponent {
     const message = this.state.signupSuccess ? this.props.content.success_text : this.props.content.error_text;
     const onButtonClick = !this.state.signupSuccess ? this.expandSnippet : null;
 
-    return <SimpleSnippet {...this.props} richText={message} onButtonClick={onButtonClick} />;
+    return (<SimpleSnippet className={this.props.className}
+      onButtonClick={onButtonClick}
+      provider={this.props.provider}
+      content={{button_label: this.props.content.button_label, text: message}} />);
   }
 
   renderSignupView() {

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
@@ -1,0 +1,103 @@
+import {Button} from "../../components/Button/Button";
+import React from "react";
+import {SimpleSnippet} from "../SimpleSnippet/SimpleSnippet";
+import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
+
+export class NewsletterSnippet extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.expandSnippet = this.expandSnippet.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.state = {
+      expanded: false,
+      signupSubmitted: false,
+      signupSuccess: false,
+    };
+  }
+
+  async handleSubmit(event) {
+    let json;
+    const fetchConfig = {
+      body: new FormData(this.refs.newsletterForm),
+      method: "POST",
+    };
+
+    event.preventDefault();
+
+    try {
+      const fetchRequest = new Request(this.refs.newsletterForm.action, fetchConfig);
+      const response = await fetch(fetchRequest);
+      json = await response.json();
+    } catch (err) {
+      console.log(err); // eslint-disable-line no-console
+    }
+    if (json && json.status === "ok") {
+      this.setState({signupSuccess: true, signupSubmitted: true});
+      this.props.onBlock({preventDismiss: true});
+    } else {
+      this.setState({signupSuccess: false, signupSubmitted: true});
+    }
+  }
+
+  expandSnippet() {
+    this.setState({
+      expanded: true,
+      signupSuccess: false,
+      signupSubmitted: false,
+    });
+  }
+
+  renderHiddenFormInputs() {
+    const {hidden_inputs} = this.props.content;
+
+    if (!hidden_inputs) {
+      return null;
+    }
+
+    return Object.keys(hidden_inputs).map((key, idx) => <input key={idx} type="hidden" name={key} value={hidden_inputs[key]} />);
+  }
+
+  renderFormPrivacyNotice() {
+    return (<label className="privacy-notice" htmlFor="id_privacy">
+        <p>
+          <input type="checkbox" id="id_privacy" name="privacy" required="required" />
+          <span>{this.props.privacyNoticeRichText}</span>
+        </p>
+      </label>);
+  }
+
+  renderSignupSubmitted() {
+    const message = this.state.signupSuccess ? this.props.content.success_text : this.props.content.error_text;
+    const onButtonClick = !this.state.signupSuccess ? this.expandSnippet : null;
+
+    return <SimpleSnippet {...this.props} richText={message} onButtonClick={onButtonClick} />;
+  }
+
+  renderSignupView() {
+    const {content} = this.props;
+
+    return (<SnippetBase {...this.props} className="NewsletterSnippet" footerDismiss={true}>
+        <div className="message">
+          <p>{content.scene2_text}</p>
+        </div>
+        <form action={content.form_action} method="POST" onSubmit={this.handleSubmit} ref="newsletterForm">
+          {this.renderHiddenFormInputs()}
+          <div>
+            <input type="email" name="email" required="required" placeholder={content.scene2_email_placeholder_text} autoFocus={true} />
+            <button type="submit" className="ASRouterButton primary" ref="formSubmitBtn">{content.scene2_button_label}</button>
+          </div>
+          {this.renderFormPrivacyNotice()}
+        </form>
+      </SnippetBase>);
+  }
+
+  render() {
+    if (this.state.signupSubmitted) {
+      return this.renderSignupSubmitted();
+    }
+    if (this.state.expanded) {
+      return this.renderSignupView();
+    }
+    return <SimpleSnippet {...this.props} onButtonClick={this.expandSnippet} />;
+  }
+}

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
@@ -85,10 +85,6 @@
       "type": "string",
       "description": "The background color of the button. Valid CSS color."
     },
-    "tall": {
-      "type": "boolean",
-      "description": "To be used by fundraising only, increases height to roughly 120px. Defaults to false."
-    },
     "do_not_autoblock": {
       "type": "boolean",
       "description": "Used to prevent blocking the snippet after the CTA (link or button) has been clicked"

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
@@ -39,87 +39,29 @@
       "type": "string",
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
     },
-    "form": {
+    "form_action": {
+      "type": "string",
+      "description": "Endpoint to submit form data."
+    },
+    "scene2_text": {
+      "type": "string",
+      "description": "Main body of the snippet in the second scene."
+    },
+    "scene2_email_placeholder_text": {
+      "type": "string",
+      "description": "Value to show while input is empty."
+    },
+    "scene2_button_label": {
+      "type": "string",
+      "description": "Label for form submit button"
+    },
+    "scene2_privacy_html": {
+      "type": "string",
+      "description": "Information about how the form data is used."
+    },
+    "hidden_inputs": {
       "type": "object",
-      "properties": {
-        "action": {
-          "type": "object",
-          "properties": {
-            "url": "string",
-            "description": "Endpoint to submit form data"
-          }
-        },
-        "heading": {
-          "type": "object",
-          "properties": {
-            "text": {
-              "type": "string",
-              "description": "Explanation about the form submission"
-            }
-          }
-        },
-        "input": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "description": "HTML attribute value"
-            },
-            "name": {
-              "type": "string",
-              "description": "HTML attribute value"
-            },
-            "placeholder": {
-              "type": "string",
-              "description": "Value to show while input is empty"
-            }
-          }
-        },
-        "button_submit_label": {
-          "type": "string",
-          "description": "Label for form submit button"
-        },
-        "privacy_notice": {
-          "type": "object",
-          "properties": {
-            "text": {
-              "type": "string",
-              "description": "Information about how the form data is used"
-            },
-            "links": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "allOf": [
-                      {"$ref": "#/definitions/link_url"},
-                      {"description": "The url where the link points to."}
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "hidden_inputs": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "HTML attribute value"
-              },
-              "value": {
-                "type": "string",
-                "description": "HTML attribute value"
-              }
-            }
-          }
-        }
-      },
-      "required": ["input", "heading", "action", "hidden_inputs"]
+      "description": "Each entry represents a hidden input, key is used as value for the name property."
     },
     "button_label": {
       "allOf": [
@@ -159,7 +101,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["text", "button_label"],
+  "required": ["text", "form_action", "scene2_text", "hidden_inputs"],
   "dependencies": {
     "button_color": ["button_label"],
     "button_background_color": ["button_label"]

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
@@ -1,0 +1,167 @@
+{
+  "title": "NewsletterSchema",
+  "description": "A template with two states: a SimpleSnippet and another that contains a form",
+  "version": "1.0.0",
+  "type": "object",
+  "definitions": {
+    "plainText": {
+      "description": "Plain text (no HTML allowed)",
+      "type": "string"
+    },
+    "richText": {
+      "description": "Text with HTML subset allowed: i, b, u, strong, em, br",
+      "type": "string"
+    },
+    "link_url": {
+      "description": "Target for links or buttons",
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "properties": {
+    "title": {
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Snippet title displayed before snippet text"}
+      ]
+    },
+    "text": {
+      "allOf": [
+        {"$ref": "#/definitions/richText"},
+        {"description": "Main body text of snippet. HTML subset allowed: i, b, u, strong, em, br"}
+      ]
+    },
+    "icon": {
+      "type": "string",
+      "description": "Snippet icon. 64x64px. SVG or PNG preferred."
+    },
+    "title_icon": {
+      "type": "string",
+      "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
+    },
+    "form": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "object",
+          "properties": {
+            "url": "string",
+            "description": "Endpoint to submit form data"
+          }
+        },
+        "heading": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Explanation about the form submission"
+            }
+          }
+        },
+        "input": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "HTML attribute value"
+            },
+            "name": {
+              "type": "string",
+              "description": "HTML attribute value"
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "Value to show while input is empty"
+            }
+          }
+        },
+        "button_submit_label": {
+          "type": "string",
+          "description": "Label for form submit button"
+        },
+        "privacy_notice": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Information about how the form data is used"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "allOf": [
+                      {"$ref": "#/definitions/link_url"},
+                      {"description": "The url where the link points to."}
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hidden_inputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "HTML attribute value"
+              },
+              "value": {
+                "type": "string",
+                "description": "HTML attribute value"
+              }
+            }
+          }
+        }
+      },
+      "required": ["input", "heading", "action", "hidden_inputs"]
+    },
+    "button_label": {
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Text for a button next to main snippet text that links to button_url. Requires button_url."}
+      ]
+    },
+    "button_color": {
+      "type": "string",
+      "description": "The text color of the button. Valid CSS color."
+    },
+    "button_background_color": {
+      "type": "string",
+      "description": "The background color of the button. Valid CSS color."
+    },
+    "tall": {
+      "type": "boolean",
+      "description": "To be used by fundraising only, increases height to roughly 120px. Defaults to false."
+    },
+    "do_not_autoblock": {
+      "type": "boolean",
+      "description": "Used to prevent blocking the snippet after the CTA (link or button) has been clicked"
+    },
+    "links": {
+      "additionalProperties": {
+        "url": {
+          "allOf": [
+            {"$ref": "#/definitions/link_url"},
+            {"description": "The url where the link points to."}
+          ]
+        },
+        "metric": {
+          "type": "string",
+          "description": "Custom event name sent with telemetry event."
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["text", "button_label"],
+  "dependencies": {
+    "button_color": ["button_label"],
+    "button_background_color": ["button_label"]
+  }
+}

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json
@@ -43,6 +43,14 @@
       "type": "string",
       "description": "Endpoint to submit form data."
     },
+    "success_text": {
+      "type": "string",
+      "description": "Message shown on successful registration."
+    },
+    "error_text": {
+      "type": "string",
+      "description": "Message shown if registration failed."
+    },
     "scene2_text": {
       "type": "string",
       "description": "Main body of the snippet in the second scene."

--- a/content-src/asrouter/templates/NewsletterSnippet/_NewsletterSnippet.scss
+++ b/content-src/asrouter/templates/NewsletterSnippet/_NewsletterSnippet.scss
@@ -1,0 +1,66 @@
+.NewsletterSnippet {
+  flex-direction: column;
+  flex: 1 1 100%;
+  width: 100%;
+
+  .ASRouterButton {
+    &.primary {
+      font-size: 15px;
+      flex: 1 1 0;
+    }
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .message {
+    font-size: 14px;
+    align-self: stretch;
+    flex: 0 0 100%;
+  }
+
+  .privacy-notice {
+    color: var(--newtab-text-secondary-color);
+    flex: 0 0 100%;
+  }
+
+  .innerWrapper {
+    max-width: 670px;
+    flex-wrap: wrap;
+    justify-items: center;
+  }
+
+  .footer {
+    width: 100%;
+    margin: 0 auto;
+    text-align: right;
+    background: $grey-20;
+    padding: 10px 0;
+
+    .footer-content {
+      margin: 0 auto;
+      max-width: 768px;
+      width: 100%;
+      text-align: right;
+    }
+  }
+
+  input {
+    &[type='email'] {
+      background-color: var(--newtab-textbox-background-color);
+      border: $input-border;
+      padding: 0 8px;
+      height: 32px;
+      font-size: 15px;
+      width: 50%;
+
+      &:focus {
+        border: $input-border-active;
+        box-shadow: var(--newtab-textbox-focus-boxshadow);
+      }
+    }
+  }
+}

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -33,12 +33,12 @@ export class SimpleSnippet extends React.PureComponent {
 
   renderButton() {
     const {props} = this;
-    if (!props.content.button_action) {
+    if (!props.content.button_action && !props.onButtonClick) {
       return null;
     }
 
     return (<Button
-      onClick={this.onButtonClick}
+      onClick={props.onButtonClick || this.onButtonClick}
       color={props.content.button_color}
       backgroundColor={props.content.button_background_color}>
       {props.content.button_label}

--- a/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -25,13 +25,6 @@
     margin: 0;
   }
 
-  .icon {
-    height: 42px;
-    width: 42px;
-    margin-inline-end: 12px;
-    flex-shrink: 0;
-  }
-
   &.tall .icon {
     margin-inline-end: 20px;
   }

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -159,4 +159,5 @@ input {
 @import '../asrouter/components/SnippetBase/SnippetBase';
 @import '../asrouter/components/ModalOverlay/ModalOverlay';
 @import '../asrouter/templates/SimpleSnippet/SimpleSnippet';
+@import '../asrouter/templates/NewsletterSnippet/NewsletterSnippet';
 @import '../asrouter/templates/OnboardingMessage/OnboardingMessage';

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -965,6 +965,11 @@ class _ASRouter {
         break;
       case "BLOCK_MESSAGE_BY_ID":
         await this.blockMessageById(action.data.id);
+        // Block the message but don't dismiss it in case the action taken has
+        // another state that needs to be visible
+        if (action.data.preventDismiss) {
+          break;
+        }
         this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: action.data.id}});
         break;
       case "BLOCK_PROVIDER_BY_ID":

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -972,6 +972,9 @@ class _ASRouter {
         }
         this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: action.data.id}});
         break;
+      case "DISMISS_MESSAGE_BY_ID":
+        this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: action.data.id}});
+        break;
       case "BLOCK_PROVIDER_BY_ID":
         await this.blockProviderById(action.data.id);
         this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_PROVIDER", data: {id: action.data.id}});

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -580,6 +580,16 @@ describe("ASRouter", () => {
     });
   });
 
+  describe("#onMessage: DISMISS_MESSAGE_BY_ID", () => {
+    it("should reply with CLEAR_MESSAGE with the correct id", async () => {
+      const msg = fakeAsyncMessage({type: "DISMISS_MESSAGE_BY_ID", data: {id: "foo"}});
+
+      await Router.onMessage(msg);
+
+      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
+    });
+  });
+
   describe("#onMessage: BLOCK_PROVIDER_BY_ID", () => {
     it("should add the provider id to the providerBlockList and broadcast a CLEAR_PROVIDER with the provider id", async () => {
       const msg = fakeAsyncMessage({type: "BLOCK_PROVIDER_BY_ID", data: {id: "bar"}});

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -572,6 +572,12 @@ describe("ASRouter", () => {
       assert.isTrue(Router.state.messageBlockList.includes("foo"));
       assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
     });
+    it("should not broadcast CLEAR_MESSAGE if preventDismiss is true", async () => {
+      const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo", preventDismiss: true}});
+      await Router.onMessage(msg);
+
+      assert.notCalled(channel.sendAsyncMessage);
+    });
   });
 
   describe("#onMessage: BLOCK_PROVIDER_BY_ID", () => {

--- a/test/unit/asrouter/constants.js
+++ b/test/unit/asrouter/constants.js
@@ -2,9 +2,9 @@ export const CHILD_TO_PARENT_MESSAGE_NAME = "ASRouter:child-to-parent";
 export const PARENT_TO_CHILD_MESSAGE_NAME = "ASRouter:parent-to-child";
 
 export const FAKE_LOCAL_MESSAGES = [
-  {id: "foo", template: "simple_template", content: {title: "Foo", body: "Foo123"}},
-  {id: "foo1", template: "simple_template", bundled: 2, order: 1, content: {title: "Foo1", body: "Foo123-1"}},
-  {id: "foo2", template: "simple_template", bundled: 2, order: 2, content: {title: "Foo2", body: "Foo123-2"}},
+  {id: "foo", template: "simple_snippet", content: {title: "Foo", body: "Foo123"}},
+  {id: "foo1", template: "simple_snippet", bundled: 2, order: 1, content: {title: "Foo1", body: "Foo123-1"}},
+  {id: "foo2", template: "simple_snippet", bundled: 2, order: 2, content: {title: "Foo2", body: "Foo123-2"}},
   {id: "bar", template: "fancy_template", content: {title: "Foo", body: "Foo123"}},
   {id: "baz", content: {title: "Foo", body: "Foo123"}},
 ];
@@ -12,7 +12,7 @@ export const FAKE_LOCAL_PROVIDER = {id: "onboarding", type: "local", localProvid
 export const FAKE_LOCAL_PROVIDERS = {FAKE_LOCAL_PROVIDER: {getMessages: () => FAKE_LOCAL_MESSAGES}};
 
 export const FAKE_REMOTE_MESSAGES = [
-  {id: "qux", template: "simple_template", content: {title: "Qux", body: "hello world"}},
+  {id: "qux", template: "simple_snippet", content: {title: "Qux", body: "hello world"}},
 ];
 export const FAKE_REMOTE_PROVIDER = {id: "remotey", type: "remote", url: "http://fake.com/endpoint", enabled: true};
 

--- a/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
+++ b/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
@@ -25,6 +25,7 @@ describe("NewsletterSnippet", () => {
     const props = {
       content: Object.assign({}, DEFAULT_CONTENT, content),
       onBlock: onBlockStub,
+      onDismiss: sandbox.stub(),
       sendUserActionTelemetry: sandbox.stub(),
       onAction: sandbox.stub(),
     };
@@ -82,6 +83,13 @@ describe("NewsletterSnippet", () => {
       wrapper.setState({expanded: true});
 
       assert.isTrue(wrapper.find("form").exists());
+    });
+    it("should dismiss the snippet", () => {
+      wrapper.setState({expanded: true});
+
+      wrapper.find(".ASRouterButton.secondary").simulate("click");
+
+      assert.calledOnce(wrapper.props().onDismiss);
     });
     it("should render hidden inputs + email input", () => {
       wrapper.setState({expanded: true});

--- a/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
+++ b/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
@@ -103,6 +103,13 @@ describe("NewsletterSnippet", () => {
       wrapper.find("form").simulate("submit");
       assert.calledOnce(window.fetch);
     });
+    it("should send user telemetry when submitted", () => {
+      wrapper.setState({expanded: true});
+
+      wrapper.find("form").simulate("submit");
+
+      assert.equal(wrapper.props().sendUserActionTelemetry.firstCall.args[0].value, "conversion-subscribe-activation");
+    });
     it("should set signupSuccess when submission status is ok", async () => {
       sandbox.stub(window, "fetch").resolves(fetchOk);
       wrapper.setState({expanded: true});
@@ -113,6 +120,13 @@ describe("NewsletterSnippet", () => {
       assert.calledOnce(onBlockStub);
       assert.calledWithExactly(onBlockStub, {preventDismiss: true});
     });
+    it("should send user telemetry when submission status is ok", async () => {
+      sandbox.stub(window, "fetch").resolves(fetchOk);
+      wrapper.setState({expanded: true});
+      await wrapper.instance().handleSubmit({preventDefault: sandbox.stub()});
+
+      assert.equal(wrapper.props().sendUserActionTelemetry.secondCall.args[0].value, "subscribe-success");
+    });
     it("should not block the snippet if submission failed", async () => {
       sandbox.stub(window, "fetch").resolves(fetchFail);
       wrapper.setState({expanded: true});
@@ -121,6 +135,13 @@ describe("NewsletterSnippet", () => {
       assert.equal(wrapper.state().signupSuccess, false);
       assert.equal(wrapper.state().signupSubmitted, true);
       assert.notCalled(onBlockStub);
+    });
+    it("should send user telemetry if submission failed", async () => {
+      sandbox.stub(window, "fetch").resolves(fetchFail);
+      wrapper.setState({expanded: true});
+      await wrapper.instance().handleSubmit({preventDefault: sandbox.stub()});
+
+      assert.equal(wrapper.props().sendUserActionTelemetry.secondCall.args[0].value, "subscribe-error");
     });
     it("should render the signup success message", () => {
       wrapper.setProps({content: {success_text: "success"}});

--- a/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
+++ b/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
@@ -1,0 +1,140 @@
+import {mount} from "enzyme";
+import {NewsletterSnippet} from "content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx";
+import React from "react";
+import schema from "content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json";
+
+const DEFAULT_CONTENT = {text: "foo", button_label: "Sign Up"};
+
+describe("NewsletterSnippet", () => {
+  let sandbox;
+  let onBlockStub;
+
+  /**
+   * mountAndCheckProps - Mounts a NewsletterSnippet with DEFAULT_CONTENT extended with any props
+   *                      passed in the content param and validates props against the schema.
+   * @param {obj} content Object containing custom message content (e.g. {text, icon, title})
+   * @returns enzyme wrapper for SimpleSnippet
+   */
+  function mountAndCheckProps(content = {}) {
+    const props = {
+      content: Object.assign({}, DEFAULT_CONTENT, content),
+      onBlock: onBlockStub,
+      sendUserActionTelemetry: sandbox.stub(),
+      onAction: sandbox.stub(),
+    };
+    assert.jsonSchema(props.content, schema);
+    return mount(<NewsletterSnippet {...props} />);
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    onBlockStub = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render .text", () => {
+    const wrapper = mountAndCheckProps({text: "bar"});
+    assert.equal(wrapper.find(".body").text(), "bar");
+  });
+  it("should not render title element if no .title prop is supplied", () => {
+    const wrapper = mountAndCheckProps();
+    assert.lengthOf(wrapper.find(".title"), 0);
+  });
+  it("should render .title", () => {
+    const wrapper = mountAndCheckProps({title: "Foo"});
+    assert.equal(wrapper.find(".title").text(), "Foo");
+  });
+  it("should render .icon", () => {
+    const wrapper = mountAndCheckProps({icon: "data:image/gif;base64,R0lGODl"});
+    assert.equal(wrapper.find(".icon").prop("src"), "data:image/gif;base64,R0lGODl");
+  });
+  it("should render .button_label and default className", () => {
+    const wrapper = mountAndCheckProps({button_label: "Click here"});
+
+    const button = wrapper.find("button.ASRouterButton");
+    assert.equal(button.text(), "Click here");
+    assert.equal(button.prop("className"), "ASRouterButton");
+  });
+
+  describe("#SignupView", () => {
+    let wrapper;
+    const fetchOk = {json: () => Promise.resolve({status: "ok"})};
+    const fetchFail = {json: () => Promise.resolve({status: "fail"})};
+
+    beforeEach(() => {
+      wrapper = mountAndCheckProps({
+        text: "bar",
+        form: {
+          input: {type: "email"},
+          heading: {text: "signup"},
+          hidden_inputs: [{name: "foo", value: "foo"}],
+          action: {url: "foo.com"},
+        },
+      });
+    });
+
+    it("should show the signup form if state.expanded is true", () => {
+      wrapper.setState({expanded: true});
+
+      assert.isTrue(wrapper.find("form").exists());
+    });
+    it("should render hidden inputs + email input", () => {
+      wrapper.setState({expanded: true});
+
+      assert.lengthOf(wrapper.find("input"), 2);
+    });
+    it("should open the SignupView when the action button is clicked", () => {
+      assert.isFalse(wrapper.find("form").exists());
+
+      wrapper.find(".ASRouterButton").simulate("click");
+
+      assert.isTrue(wrapper.state().expanded);
+      assert.isTrue(wrapper.find("form").exists());
+    });
+    it("should submit form data when submitted", () => {
+      sandbox.stub(window, "fetch").resolves(fetchOk);
+      wrapper.setState({expanded: true});
+
+      wrapper.find("form").simulate("submit");
+      assert.calledOnce(window.fetch);
+    });
+    it("should set signupSuccess when submission status is ok", async () => {
+      sandbox.stub(window, "fetch").resolves(fetchOk);
+      wrapper.setState({expanded: true});
+      await wrapper.instance().handleSubmit({preventDefault: sandbox.stub()});
+
+      assert.equal(wrapper.state().signupSuccess, true);
+      assert.equal(wrapper.state().signupSubmitted, true);
+      assert.calledOnce(onBlockStub);
+      assert.calledWithExactly(onBlockStub, {preventDismiss: true});
+    });
+    it("should not block the snippet if submission failed", async () => {
+      sandbox.stub(window, "fetch").resolves(fetchFail);
+      wrapper.setState({expanded: true});
+      await wrapper.instance().handleSubmit({preventDefault: sandbox.stub()});
+
+      assert.equal(wrapper.state().signupSuccess, false);
+      assert.equal(wrapper.state().signupSubmitted, true);
+      assert.notCalled(onBlockStub);
+    });
+    it("should render the signup success message", () => {
+      wrapper.setProps({content: {success_text: "success"}});
+      wrapper.setState({signupSuccess: true, signupSubmitted: true});
+
+      assert.isTrue(wrapper.find(".body").exists());
+      assert.equal(wrapper.find(".body").text(), "success");
+      assert.isFalse(wrapper.find(".ASRouterButton").exists());
+    });
+    it("should render the button to return to the signup form", () => {
+      wrapper.setState({signupSubmitted: true, signupSuccess: false});
+
+      assert.isTrue(wrapper.find(".ASRouterButton").exists());
+      wrapper.find(".ASRouterButton").simulate("click");
+
+      assert.equal(wrapper.state().signupSubmitted, false);
+    });
+  });
+});

--- a/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
+++ b/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
@@ -3,7 +3,13 @@ import {NewsletterSnippet} from "content-src/asrouter/templates/NewsletterSnippe
 import React from "react";
 import schema from "content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.schema.json";
 
-const DEFAULT_CONTENT = {text: "foo", button_label: "Sign Up"};
+const DEFAULT_CONTENT = {
+  text: "foo",
+  scene2_text: "bar",
+  button_label: "Sign Up",
+  form_action: "foo.com",
+  hidden_inputs: {"foo": "foo"},
+};
 
 describe("NewsletterSnippet", () => {
   let sandbox;
@@ -67,12 +73,8 @@ describe("NewsletterSnippet", () => {
     beforeEach(() => {
       wrapper = mountAndCheckProps({
         text: "bar",
-        form: {
-          input: {type: "email"},
-          heading: {text: "signup"},
-          hidden_inputs: [{name: "foo", value: "foo"}],
-          action: {url: "foo.com"},
-        },
+        scene2_email_placeholder_text: "Email",
+        scene2_text: "signup",
       });
     });
 
@@ -84,7 +86,7 @@ describe("NewsletterSnippet", () => {
     it("should render hidden inputs + email input", () => {
       wrapper.setState({expanded: true});
 
-      assert.lengthOf(wrapper.find("input"), 2);
+      assert.lengthOf(wrapper.find("input[type='hidden']"), 1);
     });
     it("should open the SignupView when the action button is clicked", () => {
       assert.isFalse(wrapper.find("form").exists());


### PR DESCRIPTION
Working demo https://snippets-admin.moz.works/show/7894/

In order to test this 

```javascript
Services.prefs.setStringPref(
"browser.newtab.activity-stream.asrouter.whitelistHosts",
"[\"gist.githubusercontent.com\"]"
);
```

Restart the browser.
Then navigate to `about:newtab?endpoint=https://gist.githubusercontent.com/piatra/70234f08696c0a0509d7ba5568cd830f/raw/f5bdddaa700390532fb70cfc33348d42aef6ba4a/messages.json`

#1st Screen
<img width="1283" alt="grafik" src="https://user-images.githubusercontent.com/810040/45834289-43c8a600-bcf6-11e8-867e-4c9452495013.png">

#2nd Screen (after clicking the button)
<img width="1278" alt="grafik" src="https://user-images.githubusercontent.com/810040/45834334-5b079380-bcf6-11e8-975d-e83c7daed86b.png">

Content isn't really important, just overall layout and function. 
