### PR TITLE
Getting started, text modified to fix broken link

### DIFF
--- a/docs/v2-system-addon/1.GETTING_STARTED.md
+++ b/docs/v2-system-addon/1.GETTING_STARTED.md
@@ -17,7 +17,7 @@ and make sure the `browser.newtabpage.activity-stream.enabled` pref is set to `t
 
 ## Source code and submitting pull requests
 
-A copy of the code in the [system-addon/](../../system-addon/) subdirectory of this repository
+A copy of the code in the root directory of this repository is exported
 is exported to Mozilla central on a regular basis, which can be found at [browser/components/newtab](https://searchfox.org/mozilla-central/source/browser/components/newtab).
 Keep in mind that some of these files are generated, so if you intend on editing any files, you should
 do so in the Github version.


### PR DESCRIPTION
Change
`A copy of the code in the system-addon/ subdirectory of this repository is exported....`
to
`A copy of the code in the root directory of this repository is exported .....`

Since the `system-addon` content is moved to root directory