### PR TITLE
Fix Bug 1485633 - Context menu is displayed wrong for the last Highlight from a row

### DIFF
--- a/content-src/components/Sections/_Sections.scss
+++ b/content-src/components/Sections/_Sections.scss
@@ -22,7 +22,9 @@
     }
 
     @media (min-width: $break-point-widest) and (max-width: $break-point-widest + 2 * $card-width) {
-      :nth-child(3n) {
+      // 3n for normal cards, 4n for compact cards
+      :nth-child(3n),
+      :nth-child(4n) {
         @include context-menu-open-left;
       }
     }


### PR DESCRIPTION
When compact cards were added and we fit 4 cards on a row, this needed to be adjusted for a 4th child
Before:
<img width="1130" alt="screen shot 2018-10-11 at 10 54 23 am" src="https://user-images.githubusercontent.com/7219526/46813088-0929ba80-cd44-11e8-835f-bc0c7e009cbc.png">

After:
<img width="1066" alt="screen shot 2018-10-11 at 10 53 07 am" src="https://user-images.githubusercontent.com/7219526/46812991-de3f6680-cd43-11e8-83ee-06fef84b2c6e.png">
