### PR TITLE
Fix Bug 1499068 - Adjust modal button to have variable width

### DIFF
--- a/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
+++ b/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
@@ -95,9 +95,9 @@
 
     .modalButton {
       margin-top: 20px;
-      width: 150px;
+      min-width: 150px;
       height: 30px;
-      padding: 4px 0 6px;
+      padding: 4px 30px 6px;
       font-size: 15px;
 
       &:focus,


### PR DESCRIPTION
oops my bad
Before:
<img width="932" alt="screen shot 2018-10-15 at 10 58 09 am" src="https://user-images.githubusercontent.com/7219526/46959291-b4e74900-d069-11e8-9ef5-1be146c4e3fb.png">
After:
<img width="922" alt="screen shot 2018-10-15 at 10 57 50 am" src="https://user-images.githubusercontent.com/7219526/46959297-b6b10c80-d069-11e8-905b-df99e653fc13.png">