### PR TITLE
Port Bug 1497960: Make ProfileAge return the same instances for the same profile directory and preload times.json to avoid data races. r=janerik

### DIFF
--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -125,10 +125,10 @@ const TargetingGetters = {
     return new Date();
   },
   get profileAgeCreated() {
-    return new ProfileAge(null, null).created;
+    return ProfileAge().then(times => times.created);
   },
   get profileAgeReset() {
-    return new ProfileAge(null, null).reset;
+    return ProfileAge().then(times => times.reset);
   },
   get usesFirefoxSync() {
     return Services.prefs.prefHasUserValue(FXA_USERNAME_PREF);

--- a/lib/ManualMigration.jsm
+++ b/lib/ManualMigration.jsm
@@ -39,7 +39,7 @@ this.ManualMigration = class ManualMigration {
   }
 
   async isMigrationMessageExpired() {
-    let profileAge = new ProfileAge();
+    let profileAge = await ProfileAge();
     let profileCreationDate = await profileAge.created;
     let daysSinceProfileCreation = (Date.now() - profileCreationDate) / MS_PER_DAY;
 
@@ -93,10 +93,10 @@ this.ManualMigration = class ManualMigration {
     this.store.dispatch({type: at.MIGRATION_COMPLETED});
   }
 
-  onAction(action) {
+  async onAction(action) {
     switch (action.type) {
       case at.PREFS_INITIAL_VALUES:
-        this.expireIfNecessary(action.data.migrationExpired);
+        await this.expireIfNecessary(action.data.migrationExpired);
         break;
       case at.MIGRATION_START:
         MigrationUtils.showMigrationWizard(action._target.browser.ownerGlobal, [MigrationUtils.MIGRATION_ENTRYPOINT_NEWTAB]);

--- a/lib/SnippetsFeed.jsm
+++ b/lib/SnippetsFeed.jsm
@@ -59,7 +59,7 @@ this.SnippetsFeed = class SnippetsFeed {
   }
 
   async getProfileInfo() {
-    const profileAge = new ProfileAge(null, null);
+    const profileAge = await ProfileAge();
     const createdDate = await profileAge.created;
     const resetDate = await profileAge.reset;
     return {

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -109,7 +109,7 @@ add_task(async function check_localeLanguageCode() {
 });
 
 add_task(async function checkProfileAgeCreated() {
-  let profileAccessor = new ProfileAge();
+  let profileAccessor = await ProfileAge();
   is(await ASRouterTargeting.Environment.profileAgeCreated, await profileAccessor.created,
     "should return correct profile age creation date");
 
@@ -119,7 +119,7 @@ add_task(async function checkProfileAgeCreated() {
 });
 
 add_task(async function checkProfileAgeReset() {
-  let profileAccessor = new ProfileAge();
+  let profileAccessor = await ProfileAge();
   is(await ASRouterTargeting.Environment.profileAgeReset, await profileAccessor.reset,
     "should return correct profile age reset");
 

--- a/test/unit/lib/ManualMigration.test.js
+++ b/test/unit/lib/ManualMigration.test.js
@@ -23,14 +23,7 @@ describe("ManualMigration", () => {
       MIGRATION_ENTRYPOINT_NEWTAB: "MIGRATION_ENTRYPOINT_NEWTAB",
     };
 
-    fakeProfileAge = function() {};
-    fakeProfileAge.prototype = {
-      get created() {
-        return new Promise(resolve => {
-          resolve(Date.now());
-        });
-      },
-    };
+    fakeProfileAge = () => Promise.resolve({created: Promise.resolve(fakeProfileAge.created || Date.now())});
 
     sandbox = sinon.sandbox.create();
     globals = new GlobalOverrider();
@@ -187,13 +180,7 @@ describe("ManualMigration", () => {
       it("should return true if profile age > 3", async () => {
         let today = new Date();
         let someDaysAgo = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 4);
-        fakeProfileAge.prototype = {
-          get created() {
-            return new Promise(resolve => {
-              resolve(someDaysAgo.valueOf());
-            });
-          },
-        };
+        fakeProfileAge.created = someDaysAgo.valueOf();
         prefs.migrationLastShownDate = someDaysAgo.valueOf() / 1000;
         prefs.migrationRemainingDays = 2;
 
@@ -203,13 +190,7 @@ describe("ManualMigration", () => {
       it("should return early and not check prefs if profile age > 3", async () => {
         let today = new Date();
         let someDaysAgo = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 4);
-        fakeProfileAge.prototype = {
-          get created() {
-            return new Promise(resolve => {
-              resolve(someDaysAgo.valueOf());
-            });
-          },
-        };
+        fakeProfileAge.created = someDaysAgo.valueOf();
 
         const result = await instance.isMigrationMessageExpired();
 

--- a/test/unit/lib/SnippetsFeed.test.js
+++ b/test/unit/lib/SnippetsFeed.test.js
@@ -35,12 +35,10 @@ describe("SnippetsFeed", () => {
     clock = sinon.useFakeTimers();
     sandbox = sinon.sandbox.create();
     overrider.set({
-      ProfileAge: class ProfileAge {
-        constructor() {
-          this.created = Promise.resolve(0);
-          this.reset = Promise.resolve(WEEK_IN_MS);
-        }
-      },
+      ProfileAge: () => Promise.resolve({
+        created: Promise.resolve(0),
+        reset: Promise.resolve(WEEK_IN_MS),
+      }),
       FxAccounts: {config: {promiseSignUpURI: sandbox.stub().returns(Promise.resolve(signUpUrl))}},
       NewTabUtils: {activityStreamProvider: {getTotalBookmarksCount: () => Promise.resolve(42)}},
     });


### PR DESCRIPTION
r?@piatra Took a while to finally track down why tests weren't passing and turns out `await onAction` wasn't actually waiting because it wasn't returning a Promise. I also simplified getting a custom test value by optionally stashing a `fakeProfileAge.created`.

https://hg.mozilla.org/mozilla-central/rev/3edf43a3f1a4