### PR TITLE
Add enable/disable/reset devtools for ASRouter

### DIFF
--- a/content-src/components/Base/Base.jsx
+++ b/content-src/components/Base/Base.jsx
@@ -82,8 +82,11 @@ export class _Base extends React.PureComponent {
     const {initialized} = App;
 
     const prefs = props.Prefs.values;
-    if (prefs["asrouter.devtoolsEnabled"] && window.location.hash === "#asrouter") {
-      return (<ASRouterAdmin />);
+    if (prefs["asrouter.devtoolsEnabled"]) {
+      if (window.location.hash === "#asrouter") {
+        return (<ASRouterAdmin />);
+      }
+      console.log("ASRouter devtools enabled. To access visit %cabout:newtab#asrouter", "font-weight: bold"); // eslint-disable-line no-console
     }
 
     if (!props.isPrerendered && !initialized) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -497,7 +497,13 @@ class _ASRouter {
 
   _updateAdminState(target) {
     const channel = target || this.messageChannel;
-    channel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: this.state});
+    channel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
+      type: "ADMIN_SET_STATE",
+      data: {
+        ...this.state,
+        providerPrefs: ASRouterPreferences.providers,
+      },
+    });
   }
 
   _handleTargetingError(type, error, message) {
@@ -995,6 +1001,15 @@ class _ASRouter {
         break;
       case "EXPIRE_QUERY_CACHE":
         QueryCache.expireAll();
+        break;
+      case "ENABLE_PROVIDER":
+        ASRouterPreferences.enableOrDisableProvider(action.data, true);
+        break;
+      case "DISABLE_PROVIDER":
+        ASRouterPreferences.enableOrDisableProvider(action.data, false);
+        break;
+      case "RESET_PROVIDER_PREF":
+        ASRouterPreferences.resetProviderPref();
         break;
     }
   }

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -31,16 +31,19 @@ class _ASRouterPreferences {
     this._callbacks = new Set();
   }
 
+  _getProviderConfig() {
+    try {
+      return JSON.parse(Services.prefs.getStringPref(this._providerPref, ""));
+    } catch (e) {
+      Cu.reportError(`Could not parse ASRouter preference. Try resetting ${this._providerPref} in about:config.`);
+    }
+    return null;
+  }
+
   get providers() {
     if (!this._initialized || this._providers === null) {
-      let providers;
-      try {
-        const parsed = JSON.parse(Services.prefs.getStringPref(this._providerPref, ""));
-        providers = parsed.map(provider => Object.freeze(provider));
-      } catch (e) {
-        Cu.reportError("Problem parsing JSON message provider pref for ASRouter");
-        providers = [];
-      }
+      const config = this._getProviderConfig() || [];
+      const providers = config.map(provider => Object.freeze(provider));
       if (this.devtoolsEnabled) {
         providers.unshift(TEST_PROVIDER);
       }
@@ -48,6 +51,30 @@ class _ASRouterPreferences {
     }
 
     return this._providers;
+  }
+
+  enableOrDisableProvider(id, value) {
+    const providers = this._getProviderConfig();
+    if (!providers) {
+      Cu.reportError(`Cannot enable/disable providers if ${this._providerPref} is unparseable.`);
+      return;
+    }
+    if (!providers.find(p => p.id === id)) {
+      Cu.reportError(`Cannot set enabled state for '${id}' because it does not exist in ${this._providerPref}`);
+      return;
+    }
+
+    const newConfig = providers.map(provider => {
+      if (provider.id === id) {
+        return {...provider, enabled: value};
+      }
+      return provider;
+    });
+    Services.prefs.setStringPref(this._providerPref, JSON.stringify(newConfig));
+  }
+
+  resetProviderPref() {
+    Services.prefs.clearUserPref(this._providerPref);
   }
 
   get devtoolsEnabled() {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -208,7 +208,11 @@ describe("ASRouter", () => {
       sandbox.stub(ASRouterPreferences, "devtoolsEnabled").get(() => true);
       await Router.setState({foo: 123});
 
-      assert.calledWith(channel.sendAsyncMessage, "ASRouter:parent-to-child", {type: "ADMIN_SET_STATE", data: Router.state});
+      assert.calledOnce(channel.sendAsyncMessage);
+      assert.deepEqual(channel.sendAsyncMessage.firstCall.args[1], {
+        type: "ADMIN_SET_STATE",
+        data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers}),
+      });
     });
     it("should not send a message on a state change asrouter.devtoolsEnabled pref is on", async () => {
       sandbox.stub(ASRouterPreferences, "devtoolsEnabled").get(() => false);
@@ -393,452 +397,491 @@ describe("ASRouter", () => {
     });
   });
 
