### PR TITLE
Bug 1500518 - Add user preference for CFR

### DIFF
--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -78,6 +78,9 @@ class _ASRouterPreferences {
 
   resetProviderPref() {
     Services.prefs.clearUserPref(this._providerPref);
+    for (const id of Object.keys(USER_PREFERENCES)) {
+      Services.prefs.clearUserPref(USER_PREFERENCES[id]);
+    }
   }
 
   get devtoolsEnabled() {

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -18,6 +18,7 @@ const DEFAULT_STATE = {
 
 const USER_PREFERENCES = {
   snippets: "browser.newtabpage.activity-stream.feeds.snippets",
+  cfr: "browser.newtabpage.activity-stream.asrouter.userprefs.cfr",
 };
 
 const TEST_PROVIDER = {

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -198,6 +198,10 @@ const PREFS_CONFIG = new Map([
     title: "Are the asrouter devtools enabled?",
     value: false,
   }],
+  ["asrouter.userprefs.cfr", {
+    title: "Does the user allow CFR recommendations?",
+    value: true,
+  }],
   ["asrouter.messageProviders", {
     title: "Configuration for ASRouter message providers",
 

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -196,10 +196,11 @@ describe("ASRouterPreferences", () => {
     });
   });
   describe("#resetProviderPref", () => {
-    it("should reset the pref", () => {
+    it("should reset the pref and user prefs", () => {
       const resetStub = sandbox.stub(global.Services.prefs, "clearUserPref");
       ASRouterPreferences.resetProviderPref();
       assert.calledWith(resetStub, PROVIDER_PREF);
+      assert.calledWith(resetStub, SNIPPETS_USER_PREF);
     });
   });
   describe("observer, listeners", () => {

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -9,8 +9,9 @@ const SNIPPETS_USER_PREF = "browser.newtabpage.activity-stream.feeds.snippets";
  *  1. asrouter.messageProvider
  *  2. asrouter.devtoolsEnabled
  *  3. browser.newtabpage.activity-stream.feeds.snippets (user preference - snippets)
+ *  4. browser.newtabpage.activity-stream.asrouter.userprefs.cfr (user preference - cfr)
  */
-const NUMBER_OF_PREFS_TO_OBSERVE = 3;
+const NUMBER_OF_PREFS_TO_OBSERVE = 4;
 
 describe("ASRouterPreferences", () => {
   let ASRouterPreferences;


### PR DESCRIPTION
No UI for this yet. To test:

1. Ensure `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` is on
2. about about:newtab#asrouter
3. Ensure `browser.newtabpage.activity-stream.asrouter.userprefs.cfr` is true by default in about:config
4. Ensure 'cfr' shows up in the dropdown menu for messages on the debug page
5. set `browser.newtabpage.activity-stream.asrouter.userprefs.cfr` to false
6. Ensure 'cfr' is no longer in the dropdown for messages on the debug page