### PR TITLE
Bug 1492556 - Intermittent browser/components/newtab/test/browser/browser_topsites_section.js | Uncaught exception - No context menu found - timed out after 50 tries.

### DIFF
--- a/test/browser/browser_topsites_section.js
+++ b/test/browser/browser_topsites_section.js
@@ -25,10 +25,11 @@ test_newtab({
   before: setDefaultTopSites,
   // it should pin the website when we click the first option of the topsite context menu.
   test: async function topsites_pin_unpin() {
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".top-site-icon"),
+    const siteSelector = ".top-site-outer:not(.search-shortcut):not(.placeholder)";
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelector(siteSelector),
       "Topsite tippytop icon not found");
     // There are only topsites on the page, the selector with find the first topsite menu button.
-    let topsiteEl = content.document.querySelector(".top-site-outer:not(.search-shortcut)");
+    let topsiteEl = content.document.querySelector(siteSelector);
     let topsiteContextBtn = topsiteEl.querySelector(".context-menu-button");
     topsiteContextBtn.click();
 


### PR DESCRIPTION
r?@sarracini Basically the same fix as #4491 Wait for an actual top site before trying to interact with context menu. (What ended up happening was the "context menu" button for a placeholder was clicked resulting in the edit top site form.)

same try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=067ab2f42014950e461c6bc8099294fd2bd68748