### PR TITLE
Snippets RichText component and debug content

### DIFF
--- a/content-src/asrouter/components/RichText/RichText.jsx
+++ b/content-src/asrouter/components/RichText/RichText.jsx
@@ -1,0 +1,51 @@
+import {Localized} from "fluent-react";
+import React from "react";
+import {RICH_TEXT_KEYS} from "../../rich-text-strings";
+import {safeURI} from "../../template-utils";
+
+// Elements allowed in snippet content
+const ALLOWED_TAGS = {
+  b: <b />,
+  i: <i />,
+  u: <u />,
+  strong: <strong />,
+  em: <em />,
+  br: <br />,
+};
+
+/**
+ * Transform an object (tag name: {url}) into (tag name: anchor) where the url
+ * is used as href, in order to render links inside a Fluent.Localized component.
+ */
+export function convertLinks(links, sendClick) {
+  if (links) {
+    return Object.keys(links).reduce((acc, linkTag) => {
+      const {action} = links[linkTag];
+      // Setting the value to false will not include the attribute in the anchor
+      const url = action ? false : safeURI(links[linkTag].url);
+
+      acc[linkTag] = (<a href={url}
+        data-metric={links[linkTag].metric}
+        data-action={action}
+        data-args={links[linkTag].args}
+        onClick={sendClick} />);
+      return acc;
+    }, {});
+  }
+
+  return null;
+}
+
+/**
+ * Message wrapper used to sanitize markup and render HTML.
+ */
+export function RichText(props) {
+  if (!RICH_TEXT_KEYS.includes(props.localization_id)) {
+    throw new Error(`ASRouter: ${props.localization_id} is not a valid rich text property. If you want it to be processed, you need to add it to asrouter/rich-text-strings.js`);
+  }
+  return (
+    <Localized id={props.localization_id} {...ALLOWED_TAGS} {...convertLinks(props.links, props.sendClick)}>
+      <span>{props.text}</span>
+    </Localized>
+  );
+}

--- a/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -19,7 +19,11 @@ export class SnippetBase extends React.PureComponent {
       return (
         <div className="footer">
           <div className="footer-content">
-            <button className="ASRouterButton secondary" title={this.props.content.block_button_text} onClick={this.props.onDismiss}>{this.props.content.dismiss_button_label}</button>
+            <button
+              className="ASRouterButton secondary"
+              onClick={this.props.onDismiss}>
+              {this.props.content.scene2_dismiss_button_text}
+            </button>
           </div>
         </div>
       );

--- a/content-src/asrouter/rich-text-strings.js
+++ b/content-src/asrouter/rich-text-strings.js
@@ -1,0 +1,35 @@
+import {MessageContext} from "fluent";
+
+/**
+ * Properties that allow rich text MUST be added to this list.
+ *   key: the localization_id that should be used
+ *   value: a property or array of properties on the message.content object
+ */
+const RICH_TEXT_CONFIG = {
+  "text": ["text", "scene1_text"],
+  "privacy_html": "scene2_privacy_html",
+};
+
+export const RICH_TEXT_KEYS = Object.keys(RICH_TEXT_CONFIG);
+
+/**
+ * Generates an array of messages suitable for fluent's localization provider
+ * including all needed strings for rich text.
+ * @param {object} content A .content object from an ASR message (i.e. message.content)
+ * @returns {MessageContext[]} A array containing the fluent message context
+ */
+export function generateMessages(content) {
+  const cx = new MessageContext("en-US");
+
+  RICH_TEXT_KEYS.forEach(key => {
+    const attrs = RICH_TEXT_CONFIG[key];
+    const attrsToTry = Array.isArray(attrs) ? [...attrs] : [attrs];
+    let string = "";
+    while (!string && attrsToTry.length) {
+      const attr = attrsToTry.pop();
+      string = content[attr];
+    }
+    cx.addMessages(`${key} = ${string}`);
+  });
+  return [cx];
+}

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -1,5 +1,6 @@
 import {Button} from "../../components/Button/Button";
 import React from "react";
+import {RichText} from "../../components/RichText/RichText";
 import {safeURI} from "../../template-utils";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
@@ -48,13 +49,21 @@ export class SimpleSnippet extends React.PureComponent {
     </Button>);
   }
 
