### PR TITLE
Fix Bug 1492777 - Failing CFR mochitest browser_asrouter_cfr.js 

### DIFF
--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -19,4 +19,3 @@ prefs =
 [browser_topsites_contextMenu_options.js]
 [browser_topsites_section.js]
 [browser_asrouter_cfr.js]
-skip-if = true # bug 1492777, disabled to permit Activity Stream export

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -43,7 +43,7 @@ function trigger_cfr_panel(browser, trigger, cb) {
 add_task(async function test_cfr_notification_show() {
   // addRecommendation checks that scheme starts with http and host matches
   let browser = gBrowser.selectedBrowser;
-  browser.loadURI("http://example.com");
+  await BrowserTestUtils.loadURI(browser, "http://example.com/");
   await BrowserTestUtils.browserLoaded(browser, false, "http://example.com/");
 
   const response = await trigger_cfr_panel(browser, "example.com", () => {});


### PR DESCRIPTION
This reverts https://github.com/mozilla/activity-stream/commit/89f12a8030bcb8e53018b829c2175b5261bdb7c4 and fixes the test. Try run https://treeherder.mozilla.org/#/jobs?repo=try&revision=d24d95071523427d57b0befae3073ff71d293313&selectedJob=200464695