### PR TITLE
Fix Bug 1496352 - Add SHOW_FIREFOX_ACCOUTS Router action

### DIFF
--- a/common/Actions.jsm
+++ b/common/Actions.jsm
@@ -134,6 +134,7 @@ for (const type of [
   "OPEN_PRIVATE_BROWSER_WINDOW",
   "OPEN_URL",
   "OPEN_ABOUT_PAGE",
+  "SHOW_FIREFOX_ACCOUNTS",
 ]) {
   ASRouterActions[type] = type;
 }

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -9,6 +9,7 @@ XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 XPCOMUtils.defineLazyModuleGetters(this, {
   AddonManager: "resource://gre/modules/AddonManager.jsm",
   UITour: "resource:///modules/UITour.jsm",
+  FxAccounts: "resource://gre/modules/FxAccounts.jsm",
 });
 const {ASRouterActions: ra, actionTypes: at, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {CFRMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/CFRMessageProvider.jsm", {});
@@ -937,6 +938,14 @@ class _ASRouter {
         break;
       case ra.INSTALL_ADDON_FROM_URL:
         await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);
+        break;
+      case ra.SHOW_FIREFOX_ACCOUNTS:
+        const url = await FxAccounts.config.promiseSignUpURI("snippets");
+        // We want to replace the current tab.
+        target.browser.ownerGlobal.openLinkIn(url, "tabshifted", {
+          private: false,
+          triggeringPrincipal: Services.scriptSecurityManager.createNullPrincipal({}),
+        });
         break;
     }
   }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -839,6 +839,24 @@ describe("ASRouter", () => {
     });
   });
 
+  describe("#onMessage: SHOW_FIREFOX_ACCOUNTS", () => {
+    let globals;
+    beforeEach(() => {
+      globals = new GlobalOverrider();
+      globals.set("FxAccounts", {config: {promiseSignUpURI: sandbox.stub().resolves("some/url")}});
+    });
+    it("should call openLinkIn with the correct params on OPEN_URL", async () => {
+      let [testMessage] = Router.state.messages;
+      testMessage.button_action = {type: "SHOW_FIREFOX_ACCOUNTS"};
+      const msg = fakeExecuteUserAction(testMessage.button_action);
+      await Router.onMessage(msg);
+
+      assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
+      assert.calledWith(msg.target.browser.ownerGlobal.openLinkIn,
+        "some/url", "tabshifted", {"private": false, "triggeringPrincipal": undefined});
+    });
+  });
+
   describe("#onMessage: INSTALL_ADDON_FROM_URL", () => {
     it("should call installAddonFromURL with correct arguments", async () => {
       sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);


### PR DESCRIPTION
Preview snippet to test https://gist.githubusercontent.com/piatra/d45d10f1aee80a5ac46c9a664cab1f44/raw/0214adecb154d3004c699c59266fda1bc9033d28/gistfile1.txt (clicking the button should open a page with a "register for firefox accounts" form).