+  renderText() {
+    const {props} = this;
+    return (<RichText text={props.content.text}
+      localization_id="text"
+      links={props.content.links}
+      sendClick={props.sendClick} />);
+  }
+
   render() {
     const {props} = this;
     const className = `SimpleSnippet${props.content.tall ? " tall" : ""}`;
     return (<SnippetBase {...props} className={className}>
       <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon" />
       <div>
-        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{props.richText || props.content.text}</p>
+        {this.renderTitleIcon()} {this.renderTitle()} <p className="body">{this.renderText()}</p>
       </div>
       {<div>{this.renderButton()}</div>}
     </SnippetBase>);

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import {RichText} from "../../components/RichText/RichText";
 import {SimpleSnippet} from "../SimpleSnippet/SimpleSnippet";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
@@ -74,10 +75,18 @@ export class SubmitFormSnippet extends React.PureComponent {
   }
 
   renderFormPrivacyNotice() {
-    return this.props.privacyNoticeRichText && (<label className="privacy-notice" htmlFor="id_privacy">
+    const {content} = this.props;
+    if (!content.scene2_privacy_html) {
+      return null;
+    }
+    return (<label className="privacy-notice" htmlFor="id_privacy">
         <p>
           <input type="checkbox" id="id_privacy" name="privacy" required="required" />
-          <span>{this.props.privacyNoticeRichText}</span>
+          <span><RichText text={content.scene2_privacy_html}
+            localization_id="privacy_html"
+            links={content.links}
+            sendClick={this.props.sendClick} />
+          </span>
         </p>
       </label>);
   }

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
@@ -69,6 +69,10 @@
       "type": "string",
       "description": "Information about how the form data is used."
     },
+    "scene2_dismiss_button_text": {
+      "type": "string",
+      "description": "Label for the dismiss button when the sign-up form is expanded."
+    },
     "hidden_inputs": {
       "type": "object",
       "description": "Each entry represents a hidden input, key is used as value for the name property."

--- a/content-src/lib/snippets.js
+++ b/content-src/lib/snippets.js
@@ -393,7 +393,8 @@ export function addSnippetsSubscriber(store) {
       !snippets.initialized &&
       // Don't call init multiple times
       !initializing &&
-      location.href !== "about:welcome"
+      location.href !== "about:welcome" &&
+      location.hash !== "#asrouter"
     ) {
       initializing = true;
       await snippets.init({appData: state.Snippets});

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -14,6 +14,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
 const {ASRouterActions: ra, actionTypes: at, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm", {});
 const {CFRMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/CFRMessageProvider.jsm", {});
 const {OnboardingMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/OnboardingMessageProvider.jsm", {});
+const {SnippetsTestMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/SnippetsTestMessageProvider.jsm", {});
 const {RemoteSettings} = ChromeUtils.import("resource://services-settings/remote-settings.js", {});
 const {CFRPageActions} = ChromeUtils.import("resource://activity-stream/lib/CFRPageActions.jsm", {});
 
@@ -39,7 +40,7 @@ const SNIPPETS_ENDPOINT_WHITELIST = "browser.newtab.activity-stream.asrouter.whi
 // Max possible impressions cap for any message
 const MAX_MESSAGE_LIFETIME_CAP = 100;
 
-const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider, CFRMessageProvider};
+const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider, CFRMessageProvider, SnippetsTestMessageProvider};
 const STARTPAGE_VERSION = "6";
 
 const MessageLoaderUtils = {

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -18,6 +18,13 @@ const DEFAULT_STATE = {
 
 const USER_PREFERENCES = {snippets: "browser.newtabpage.activity-stream.feeds.snippets"};
 
+const TEST_PROVIDER = {
+  id: "snippets_local_testing",
+  type: "local",
+  localProvider: "SnippetsTestMessageProvider",
+  enabled: true,
+};
+
 class _ASRouterPreferences {
   constructor() {
     Object.assign(this, DEFAULT_STATE);
@@ -26,14 +33,20 @@ class _ASRouterPreferences {
 
   get providers() {
     if (!this._initialized || this._providers === null) {
+      let providers;
       try {
         const parsed = JSON.parse(Services.prefs.getStringPref(this._providerPref, ""));
-        this._providers = Object.freeze(parsed.map(provider => Object.freeze(provider)));
+        providers = parsed.map(provider => Object.freeze(provider));
       } catch (e) {
         Cu.reportError("Problem parsing JSON message provider pref for ASRouter");
-        this._providers = [];
+        providers = [];
       }
+      if (this.devtoolsEnabled) {
+        providers.unshift(TEST_PROVIDER);
+      }
+      this._providers = Object.freeze(providers);
     }
+
     return this._providers;
   }
 
@@ -60,6 +73,7 @@ class _ASRouterPreferences {
         this._providers = null;
         break;
       case this._devtoolsPref:
+        this._providers = null;
         this._devtoolsEnabled = null;
         break;
     }
@@ -108,5 +122,6 @@ class _ASRouterPreferences {
 this._ASRouterPreferences = _ASRouterPreferences;
 
 this.ASRouterPreferences = new _ASRouterPreferences();
+this.TEST_PROVIDER = TEST_PROVIDER;
 
-const EXPORTED_SYMBOLS = ["_ASRouterPreferences", "ASRouterPreferences"];
+const EXPORTED_SYMBOLS = ["_ASRouterPreferences", "ASRouterPreferences", "TEST_PROVIDER"];

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const TEST_ICON = "chrome://branding/content/icon64.png";
+
+const MESSAGES = () => ([
+  {
+    "id": "SIMPLE_TEST_1",
+    "template": "simple_snippet",
+    "content": {
+      "icon": TEST_ICON,
+      "text": "<syncLink>Sync it, link it, take it with you</syncLink>. All this and more with a Firefox Account.",
+      "links": {"syncLink": {"url": "https://www.mozilla.org/en-US/firefox/accounts"}},
+      "block_button_text": "Block",
+    },
+  },
+  {
+    "id": "SIMPLE_WITH_TITLE_TEST_1",
+    "template": "simple_snippet",
+    "content": {
+      "icon": TEST_ICON,
+      "title": "Ready to sync?",
+      "text": "Get connected with a <syncLink>Firefox account</syncLink>.",
+      "links": {"syncLink": {"url": "https://www.mozilla.org/en-US/firefox/accounts"}},
+      "block_button_text": "Block",
+    },
+  },
+  {
+    "id": "NEWSLETTER_TEST_1",
+    "template": "newsletter_snippet",
+    "content": {
+      "scene1_icon": TEST_ICON,
+      "scene1_title": "Be a part of a movement.",
+      "scene1_title_icon": "",
+      "scene1_text": "Internet shutdowns, hackers, harassment &ndash; the health of the internet is on the line. Sign up and Mozilla will keep you updated on how you can help.",
+      "scene1_button_label": "Continue",
+       // TODO: Need to update schema
+      // "scene1_button_color": "#712b00",
+      // "scene1_button_background_color": "#ff9400",
+      "scene2_dismiss_button_text": "Dismiss",
+      "scene2_text": "Sign up for the Mozilla newsletter and we will keep you updated on how you can help.",
+      "scene2_privacy_html": "I'm okay with Mozilla handling my info as explained in this <privacyLink>Privacy Notice</privacyLink>.",
+      "scene2_button_label": "Sign Me up",
+      "scene2_email_placeholder_text": "Your email here",
+      "form_action": "https://basket.mozilla.org/subscribe.json",
+      "success_text": "Check your inbox for the confirmation!",
+      "error_text": "Error!",
+      "hidden_inputs": {
+        "fmt": "H",
+        "lang": "en-US",
+        "newsletters": "mozilla-foundation",
+      },
+      "links": {"privacyLink": {"url": "https://www.mozilla.org/privacy/websites/?sample_rate=0.001&snippet_name=7894"}},
+    },
+  },
+  {
+    "id": "FXA_SNIPPET_TEST_1",
+    "template": "fxa_signup_snippet",
+    "content": {
+      "scene1_icon": TEST_ICON,
+      "scene1_button_label": "Get connected with sync!",
+      // TODO: Need to update schema
+      // "scene1_button_color": "#712b00",
+      // "scene1_button_background_color": "#ff9400",
+
+      "scene1_text": "Connect to Firefox by securely syncing passwords, bookmarks, and open tabs.",
+      "scene1_title": "Browser better.",
+      "scene1_title_icon": "",
+
+      "scene2_text": "Connect to your Firefox account to securely sync passwords, bookmarks, and open tabs.",
+      // TODO: needs to be added
+      // "scene2_title": "Title 123",
+      "scene2_email_placeholder_text": "Your email",
+      "scene2_button_label": "Continue",
+      "scene2_dismiss_button_text": "Dismiss",
+      "form_action": "https://basket.mozilla.org/subscribe.json",
+
+      // TODO: This should not be required
+      "success_text": "Check your inbox for the confirmation!",
+      "error_text": "Error!",
+      "hidden_inputs": {},
+    },
+  },
+]);
+
+const SnippetsTestMessageProvider = {
+  getMessages() {
+    return MESSAGES()
+      // Ensures we never actually show test except when triggered by debug tools
+      .map(message => ({...message, targeting: `providerCohorts.snippets_local_testing == "SHOW_TEST"`}));
+  },
+};
+this.SnippetsTestMessageProvider = SnippetsTestMessageProvider;
+
+const EXPORTED_SYMBOLS = ["SnippetsTestMessageProvider"];

--- a/test/unit/asrouter/RichText.test.jsx
+++ b/test/unit/asrouter/RichText.test.jsx
@@ -1,0 +1,43 @@
+import {convertLinks} from "content-src/asrouter/components/RichText/RichText";
+
+describe("convertLinks", () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  it("should return an object with anchor elements", () => {
+    const cta = {
+      url: "https://foo.com",
+      metric: "foo",
+    };
+    const stub = sandbox.stub();
+    const result = convertLinks({cta}, stub);
+
+    assert.property(result, "cta");
+    assert.propertyVal(result.cta, "type", "a");
+    assert.propertyVal(result.cta.props, "href", cta.url);
+    assert.propertyVal(result.cta.props, "data-metric", cta.metric);
+    assert.propertyVal(result.cta.props, "onClick", stub);
+  });
+  it("should return an anchor element without href", () => {
+    const cta = {
+      url: "https://foo.com",
+      metric: "foo",
+      action: "OPEN_MENU",
+      args: "appMenu",
+    };
+    const stub = sandbox.stub();
+    const result = convertLinks({cta}, stub);
+
+    assert.property(result, "cta");
+    assert.propertyVal(result.cta, "type", "a");
+    assert.propertyVal(result.cta.props, "href", false);
+    assert.propertyVal(result.cta.props, "data-metric", cta.metric);
+    assert.propertyVal(result.cta.props, "data-action", cta.action);
+    assert.propertyVal(result.cta.props, "data-args", cta.args);
+    assert.propertyVal(result.cta.props, "onClick", stub);
+  });
+});

--- a/test/unit/asrouter/SnippetsTestMessageProvider.test.js
+++ b/test/unit/asrouter/SnippetsTestMessageProvider.test.js
@@ -1,0 +1,30 @@
+import SimpleSnippetSchema from "../../../content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json";
+import {SnippetsTestMessageProvider} from "../../../lib/SnippetsTestMessageProvider.jsm";
+import SubmitFormSnippetSchema from "../../../content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json";
+
+const schemas = {
+  "simple_snippet": SimpleSnippetSchema,
+  "newsletter_snippet": SubmitFormSnippetSchema,
+  "fxa_signup_snippet": SubmitFormSnippetSchema,
+};
+
+describe("SnippetsTestMessageProvider", () => {
+  let messages = SnippetsTestMessageProvider.getMessages();
+
+  it("should return an array of messages", () => {
+    assert.isArray(messages);
+  });
+
+  it("should have a valid example of each schema", () => {
+    Object.keys(schemas).forEach(templateName => {
+      const example = messages.find(message => message.template === templateName);
+      assert.ok(example, `has a ${templateName} example`);
+    });
+  });
+
+  it("should have examples that are valid", () => {
+    messages.forEach(example => {
+      assert.jsonSchema(example.content, schemas[example.template], `${example.id} should be valid`);
+    });
+  });
+});

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -1,4 +1,4 @@
-import {ASRouterUISurface, ASRouterUtils, convertLinks} from "content-src/asrouter/asrouter-content";
+import {ASRouterUISurface, ASRouterUtils} from "content-src/asrouter/asrouter-content";
 import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content-src/lib/init-store";
 import {FAKE_LOCAL_MESSAGES} from "./constants";
 import {GlobalOverrider} from "test/unit/utils";
@@ -130,41 +130,6 @@ describe("ASRouterUISurface", () => {
 
       wrapper.find(".blockButton").simulate("click");
       assert.notCalled(ASRouterUtils.sendTelemetry);
-    });
-  });
-
-  describe("convertLinks", () => {
-    it("should return an object with anchor elements", () => {
-      const cta = {
-        url: "https://foo.com",
-        metric: "foo",
-      };
-      const stub = sandbox.stub();
-      const result = convertLinks({cta}, stub);
-
-      assert.property(result, "cta");
-      assert.propertyVal(result.cta, "type", "a");
-      assert.propertyVal(result.cta.props, "href", cta.url);
-      assert.propertyVal(result.cta.props, "data-metric", cta.metric);
-      assert.propertyVal(result.cta.props, "onClick", stub);
-    });
-    it("should return an anchor element without href", () => {
-      const cta = {
-        url: "https://foo.com",
-        metric: "foo",
-        action: "OPEN_MENU",
-        args: "appMenu",
-      };
-      const stub = sandbox.stub();
-      const result = convertLinks({cta}, stub);
-
-      assert.property(result, "cta");
-      assert.propertyVal(result.cta, "type", "a");
-      assert.propertyVal(result.cta.props, "href", false);
-      assert.propertyVal(result.cta.props, "data-metric", cta.metric);
-      assert.propertyVal(result.cta.props, "data-action", cta.action);
-      assert.propertyVal(result.cta.props, "data-args", cta.args);
-      assert.propertyVal(result.cta.props, "onClick", stub);
     });
   });
 

--- a/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
@@ -176,7 +176,7 @@ describe("SubmitFormSnippet", () => {
       assert.isFalse(wrapper.find(".privacy-notice").exists());
     });
     it("should render the privacy notice checkbox if prop is provided", () => {
-      wrapper.setProps({privacyNoticeRichText: "privacy notice"});
+      wrapper.setProps({content: {...DEFAULT_CONTENT, scene2_privacy_html: "privacy notice"}});
       wrapper.setState({expanded: true});
 
       assert.isTrue(wrapper.find(".privacy-notice").exists());


### PR DESCRIPTION
This patch refactors the richtext stuff to a new `RichText` component and adds some test content that is only available when `asrouter.devtoolsEnabled` is on.

To test, starting with default settings (`./mach run --temp-profile`) 

1. Ensure you still see legacy snippets as normal on `about:newtab`
2. Set `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` to `true`
3. Open `about:newtab#asrouter`
4. Ensure you don’t see legacy snippets
5. Ensure you see `snippets_local_testing` in the list of providers; try testing each of the test snippets.