### PR TITLE
Backport Bug 1485305

### DIFF
--- a/lib/SnippetsFeed.jsm
+++ b/lib/SnippetsFeed.jsm
@@ -190,7 +190,9 @@ this.SnippetsFeed = class SnippetsFeed {
   async showFirefoxAccounts(browser) {
     const url = await FxAccounts.config.promiseSignUpURI("snippets");
     // We want to replace the current tab.
-    browser.loadURI(url);
+    browser.loadURI(url, {
+      triggeringPrincipal: Services.scriptSecurityManager.createNullPrincipal({}),
+    });
   }
 
   async onAction(action) {

--- a/lib/SnippetsFeed.jsm
+++ b/lib/SnippetsFeed.jsm
@@ -190,9 +190,7 @@ this.SnippetsFeed = class SnippetsFeed {
   async showFirefoxAccounts(browser) {
     const url = await FxAccounts.config.promiseSignUpURI("snippets");
     // We want to replace the current tab.
-    browser.loadURI(url, {
-      triggeringPrincipal: Services.scriptSecurityManager.createNullPrincipal({}),
-    });
+    browser.loadURI(url, {triggeringPrincipal: Services.scriptSecurityManager.createNullPrincipal({})});
   }
 
   async onAction(action) {


### PR DESCRIPTION
Looks like we missed backporting this bug back in August:

See [mozilla-central](https://searchfox.org/mozilla-central/source/browser/components/newtab/lib/SnippetsFeed.jsm#193) v.s. [activity-stream/master](https://github.com/mozilla/activity-stream/blob/master/lib/SnippetsFeed.jsm#L193)