-  describe("#onMessage: SNIPPETS_REQUEST", () => {
-    it("should set state.lastMessageId to a message id", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "SNIPPETS_REQUEST"}));
+  describe("onMessage", () => {
+    describe("#onMessage: SNIPPETS_REQUEST", () => {
+      it("should set state.lastMessageId to a message id", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "SNIPPETS_REQUEST"}));
 
-      assert.include(ALL_MESSAGE_IDS, Router.state.lastMessageId);
-    });
-    it("should send a message back to the to the target", async () => {
-      // force the only message to be a regular message so getRandomItemFromArray picks it
-      await Router.setState({messages: [{id: "foo", template: "simple_template", content: {title: "Foo", body: "Foo123"}}]});
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-      await Router.onMessage(msg);
-      const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: currentMessage});
-    });
-    it("should send a message back to the to the target if there is a bundle, too", async () => {
-      // force the only message to be a bundled message so getRandomItemFromArray picks it
-      sandbox.stub(Router, "_findProvider").returns(null);
-      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 1, content: {title: "Foo1", body: "Foo123-1"}}]});
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-      await Router.onMessage(msg);
-      const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
-      assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].type, "SET_BUNDLED_MESSAGES");
-      assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[0].content, currentMessage.content);
-    });
-    it("should properly order the message's bundle if specified", async () => {
-      // force the only messages to be a bundled messages so getRandomItemFromArray picks one of them
-      sandbox.stub(Router, "_findProvider").returns(null);
-      const firstMessage = {id: "foo2", template: "simple_template", bundled: 2, order: 1, content: {title: "Foo2", body: "Foo123-2"}};
-      const secondMessage = {id: "foo1", template: "simple_template", bundled: 2, order: 2, content: {title: "Foo1", body: "Foo123-1"}};
-      await Router.setState({messages: [secondMessage, firstMessage]});
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-      await Router.onMessage(msg);
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
-      assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].type, "SET_BUNDLED_MESSAGES");
-      assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[0].content, firstMessage.content);
-      assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[1].content, secondMessage.content);
-    });
-    it("should return a null bundle if we do not have enough messages to fill the bundle", async () => {
-      // force the only message to be a bundled message that needs 2 messages in the bundle
-      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
-      const bundle = await Router._getBundledMessages(Router.state.messages[0]);
-      assert.equal(bundle, null);
-    });
-    it("should send down extra attributes in the bundle if they exist", async () => {
-      sandbox.stub(Router, "_findProvider").returns({getExtraAttributes() { return Promise.resolve({header: "header"}); }});
-      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 1, content: {title: "Foo1", body: "Foo123-1"}}]});
-      const result = await Router._getBundledMessages(Router.state.messages[0]);
-      assert.equal(result.extraTemplateStrings.header, "header");
-    });
-    it("should send a CLEAR_ALL message if no bundle available", async () => {
-      // force the only message to be a bundled message that needs 2 messages in the bundle
-      await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-      await Router.onMessage(msg);
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
-    });
-    it("should send a CLEAR_ALL message if no messages are available", async () => {
-      await Router.setState({messages: []});
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-      await Router.onMessage(msg);
+        assert.include(ALL_MESSAGE_IDS, Router.state.lastMessageId);
+      });
+      it("should send a message back to the to the target", async () => {
+        // force the only message to be a regular message so getRandomItemFromArray picks it
+        await Router.setState({messages: [{id: "foo", template: "simple_template", content: {title: "Foo", body: "Foo123"}}]});
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
+        await Router.onMessage(msg);
+        const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: currentMessage});
+      });
+      it("should send a message back to the to the target if there is a bundle, too", async () => {
+        // force the only message to be a bundled message so getRandomItemFromArray picks it
+        sandbox.stub(Router, "_findProvider").returns(null);
+        await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 1, content: {title: "Foo1", body: "Foo123-1"}}]});
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
+        await Router.onMessage(msg);
+        const [currentMessage] = Router.state.messages.filter(message => message.id === Router.state.lastMessageId);
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
+        assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].type, "SET_BUNDLED_MESSAGES");
+        assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[0].content, currentMessage.content);
+      });
+      it("should properly order the message's bundle if specified", async () => {
+        // force the only messages to be a bundled messages so getRandomItemFromArray picks one of them
+        sandbox.stub(Router, "_findProvider").returns(null);
+        const firstMessage = {id: "foo2", template: "simple_template", bundled: 2, order: 1, content: {title: "Foo2", body: "Foo123-2"}};
+        const secondMessage = {id: "foo1", template: "simple_template", bundled: 2, order: 2, content: {title: "Foo1", body: "Foo123-1"}};
+        await Router.setState({messages: [secondMessage, firstMessage]});
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
+        await Router.onMessage(msg);
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME);
+        assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].type, "SET_BUNDLED_MESSAGES");
+        assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[0].content, firstMessage.content);
+        assert.equal(msg.target.sendAsyncMessage.firstCall.args[1].data.bundle[1].content, secondMessage.content);
+      });
+      it("should return a null bundle if we do not have enough messages to fill the bundle", async () => {
+        // force the only message to be a bundled message that needs 2 messages in the bundle
+        await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
+        const bundle = await Router._getBundledMessages(Router.state.messages[0]);
+        assert.equal(bundle, null);
+      });
+      it("should send down extra attributes in the bundle if they exist", async () => {
+        sandbox.stub(Router, "_findProvider").returns({getExtraAttributes() { return Promise.resolve({header: "header"}); }});
+        await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 1, content: {title: "Foo1", body: "Foo123-1"}}]});
+        const result = await Router._getBundledMessages(Router.state.messages[0]);
+        assert.equal(result.extraTemplateStrings.header, "header");
+      });
+      it("should send a CLEAR_ALL message if no bundle available", async () => {
+        // force the only message to be a bundled message that needs 2 messages in the bundle
+        await Router.setState({messages: [{id: "foo1", template: "simple_template", bundled: 2, content: {title: "Foo1", body: "Foo123-1"}}]});
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
+        await Router.onMessage(msg);
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
+      });
+      it("should send a CLEAR_ALL message if no messages are available", async () => {
+        await Router.setState({messages: []});
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
+        await Router.onMessage(msg);
 
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
-    });
-    it("should make a request to the provided endpoint on SNIPPETS_REQUEST", async () => {
-      const url = "https://snippets-admin.mozilla.org/foo";
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
-      await Router.onMessage(msg);
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
+      });
+      it("should make a request to the provided endpoint on SNIPPETS_REQUEST", async () => {
+        const url = "https://snippets-admin.mozilla.org/foo";
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
+        await Router.onMessage(msg);
 
-      assert.calledWith(global.fetch, url);
-      assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
-    });
-    it("should make a request to the provided endpoint on ADMIN_CONNECT_STATE and remove the endpoint", async () => {
-      const url = "https://snippets-admin.mozilla.org/foo";
-      const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE", data: {endpoint: {url}}});
-      await Router.onMessage(msg);
+        assert.calledWith(global.fetch, url);
+        assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
+      });
+      it("should make a request to the provided endpoint on ADMIN_CONNECT_STATE and remove the endpoint", async () => {
+        const url = "https://snippets-admin.mozilla.org/foo";
+        const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE", data: {endpoint: {url}}});
+        await Router.onMessage(msg);
 
-      assert.calledWith(global.fetch, url);
-      assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
-    });
-    it("should dispatch SNIPPETS_PREVIEW_MODE when adding a preview endpoint", async () => {
-      const url = "https://snippets-admin.mozilla.org/foo";
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
-      await Router.onMessage(msg);
+        assert.calledWith(global.fetch, url);
+        assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
+      });
+      it("should dispatch SNIPPETS_PREVIEW_MODE when adding a preview endpoint", async () => {
+        const url = "https://snippets-admin.mozilla.org/foo";
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
+        await Router.onMessage(msg);
 
-      assert.calledWithExactly(Router.dispatchToAS, ac.OnlyToOneContent({type: "SNIPPETS_PREVIEW_MODE"}, msg.target.portID));
-    });
-    it("should not add a url that is not from a whitelisted host", async () => {
-      const url = "https://mozilla.org";
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
-      await Router.onMessage(msg);
+        assert.calledWithExactly(Router.dispatchToAS, ac.OnlyToOneContent({type: "SNIPPETS_PREVIEW_MODE"}, msg.target.portID));
+      });
+      it("should not add a url that is not from a whitelisted host", async () => {
+        const url = "https://mozilla.org";
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
+        await Router.onMessage(msg);
 
-      assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
-    });
-    it("should reject bad urls", async () => {
-      const url = "foo";
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
-      await Router.onMessage(msg);
+        assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
+      });
+      it("should reject bad urls", async () => {
+        const url = "foo";
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST", data: {endpoint: {url}}});
+        await Router.onMessage(msg);
 
-      assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
-    });
-  });
-
-  describe("#onMessage: BLOCK_MESSAGE_BY_ID", () => {
-    it("should add the id to the messageBlockList and broadcast a CLEAR_MESSAGE message with the id", async () => {
-      await Router.setState({lastMessageId: "foo"});
-      const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo"}});
-      await Router.onMessage(msg);
-
-      assert.isTrue(Router.state.messageBlockList.includes("foo"));
-      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
-    });
-    it("should not broadcast CLEAR_MESSAGE if preventDismiss is true", async () => {
-      const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo", preventDismiss: true}});
-      await Router.onMessage(msg);
-
-      assert.notCalled(channel.sendAsyncMessage);
-    });
-  });
-
-  describe("#onMessage: DISMISS_MESSAGE_BY_ID", () => {
-    it("should reply with CLEAR_MESSAGE with the correct id", async () => {
-      const msg = fakeAsyncMessage({type: "DISMISS_MESSAGE_BY_ID", data: {id: "foo"}});
-
-      await Router.onMessage(msg);
-
-      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
-    });
-  });
-
-  describe("#onMessage: BLOCK_PROVIDER_BY_ID", () => {
-    it("should add the provider id to the providerBlockList and broadcast a CLEAR_PROVIDER with the provider id", async () => {
-      const msg = fakeAsyncMessage({type: "BLOCK_PROVIDER_BY_ID", data: {id: "bar"}});
-      await Router.onMessage(msg);
-
-      assert.isTrue(Router.state.providerBlockList.includes("bar"));
-      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_PROVIDER", data: {id: "bar"}});
-    });
-  });
-
-  describe("#onMessage: BLOCK_BUNDLE", () => {
-    it("should add all the ids in the bundle to the messageBlockList and send a CLEAR_BUNDLE message", async () => {
-      const bundleIds = [FAKE_BUNDLE[0].id, FAKE_BUNDLE[1].id];
-      await Router.setState({lastMessageId: "foo"});
-      const msg = fakeAsyncMessage({type: "BLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}});
-      await Router.onMessage(msg);
-
-      assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[0].id));
-      assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[1].id));
-      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_BUNDLE"});
-      assert.calledWithExactly(Router._storage.set, "messageBlockList", bundleIds);
-    });
-  });
-
-  describe("#onMessage: UNBLOCK_MESSAGE_BY_ID", () => {
-    it("should remove the id from the messageBlockList", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
-      assert.isTrue(Router.state.messageBlockList.includes("foo"));
-      await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
-
-      assert.isFalse(Router.state.messageBlockList.includes("foo"));
-    });
-    it("should save the messageBlockList", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
-
-      assert.calledWithExactly(Router._storage.set, "messageBlockList", []);
-    });
-  });
-
-  describe("#onMessage: UNBLOCK_PROVIDER_BY_ID", () => {
-    it("should remove the id from the providerBlockList", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "BLOCK_PROVIDER_BY_ID", data: {id: "foo"}}));
-      assert.isTrue(Router.state.providerBlockList.includes("foo"));
-      await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_PROVIDER_BY_ID", data: {id: "foo"}}));
-
-      assert.isFalse(Router.state.providerBlockList.includes("foo"));
-    });
-    it("should save the providerBlockList", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_PROVIDER_BY_ID", data: {id: "foo"}}));
-
-      assert.calledWithExactly(Router._storage.set, "providerBlockList", []);
-    });
-  });
-
-  describe("#onMessage: UNBLOCK_BUNDLE", () => {
-    it("should remove all the ids in the bundle from the messageBlockList", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "BLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}}));
-      assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[0].id));
-      assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[1].id));
-      await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}}));
-
-      assert.isFalse(Router.state.messageBlockList.includes(FAKE_BUNDLE[0].id));
-      assert.isFalse(Router.state.messageBlockList.includes(FAKE_BUNDLE[1].id));
-    });
-    it("should save the messageBlockList", async () => {
-      await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}}));
-
-      assert.calledWithExactly(Router._storage.set, "messageBlockList", []);
-    });
-  });
-
-  describe("#onMessage: ADMIN_CONNECT_STATE", () => {
-    it("should send a message containing the whole state", async () => {
-      const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE"});
-      await Router.onMessage(msg);
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: Router.state});
-    });
-  });
-
-  describe("#onMessage: SNIPPETS_REQUEST", () => {
-    it("should call sendNextMessage on SNIPPETS_REQUEST", async () => {
-      sandbox.stub(Router, "sendNextMessage").resolves();
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-
-      await Router.onMessage(msg);
-
-      assert.calledOnce(Router.sendNextMessage);
-      assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {});
-    });
-    it("should return the preview message if that's available and remove it from Router.state", async () => {
-      const expectedObj = {provider: "preview"};
-      Router.setState({messages: [expectedObj]});
-
-      await Router.sendNextMessage(channel);
-
-      assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: expectedObj});
-      assert.isUndefined(Router.state.messages.find(m => m.provider === "preview"));
-    });
-    it("should call _getBundledMessages if we request a message that needs to be bundled", async () => {
-      sandbox.stub(Router, "_getBundledMessages").resolves();
-      // forcefully pick a message which needs to be bundled (the second message in FAKE_LOCAL_MESSAGES)
-      const [, testMessage] = Router.state.messages;
-      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
-      await Router.onMessage(msg);
-
-      assert.calledOnce(Router._getBundledMessages);
-    });
-    it("should properly pick another message of the same template if it is bundled; force = true", async () => {
-      // forcefully pick a message which needs to be bundled (the second message in FAKE_LOCAL_MESSAGES)
-      const [, testMessage1, testMessage2] = Router.state.messages;
-      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage1.id}});
-      await Router.onMessage(msg);
-
-      // Expected object should have some properties of the original message it picked (testMessage1)
-      // plus the bundled content of the others that it picked of the same template (testMessage2)
-      const expectedObj = {
-        template: testMessage1.template,
-        provider: testMessage1.provider,
-        bundle: [{content: testMessage1.content, id: testMessage1.id, order: 1}, {content: testMessage2.content, id: testMessage2.id}],
-      };
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_BUNDLED_MESSAGES", data: expectedObj});
-    });
-    it("should properly pick another message of the same template if it is bundled; force = false", async () => {
-      // forcefully pick a message which needs to be bundled (the second message in FAKE_LOCAL_MESSAGES)
-      const [, testMessage1, testMessage2] = Router.state.messages;
-      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage1.id}});
-      await Router.setMessageById(testMessage1.id, msg.target, false);
-
-      // Expected object should have some properties of the original message it picked (testMessage1)
-      // plus the bundled content of the others that it picked of the same template (testMessage2)
-      const expectedObj = {
-        template: testMessage1.template,
-        provider: testMessage1.provider,
-        bundle: [{content: testMessage1.content, id: testMessage1.id, order: 1}, {content: testMessage2.content, id: testMessage2.id, order: 2}],
-      };
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_BUNDLED_MESSAGES", data: expectedObj});
-    });
-    it("should get the bundle and send the message if the message has a bundle", async () => {
-      sandbox.stub(Router, "sendNextMessage").resolves();
-      const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
-      msg.bundled = 2; // force this message to want to be bundled
-      await Router.onMessage(msg);
-      assert.calledOnce(Router.sendNextMessage);
-    });
-  });
-
-  describe("#onMessage: TRIGGER", () => {
-    it("should pass the trigger to ASRouterTargeting on TRIGGER message", async () => {
-      sandbox.stub(Router, "_findMessage").resolves();
-      const msg = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "firstRun"}}});
-      await Router.onMessage(msg);
-
-      assert.calledOnce(Router._findMessage);
-      assert.deepEqual(Router._findMessage.firstCall.args[1], {id: "firstRun"});
-    });
-    it("consider the trigger when picking a message", async () => {
-      const messages = [
-        {id: "foo1", template: "simple_template", bundled: 1, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}},
-      ];
-
-      const {data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
-      const message = await Router._findMessage(messages, data.data.trigger);
-      assert.equal(message, messages[0]);
-    });
-    it("should pick a message with the right targeting and trigger", async () => {
-      let messages = [
-        {id: "foo1", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}},
-        {id: "foo2", template: "simple_template", bundled: 2, trigger: {id: "bar"}, content: {title: "Foo2", body: "Foo123-2"}},
-        {id: "foo3", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo3", body: "Foo123-3"}},
-      ];
-      sandbox.stub(Router, "_findProvider").returns(null);
-      await Router.setState({messages});
-      const {target} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
-      let {bundle} = await Router._getBundledMessages(messages[0], target, {id: "foo"});
-      assert.equal(bundle.length, 2);
-      // it should have picked foo1 and foo3 only
-      assert.isTrue(bundle.every(elem => elem.id === "foo1" || elem.id === "foo3"));
-    });
-    it("should have previousSessionEnd in the message context", () => {
-      assert.propertyVal(Router._getMessagesContext(), "previousSessionEnd", 100);
-    });
-  });
-
-  describe("#onMessage: OVERRIDE_MESSAGE", () => {
-    it("should broadcast a SET_MESSAGE message to all clients with a particular id", async () => {
-      const [testMessage] = Router.state.messages;
-      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
-      await Router.onMessage(msg);
-
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: testMessage});
+        assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
+      });
     });
 
