### PR TITLE
Bug 1493032 - Intermittent browser/components/newtab/test/browser/browser_topsites_contextMenu_options.js | Uncaught exception - TypeError: contextMenu is null; can't access its "querySelector" property

### DIFF
--- a/test/browser/browser_topsites_contextMenu_options.js
+++ b/test/browser/browser_topsites_contextMenu_options.js
@@ -8,11 +8,11 @@ test_newtab({
   before: setDefaultTopSites,
   // Test verifies the menu options for a default top site.
   test: async function defaultTopSites_menuOptions() {
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".top-site-icon"),
+    const siteSelector = ".top-site-outer:not(.search-shortcut):not(.placeholder)";
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(siteSelector),
       "Topsite tippytop icon not found");
 
-    let contextMenuItems = content.openContextMenuAndGetOptions(".top-sites-list li:not(.search-shortcut)").map(v => v.textContent);
-
+    const contextMenuItems = content.openContextMenuAndGetOptions(siteSelector).map(v => v.textContent);
     Assert.equal(contextMenuItems.length, 5, "Number of options is correct");
 
     const expectedItemsText = ["Pin", "Edit", "Open in a New Window", "Open in a New Private Window", "Dismiss"];
@@ -27,26 +27,27 @@ test_newtab({
   before: setDefaultTopSites,
   // Test verifies that the next top site in queue replaces a dismissed top site.
   test: async function defaultTopSites_dismiss() {
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".top-site-icon"),
+    const siteSelector = ".top-site-outer:not(.search-shortcut):not(.placeholder)";
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(siteSelector),
       "Topsite tippytop icon not found");
 
     // Don't count search topsites
-    let defaultTopSitesNumber = content.document.querySelectorAll(".top-site-outer:not(.placeholder):not(.search-shortcut)").length;
+    const defaultTopSitesNumber = content.document.querySelectorAll(siteSelector).length;
     Assert.equal(defaultTopSitesNumber, 5, "5 top sites are loaded by default");
 
     // Skip the search topsites select the second default topsite
-    let secondTopSite = content.document.querySelectorAll(".top-sites-list li:not(.search-shortcut):not(.placeholder)")[1].getAttribute("href");
+    const secondTopSite = content.document.querySelectorAll(siteSelector)[1].getAttribute("href");
 
-    let contextMenuItems = content.openContextMenuAndGetOptions("li:not(.search-shortcut)");
+    const contextMenuItems = content.openContextMenuAndGetOptions(siteSelector);
     Assert.equal(contextMenuItems[4].textContent, "Dismiss", "'Dismiss' is the 5th item in the context menu list");
 
     contextMenuItems[4].querySelector("a").click();
 
     // Wait for the topsite to be dismissed and the second one to replace it
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".top-sites-list li:not(.search-shortcut):not(.placeholder)").getAttribute("href") === secondTopSite,
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(siteSelector).getAttribute("href") === secondTopSite,
       "First default topsite was dismissed");
 
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(".top-site-outer:not(.placeholder):not(.search-shortcut)").length === 4, "4 top sites are displayed after one of them is dismissed");
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(siteSelector).length === 4, "4 top sites are displayed after one of them is dismissed");
   },
   async after() {
     await new Promise(resolve => NewTabUtils.undoAll(resolve));
@@ -56,16 +57,17 @@ test_newtab({
 test_newtab({
   before: setDefaultTopSites,
   test: async function searchTopSites_dismiss() {
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(".search-shortcut").length === 2,
+    const siteSelector = ".search-shortcut";
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(siteSelector).length === 2,
       "2 search topsites are loaded by default");
 
-    let contextMenuItems = content.openContextMenuAndGetOptions(".search-shortcut");
+    const contextMenuItems = content.openContextMenuAndGetOptions(siteSelector);
     is(contextMenuItems.length, 2, "Search TopSites should only have Unpin and Dismiss");
 
     // Unpin
     contextMenuItems[0].querySelector("a").click();
 
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(".search-shortcut").length === 1,
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(siteSelector).length === 1,
       "1 search topsite displayed after we unpin the other one");
   },
   after: () => {


### PR DESCRIPTION
r?@sarracini Consistently wait for the same non-search non-placeholder site to get context menu. (Turning on search shortcuts by default resulted in a delay in top sites, so it ended up selecting the placeholder.)

try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=067ab2f42014950e461c6bc8099294fd2bd68748