### PR TITLE
Fix Bug 1494778 - CFR should respect the xpinstall.enabled pref

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -26,6 +26,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [sync](#sync)
 * [topFrecentSites](#topfrecentsites)
 * [totalBookmarksCount](#totalbookmarkscount)
+* [xpinstallEnabled](#xpinstallEnabled)
 
 ## Detailed usage
 
@@ -374,4 +375,12 @@ Total number of bookmarks.
 declare const totalBookmarksCount: number;
 ```
 
+### `xpinstallEnabled`
 
+Pref used by system administrators to disallow add-ons from installed altogether.
+
+#### Definition
+
+```ts
+declare const xpinstallEnabled: boolean;
+```

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -140,6 +140,10 @@ const TargetingGetters = {
       totalDevices: Services.prefs.getIntPref("services.sync.numClients", 0),
     };
   },
+  get xpinstallEnabled() {
+    // This is needed for all add-on recommendations, to know if we allow xpi installs in the first place
+    return Services.prefs.getBoolPref("xpinstall.enabled", true);
+  },
   get addonsInfo() {
     return AddonManager.getActiveAddons(["extension", "service"])
       .then(({addons, fullData}) => {

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -84,6 +84,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "one_per_day_amazon") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(AMAZON_ASSISTANT_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(AMAZON_ASSISTANT_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${AMAZON_ASSISTANT_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: AMAZON_ASSISTANT_PARAMS.open_urls},
@@ -127,6 +128,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "three_per_day_amazon") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(AMAZON_ASSISTANT_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(AMAZON_ASSISTANT_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${AMAZON_ASSISTANT_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: AMAZON_ASSISTANT_PARAMS.open_urls},
@@ -170,6 +172,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${FACEBOOK_CONTAINER_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: FACEBOOK_CONTAINER_PARAMS.open_urls},
@@ -213,6 +216,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "three_per_day") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${FACEBOOK_CONTAINER_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: FACEBOOK_CONTAINER_PARAMS.open_urls},
@@ -256,6 +260,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${GOOGLE_TRANSLATE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: GOOGLE_TRANSLATE_PARAMS.open_urls},
@@ -299,6 +304,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "three_per_day") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${GOOGLE_TRANSLATE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: GOOGLE_TRANSLATE_PARAMS.open_urls},
@@ -342,6 +348,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${YOUTUBE_ENHANCE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: YOUTUBE_ENHANCE_PARAMS.open_urls},
@@ -385,6 +392,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "three_per_day") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${YOUTUBE_ENHANCE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: YOUTUBE_ENHANCE_PARAMS.open_urls},
@@ -428,6 +436,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls},
@@ -471,6 +480,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "three_per_day") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls},
@@ -514,6 +524,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${REDDIT_ENHANCEMENT_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: REDDIT_ENHANCEMENT_PARAMS.open_urls},
@@ -557,6 +568,7 @@ const CFR_MESSAGES = [
     targeting: `
       localeLanguageCode == "en" &&
       (providerCohorts.cfr == "three_per_day") &&
+      (xpinstallEnabled == true) &&
       (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${REDDIT_ENHANCEMENT_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: REDDIT_ENHANCEMENT_PARAMS.open_urls},

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -362,3 +362,14 @@ add_task(async function check_provider_cohorts() {
   is(await ASRouterTargeting.Environment.providerCohorts.onboarding, "foo");
   is(await ASRouterTargeting.Environment.providerCohorts.cfr, "bar");
 });
+
+add_task(async function check_xpinstall_enabled() {
+  // should default to true if pref doesn't exist
+  is(await ASRouterTargeting.Environment.xpinstallEnabled, true);
+  // flip to false, check targeting reflects that
+  await pushPrefs(["xpinstall.enabled", false]);
+  is(await ASRouterTargeting.Environment.xpinstallEnabled, false);
+  // flip to true, check targeting reflects that
+  await pushPrefs(["xpinstall.enabled", true]);
+  is(await ASRouterTargeting.Environment.xpinstallEnabled, true);
+});

--- a/test/unit/asrouter/CFRMessageProvider.test.js
+++ b/test/unit/asrouter/CFRMessageProvider.test.js
@@ -41,4 +41,12 @@ describe("CFRMessageProvider", () => {
     assert.deepEqual(cohort3.frequency, {lifetime: 3}, "three day cohort has the right frequency cap");
     assert.include(cohort3.targeting, `(providerCohorts.cfr == "three_per_day_amazon")`);
   });
+  it("should always have xpinstallEnabled as targeting if it is an addon", () => {
+    for (const message of messages) {
+      // Ensure that the CFR messages that are recommending an addon have this targeting.
+      // In the future when we can do targeting based on category, this test will change.
+      // See bug 1494778 and 1497653
+      assert.include(message.targeting, `(xpinstallEnabled == true)`);
+    }
+  });
 });


### PR DESCRIPTION
Using targeting was the easiest way to do this - alternatively we can just not enable all of CFR if this pref is false. But CFR may not be just add-ons, so it might not be good to disable it altogether based off this pref. 
To test this, you can just make sure you see a recommendation, and then flip the pref to false and ensure the recommendation is not shown. Chances are on new profiles the pref doesn't exist (that's why we fallback to `true`), so you may need to create the pref