### PR TITLE
BUG: fix Services.locale.getAppLocalesAsBCP47

### DIFF
--- a/aboutNewTabService.js
+++ b/aboutNewTabService.js
@@ -310,7 +310,7 @@ AboutNewTabService.prototype = {
     return Services.locale.negotiateLanguages(
       // Fix up incorrect BCP47 that are actually lang tags as a workaround for
       // bug 1479606 returning the wrong values in the content process
-      Services.locale.appLocalesAsBCP47.map(l => l.replace(/^(ja-JP-mac)$/, "$1os")),
+      Services.locale.getAppLocalesAsBCP47().map(l => l.replace(/^(ja-JP-mac)$/, "$1os")),
       ACTIVITY_STREAM_BCP47,
       // defaultLocale's strings aren't necessarily packaged, but en-US' are
       "en-US",


### PR DESCRIPTION
## Description

Firefox is failing to start activity stream because of this error.
```
JavaScript error: file:///Users/jkoren/devel/mozilla-central/objdir-frontend/dist/Nightly.app/Contents/Resources/browser/components/aboutNewTabService.js, line 313: TypeError: Services.locale.appLocalesAsBCP47 is undefined; can't access its "map" property
```
This PR fixes the pull request.

## Testing

1. Build activity-stream and nightly from moz-central. 
2. Start nightly
3. See that activity stream loaded