-    it("should call CFRPageActions.forceRecommendation if the template is cfr_action and force is true", async () => {
-      sandbox.stub(CFRPageActions, "forceRecommendation");
-      const testMessage = {id: "foo", template: "cfr_doorhanger"};
-      await Router.setState({messages: [testMessage]});
-      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
-      await Router.onMessage(msg);
+    describe("#onMessage: BLOCK_MESSAGE_BY_ID", () => {
+      it("should add the id to the messageBlockList and broadcast a CLEAR_MESSAGE message with the id", async () => {
+        await Router.setState({lastMessageId: "foo"});
+        const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo"}});
+        await Router.onMessage(msg);
 
-      assert.notCalled(msg.target.sendAsyncMessage);
-      assert.calledOnce(CFRPageActions.forceRecommendation);
+        assert.isTrue(Router.state.messageBlockList.includes("foo"));
+        assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
+      });
+      it("should not broadcast CLEAR_MESSAGE if preventDismiss is true", async () => {
+        const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo", preventDismiss: true}});
+        await Router.onMessage(msg);
+
+        assert.notCalled(channel.sendAsyncMessage);
+      });
     });
 
-    it("should call CFRPageActions.addRecommendation if the template is cfr_action and force is false", async () => {
-      sandbox.stub(CFRPageActions, "addRecommendation");
-      const testMessage = {id: "foo", template: "cfr_doorhanger"};
-      await Router.setState({messages: [testMessage]});
-      await Router._sendMessageToTarget(testMessage, {}, {}, false);
+    describe("#onMessage: DISMISS_MESSAGE_BY_ID", () => {
+      it("should reply with CLEAR_MESSAGE with the correct id", async () => {
+        const msg = fakeAsyncMessage({type: "DISMISS_MESSAGE_BY_ID", data: {id: "foo"}});
 
-      assert.calledOnce(CFRPageActions.addRecommendation);
+        await Router.onMessage(msg);
+
+        assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
+      });
     });
 
-    it("should broadcast CLEAR_ALL if provided id did not resolve to a message", async () => {
-      const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: -1}});
-      await Router.onMessage(msg);
+    describe("#onMessage: BLOCK_PROVIDER_BY_ID", () => {
+      it("should add the provider id to the providerBlockList and broadcast a CLEAR_PROVIDER with the provider id", async () => {
+        const msg = fakeAsyncMessage({type: "BLOCK_PROVIDER_BY_ID", data: {id: "bar"}});
+        await Router.onMessage(msg);
 
-      assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
+        assert.isTrue(Router.state.providerBlockList.includes("bar"));
+        assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_PROVIDER", data: {id: "bar"}});
+      });
     });
-  });
 
-  describe("#onMessage: Onboarding actions", () => {
-    it("should call OpenBrowserWindow with a private window on OPEN_PRIVATE_BROWSER_WINDOW", async () => {
-      let [testMessage] = Router.state.messages;
-      const msg = fakeExecuteUserAction({type: "OPEN_PRIVATE_BROWSER_WINDOW", data: testMessage});
-      await Router.onMessage(msg);
+    describe("#onMessage: BLOCK_BUNDLE", () => {
+      it("should add all the ids in the bundle to the messageBlockList and send a CLEAR_BUNDLE message", async () => {
+        const bundleIds = [FAKE_BUNDLE[0].id, FAKE_BUNDLE[1].id];
+        await Router.setState({lastMessageId: "foo"});
+        const msg = fakeAsyncMessage({type: "BLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}});
+        await Router.onMessage(msg);
 
-      assert.calledWith(msg.target.browser.ownerGlobal.OpenBrowserWindow, {private: true});
+        assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[0].id));
+        assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[1].id));
+        assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_BUNDLE"});
+        assert.calledWithExactly(Router._storage.set, "messageBlockList", bundleIds);
+      });
     });
-    it("should call openLinkIn with the correct params on OPEN_URL", async () => {
-      let [testMessage] = Router.state.messages;
-      testMessage.button_action = {type: "OPEN_URL", data: {args: "some/url.com"}};
-      const msg = fakeExecuteUserAction(testMessage.button_action);
-      await Router.onMessage(msg);
 
-      assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
-      assert.calledWith(msg.target.browser.ownerGlobal.openLinkIn,
-        "some/url.com", "tabshifted", {"private": false, "triggeringPrincipal": undefined});
+    describe("#onMessage: UNBLOCK_MESSAGE_BY_ID", () => {
+      it("should remove the id from the messageBlockList", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
+        assert.isTrue(Router.state.messageBlockList.includes("foo"));
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
+
+        assert.isFalse(Router.state.messageBlockList.includes("foo"));
+      });
+      it("should save the messageBlockList", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
+
+        assert.calledWithExactly(Router._storage.set, "messageBlockList", []);
+      });
     });
-    it("should call openLinkIn with the correct params on OPEN_ABOUT_PAGE", async () => {
-      let [testMessage] = Router.state.messages;
-      testMessage.button_action = {type: "OPEN_ABOUT_PAGE", data: {args: "something"}};
-      const msg = fakeExecuteUserAction(testMessage.button_action);
-      await Router.onMessage(msg);
 
-      assert.calledOnce(msg.target.browser.ownerGlobal.openTrustedLinkIn);
-      assert.calledWith(msg.target.browser.ownerGlobal.openTrustedLinkIn, "about:something", "tab");
+    describe("#onMessage: UNBLOCK_PROVIDER_BY_ID", () => {
+      it("should remove the id from the providerBlockList", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "BLOCK_PROVIDER_BY_ID", data: {id: "foo"}}));
+        assert.isTrue(Router.state.providerBlockList.includes("foo"));
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_PROVIDER_BY_ID", data: {id: "foo"}}));
+
+        assert.isFalse(Router.state.providerBlockList.includes("foo"));
+      });
+      it("should save the providerBlockList", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_PROVIDER_BY_ID", data: {id: "foo"}}));
+
+        assert.calledWithExactly(Router._storage.set, "providerBlockList", []);
+      });
     });
