### PR TITLE
chore(lint): Disallow margin-{left,right} to avoid RTL issues

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -17,7 +17,7 @@ rules:
   mixins-before-declarations: [2, {exclude: [breakpoint, mq]}]
   nesting-depth: [2, {max-depth: 4}]
   no-debug: 1
-  no-disallowed-properties: [1, {properties: [text-transform]}]
+  no-disallowed-properties: [1, {properties: [margin-left, margin-right, text-transform]}]
   no-duplicate-properties: 2
   no-misspelled-properties: [2, {extra-properties: [-moz-context-properties]}]
   no-url-domains: 0

--- a/content-src/components/ConfirmDialog/_ConfirmDialog.scss
+++ b/content-src/components/ConfirmDialog/_ConfirmDialog.scss
@@ -1,9 +1,10 @@
 .confirmation-dialog {
   .modal {
     box-shadow: 0 2px 2px 0 $black-10;
-    left: 50%;
-    margin-left: -200px;
+    left: 0;
+    margin: auto;
     position: fixed;
+    right: 0;
     top: 20%;
     width: 400px;
   }


### PR DESCRIPTION
r?@sarracini This should help avoid some issues but won't catch stuff in `margin:`, etc. The ConfirmDialog was working correctly in rtl as it was offsetting the modal block half of the width to be centered, so this was just cleaning up without needing 50% and 200px.

Not disallowing left/right as those are often used with 0.. (not sure if sass can conditionally disallow based on value?)