### PR TITLE
Fix Bug 1492454: Normalise ASRouter frequency caps

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -297,6 +297,18 @@ class _ASRouter {
     this.dispatchToAS(ac.BroadcastToContent({type: at.AS_ROUTER_PREF_CHANGED, data: ASRouterPreferences.specialConditions}));
   }
 
+  // Replace all frequency time period aliases with their millisecond values
+  // This allows us to avoid accounting for special cases later on
+  normalizeItemFrequency({frequency}) {
+    if (frequency && frequency.custom) {
+      for (const setting of frequency.custom) {
+        if (setting.period === "daily") {
+          setting.period = ONE_DAY_IN_MS;
+        }
+      }
+    }
+  }
+
   // Fetch and decode the message provider pref JSON, and update the message providers
   _updateMessageProviders() {
     const providers = [
@@ -316,6 +328,7 @@ class _ASRouter {
         provider.url = provider.url.replace(/%STARTPAGE_VERSION%/g, STARTPAGE_VERSION);
         provider.url = Services.urlFormatter.formatURL(provider.url);
       }
+      this.normalizeItemFrequency(provider);
       // Reset provider update timestamp to force message refresh
       provider.lastUpdated = undefined;
       return provider;
@@ -376,6 +389,10 @@ class _ASRouter {
           newState.providers.push(provider);
           newState.messages = [...newState.messages, ...messages];
         }
+      }
+
+      for (const message of newState.messages) {
+        this.normalizeItemFrequency(message);
       }
 
       // Some messages have triggers that require us to initalise trigger listeners
@@ -538,9 +555,6 @@ class _ASRouter {
         const now = Date.now();
         for (const setting of item.frequency.custom) {
           let {period} = setting;
-          if (period === "daily") {
-            period = ONE_DAY_IN_MS;
-          }
           const impressionsInPeriod = impressions.filter(t => (now - t) < period);
           if (impressionsInPeriod.length >= setting.cap) {
             return false;
@@ -660,16 +674,16 @@ class _ASRouter {
   /**
    * getLongestPeriod
    *
-   * @param {obj} message An ASRouter message
-   * @returns {int|null} if the message has custom frequency caps, the longest period found in the list of caps.
-                         if the message has no custom frequency caps, null
+   * @param {obj} item Either an ASRouter message or an ASRouter provider
+   * @returns {int|null} if the item has custom frequency caps, the longest period found in the list of caps.
+                         if the item has no custom frequency caps, null
    * @memberof _ASRouter
    */
-  getLongestPeriod(message) {
-    if (!message.frequency || !message.frequency.custom) {
+  getLongestPeriod(item) {
+    if (!item.frequency || !item.frequency.custom) {
       return null;
     }
-    return message.frequency.custom.sort((a, b) => b.period - a.period)[0].period;
+    return item.frequency.custom.sort((a, b) => b.period - a.period)[0].period;
   }
 
   /**


### PR DESCRIPTION
This bug was caused by [this line](https://github.com/mozilla/activity-stream/blob/d2c948f0fddd54335fca6fcfab3c64436727b3d2/lib/ASRouter.jsm#L717) in the impression cleanup. We filter out all the provider impressions older than the longest cap period (from `getLongestPeriod`), and the provider cap period was given as `"daily"` i.e. not a number, so all the provider impressions were getting removed.

I think the most straightforward solution to this is to replace all aliases like `"daily"` with their appropriate numerical values when we load the providers/messages so that we don't have to consider these special cases each time we use the frequency caps.