-  });
 
-  describe("#onMessage: SHOW_FIREFOX_ACCOUNTS", () => {
-    let globals;
-    beforeEach(() => {
-      globals = new GlobalOverrider();
-      globals.set("FxAccounts", {config: {promiseSignUpURI: sandbox.stub().resolves("some/url")}});
+    describe("#onMessage: UNBLOCK_BUNDLE", () => {
+      it("should remove all the ids in the bundle from the messageBlockList", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "BLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}}));
+        assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[0].id));
+        assert.isTrue(Router.state.messageBlockList.includes(FAKE_BUNDLE[1].id));
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}}));
+
+        assert.isFalse(Router.state.messageBlockList.includes(FAKE_BUNDLE[0].id));
+        assert.isFalse(Router.state.messageBlockList.includes(FAKE_BUNDLE[1].id));
+      });
+      it("should save the messageBlockList", async () => {
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_BUNDLE", data: {bundle: FAKE_BUNDLE}}));
+
+        assert.calledWithExactly(Router._storage.set, "messageBlockList", []);
+      });
     });
-    it("should call openLinkIn with the correct params on OPEN_URL", async () => {
-      let [testMessage] = Router.state.messages;
-      testMessage.button_action = {type: "SHOW_FIREFOX_ACCOUNTS"};
-      const msg = fakeExecuteUserAction(testMessage.button_action);
-      await Router.onMessage(msg);
 
-      assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
-      assert.calledWith(msg.target.browser.ownerGlobal.openLinkIn,
-        "some/url", "tabshifted", {"private": false, "triggeringPrincipal": undefined});
+    describe("#onMessage: ADMIN_CONNECT_STATE", () => {
+      it("should send a message containing the whole state", async () => {
+        const msg = fakeAsyncMessage({type: "ADMIN_CONNECT_STATE"});
+        await Router.onMessage(msg);
+        assert.calledOnce(msg.target.sendAsyncMessage);
+        assert.deepEqual(msg.target.sendAsyncMessage.firstCall.args[1], {
+          type: "ADMIN_SET_STATE",
+          data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers}),
+        });
+      });
     });
