### PR TITLE
[Uplift backport] Bug 1493041 - Topstories feed uninit can remove idle-daily observer before init has a chance to add it 

### DIFF
--- a/lib/TopStoriesFeed.jsm
+++ b/lib/TopStoriesFeed.jsm
@@ -53,6 +53,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
       this.storiesLoaded = false;
       this.domainAffinitiesLastUpdated = 0;
       this.dispatchPocketCta(this._prefs.get("pocketCta"), false);
+      Services.obs.addObserver(this, "idle-daily");
 
       // Cache is used for new page loads, which shouldn't have changed data.
       // If we have changed data, cache should be cleared,
@@ -69,8 +70,6 @@ this.TopStoriesFeed = class TopStoriesFeed {
 
       // This is filtered so an update function can return true to retry on the next run
       this.contentUpdateQueue = this.contentUpdateQueue.filter(update => update());
-
-      Services.obs.addObserver(this, "idle-daily");
     } catch (e) {
       Cu.reportError(`Problem initializing top stories feed: ${e.message}`);
     }

--- a/test/unit/lib/TopStoriesFeed.test.js
+++ b/test/unit/lib/TopStoriesFeed.test.js
@@ -1021,6 +1021,13 @@ describe("Top Stories Feed", () => {
       assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
       assert.equal(action.data.event, "topstories.domain.affinity.calculation.ms");
     });
+    it("should add idle-daily observer right away, before waiting on init data", async () => {
+      const addObserver = globals.sandbox.stub();
+      globals.set("Services", {obs: {addObserver}});
+      const initPromise = instance.onInit();
+      assert.calledOnce(addObserver);
+      await initPromise;
+    });
     it("should not call init and uninit if data doesn't match on options change ", () => {
       sinon.spy(instance, "init");
       sinon.spy(instance, "uninit");


### PR DESCRIPTION
Merge after https://bugzilla.mozilla.org/show_bug.cgi?id=1493041  has landed on beta.