### PR TITLE
Fix Bug 1484249 - Remove horizontal scrollbar in modal

### DIFF
--- a/content-src/components/TopSites/_TopSites.scss
+++ b/content-src/components/TopSites/_TopSites.scss
@@ -300,6 +300,7 @@ $hover-transition-duration: 150ms;
     margin: 0 auto;
     max-height: calc(100% - 40px);
     overflow-y: auto;
+    overflow-x: hidden;
     position: fixed;
     right: 0;
     top: 40px;


### PR DESCRIPTION
this was bothering me
Before:
<img width="597" alt="screen shot 2018-10-11 at 3 29 14 pm" src="https://user-images.githubusercontent.com/7219526/46828968-6f293880-cd6a-11e8-9bbc-2f9b4e82f26c.png">

After:
<img width="605" alt="screen shot 2018-10-11 at 3 28 09 pm" src="https://user-images.githubusercontent.com/7219526/46828915-53be2d80-cd6a-11e8-979a-4d3c6a56a4fd.png">
