### PR TITLE
Fix Bug 1496167 - Add installation source to addons installed from activitystream

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -215,7 +215,12 @@ const MessageLoaderUtils = {
     try {
       const aUri = Services.io.newURI(url);
       const systemPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
-      const install = await AddonManager.getInstallForURL(aUri.spec, "application/x-xpinstall");
+
+      // AddonManager installation source associated to the addons installed from activitystream
+      // (See Bug 1496167 for a rationale).
+      const amTelemetryInfo = {source: "activitystream"};
+      const install = await AddonManager.getInstallForURL(aUri.spec, "application/x-xpinstall", null,
+                                                          null, null, null, null, amTelemetryInfo);
       await AddonManager.installAddonFromWebpage("application/x-xpinstall", browser,
         systemPrincipal, install);
     } catch (e) {}

--- a/test/unit/asrouter/MessageLoaderUtils.test.js
+++ b/test/unit/asrouter/MessageLoaderUtils.test.js
@@ -252,6 +252,11 @@ describe("MessageLoaderUtils", () => {
 
       assert.calledOnce(getInstallStub);
       assert.calledOnce(installAddonStub);
+
+      // Verify that the expected installation source has been passed to the getInstallForURL
+      // method (See Bug 1496167 for a rationale).
+      assert.calledWithExactly(getInstallStub, "foo.com", "application/x-xpinstall", null,
+                               null, null, null, null, {source: "activitystream"});
     });
     it("should not call the Addons API on invalid URLs", async () => {
       sandbox.stub(global.Services.scriptSecurityManager, "getSystemPrincipal").throws();


### PR DESCRIPTION
This PR adds an additional `telemetryInfo` parameter (introduced in [Bug 1433334](https://bugzilla.mozilla.org/1433334)) to the `AddonManager.getInstallForURL` call (and add an additional assertion in the existing unit test that cover that ActivityStream feature).

This additional `telemetryInfo` parameter ensures that we can store the original "installation source" and be able to include it into the addonsManager telemetry events related to the addons installed from ActivityStream (e.g. when the addon has been disable/enabled/uninstalled by the users, even across Firefox restarts).