-  });
 
-  describe("#onMessage: INSTALL_ADDON_FROM_URL", () => {
-    it("should call installAddonFromURL with correct arguments", async () => {
-      sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);
-      const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com"}});
+    describe("#onMessage: SNIPPETS_REQUEST", () => {
+      it("should call sendNextMessage on SNIPPETS_REQUEST", async () => {
+        sandbox.stub(Router, "sendNextMessage").resolves();
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
 
-      await Router.onMessage(msg);
+        await Router.onMessage(msg);
 
-      assert.calledOnce(MessageLoaderUtils.installAddonFromURL);
-      assert.calledWithExactly(MessageLoaderUtils.installAddonFromURL, msg.target.browser, "foo.com");
+        assert.calledOnce(Router.sendNextMessage);
+        assert.calledWithExactly(Router.sendNextMessage, sinon.match.instanceOf(FakeRemotePageManager), {});
+      });
+      it("should return the preview message if that's available and remove it from Router.state", async () => {
+        const expectedObj = {provider: "preview"};
+        Router.setState({messages: [expectedObj]});
+
+        await Router.sendNextMessage(channel);
+
+        assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: expectedObj});
+        assert.isUndefined(Router.state.messages.find(m => m.provider === "preview"));
+      });
+      it("should call _getBundledMessages if we request a message that needs to be bundled", async () => {
+        sandbox.stub(Router, "_getBundledMessages").resolves();
+        // forcefully pick a message which needs to be bundled (the second message in FAKE_LOCAL_MESSAGES)
+        const [, testMessage] = Router.state.messages;
+        const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
+        await Router.onMessage(msg);
+
+        assert.calledOnce(Router._getBundledMessages);
+      });
+      it("should properly pick another message of the same template if it is bundled; force = true", async () => {
+        // forcefully pick a message which needs to be bundled (the second message in FAKE_LOCAL_MESSAGES)
+        const [, testMessage1, testMessage2] = Router.state.messages;
+        const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage1.id}});
+        await Router.onMessage(msg);
+
+        // Expected object should have some properties of the original message it picked (testMessage1)
+        // plus the bundled content of the others that it picked of the same template (testMessage2)
+        const expectedObj = {
+          template: testMessage1.template,
+          provider: testMessage1.provider,
+          bundle: [{content: testMessage1.content, id: testMessage1.id, order: 1}, {content: testMessage2.content, id: testMessage2.id}],
+        };
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_BUNDLED_MESSAGES", data: expectedObj});
+      });
+      it("should properly pick another message of the same template if it is bundled; force = false", async () => {
+        // forcefully pick a message which needs to be bundled (the second message in FAKE_LOCAL_MESSAGES)
+        const [, testMessage1, testMessage2] = Router.state.messages;
+        const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage1.id}});
+        await Router.setMessageById(testMessage1.id, msg.target, false);
+
+        // Expected object should have some properties of the original message it picked (testMessage1)
+        // plus the bundled content of the others that it picked of the same template (testMessage2)
+        const expectedObj = {
+          template: testMessage1.template,
+          provider: testMessage1.provider,
+          bundle: [{content: testMessage1.content, id: testMessage1.id, order: 1}, {content: testMessage2.content, id: testMessage2.id, order: 2}],
+        };
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_BUNDLED_MESSAGES", data: expectedObj});
+      });
+      it("should get the bundle and send the message if the message has a bundle", async () => {
+        sandbox.stub(Router, "sendNextMessage").resolves();
+        const msg = fakeAsyncMessage({type: "SNIPPETS_REQUEST"});
+        msg.bundled = 2; // force this message to want to be bundled
+        await Router.onMessage(msg);
+        assert.calledOnce(Router.sendNextMessage);
+      });
     });
