### PR TITLE
(nobug) Add more support for setting user preferences in ASR devtools

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -14,9 +14,27 @@
     font-size: 32px;
   }
 
+  h2 .button {
+    font-size: 14px;
+    padding: 6px 12px;
+    margin-inline-start: 5px;
+    margin-bottom: 0;
+  }
+
   table {
     border-collapse: collapse;
     width: 100%;
+  }
+
+  .sourceLabel {
+    background: $grey-20;
+    padding: 2px 5px;
+    border-radius: 3px;
+
+    &.isDisabled {
+      background: $email-input-invalid;
+      color: $red-60;
+    }
   }
 
   .message-item {
@@ -28,6 +46,13 @@
       vertical-align: top;
       border-bottom: 1px solid $border-color;
       padding: 8px;
+
+
+
+      &.min {
+        width: 1%;
+        white-space: nowrap;
+      }
 
       &:first-child {
         border-left: 1px solid $border-color;

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -502,6 +502,7 @@ class _ASRouter {
       data: {
         ...this.state,
         providerPrefs: ASRouterPreferences.providers,
+        userPrefs: ASRouterPreferences.getAllUserPreferences(),
       },
     });
   }
@@ -1013,6 +1014,9 @@ class _ASRouter {
         break;
       case "RESET_PROVIDER_PREF":
         ASRouterPreferences.resetProviderPref();
+        break;
+      case "SET_PROVIDER_USER_PREF":
+        ASRouterPreferences.setUserPreference(action.data.id, action.data.value);
         break;
     }
   }

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -120,6 +120,21 @@ class _ASRouterPreferences {
     return Services.prefs.getBoolPref(USER_PREFERENCES[providerId], true);
   }
 
+  getAllUserPreferences() {
+    const values = {};
+    for (const id of Object.keys(USER_PREFERENCES)) {
+      values[id] = this.getUserPreference(id);
+    }
+    return values;
+  }
+
+  setUserPreference(providerId, value) {
+    if (!USER_PREFERENCES[providerId]) {
+      return;
+    }
+    Services.prefs.setBoolPref(USER_PREFERENCES[providerId], value);
+  }
+
   addListener(callback) {
     this._callbacks.add(callback);
   }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -211,7 +211,7 @@ describe("ASRouter", () => {
       assert.calledOnce(channel.sendAsyncMessage);
       assert.deepEqual(channel.sendAsyncMessage.firstCall.args[1], {
         type: "ADMIN_SET_STATE",
-        data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers}),
+        data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers, userPrefs: ASRouterPreferences.getAllUserPreferences()}),
       });
     });
     it("should not send a message on a state change asrouter.devtoolsEnabled pref is on", async () => {
@@ -606,7 +606,7 @@ describe("ASRouter", () => {
         assert.calledOnce(msg.target.sendAsyncMessage);
         assert.deepEqual(msg.target.sendAsyncMessage.firstCall.args[1], {
           type: "ADMIN_SET_STATE",
-          data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers}),
+          data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers, userPrefs: ASRouterPreferences.getAllUserPreferences()}),
         });
       });
     });
@@ -893,6 +893,16 @@ describe("ASRouter", () => {
         await Router.onMessage(msg);
 
         assert.calledOnce(ASRouterPreferences.resetProviderPref);
+      });
+    });
+    describe("#onMessage: SET_PROVIDER_USER_PREF", () => {
+      it("should set provider user pref via ASRouterPreferences", async () => {
+        const msg = fakeAsyncMessage({type: "SET_PROVIDER_USER_PREF", data: {id: "foo", value: true}});
+        sandbox.stub(ASRouterPreferences, "setUserPreference");
+
+        await Router.onMessage(msg);
+
+        assert.calledWith(ASRouterPreferences.setUserPreference, "foo", true);
       });
     });
   });

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -4,6 +4,7 @@ const FAKE_PROVIDERS = [{id: "foo"}, {id: "bar"}];
 const PROVIDER_PREF = "browser.newtabpage.activity-stream.asrouter.messageProviders";
 const DEVTOOLS_PREF = "browser.newtabpage.activity-stream.asrouter.devtoolsEnabled";
 const SNIPPETS_USER_PREF = "browser.newtabpage.activity-stream.feeds.snippets";
+const CFR_USER_PREF = "browser.newtabpage.activity-stream.asrouter.userprefs.cfr";
 
 /** NUMBER_OF_PREFS_TO_OBSERVE includes:
  *  1. asrouter.messageProvider
@@ -164,6 +165,14 @@ describe("ASRouterPreferences", () => {
       assert.isTrue(ASRouterPreferences.getUserPreference("snippets"));
     });
   });
+  describe("#getAllUserPreferences", () => {
+    it("should return all user preferences", () => {
+      boolPrefStub.withArgs(SNIPPETS_USER_PREF).returns(true);
+      boolPrefStub.withArgs(CFR_USER_PREF).returns(false);
+      const result = ASRouterPreferences.getAllUserPreferences();
+      assert.deepEqual(result, {snippets: true, cfr: false});
+    });
+  });
   describe("#enableOrDisableProvider", () => {
     it("should enable an existing provider if second param is true", () => {
       const setStub = sandbox.stub(global.Services.prefs, "setStringPref");
@@ -193,6 +202,17 @@ describe("ASRouterPreferences", () => {
       assert.doesNotThrow(() => {
         ASRouterPreferences.enableOrDisableProvider("foo", true);
       });
+    });
+  });
+  describe("#setUserPreference", () => {
+    it("should do nothing if the pref doesn't exist", () => {
+      ASRouterPreferences.setUserPreference("foo", true);
+      assert.notCalled(boolPrefStub);
+    });
+    it("should set the given pref", () => {
+      const setStub = sandbox.stub(global.Services.prefs, "setBoolPref");
+      ASRouterPreferences.setUserPreference("snippets", true);
+      assert.calledWith(setStub, SNIPPETS_USER_PREF, true);
     });
   });
   describe("#resetProviderPref", () => {


### PR DESCRIPTION
Adds support for setting user preferences via UI. Test by visiting `about:newtab#asrouter` with `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` on.