### PR TITLE
Backport Bug 1495517 - Migrate improvesearch.topSiteSearchShortcuts pref from ActivityStream.jsm to firefox.js r=k88hudson

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -167,10 +167,6 @@ const PREFS_CONFIG = new Map([
     title: "Experiment to remove tiles that are the same as the default search",
     value: true,
   }],
-  ["improvesearch.topSiteSearchShortcuts", {
-    title: "Experiment to show special top sites that perform keyword searches",
-    value: UpdateUtils.getUpdateChannel(true) !== "release",
-  }],
   ["improvesearch.topSiteSearchShortcuts.searchEngines", {
     title: "An ordered, comma-delimited list of search shortcuts that we should try and pin",
     // This pref is dynamic as the shortcuts vary depending on the region

--- a/lib/PrefsFeed.jsm
+++ b/lib/PrefsFeed.jsm
@@ -105,6 +105,13 @@ this.PrefsFeed = class PrefsFeed {
     values.fxa_endpoint = Services.prefs.getStringPref(
       "browser.newtabpage.activity-stream.fxaccounts.endpoint", "https://accounts.firefox.com");
 
+    // Read the pref for search shortcuts top sites experiment from firefox.js and store it
+    // in our interal list of prefs to watch
+    let searchTopSiteExperimentPrefValue = Services.prefs.getBoolPref(
+      "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts");
+    values["improvesearch.topSiteSearchShortcuts"] = searchTopSiteExperimentPrefValue;
+    this._prefMap.set("improvesearch.topSiteSearchShortcuts", searchTopSiteExperimentPrefValue);
+
     // Set the initial state of all prefs in redux
     this.store.dispatch(ac.BroadcastToContent({type: at.PREFS_INITIAL_VALUES, data: values}));
 


### PR DESCRIPTION
wait for https://bugzilla.mozilla.org/show_bug.cgi?id=1495517 to land in central