### PR TITLE
Fix Bug 1495768 - add Amazon to Search Shortcuts for Austria

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -182,7 +182,7 @@ const PREFS_CONFIG = new Map([
       } else {
         searchShortcuts.push("google");
       }
-      if (["DE", "FR", "GB", "IT", "JP", "US"].includes(geo)) {
+      if (["AT", "DE", "FR", "GB", "IT", "JP", "US"].includes(geo)) {
         searchShortcuts.push("amazon");
       }
       return searchShortcuts.join(",");


### PR DESCRIPTION
This is wanted in 63, I think this is all there is to the fix, right @Mardak 