### PR TITLE
Fix Bug 1463775 - Buttons from the new onboarding have the wrong highlight on Dark theme

### DIFF
--- a/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
+++ b/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
@@ -101,8 +101,9 @@
       font-size: 15px;
 
       &:focus,
-      &.active {
-        box-shadow: $shadow-primary;
+      &.active,
+      &:hover {
+        box-shadow: 0 0 0 5px $grey-30;
         transition: box-shadow 150ms;
       }
     }

--- a/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
+++ b/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
@@ -133,8 +133,9 @@
     }
 
     &:focus,
-    &.active {
-      box-shadow: $shadow-primary;
+    &.active,
+    &:hover {
+      box-shadow: 0 0 0 5px $grey-30;
       transition: box-shadow 150ms;
     }
   }


### PR DESCRIPTION
Before: 
<img width="908" alt="screen shot 2018-10-01 at 11 18 35 am" src="https://user-images.githubusercontent.com/7219526/46297892-c7428c80-c56b-11e8-8c2e-b7012d8fe6de.png">

After:
<img width="866" alt="screen shot 2018-10-01 at 11 17 28 am" src="https://user-images.githubusercontent.com/7219526/46297835-a5e1a080-c56b-11e8-8525-d0ce07563d1a.png">

We don't have specs yet for dark theme for onboarding modal in general so leaving it as original light theme specs for now