### PR TITLE
Bug 1492088 - Add ASR Send to device template

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -6,6 +6,7 @@ import {LocalizationProvider} from "fluent-react";
 import {OnboardingMessage} from "./templates/OnboardingMessage/OnboardingMessage";
 import React from "react";
 import ReactDOM from "react-dom";
+import {SendToDeviceSnippet} from "./templates/SendToDeviceSnippet/SendToDeviceSnippet";
 import {SimpleSnippet} from "./templates/SimpleSnippet/SimpleSnippet";
 import {SubmitFormSnippet} from "./templates/SubmitFormSnippet/SubmitFormSnippet";
 
@@ -14,6 +15,7 @@ const SnippetComponents = {
   simple_snippet: SimpleSnippet,
   newsletter_snippet: props => <SubmitFormSnippet {...props} form_method="POST" />,
   fxa_signup_snippet: props => <SubmitFormSnippet {...props} form_method="GET" />,
+  send_to_device_snippet: SendToDeviceSnippet,
 };
 
 const INCOMING_MESSAGE_NAME = "ASRouter:parent-to-child";
@@ -129,7 +131,7 @@ export class ASRouterUISurface extends React.PureComponent {
     if (action.type) {
       ASRouterUtils.executeAction(action);
     }
-    if (!this.state.message.content.do_not_autoblock) {
+    if (!this.state.message.content.do_not_autoblock && !event.target.dataset.do_not_autoblock) {
       ASRouterUtils.blockById(this.state.message.id);
     }
     if (this.state.message.provider !== "preview") {

--- a/content-src/asrouter/components/Button/_Button.scss
+++ b/content-src/asrouter/components/Button/_Button.scss
@@ -1,4 +1,5 @@
 .ASRouterButton {
+  font-weight: bold;
   white-space: nowrap;
   border-radius: 4px;
   border: 1px solid var(--newtab-border-secondary-color);
@@ -14,7 +15,7 @@
   }
 
   &.primary {
-    border: 1px solid var(--newtab-border-primary-color);
+    border: 1px solid var(--newtab-button-primary-color);
     background-color: var(--newtab-button-primary-color);
     color: $grey-10;
   }

--- a/content-src/asrouter/components/RichText/RichText.jsx
+++ b/content-src/asrouter/components/RichText/RichText.jsx
@@ -17,7 +17,7 @@ const ALLOWED_TAGS = {
  * Transform an object (tag name: {url}) into (tag name: anchor) where the url
  * is used as href, in order to render links inside a Fluent.Localized component.
  */
-export function convertLinks(links, sendClick) {
+export function convertLinks(links, sendClick, autoBlock) {
   if (links) {
     return Object.keys(links).reduce((acc, linkTag) => {
       const {action} = links[linkTag];
@@ -25,9 +25,11 @@ export function convertLinks(links, sendClick) {
       const url = action ? false : safeURI(links[linkTag].url);
 
       acc[linkTag] = (<a href={url}
+        target={autoBlock === false ? "_blank" : ""}
         data-metric={links[linkTag].metric}
         data-action={action}
         data-args={links[linkTag].args}
+        data-do_not_autoblock={autoBlock === false}
         onClick={sendClick} />);
       return acc;
     }, {});
@@ -44,7 +46,7 @@ export function RichText(props) {
     throw new Error(`ASRouter: ${props.localization_id} is not a valid rich text property. If you want it to be processed, you need to add it to asrouter/rich-text-strings.js`);
   }
   return (
-    <Localized id={props.localization_id} {...ALLOWED_TAGS} {...convertLinks(props.links, props.sendClick)}>
+    <Localized id={props.localization_id} {...ALLOWED_TAGS} {...convertLinks(props.links, props.sendClick, props.autoBlock)}>
       <span>{props.text}</span>
     </Localized>
   );

--- a/content-src/asrouter/rich-text-strings.js
+++ b/content-src/asrouter/rich-text-strings.js
@@ -8,6 +8,7 @@ import {MessageContext} from "fluent";
 const RICH_TEXT_CONFIG = {
   "text": ["text", "scene1_text"],
   "privacy_html": "scene2_privacy_html",
+  "disclaimer_html": "scene2_disclaimer_html",
 };
 
 export const RICH_TEXT_KEYS = Object.keys(RICH_TEXT_CONFIG);

--- a/content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet.jsx
+++ b/content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet.jsx
@@ -1,0 +1,37 @@
+import {isEmailOrPhoneNumber} from "./isEmailOrPhoneNumber";
+import React from "react";
+import {SubmitFormSnippet} from "../SubmitFormSnippet/SubmitFormSnippet.jsx";
+
+function validateInput(value, content) {
+  const type = isEmailOrPhoneNumber(value, content);
+  return type ? "" : "Must be an email or a phone number.";
+}
+
+function processFormData(input, message) {
+  const {content} = message;
+  const type = content.include_sms ? isEmailOrPhoneNumber(input.value, content) : "email";
+  const formData = new FormData();
+  let url;
+  if (type === "phone") {
+    url = "https://basket.mozilla.org/news/subscribe_sms/";
+    formData.append("mobile_number", input.value);
+    formData.append("msg_name", content.message_id_sms);
+    formData.append("country", content.country);
+  } else if (type === "email") {
+    url = "https://basket.mozilla.org/news/subscribe/";
+    formData.append("email", input.value);
+    formData.append("newsletters", content.message_id_email);
+    formData.append("source_url", encodeURIComponent(`https://snippets.mozilla.com/show/${message.id}`));
+  }
+  formData.append("lang", content.locale);
+  return {formData, url};
+}
+
+export const SendToDeviceSnippet = props => (
+  <SubmitFormSnippet {...props}
+    form_method="POST"
+    className="send_to_device_snippet"
+    inputType={props.content.include_sms ? "text" : "email"}
+    validateInput={props.content.include_sms ? validateInput : null}
+    processFormData={processFormData} />
+);

--- a/content-src/asrouter/templates/SendToDeviceSnippet/isEmailOrPhoneNumber.js
+++ b/content-src/asrouter/templates/SendToDeviceSnippet/isEmailOrPhoneNumber.js
@@ -1,0 +1,34 @@
+/**
+ * Checks if a given string is an email or phone number or neither
+ * @param {string} val The user input
+ * @param {ASRMessageContent} content .content property on ASR message
+ * @returns {"email"|"phone"|""} The type of the input
+ */
+export function isEmailOrPhoneNumber(val, content) {
+  const {locale} = content;
+  // http://emailregex.com/
+  const email_re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  const check_email = email_re.test(val);
+  let check_phone; // depends on locale
+  switch (locale) {
+    case "en-US":
+    case "en-CA":
+      // allow 10-11 digits in case user wants to enter country code
+      check_phone = val.length >= 10 && val.length <= 11 && !isNaN(val);
+      break;
+    case "de":
+      // allow between 2 and 12 digits for german phone numbers
+      check_phone = val.length >= 2 && val.length <= 12 && !isNaN(val);
+      break;
+    // this case should never be hit, but good to have a fallback just in case
+    default:
+      check_phone = !isNaN(val);
+      break;
+  }
+  if (check_email) {
+    return "email";
+  } else if (check_phone) {
+    return "phone";
+  }
+  return "";
+}

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
@@ -19,9 +19,17 @@
     }
   },
   "properties": {
+    "locale": {
+      "type": "string",
+      "description": "Two to five character string for the locale code"
+    },
+    "country": {
+      "type": "string",
+      "description": "Two character string for the country code (used for SMS)"
+    },
     "scene1_title": {
       "allof": [
-        {"$ref": "#/definitions/plaintext"},
+        {"$ref": "#/definitions/plainText"},
         {"description": "snippet title displayed before snippet text"}
       ]
     },
@@ -29,6 +37,12 @@
       "allOf": [
         {"$ref": "#/definitions/richText"},
         {"description": "Main body text of snippet. HTML subset allowed: i, b, u, strong, em, br"}
+      ]
+    },
+    "scene2_title": {
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Title displayed before text in scene 2. Should be plain text."}
       ]
     },
     "scene2_text": {
@@ -49,6 +63,10 @@
       "type": "string",
       "description": "Endpoint to submit form data."
     },
+    "success_title": {
+      "type": "string",
+      "description": "(send to device) Title shown before text on successful registration."
+    },
     "success_text": {
       "type": "string",
       "description": "Message shown on successful registration."
@@ -61,6 +79,10 @@
       "type": "string",
       "description": "Value to show while input is empty."
     },
+    "scene2_input_placeholder": {
+      "type": "string",
+      "description": "(send to device) Value to show while input is empty."
+    },
     "scene2_button_label": {
       "type": "string",
       "description": "Label for form submit button"
@@ -69,9 +91,17 @@
       "type": "string",
       "description": "Information about how the form data is used."
     },
+    "scene2_disclaimer_html": {
+      "type": "string",
+      "description": "(send to device) Html for disclaimer and link underneath input box."
+    },
     "scene2_dismiss_button_text": {
       "type": "string",
       "description": "Label for the dismiss button when the sign-up form is expanded."
+    },
+    "scene2_icon": {
+      "type": "string",
+      "description": "(send to device) Image to display above the form. 98x98px. SVG or PNG preferred."
     },
     "hidden_inputs": {
       "type": "object",
@@ -83,17 +113,29 @@
         {"description": "Text for a button next to main snippet text that links to button_url. Requires button_url."}
       ]
     },
-    "button_color": {
+    "scene1_button_color": {
       "type": "string",
       "description": "The text color of the button. Valid CSS color."
     },
-    "button_background_color": {
+    "scene1_button_background_color": {
       "type": "string",
       "description": "The background color of the button. Valid CSS color."
     },
     "do_not_autoblock": {
       "type": "boolean",
       "description": "Used to prevent blocking the snippet after the CTA (link or button) has been clicked"
+    },
+    "include_sms": {
+      "type": "boolean",
+      "description": "(send to device) Allow users to send an SMS message with the form?"
+    },
+    "message_id_sms": {
+      "type": "string",
+      "description": "(send to device) Newsletter/basket id representing the SMS message to be sent."
+    },
+    "message_id_email": {
+      "type": "string",
+      "description": "(send to device) Newsletter/basket id representing the email message to be sent. Must be a value from the 'Slug' column here: https://basket.mozilla.org/news/."
     },
     "links": {
       "additionalProperties": {

--- a/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
+++ b/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
@@ -3,10 +3,26 @@
   flex: 1 1 100%;
   width: 100%;
 
+  &.send_to_device_snippet {
+    text-align: center;
+
+    .message {
+      font-size: 16px;
+    }
+  }
+
   .ASRouterButton {
     &.primary {
-      font-size: 15px;
       flex: 1 1 0;
+    }
+  }
+
+  .scene2Icon {
+    width: 100%;
+
+    img {
+      width: 98px;
+      display: inline-block;
     }
   }
 
@@ -20,17 +36,27 @@
     font-size: 14px;
     align-self: stretch;
     flex: 0 0 100%;
+
+    p {
+      margin-top: 0;
+    }
   }
 
-  .privacy-notice {
+  .privacyNotice {
     color: var(--newtab-text-secondary-color);
     flex: 0 0 100%;
+
+    p {
+      margin-bottom: 0;
+    }
   }
 
   .innerWrapper {
     max-width: 670px;
     flex-wrap: wrap;
     justify-items: center;
+    padding-top: 40px;
+    padding-bottom: 40px;
   }
 
   .footer {
@@ -49,11 +75,12 @@
   }
 
   input {
-    &[type='email'] {
+    &.mainInput {
+      border-radius: 3px;
       background-color: var(--newtab-textbox-background-color);
       border: $input-border;
       padding: 0 8px;
-      height: 32px;
+      height: 100%;
       font-size: 15px;
       width: 50%;
 
@@ -62,5 +89,15 @@
         box-shadow: var(--newtab-textbox-focus-boxshadow);
       }
     }
+  }
+}
+
+.submissionStatus {
+  text-align: center;
+  font-size: 14px;
+  padding: 20px 0;
+
+  .submitStatusTitle {
+    font-size: 20px;
   }
 }

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -36,9 +36,8 @@ const MESSAGES = () => ([
       "scene1_title_icon": "",
       "scene1_text": "Internet shutdowns, hackers, harassment &ndash; the health of the internet is on the line. Sign up and Mozilla will keep you updated on how you can help.",
       "scene1_button_label": "Continue",
-       // TODO: Need to update schema
-      // "scene1_button_color": "#712b00",
-      // "scene1_button_background_color": "#ff9400",
+      "scene1_button_color": "#712b00",
+      "scene1_button_background_color": "#ff9400",
       "scene2_dismiss_button_text": "Dismiss",
       "scene2_text": "Sign up for the Mozilla newsletter and we will keep you updated on how you can help.",
       "scene2_privacy_html": "I'm okay with Mozilla handling my info as explained in this <privacyLink>Privacy Notice</privacyLink>.",
@@ -61,17 +60,15 @@ const MESSAGES = () => ([
     "content": {
       "scene1_icon": TEST_ICON,
       "scene1_button_label": "Get connected with sync!",
-      // TODO: Need to update schema
-      // "scene1_button_color": "#712b00",
-      // "scene1_button_background_color": "#ff9400",
+      "scene1_button_color": "#712b00",
+      "scene1_button_background_color": "#ff9400",
 
       "scene1_text": "Connect to Firefox by securely syncing passwords, bookmarks, and open tabs.",
       "scene1_title": "Browser better.",
       "scene1_title_icon": "",
 
       "scene2_text": "Connect to your Firefox account to securely sync passwords, bookmarks, and open tabs.",
-      // TODO: needs to be added
-      // "scene2_title": "Title 123",
+      "scene2_title": "Title 123",
       "scene2_email_placeholder_text": "Your email",
       "scene2_button_label": "Continue",
       "scene2_dismiss_button_text": "Dismiss",
@@ -81,6 +78,42 @@ const MESSAGES = () => ([
       "success_text": "Check your inbox for the confirmation!",
       "error_text": "Error!",
       "hidden_inputs": {},
+    },
+  },
+  {
+    id: "SNIPPETS_SEND_TO_DEVICE_TEST",
+    template: "send_to_device_snippet",
+    content: {
+      include_sms: true,
+      locale: "en-CA",
+      country: "us",
+      message_id_sms: "ff-mobilesn-download",
+      message_id_email: "download-firefox-mobile",
+
+      scene1_button_background_color: "#6200a4",
+      scene1_button_color: "#FFFFFF",
+      scene1_button_label: "Install now",
+      scene1_icon: TEST_ICON,
+      scene1_text: "Browse without compromise with Firefox Mobile.",
+      scene1_title: "Full-featured. Customizable. Lightning fast",
+      scene1_title_icon: "",
+
+      scene2_button_label: "Send",
+      scene2_disclaimer_html: "The intended recipient of the email must have consented. <privacyLink>Learn more.</privacyLink>",
+      scene2_dismiss_button_text: "Dismiss",
+      scene2_icon: TEST_ICON,
+      scene2_input_placeholder: "Your email address or phone number",
+      scene2_text: "Send Firefox to your phone and take a powerful independent browser with you.",
+      scene2_title: "",
+
+      error_text: "Oops, there was a problem.",
+      success_title: "Your download link was sent.",
+      success_text: "Check your device for the email message!",
+      links: {"privacyLink": {"url": "https://www.mozilla.org/privacy/websites/?sample_rate=0.001&snippet_name=7894"}},
+
+      // TODO: Not actually defined in the send to device schema
+      form_action: "https://basket.mozilla.org/subscribe.json",
+      hidden_inputs: {},
     },
   },
 ]);

--- a/test/unit/asrouter/SnippetsTestMessageProvider.test.js
+++ b/test/unit/asrouter/SnippetsTestMessageProvider.test.js
@@ -6,6 +6,7 @@ const schemas = {
   "simple_snippet": SimpleSnippetSchema,
   "newsletter_snippet": SubmitFormSnippetSchema,
   "fxa_signup_snippet": SubmitFormSnippetSchema,
+  "send_to_device_snippet": SubmitFormSnippetSchema,
 };
 
 describe("SnippetsTestMessageProvider", () => {

--- a/test/unit/asrouter/templates/SendToDeviceSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SendToDeviceSnippet.test.jsx
@@ -1,0 +1,128 @@
+import {mount} from "enzyme";
+import React from "react";
+import schema from "content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json";
+import {SendToDeviceSnippet} from "content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet";
+import {SnippetsTestMessageProvider} from "lib/SnippetsTestMessageProvider.jsm";
+
+const DEFAULT_CONTENT = SnippetsTestMessageProvider.getMessages().find(msg => msg.template === "send_to_device_snippet").content;
+
+async function testBodyContains(body, key, value) {
+  const regex = new RegExp(`Content-Disposition: form-data; name="${key}"${value}`);
+  const match = regex.exec(body);
+  return match;
+}
+
+/**
+ * Simulates opening the second panel (form view), filling in the input, and submitting
+ * @param {EnzymeWrapper} wrapper A SendToDevice wrapper
+ * @param {string} value Email or phone number
+ * @param {function?} setCustomValidity setCustomValidity stub
+ */
+function openFormAndSetValue(wrapper, value, setCustomValidity = () => {}) {
+  // expand
+  wrapper.find(".ASRouterButton").simulate("click");
+  // Fill in email
+  const input =  wrapper.find(".mainInput");
+  input.instance().value = value;
+  input.simulate("change", {target: {value, setCustomValidity}});
+  wrapper.find("form").simulate("submit");
+}
+
+describe("SendToDeviceSnippet", () => {
+  let sandbox;
+  let fetchStub;
+  let jsonResponse;
+
+  function mountAndCheckProps(content = {}) {
+    const props = {
+      id: "foo123",
+      content: Object.assign({}, DEFAULT_CONTENT, content),
+      onBlock() {},
+      onDismiss: sandbox.stub(),
+      sendUserActionTelemetry: sandbox.stub(),
+      onAction: sandbox.stub(),
+      form_method: "POST",
+    };
+    assert.jsonSchema(props.content, schema);
+    return mount(<SendToDeviceSnippet {...props} />);
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    jsonResponse = {status: "ok"};
+    fetchStub = sandbox.stub(global, "fetch")
+      .returns(Promise.resolve({json: () => Promise.resolve(jsonResponse)}));
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("form input", () => {
+    it("should set the input type to text if content.include_sms is true", () => {
+      const wrapper = mountAndCheckProps({include_sms: true});
+      wrapper.find(".ASRouterButton").simulate("click");
+      assert.equal(wrapper.find(".mainInput").instance().type, "text");
+    });
+    it("should set the input type to email if content.include_sms is false", () => {
+      const wrapper = mountAndCheckProps({include_sms: false});
+      wrapper.find(".ASRouterButton").simulate("click");
+      assert.equal(wrapper.find(".mainInput").instance().type, "email");
+    });
+    it("should validate the input with isEmailOrPhoneNumber if include_sms is true", () => {
+      const wrapper = mountAndCheckProps({include_sms: true});
+      const setCustomValidity = sandbox.stub();
+      openFormAndSetValue(wrapper, "foo", setCustomValidity);
+      assert.calledWith(setCustomValidity, "Must be an email or a phone number.");
+    });
+    it("should not custom validate the input if include_sms is false", () => {
+      const wrapper = mountAndCheckProps({include_sms: false});
+      const setCustomValidity = sandbox.stub();
+      openFormAndSetValue(wrapper, "foo", setCustomValidity);
+      assert.notCalled(setCustomValidity);
+    });
+  });
+
+  describe("submitting", () => {
+    it("should send the right information to basket.mozilla.org/news/subscribe for an email", async () => {
+      const wrapper = mountAndCheckProps({
+        locale: "fr-CA",
+        include_sms: true,
+        message_id_email: "foo",
+      });
+
+      openFormAndSetValue(wrapper, "foo@bar.com");
+      wrapper.find("form").simulate("submit");
+
+      assert.calledOnce(fetchStub);
+      const [request] = fetchStub.firstCall.args;
+
+      assert.equal(request.url, "https://basket.mozilla.org/news/subscribe/");
+      const body = await request.text();
+      assert.ok(testBodyContains(body, "email", "foo@bar.com"), "has email");
+      assert.ok(testBodyContains(body, "lang", "fr-CA"), "has lang");
+      assert.ok(testBodyContains(body, "newsletters", "foo"), "has newsletters");
+      assert.ok(testBodyContains(body, "source_url", "foo"), "https%3A%2F%2Fsnippets.mozilla.com%2Fshow%2Ffoo123");
+    });
+    it("should send the right information for an sms", async () => {
+      const wrapper = mountAndCheckProps({
+        locale: "fr-CA",
+        include_sms: true,
+        message_id_sms: "foo",
+        country: "CA",
+      });
+
+      openFormAndSetValue(wrapper, "5371283767");
+      wrapper.find("form").simulate("submit");
+
+      assert.calledOnce(fetchStub);
+      const [request] = fetchStub.firstCall.args;
+
+      assert.equal(request.url, "https://basket.mozilla.org/news/subscribe_sms/");
+      const body = await request.text();
+      assert.ok(testBodyContains(body, "mobile_number", "5371283767"), "has number");
+      assert.ok(testBodyContains(body, "lang", "fr-CA"), "has lang");
+      assert.ok(testBodyContains(body, "country", "CA"), "CA");
+      assert.ok(testBodyContains(body, "msg_name", "foo"), "has msg_name");
+    });
+  });
+});

--- a/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
@@ -82,6 +82,32 @@ describe("SubmitFormSnippet", () => {
       });
     });
 
+    it("should set the input type if provided through props.inputType", () => {
+      wrapper.setProps({inputType: "number"});
+      wrapper.setState({expanded: true});
+      assert.equal(wrapper.find(".mainInput").instance().type, "number");
+    });
+
+    it("should validate via props.validateInput if provided", () => {
+      function validateInput(value, content) {
+        if (content.country === "CA" && value === "poutine") {
+          return "";
+        }
+        return "Must be poutine";
+      }
+      const setCustomValidity = sandbox.stub();
+      wrapper.setProps({validateInput, content: {...DEFAULT_CONTENT, country: "CA"}});
+      wrapper.setState({expanded: true});
+      const input = wrapper.find(".mainInput");
+      input.instance().value = "poutine";
+      input.simulate("change", {target: {value: "poutine", setCustomValidity}});
+      assert.calledWith(setCustomValidity, "");
+
+      input.instance().value = "fried chicken";
+      input.simulate("change", {target: {value: "fried chicken", setCustomValidity}});
+      assert.calledWith(setCustomValidity, "Must be poutine");
+    });
+
     it("should show the signup form if state.expanded is true", () => {
       wrapper.setState({expanded: true});
 
@@ -158,11 +184,11 @@ describe("SubmitFormSnippet", () => {
       wrapper.setProps({content: {success_text: "success"}});
       wrapper.setState({signupSuccess: true, signupSubmitted: true});
 
-      assert.isTrue(wrapper.find(".body").exists());
-      assert.equal(wrapper.find(".body").text(), "success");
+      assert.isTrue(wrapper.find(".submissionStatus").exists());
+      assert.equal(wrapper.find(".submissionStatus").text(), "success");
       assert.isFalse(wrapper.find(".ASRouterButton").exists());
     });
-    it("should render the button to return to the signup form", () => {
+    it("should render the button to return to the signup form if there was an error", () => {
       wrapper.setState({signupSubmitted: true, signupSuccess: false});
 
       assert.isTrue(wrapper.find(".ASRouterButton").exists());
@@ -173,13 +199,13 @@ describe("SubmitFormSnippet", () => {
     it("should not render the privacy notice checkbox if prop is missing", () => {
       wrapper.setState({expanded: true});
 
-      assert.isFalse(wrapper.find(".privacy-notice").exists());
+      assert.isFalse(wrapper.find(".privacyNotice").exists());
     });
     it("should render the privacy notice checkbox if prop is provided", () => {
       wrapper.setProps({content: {...DEFAULT_CONTENT, scene2_privacy_html: "privacy notice"}});
       wrapper.setState({expanded: true});
 
-      assert.isTrue(wrapper.find(".privacy-notice").exists());
+      assert.isTrue(wrapper.find(".privacyNotice").exists());
     });
     it("should not call fetch if form_method is GET", async () => {
       sandbox.stub(window, "fetch").resolves(fetchOk);

--- a/test/unit/asrouter/templates/isEmailOrPhoneNumber.test.js
+++ b/test/unit/asrouter/templates/isEmailOrPhoneNumber.test.js
@@ -1,0 +1,31 @@
+import {isEmailOrPhoneNumber} from "content-src/asrouter/templates/SendToDeviceSnippet/isEmailOrPhoneNumber";
+
+const CONTENT = {};
+
+describe("isEmailOrPhoneNumber", () => {
+  it("should return 'email' for emails", () => {
+    assert.equal(isEmailOrPhoneNumber("foobar@asd.com", CONTENT), "email");
+    assert.equal(isEmailOrPhoneNumber("foobar@asd.co.uk", CONTENT), "email");
+  });
+  it("should return 'phone' for valid en-US/en-CA phone numbers", () => {
+    assert.equal(isEmailOrPhoneNumber("14582731273", {locale: "en-US"}), "phone");
+    assert.equal(isEmailOrPhoneNumber("4582731273", {locale: "en-CA"}), "phone");
+  });
+  it("should return an empty string for invalid phone number lengths in en-US/en-CA", () => {
+    // Not enough digits
+    assert.equal(isEmailOrPhoneNumber("4522", {locale: "en-US"}), "");
+    assert.equal(isEmailOrPhoneNumber("4522", {locale: "en-CA"}), "");
+  });
+  it("should return 'phone' for valid German phone numbers", () => {
+    assert.equal(isEmailOrPhoneNumber("145827312732", {locale: "de"}), "phone");
+  });
+  it("should return 'phone' for any number of digits in other locales", () => {
+    assert.equal(isEmailOrPhoneNumber("4", CONTENT), "phone");
+  });
+  it("should return an empty string for other invalid inputs", () => {
+    assert.equal(isEmailOrPhoneNumber("abc", CONTENT), "", "abc should be invalid");
+    assert.equal(isEmailOrPhoneNumber("abc@", CONTENT), "", "abc@ should be invalid");
+    assert.equal(isEmailOrPhoneNumber("abc@foo", CONTENT), "", "abc@foo should be invalid");
+    assert.equal(isEmailOrPhoneNumber("123d1232", CONTENT), "", "123d1232 should be invalid");
+  });
+});


### PR DESCRIPTION
Adds the Send to Device template. Also fixes:
* Privacy links should not auto-block
* Minor style issues (wrong border colour on buttons)

## Testing instructions

[References]
https://snippets-admin.moz.works/show/7924/
https://snippets-admin.moz.works/show/7991/

1. Set `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` to `true` to enable test data.
2. Open `about:newtab#asrouter`
3. Trigger the `SNIPPETS_SEND_TO_DEVICE_TEST` snippet
4. Try clicking on the first button to open the form.
5. Try clicking on the “Learn more” link in the disclaimer text. Note that it should not block/close the snippet and open in a new window.
6. Try entering some invalid text (not a phone number) such as “test123”. Attempt to submit; you should see an error message.
7. Change the text to a valid phone number (example: 1273123234). Submit; the submission will happen but you will see an error message because there is something wrong with the test endpoint.
8. Change the text to a valid email (example: foo@bar.com). Submit, you should see a success message.
