### PR TITLE
Fix Bug 1495546 - Localization fails in OnboardingMessageProvider if we've already localized strings before

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -8,7 +8,7 @@ const L10N = new Localization([
   "browser/newtab/onboarding.ftl",
 ]);
 
-const ONBOARDING_MESSAGES = [
+const ONBOARDING_MESSAGES = () => ([
   {
     id: "ONBOARDING_1",
     template: "onboarding",
@@ -76,7 +76,7 @@ const ONBOARDING_MESSAGES = [
     targeting: "isInExperimentCohort == 2",
     trigger: {id: "firstRun"},
   },
-];
+]);
 
 const OnboardingMessageProvider = {
   async getExtraAttributes() {
@@ -87,7 +87,7 @@ const OnboardingMessageProvider = {
     return {header: header.value, button_label: button_label.value};
   },
   async getMessages() {
-    const messages = await this.translateMessages(ONBOARDING_MESSAGES);
+    const messages = await this.translateMessages(ONBOARDING_MESSAGES());
     return messages;
   },
   async translateMessages(messages) {


### PR DESCRIPTION
I was shallow copying `msg` before and so it was changing `ONBOARDING_MESSAGES` and then the next time we looked up the strings and passed them into `L10N` they no longer had `string_id` and the function would throw, giving us an error.
I'm deep copying now - any more elegant solutions for deep copying the entire nested object @k88hudson ?
