### PR TITLE
Backport - Replace nsINavBookmarksService::onItemAdded with 'page-bookmarked'

### DIFF
--- a/lib/PlacesFeed.jsm
+++ b/lib/PlacesFeed.jsm
@@ -80,46 +80,6 @@ class BookmarksObserver extends Observer {
   }
 
   /**
-   * onItemAdded - Called when a bookmark is added
-   *
-   * @param  {str} id
-   * @param  {str} folderId
-   * @param  {int} index
-   * @param  {int} type       Indicates if the bookmark is an actual bookmark,
-   *                          a folder, or a separator.
-   * @param  {str} uri
-   * @param  {str} title
-   * @param  {int} dateAdded
-   * @param  {str} guid      The unique id of the bookmark
-   * @param  {str} parent guid
-   * @param  {int} source    Used to distinguish bookmarks made by different
-   *                         actions: sync, bookmarks import, other.
-   */
-  onItemAdded(id, folderId, index, type, uri, bookmarkTitle, dateAdded, bookmarkGuid, parentGuid, source) { // eslint-disable-line max-params
-    // Skips items that are not bookmarks (like folders), about:* pages or
-    // default bookmarks, added when the profile is created.
-    if (type !== PlacesUtils.bookmarks.TYPE_BOOKMARK ||
-        source === PlacesUtils.bookmarks.SOURCES.IMPORT ||
-        source === PlacesUtils.bookmarks.SOURCES.RESTORE ||
-        source === PlacesUtils.bookmarks.SOURCES.RESTORE_ON_STARTUP ||
-        source === PlacesUtils.bookmarks.SOURCES.SYNC ||
-        (uri.scheme !== "http" && uri.scheme !== "https")) {
-      return;
-    }
-
-    this.dispatch({type: at.PLACES_LINKS_CHANGED});
-    this.dispatch({
-      type: at.PLACES_BOOKMARK_ADDED,
-      data: {
-        bookmarkGuid,
-        bookmarkTitle,
-        dateAdded,
-        url: uri.spec,
-      },
-    });
-  }
-
-  /**
    * onItemRemoved - Called when a bookmark is removed
    *
    * @param  {str} id
@@ -158,12 +118,50 @@ class BookmarksObserver extends Observer {
   onItemChanged() {}
 }
 
+/**
+ * PlacesObserver - observes events from PlacesUtils.observers
+ */
+class PlacesObserver extends Observer {
+  constructor(dispatch) {
+    super(dispatch, Ci.nsINavBookmarkObserver);
+    this.handlePlacesEvent = this.handlePlacesEvent.bind(this);
+  }
+
+  handlePlacesEvent(events) {
+    for (let {itemType, source, dateAdded, guid, title, url, isTagging} of events) {
+      // Skips items that are not bookmarks (like folders), about:* pages or
+      // default bookmarks, added when the profile is created.
+      if (isTagging ||
+          itemType !== PlacesUtils.bookmarks.TYPE_BOOKMARK ||
+          source === PlacesUtils.bookmarks.SOURCES.IMPORT ||
+          source === PlacesUtils.bookmarks.SOURCES.RESTORE ||
+          source === PlacesUtils.bookmarks.SOURCES.RESTORE_ON_STARTUP ||
+          source === PlacesUtils.bookmarks.SOURCES.SYNC ||
+          (!url.startsWith("http://") && !url.startsWith("https://"))) {
+        return;
+      }
+
+      this.dispatch({type: at.PLACES_LINKS_CHANGED});
+      this.dispatch({
+        type: at.PLACES_BOOKMARK_ADDED,
+        data: {
+          bookmarkGuid: guid,
+          bookmarkTitle: title,
+          dateAdded: dateAdded * 1000,
+          url,
+        },
+      });
+    }
+  }
+}
+
 class PlacesFeed {
   constructor() {
     this.placesChangedTimer = null;
     this.customDispatch = this.customDispatch.bind(this);
     this.historyObserver = new HistoryObserver(this.customDispatch);
     this.bookmarksObserver = new BookmarksObserver(this.customDispatch);
+    this.placesObserver = new PlacesObserver(this.customDispatch);
   }
 
   addObservers() {
@@ -174,6 +172,8 @@ class PlacesFeed {
     Cc["@mozilla.org/browser/nav-bookmarks-service;1"]
       .getService(Ci.nsINavBookmarksService)
       .addObserver(this.bookmarksObserver, true);
+    PlacesUtils.observers.addListener(["bookmark-added"],
+                                      this.placesObserver.handlePlacesEvent);
 
     Services.obs.addObserver(this, LINK_BLOCKED_EVENT);
   }
@@ -214,6 +214,8 @@ class PlacesFeed {
     }
     PlacesUtils.history.removeObserver(this.historyObserver);
     PlacesUtils.bookmarks.removeObserver(this.bookmarksObserver);
+    PlacesUtils.observers.removeListener(["bookmark-added"],
+                                         this.placesObserver.handlePlacesEvent);
     Services.obs.removeObserver(this, LINK_BLOCKED_EVENT);
   }
 
@@ -334,5 +336,6 @@ this.PlacesFeed = PlacesFeed;
 // Exported for testing only
 PlacesFeed.HistoryObserver = HistoryObserver;
 PlacesFeed.BookmarksObserver = BookmarksObserver;
+PlacesFeed.PlacesObserver = PlacesObserver;
 
 const EXPORTED_SYMBOLS = ["PlacesFeed"];

--- a/test/unit/lib/PlacesFeed.test.js
+++ b/test/unit/lib/PlacesFeed.test.js
@@ -1,7 +1,7 @@
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import {GlobalOverrider} from "test/unit/utils";
 import {PlacesFeed} from "lib/PlacesFeed.jsm";
-const {HistoryObserver, BookmarksObserver} = PlacesFeed;
+const {HistoryObserver, BookmarksObserver, PlacesObserver} = PlacesFeed;
 
 const FAKE_BOOKMARK = {bookmarkGuid: "xi31", bookmarkTitle: "Foo", dateAdded: 123214232, url: "foo.com"};
 const TYPE_BOOKMARK = 0; // This is fake, for testing
@@ -38,6 +38,8 @@ describe("PlacesFeed", () => {
     sandbox.spy(global.PlacesUtils.bookmarks, "removeObserver");
     sandbox.spy(global.PlacesUtils.history, "addObserver");
     sandbox.spy(global.PlacesUtils.history, "removeObserver");
+    sandbox.spy(global.PlacesUtils.observers, "addListener");
+    sandbox.spy(global.PlacesUtils.observers, "removeListener");
     sandbox.spy(global.Services.obs, "addObserver");
     sandbox.spy(global.Services.obs, "removeObserver");
     sandbox.spy(global.Cu, "reportError");
@@ -74,21 +76,33 @@ describe("PlacesFeed", () => {
     assert.calledOnce(feed.store.dispatch);
     assert.equal(feed.store.dispatch.firstCall.args[0].type, action.type);
   });
+
+  it("should have a PlacesObserver that dispatches to the store", () => {
+    assert.instanceOf(feed.placesObserver, PlacesObserver);
+    const action = {type: "FOO"};
+
+    feed.placesObserver.dispatch(action);
+
+    assert.calledOnce(feed.store.dispatch);
+    assert.equal(feed.store.dispatch.firstCall.args[0].type, action.type);
+  });
   describe("#onAction", () => {
-    it("should add bookmark, history, blocked observers on INIT", () => {
+    it("should add bookmark, history, places, blocked observers on INIT", () => {
       feed.onAction({type: at.INIT});
 
       assert.calledWith(global.PlacesUtils.history.addObserver, feed.historyObserver, true);
       assert.calledWith(global.PlacesUtils.bookmarks.addObserver, feed.bookmarksObserver, true);
+      assert.calledWith(global.PlacesUtils.observers.addListener, ["bookmark-added"], feed.placesObserver.handlePlacesEvent);
       assert.calledWith(global.Services.obs.addObserver, feed, BLOCKED_EVENT);
     });
-    it("should remove bookmark, history, blocked observers, and timers on UNINIT", () => {
+    it("should remove bookmark, history, places, blocked observers, and timers on UNINIT", () => {
       feed.placesChangedTimer = global.Cc["@mozilla.org/timer;1"].createInstance();
       let spy = feed.placesChangedTimer.cancel;
       feed.onAction({type: at.UNINIT});
 
       assert.calledWith(global.PlacesUtils.history.removeObserver, feed.historyObserver);
       assert.calledWith(global.PlacesUtils.bookmarks.removeObserver, feed.bookmarksObserver);
+      assert.calledWith(global.PlacesUtils.observers.removeListener, ["bookmark-added"], feed.placesObserver.handlePlacesEvent);
       assert.calledWith(global.Services.obs.removeObserver, feed, BLOCKED_EVENT);
       assert.equal(feed.placesChangedTimer, null);
       assert.calledOnce(spy);
@@ -343,15 +357,21 @@ describe("PlacesFeed", () => {
   });
 
   describe("Custom dispatch", () => {
-    it("should only dispatch 1 PLACES_LINKS_CHANGED action if many onItemAdded notifications happened at once", async () => {
+    it("should only dispatch 1 PLACES_LINKS_CHANGED action if many bookmark-added notifications happened at once", async () => {
       // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-      const args = [null, null, null, TYPE_BOOKMARK,
-        {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
-        FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.DEFAULT];
-      await feed.bookmarksObserver.onItemAdded(...args);
-      await feed.bookmarksObserver.onItemAdded(...args);
-      await feed.bookmarksObserver.onItemAdded(...args);
-      await feed.bookmarksObserver.onItemAdded(...args);
+      const args = [{
+        itemType: TYPE_BOOKMARK,
+        source:  SOURCES.DEFAULT,
+        dateAdded: FAKE_BOOKMARK.dateAdded,
+        guid: FAKE_BOOKMARK.bookmarkGuid,
+        title: FAKE_BOOKMARK.bookmarkTitle,
+        url: "https://www.foo.com",
+        isTagging: false,
+      }];
+      await feed.placesObserver.handlePlacesEvent(args);
+      await feed.placesObserver.handlePlacesEvent(args);
+      await feed.placesObserver.handlePlacesEvent(args);
+      await feed.placesObserver.handlePlacesEvent(args);
       assert.calledOnce(feed.store.dispatch.withArgs(ac.OnlyToMain({type: at.PLACES_LINKS_CHANGED})));
     });
     it("should only dispatch 1 PLACES_LINKS_CHANGED action if many onItemRemoved notifications happened at once", async () => {
@@ -372,6 +392,145 @@ describe("PlacesFeed", () => {
     });
   });
 
+  describe("PlacesObserver", () => {
+    describe("#bookmark-added", () => {
+      let dispatch;
+      let observer;
+      beforeEach(() => {
+        dispatch = sandbox.spy();
+        observer = new PlacesObserver(dispatch);
+      });
+      it("should dispatch a PLACES_BOOKMARK_ADDED action with the bookmark data - http", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.DEFAULT,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "http://www.foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.calledWith(dispatch.secondCall, {
+          type: at.PLACES_BOOKMARK_ADDED,
+          data: {
+            bookmarkGuid: FAKE_BOOKMARK.bookmarkGuid,
+            bookmarkTitle: FAKE_BOOKMARK.bookmarkTitle,
+            dateAdded: FAKE_BOOKMARK.dateAdded * 1000,
+            url: "http://www.foo.com",
+          },
+        });
+      });
+      it("should dispatch a PLACES_BOOKMARK_ADDED action with the bookmark data - https", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.DEFAULT,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "https://www.foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.calledWith(dispatch.secondCall, {
+          type: at.PLACES_BOOKMARK_ADDED,
+          data: {
+            bookmarkGuid: FAKE_BOOKMARK.bookmarkGuid,
+            bookmarkTitle: FAKE_BOOKMARK.bookmarkTitle,
+            dateAdded: FAKE_BOOKMARK.dateAdded * 1000,
+            url: "https://www.foo.com",
+          },
+        });
+      });
+      it("should not dispatch a PLACES_BOOKMARK_ADDED action - not http/https", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.DEFAULT,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.notCalled(dispatch);
+      });
+      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has IMPORT source", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.IMPORT,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.notCalled(dispatch);
+      });
+      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has RESTORE source", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.RESTORE,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.notCalled(dispatch);
+      });
+      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has RESTORE_ON_STARTUP source", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.RESTORE_ON_STARTUP,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.notCalled(dispatch);
+      });
+      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has SYNC source", async () => {
+        const args = [{
+          itemType: TYPE_BOOKMARK,
+          source:  SOURCES.SYNC,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.notCalled(dispatch);
+      });
+      it("should ignore events that are not of TYPE_BOOKMARK", async () => {
+        const args = [{
+          itemType: "nottypebookmark",
+          source:  SOURCES.DEFAULT,
+          dateAdded: FAKE_BOOKMARK.dateAdded,
+          guid: FAKE_BOOKMARK.bookmarkGuid,
+          title: FAKE_BOOKMARK.bookmarkTitle,
+          url: "https://www.foo.com",
+          isTagging: false,
+        }];
+        await observer.handlePlacesEvent(args);
+
+        assert.notCalled(dispatch);
+      });
+    });
+  });
+
   describe("BookmarksObserver", () => {
     let dispatch;
     let observer;
@@ -381,78 +540,6 @@ describe("PlacesFeed", () => {
     });
     it("should have a QueryInterface property", () => {
       assert.property(observer, "QueryInterface");
-    });
-    describe("#onItemAdded", () => {
-      beforeEach(() => {
-      });
-      it("should dispatch a PLACES_BOOKMARK_ADDED action with the bookmark data - http", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.DEFAULT];
-        await observer.onItemAdded(...args);
-
-        assert.calledWith(dispatch, {type: at.PLACES_BOOKMARK_ADDED, data: FAKE_BOOKMARK});
-      });
-      it("should dispatch a PLACES_BOOKMARK_ADDED action with the bookmark data - https", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "https"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.DEFAULT];
-        await observer.onItemAdded(...args);
-
-        assert.calledWith(dispatch, {type: at.PLACES_BOOKMARK_ADDED, data: FAKE_BOOKMARK});
-      });
-      it("should not dispatch a PLACES_BOOKMARK_ADDED action - not http/https", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "places"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.DEFAULT];
-        await observer.onItemAdded(...args);
-
-        assert.notCalled(dispatch);
-      });
-      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has IMPORT source", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.IMPORT];
-        await observer.onItemAdded(...args);
-
-        assert.notCalled(dispatch);
-      });
-      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has RESTORE source", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.RESTORE];
-        await observer.onItemAdded(...args);
-
-        assert.notCalled(dispatch);
-      });
-      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has RESTORE_ON_STARTUP source", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.RESTORE_ON_STARTUP];
-        await observer.onItemAdded(...args);
-
-        assert.notCalled(dispatch);
-      });
-      it("should not dispatch a PLACES_BOOKMARK_ADDED action - has SYNC source", async () => {
-        // Yes, onItemAdded has at least 8 arguments. See function definition for docs.
-        const args = [null, null, null, TYPE_BOOKMARK,
-          {spec: FAKE_BOOKMARK.url, scheme: "http"}, FAKE_BOOKMARK.bookmarkTitle,
-          FAKE_BOOKMARK.dateAdded, FAKE_BOOKMARK.bookmarkGuid, "", SOURCES.SYNC];
-        await observer.onItemAdded(...args);
-
-        assert.notCalled(dispatch);
-      });
-      it("should ignore events that are not of TYPE_BOOKMARK", async () => {
-        const args = [null, null, null, "nottypebookmark"];
-        await observer.onItemAdded(...args);
-        assert.notCalled(dispatch);
-      });
     });
     describe("#onItemRemoved", () => {
       it("should ignore events that are not of TYPE_BOOKMARK", async () => {

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -91,6 +91,10 @@ const TEST_GLOBAL = {
     get history() {
       return TEST_GLOBAL.Cc["@mozilla.org/browser/nav-history-service;1"];
     },
+    observers: {
+      addListener() {},
+      removeListener() {},
+    },
   },
   PluralForm: {get() {}},
   Preferences: FakePrefs,


### PR DESCRIPTION
Blocked on Bug 1426245 landing in central first. https://bugzilla.mozilla.org/show_bug.cgi?id=1426245
This backports the changes from PlacesFeed.jsm, but also fixes the tests, and adds 2 trailing commas to PlacesFeed.jsm, just as heads up for next export.

I'm assuming similar changes are to come with `onItemRemoved` so we might want to refactor PlacesFeed.jsm at some point when BookmarksObserver won't be valid anymore.