-  });
 
-  describe("#dispatch(action, target)", () => {
-    it("should an action and target to onMessage", async () => {
-      // use the IMPRESSION action to make sure actions are actually getting processed
-      sandbox.stub(Router, "addImpression");
-      sandbox.spy(Router, "onMessage");
-      const target = {};
-      const action = {type: "IMPRESSION"};
+    describe("#onMessage: TRIGGER", () => {
+      it("should pass the trigger to ASRouterTargeting on TRIGGER message", async () => {
+        sandbox.stub(Router, "_findMessage").resolves();
+        const msg = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "firstRun"}}});
+        await Router.onMessage(msg);
 
-      Router.dispatch(action, target);
+        assert.calledOnce(Router._findMessage);
+        assert.deepEqual(Router._findMessage.firstCall.args[1], {id: "firstRun"});
+      });
+      it("consider the trigger when picking a message", async () => {
+        const messages = [
+          {id: "foo1", template: "simple_template", bundled: 1, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}},
+        ];
 
-      assert.calledWith(Router.onMessage, {data: action, target});
-      assert.calledOnce(Router.addImpression);
+        const {data} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
+        const message = await Router._findMessage(messages, data.data.trigger);
+        assert.equal(message, messages[0]);
+      });
+      it("should pick a message with the right targeting and trigger", async () => {
+        let messages = [
+          {id: "foo1", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo1", body: "Foo123-1"}},
+          {id: "foo2", template: "simple_template", bundled: 2, trigger: {id: "bar"}, content: {title: "Foo2", body: "Foo123-2"}},
+          {id: "foo3", template: "simple_template", bundled: 2, trigger: {id: "foo"}, content: {title: "Foo3", body: "Foo123-3"}},
+        ];
+        sandbox.stub(Router, "_findProvider").returns(null);
+        await Router.setState({messages});
+        const {target} = fakeAsyncMessage({type: "TRIGGER", data: {trigger: {id: "foo"}}});
+        let {bundle} = await Router._getBundledMessages(messages[0], target, {id: "foo"});
+        assert.equal(bundle.length, 2);
+        // it should have picked foo1 and foo3 only
+        assert.isTrue(bundle.every(elem => elem.id === "foo1" || elem.id === "foo3"));
+      });
+      it("should have previousSessionEnd in the message context", () => {
+        assert.propertyVal(Router._getMessagesContext(), "previousSessionEnd", 100);
+      });
     });
