### PR TITLE
Fix Bug 1496785 - change snippet links to bold weight in Dark theme

### DIFF
--- a/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
+++ b/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
@@ -15,6 +15,10 @@
   a {
     cursor: pointer;
     color: var(--newtab-link-primary-color);
+
+    [lwt-newtab-brighttext] & {
+      font-weight: bold;
+    }
   }
 
   .innerWrapper {


### PR DESCRIPTION
Before:
<img width="402" alt="screen shot 2018-10-17 at 2 08 55 pm" src="https://user-images.githubusercontent.com/36629/47107126-80fd5680-d216-11e8-99d3-a706ca6ed530.png">

After:
<img width="399" alt="screen shot 2018-10-17 at 2 09 01 pm" src="https://user-images.githubusercontent.com/36629/47107131-835fb080-d216-11e8-893a-9a7ea7fb519b.png">
