### PR TITLE
Fix Bug 1492853 - Add isUpdated targeting parameter

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -27,6 +27,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [topFrecentSites](#topfrecentsites)
 * [totalBookmarksCount](#totalbookmarkscount)
 * [xpinstallEnabled](#xpinstallEnabled)
+* [isUpdated](#isupdated)
 
 ## Detailed usage
 
@@ -383,4 +384,12 @@ Pref used by system administrators to disallow add-ons from installed altogether
 
 ```ts
 declare const xpinstallEnabled: boolean;
+```
+
+### `isUpdated`
+
+Does the client have the latest available version installed
+
+```ts
+declare const isUpdated: boolean;
 ```

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -27,7 +27,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [topFrecentSites](#topfrecentsites)
 * [totalBookmarksCount](#totalbookmarkscount)
 * [xpinstallEnabled](#xpinstallEnabled)
-* [isUpdated](#isupdated)
+* [needsUpdate](#needsupdate)
 
 ## Detailed usage
 
@@ -386,10 +386,10 @@ Pref used by system administrators to disallow add-ons from installed altogether
 declare const xpinstallEnabled: boolean;
 ```
 
-### `isUpdated`
+### `needsUpdate`
 
 Does the client have the latest available version installed
 
 ```ts
-declare const isUpdated: boolean;
+declare const needsUpdate: boolean;
 ```

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -75,7 +75,7 @@ function CheckBrowserVersion(updateInterval = FRECENT_SITES_UPDATE_INTERVAL) {
         const now = Date.now();
         const updateServiceListener = {
           onCheckComplete(request, updates, updateCount) {
-            checker._value = updateCount === 0;
+            checker._value = updateCount;
             resolve(checker._value);
           },
           onError(request, update) {
@@ -116,7 +116,7 @@ const QueryCache = {
       }
     ),
     TotalBookmarksCount: new CachedTargetingGetter("getTotalBookmarksCount"),
-    UpdateCheck: new CheckBrowserVersion(),
+    UpdateCountCheck: new CheckBrowserVersion(),
   },
 };
 
@@ -257,8 +257,8 @@ const TargetingGetters = {
   get region() {
     return Services.prefs.getStringPref(SEARCH_REGION_PREF, "");
   },
-  get isUpdated() {
-    return QueryCache.queries.UpdateCheck.get();
+  get needsUpdate() {
+    return QueryCache.queries.UpdateCountCheck.get() > 0;
   },
 };
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -60,12 +60,16 @@ function CachedTargetingGetter(property, options = null, updateInterval = FRECEN
   };
 }
 
-function CheckBrowserVersion(updateInterval = FRECENT_SITES_UPDATE_INTERVAL) {
+function CheckBrowserNeedsUpdate(updateInterval = FRECENT_SITES_UPDATE_INTERVAL) {
   const UpdateChecker = Cc["@mozilla.org/updates/update-checker;1"].createInstance(Ci.nsIUpdateChecker);
   const checker = {
     _lastUpdated: 0,
     _value: null,
-    // For testing
+    // For testing. Avoid update check network call.
+    setUp(value) {
+      this._lastUpdated = Date.now();
+      this._value = value;
+    },
     expire() {
       this._lastUpdated = 0;
       this._value = null;
@@ -75,7 +79,7 @@ function CheckBrowserVersion(updateInterval = FRECENT_SITES_UPDATE_INTERVAL) {
         const now = Date.now();
         const updateServiceListener = {
           onCheckComplete(request, updates, updateCount) {
-            checker._value = updateCount;
+            checker._value = updateCount > 0;
             resolve(checker._value);
           },
           onError(request, update) {
@@ -116,7 +120,7 @@ const QueryCache = {
       }
     ),
     TotalBookmarksCount: new CachedTargetingGetter("getTotalBookmarksCount"),
-    UpdateCountCheck: new CheckBrowserVersion(),
+    CheckBrowserNeedsUpdate: new CheckBrowserNeedsUpdate(),
   },
 };
 
@@ -258,7 +262,7 @@ const TargetingGetters = {
     return Services.prefs.getStringPref(SEARCH_REGION_PREF, "");
   },
   get needsUpdate() {
-    return QueryCache.queries.UpdateCountCheck.get() > 0;
+    return QueryCache.queries.CheckBrowserNeedsUpdate.get();
   },
 };
 

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -172,6 +172,20 @@ add_task(async function check_totalBookmarksCount() {
   await PlacesUtils.bookmarks.remove(bookmark.guid);
 });
 
+add_task(async function check_needsUpdate() {
+  QueryCache.queries.CheckBrowserNeedsUpdate.setUp(true);
+
+  const message = {id: "foo", targeting: "needsUpdate"};
+
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), message,
+    "Should select message because update count > 0");
+
+  QueryCache.queries.CheckBrowserNeedsUpdate.setUp(false);
+
+  is(await ASRouterTargeting.findMatchingMessage({messages: [message]}), null,
+    "Should not select message because update count == 0");
+});
+
 add_task(async function checksearchEngines() {
   const result = await ASRouterTargeting.Environment.searchEngines;
   const expectedInstalled = Services.search.getVisibleEngines()

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -69,6 +69,7 @@ const TEST_GLOBAL = {
       markPageAsTyped() {},
       removeObserver() {},
     },
+    "@mozilla.org/updates/update-checker;1": {createInstance() {}},
   },
   Ci: {
     nsIHttpChannel: {REFERRER_POLICY_UNSAFE_URL: 5},


### PR DESCRIPTION
This is the relevant idl file. https://searchfox.org/mozilla-central/source/toolkit/mozapps/update/nsIUpdateService.idl#246
To test I just used the `isMatch` method from ASRouterTargeting. Not sure if this can be automated since it makes a network request.

edit: need to update the docs.