-  });
 
-  describe("#onMessage: DOORHANGER_TELEMETRY", () => {
-    it("should dispatch an AS_ROUTER_TELEMETRY_USER_EVENT on DOORHANGER_TELEMETRY message", async () => {
-      const msg = fakeAsyncMessage({type: "DOORHANGER_TELEMETRY", data: {message_id: "foo"}});
-      dispatchStub.reset();
+    describe("#onMessage: OVERRIDE_MESSAGE", () => {
+      it("should broadcast a SET_MESSAGE message to all clients with a particular id", async () => {
+        const [testMessage] = Router.state.messages;
+        const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
+        await Router.onMessage(msg);
 
-      await Router.onMessage(msg);
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "SET_MESSAGE", data: testMessage});
+      });
 
-      assert.calledOnce(dispatchStub);
-      const [action] = dispatchStub.firstCall.args;
-      assert.equal(action.type, "AS_ROUTER_TELEMETRY_USER_EVENT");
-      assert.equal(action.data.message_id, "foo");
+      it("should call CFRPageActions.forceRecommendation if the template is cfr_action and force is true", async () => {
+        sandbox.stub(CFRPageActions, "forceRecommendation");
+        const testMessage = {id: "foo", template: "cfr_doorhanger"};
+        await Router.setState({messages: [testMessage]});
+        const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
+        await Router.onMessage(msg);
+
+        assert.notCalled(msg.target.sendAsyncMessage);
+        assert.calledOnce(CFRPageActions.forceRecommendation);
+      });
+
+      it("should call CFRPageActions.addRecommendation if the template is cfr_action and force is false", async () => {
+        sandbox.stub(CFRPageActions, "addRecommendation");
+        const testMessage = {id: "foo", template: "cfr_doorhanger"};
+        await Router.setState({messages: [testMessage]});
+        await Router._sendMessageToTarget(testMessage, {}, {}, false);
+
+        assert.calledOnce(CFRPageActions.addRecommendation);
+      });
+
+      it("should broadcast CLEAR_ALL if provided id did not resolve to a message", async () => {
+        const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: -1}});
+        await Router.onMessage(msg);
+
+        assert.calledWith(msg.target.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_ALL"});
+      });
     });
-  });
 
-  describe("#onMessage: EXPIRE_QUERY_CACHE", () => {
-    it("should clear all QueryCache getters", async () => {
-      const msg = fakeAsyncMessage({type: "EXPIRE_QUERY_CACHE"});
-      sandbox.stub(QueryCache, "expireAll");
+    describe("#onMessage: Onboarding actions", () => {
+      it("should call OpenBrowserWindow with a private window on OPEN_PRIVATE_BROWSER_WINDOW", async () => {
+        let [testMessage] = Router.state.messages;
+        const msg = fakeExecuteUserAction({type: "OPEN_PRIVATE_BROWSER_WINDOW", data: testMessage});
+        await Router.onMessage(msg);
 
-      await Router.onMessage(msg);
+        assert.calledWith(msg.target.browser.ownerGlobal.OpenBrowserWindow, {private: true});
+      });
+      it("should call openLinkIn with the correct params on OPEN_URL", async () => {
+        let [testMessage] = Router.state.messages;
+        testMessage.button_action = {type: "OPEN_URL", data: {args: "some/url.com"}};
+        const msg = fakeExecuteUserAction(testMessage.button_action);
+        await Router.onMessage(msg);
 
-      assert.calledOnce(QueryCache.expireAll);
+        assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
+        assert.calledWith(msg.target.browser.ownerGlobal.openLinkIn,
+          "some/url.com", "tabshifted", {"private": false, "triggeringPrincipal": undefined});
+      });
+      it("should call openLinkIn with the correct params on OPEN_ABOUT_PAGE", async () => {
+        let [testMessage] = Router.state.messages;
+        testMessage.button_action = {type: "OPEN_ABOUT_PAGE", data: {args: "something"}};
+        const msg = fakeExecuteUserAction(testMessage.button_action);
+        await Router.onMessage(msg);
+
+        assert.calledOnce(msg.target.browser.ownerGlobal.openTrustedLinkIn);
+        assert.calledWith(msg.target.browser.ownerGlobal.openTrustedLinkIn, "about:something", "tab");
+      });
+    });
+
+    describe("#onMessage: SHOW_FIREFOX_ACCOUNTS", () => {
+      let globals;
+      beforeEach(() => {
+        globals = new GlobalOverrider();
+        globals.set("FxAccounts", {config: {promiseSignUpURI: sandbox.stub().resolves("some/url")}});
+      });
+      it("should call openLinkIn with the correct params on OPEN_URL", async () => {
+        let [testMessage] = Router.state.messages;
+        testMessage.button_action = {type: "SHOW_FIREFOX_ACCOUNTS"};
+        const msg = fakeExecuteUserAction(testMessage.button_action);
+        await Router.onMessage(msg);
+
+        assert.calledOnce(msg.target.browser.ownerGlobal.openLinkIn);
+        assert.calledWith(msg.target.browser.ownerGlobal.openLinkIn,
+          "some/url", "tabshifted", {"private": false, "triggeringPrincipal": undefined});
+      });
+    });
+
+    describe("#onMessage: INSTALL_ADDON_FROM_URL", () => {
+      it("should call installAddonFromURL with correct arguments", async () => {
+        sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);
+        const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com"}});
+
+        await Router.onMessage(msg);
+
+        assert.calledOnce(MessageLoaderUtils.installAddonFromURL);
+        assert.calledWithExactly(MessageLoaderUtils.installAddonFromURL, msg.target.browser, "foo.com");
+      });
+    });
+
+    describe("#dispatch(action, target)", () => {
+      it("should an action and target to onMessage", async () => {
+        // use the IMPRESSION action to make sure actions are actually getting processed
+        sandbox.stub(Router, "addImpression");
+        sandbox.spy(Router, "onMessage");
+        const target = {};
+        const action = {type: "IMPRESSION"};
+
+        Router.dispatch(action, target);
+
+        assert.calledWith(Router.onMessage, {data: action, target});
+        assert.calledOnce(Router.addImpression);
+      });
+    });
+
+    describe("#onMessage: DOORHANGER_TELEMETRY", () => {
+      it("should dispatch an AS_ROUTER_TELEMETRY_USER_EVENT on DOORHANGER_TELEMETRY message", async () => {
+        const msg = fakeAsyncMessage({type: "DOORHANGER_TELEMETRY", data: {message_id: "foo"}});
+        dispatchStub.reset();
+
+        await Router.onMessage(msg);
+
+        assert.calledOnce(dispatchStub);
+        const [action] = dispatchStub.firstCall.args;
+        assert.equal(action.type, "AS_ROUTER_TELEMETRY_USER_EVENT");
+        assert.equal(action.data.message_id, "foo");
+      });
+    });
+
+    describe("#onMessage: EXPIRE_QUERY_CACHE", () => {
+      it("should clear all QueryCache getters", async () => {
+        const msg = fakeAsyncMessage({type: "EXPIRE_QUERY_CACHE"});
+        sandbox.stub(QueryCache, "expireAll");
+
+        await Router.onMessage(msg);
+
+        assert.calledOnce(QueryCache.expireAll);
+      });
+    });
+
+    describe("#onMessage: ENABLE_PROVIDER", () => {
+      it("should enable the provider via ASRouterPreferences", async () => {
+        const msg = fakeAsyncMessage({type: "ENABLE_PROVIDER", data: "foo"});
+        sandbox.stub(ASRouterPreferences, "enableOrDisableProvider");
+
+        await Router.onMessage(msg);
+
+        assert.calledWith(ASRouterPreferences.enableOrDisableProvider, "foo", true);
+      });
+    });
+
+    describe("#onMessage: DISABLE_PROVIDER", () => {
+      it("should disable the provider via ASRouterPreferences", async () => {
+        const msg = fakeAsyncMessage({type: "DISABLE_PROVIDER", data: "foo"});
+        sandbox.stub(ASRouterPreferences, "enableOrDisableProvider");
+
+        await Router.onMessage(msg);
+
+        assert.calledWith(ASRouterPreferences.enableOrDisableProvider, "foo", false);
+      });
+    });
+
+    describe("#onMessage: RESET_PROVIDER_PREF", () => {
+      it("should reset provider pref via ASRouterPreferences", async () => {
+        const msg = fakeAsyncMessage({type: "RESET_PROVIDER_PREF", data: "foo"});
+        sandbox.stub(ASRouterPreferences, "resetProviderPref");
+
+        await Router.onMessage(msg);
+
+        assert.calledOnce(ASRouterPreferences.resetProviderPref);
+      });
     });
   });
 

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -163,6 +163,44 @@ describe("ASRouterPreferences", () => {
       assert.isTrue(ASRouterPreferences.getUserPreference("snippets"));
     });
   });
