### PR TITLE
Fix Bug 1485069 - Add client_id for Snippets reporting

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -13,7 +13,6 @@ class OnboardingCard extends React.PureComponent {
       event: "CLICK_BUTTON",
       message_id: props.id,
       id: props.UISurface,
-      includeClientID: true,
     };
     props.sendUserActionTelemetry(ping);
     props.onAction(props.content.button_action);

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -583,9 +583,9 @@ This reports the impression of Activity Stream Router.
 #### Snippets impression
 ```js
 {
-  "client_id": "n/a",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "action": "snippets_user_event",
-  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "impression_id": "n/a",
   "source": "SNIPPETS",
   "addon_version": "20180710100040",
   "locale": "en-US",
@@ -635,10 +635,10 @@ This reports the user's interaction with Activity Stream Router.
 #### Snippets interaction pings
 ```js
 {
-  "client_id": "n/a",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
   "action": "snippets_user_event",
   "addon_version": "20180710100040",
-  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "impression_id": "n/a",
   "locale": "en-US",
   "source": "NEWTAB_FOOTER_BAR",
   "message_id": "some_snippet_id",

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -382,9 +382,7 @@ this.TelemetryFeed = class TelemetryFeed {
 
   /**
    * Create a ping for AS router event. The client_id is set to "n/a" by default,
-   * AS router components could change that by including a boolean "includeClientID"
-   * to the payload of the action, impression_id would be set to "n/a" at the same time.
-   * Note that "includeClientID" will not be included in the result ping.
+   * different component can override this by its own telemetry collection policy.
    */
   createASRouterEvent(action) {
     const ping = {
@@ -393,21 +391,19 @@ this.TelemetryFeed = class TelemetryFeed {
       locale: Services.locale.appLocaleAsLangTag,
       impression_id: this._impressionId,
     };
-    if (action.data.includeClientID) {
-      // Ping-centre client will fill in the client_id if it's not provided in the ping
-      delete ping.client_id;
-      delete action.data.includeClientID;
-      ping.impression_id = "n/a";
-    }
     const event = Object.assign(ping, action.data);
     if (event.action === "cfr_user_event") {
       return this.applyCFRPolicy(event);
+    } else if (event.action === "snippets_user_event") {
+      return this.applySnippetsPolicy(event);
+    } else if (event.action === "onboarding_user_event") {
+      return this.applyOnboardingPolicy(event);
     }
     return event;
   }
 
   /**
-   * CFR metrics comply with following policies:
+   * Per Bug 1484035, CFR metrics comply with following policies:
    * 1). In release, it collects impression_id, and treats bucket_id as message_id
    * 2). In prerelease, it collects client_id and message_id
    * 3). In shield experiments conducted in release, it collects client_id and message_id
@@ -424,6 +420,28 @@ this.TelemetryFeed = class TelemetryFeed {
     }
     // bucket_id is no longer needed
     delete ping.bucket_id;
+    return ping;
+  }
+
+  /**
+   * Per Bug 1485069, all the metrics for Snippets in AS router use client_id in
+   * all the release channels
+   */
+  applySnippetsPolicy(ping) {
+    // Ping-centre client will fill in the client_id if it's not provided in the ping.
+    delete ping.client_id;
+    ping.impression_id = "n/a";
+    return ping;
+  }
+
+  /**
+   * Per Bug 1482134, all the metrics for Onboarding in AS router use client_id in
+   * all the release channels
+   */
+  applyOnboardingPolicy(ping) {
+    // Ping-centre client will fill in the client_id if it's not provided in the ping.
+    delete ping.client_id;
+    ping.impression_id = "n/a";
     return ping;
   }
 

--- a/test/unit/lib/TelemetryFeed.test.js
+++ b/test/unit/lib/TelemetryFeed.test.js
@@ -532,6 +532,40 @@ describe("TelemetryFeed", () => {
       assert.isUndefined(ping.bucket_id);
     });
   });
+  describe("#applySnippetsPolicy", () => {
+    it("should drop client_id and unset impression_id", () => {
+      const data = {
+        action: "snippets_user_event",
+        source: "SNIPPETS",
+        event: "IMPRESSION",
+        client_id: "n/a",
+        impression_id: "some_impression_id",
+        message_id: "snippets_message_01",
+      };
+      const ping = instance.applySnippetsPolicy(data);
+
+      assert.isUndefined(ping.client_id);
+      assert.propertyVal(ping, "impression_id", "n/a");
+      assert.propertyVal(ping, "message_id", "snippets_message_01");
+    });
+  });
+  describe("#applyOnboardingPolicy", () => {
+    it("should drop client_id and unset impression_id", () => {
+      const data = {
+        action: "onboarding_user_event",
+        source: "ONBOARDING",
+        event: "CLICK_BUTTION",
+        client_id: "n/a",
+        impression_id: "some_impression_id",
+        message_id: "onboarding_message_01",
+      };
+      const ping = instance.applyOnboardingPolicy(data);
+
+      assert.isUndefined(ping.client_id);
+      assert.propertyVal(ping, "impression_id", "n/a");
+      assert.propertyVal(ping, "message_id", "onboarding_message_01");
+    });
+  });
   describe("#createASRouterEvent", () => {
     it("should create a valid AS Router event", async () => {
       const data = {
@@ -548,34 +582,44 @@ describe("TelemetryFeed", () => {
       assert.propertyVal(ping, "source", "SNIPPETS");
       assert.propertyVal(ping, "event", "CLICK");
     });
-    it("should drop the default client_id if includeClientID presents", async () => {
-      const data = {
-        action: "snippet_user_event",
-        source: "SNIPPETS",
-        event: "CLICK",
-        message_id: "snippets_message_01",
-        includeClientID: true,
-      };
-      const action = ac.ASRouterUserEvent(data);
-      const ping = await instance.createASRouterEvent(action);
-
-      assert.isUndefined(ping.client_id);
-      assert.isUndefined(ping.includeClientID);
-      assert.propertyVal(ping, "impression_id", "n/a");
-    });
     it("should call applyCFRPolicy if action equals to cfr_user_event", async () => {
       const data = {
         action: "cfr_user_event",
         source: "CFR",
         event: "IMPRESSION",
         message_id: "cfr_message_01",
-        includeClientID: true,
       };
       sandbox.stub(instance, "applyCFRPolicy");
       const action = ac.ASRouterUserEvent(data);
       await instance.createASRouterEvent(action);
 
       assert.calledOnce(instance.applyCFRPolicy);
+    });
+    it("should call applySnippetsPolicy if action equals to snippets_user_event", async () => {
+      const data = {
+        action: "snippets_user_event",
+        source: "SNIPPETS",
+        event: "IMPRESSION",
+        message_id: "snippets_message_01",
+      };
+      sandbox.stub(instance, "applySnippetsPolicy");
+      const action = ac.ASRouterUserEvent(data);
+      await instance.createASRouterEvent(action);
+
+      assert.calledOnce(instance.applySnippetsPolicy);
+    });
+    it("should call applyOnboardingPolicy if action equals to onboarding_user_event", async () => {
+      const data = {
+        action: "onboarding_user_event",
+        source: "ONBOARDING",
+        event: "CLICK_BUTTON",
+        message_id: "onboarding_message_01",
+      };
+      sandbox.stub(instance, "applyOnboardingPolicy");
+      const action = ac.ASRouterUserEvent(data);
+      await instance.createASRouterEvent(action);
+
+      assert.calledOnce(instance.applyOnboardingPolicy);
     });
   });
   describe("#sendEvent", () => {


### PR DESCRIPTION
Highlights of this patch:

* Get rid of the `includeClientID` flag for AS router metrics
* Add two new metrics policies for Snippets and Onboarding, respectively