### PR TITLE
Fix Bug 1497261 - Revert parameter rename

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -892,7 +892,7 @@ class _ASRouter {
         UITour.showMenu(target.browser.ownerGlobal, action.data.args);
         break;
       case ra.INSTALL_ADDON_FROM_URL:
-        await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.args);
+        await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);
         break;
       case ra.SHOW_FIREFOX_ACCOUNTS:
         const url = await FxAccounts.config.promiseSignUpURI("snippets");

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -793,7 +793,7 @@ describe("ASRouter", () => {
   describe("#onMessage: INSTALL_ADDON_FROM_URL", () => {
     it("should call installAddonFromURL with correct arguments", async () => {
       sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);
-      const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {args: "foo.com"}});
+      const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com"}});
 
       await Router.onMessage(msg);
 


### PR DESCRIPTION
The rename in https://github.com/mozilla/activity-stream/commit/47f11743abcea792122a5a1d24e5b6dd370e6cc3 broke CFR addon installs. 
INSTALL_ADDON_FROM_URL was not used by snippets and the message provider was not updated.
I looked into adding a mochitest for end to end testing of the install flow but because of 
[fetchLatestAddonVersion](https://github.com/mozilla/activity-stream/blob/d2725fa471dbd348987e40782e13e0226ff57148/lib/CFRPageActions.jsm#L407) making a network request this is not possible now. Maybe by mocking the url through `forceRecommendation` I'll look into this separately.