+  describe("#enableOrDisableProvider", () => {
+    it("should enable an existing provider if second param is true", () => {
+      const setStub = sandbox.stub(global.Services.prefs, "setStringPref");
+      stringPrefStub.withArgs(PROVIDER_PREF).returns(JSON.stringify([{id: "foo", enabled: false}, {id: "bar", enabled: false}]));
+      assert.isFalse(ASRouterPreferences.providers[0].enabled);
+
+      ASRouterPreferences.enableOrDisableProvider("foo", true);
+
+      assert.calledWith(setStub, PROVIDER_PREF, JSON.stringify([{id: "foo", enabled: true}, {id: "bar", enabled: false}]));
+    });
+    it("should disable an existing provider if second param is false", () => {
+      const setStub = sandbox.stub(global.Services.prefs, "setStringPref");
+      stringPrefStub.withArgs(PROVIDER_PREF).returns(JSON.stringify([{id: "foo", enabled: true}, {id: "bar", enabled: true}]));
+      assert.isTrue(ASRouterPreferences.providers[0].enabled);
+
+      ASRouterPreferences.enableOrDisableProvider("foo", false);
+
+      assert.calledWith(setStub, PROVIDER_PREF, JSON.stringify([{id: "foo", enabled: false}, {id: "bar", enabled: true}]));
+    });
+    it("should not throw if the id does not exist", () => {
+      assert.doesNotThrow(() => {
+        ASRouterPreferences.enableOrDisableProvider("does_not_exist", true);
+      });
+    });
+    it("should not throw if pref is not parseable", () => {
+      stringPrefStub.withArgs(PROVIDER_PREF).returns("not valid");
+      assert.doesNotThrow(() => {
+        ASRouterPreferences.enableOrDisableProvider("foo", true);
+      });
+    });
+  });
+  describe("#resetProviderPref", () => {
+    it("should reset the pref", () => {
+      const resetStub = sandbox.stub(global.Services.prefs, "clearUserPref");
+      ASRouterPreferences.resetProviderPref();
+      assert.calledWith(resetStub, PROVIDER_PREF);
+    });
+  });
   describe("observer, listeners", () => {
     it("should invalidate .providers when the pref is changed", () => {
       const testProviders = [{id: "newstuff"}];

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -139,6 +139,7 @@ const TEST_GLOBAL = {
       getPrefType() {},
       clearUserPref() {},
       getStringPref() {},
+      setStringPref() {},
       getIntPref() {},
       getBoolPref() {},
       setBoolPref() {},


### PR DESCRIPTION
### IMPORTANT NOTE

A big part of this change is indentation so I would recommending viewing this with https://github.com/mozilla/activity-stream/pull/4508/files?w=1

### Summary
This patch adds some additional utilities to `about:newtab#asrouter`, including
* A way to enable/disable providers via the UI;
* A way to filter the messages shown by provider;
* A way to reset the preference via the UI

### Testing instructions
* Turn on devtools by setting `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` to `true`
* Visit `about:newtab#asrouter`
* Try enabling/disabling different providers; see if their messages show up/disappear on the page
* Try the messages filter dropdown under the "Messages" section
* After changing some settings, try the "Restore defaults" button and ensure `browser.newtabpage.activity-stream.asrouter.messageProviders` is the default value in `about:config`

