### PR TITLE
Folder path tweak for docs

### DIFF
--- a/docs/v2-system-addon/1.GETTING_STARTED.md
+++ b/docs/v2-system-addon/1.GETTING_STARTED.md
@@ -78,7 +78,7 @@ mk_add_options MOZ_OBJDIR=./objdir-frontend
 1. Install required dependencies by running `npm install`.
 2. To build Activity Stream, run `npm run buildmc` from the root of the
 `activity-stream` directory. This will build the js and css files and copy them
-into the `browser/extensions/activity-stream` directory inside Mozilla Central.
+into the `browser/components/newtab` directory inside Mozilla Central.
 3. Build and run Firefox from the `mozilla-central` directory by running `./mach build && ./mach run`.
 
 ## Continuous development


### PR DESCRIPTION
From inspecting the commands in the manifest it seems like the compiled AS folder is being generated in a different location now.