### PR TITLE
Fix Bug 1477633 - Add tooltip text to dismiss button

### DIFF
--- a/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -19,14 +19,14 @@ export class SnippetBase extends React.PureComponent {
       return (
         <div className="footer">
           <div className="footer-content">
-            <button className="ASRouterButton secondary" onClick={this.props.onDismiss}>{this.props.content.dismiss_button_label}</button>
+            <button className="ASRouterButton secondary" title={this.props.content.block_button_text} onClick={this.props.onDismiss}>{this.props.content.dismiss_button_label}</button>
           </div>
         </div>
       );
     }
 
     return (
-      <button className="blockButton" onClick={this.onBlockClicked} />
+      <button className="blockButton" title={this.props.content.block_button_text} onClick={this.onBlockClicked} />
     );
   }
 

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -71,6 +71,10 @@
       "type": "string",
       "description": "The background color of the button. Valid CSS color."
     },
+    "block_button_text": {
+      "type": "string",
+      "description": "Tooltip text used for dismiss button."
+    },
     "tall": {
       "type": "boolean",
       "description": "To be used by fundraising only, increases height to roughly 120px. Defaults to false."


### PR DESCRIPTION
Added `block_button_text` as alt text to the dismiss button. The translation and english fallback should come from snippets endpoint.

@glogiotatidis r?