### PR TITLE
 Fixes bug 1507973 - v2 with attachments for personality provider in activity stream.

### DIFF
--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -96,7 +96,9 @@ this.PersonalityProvider = class PersonalityProvider {
     const {attachment: {filename}} = record;
     await OS.File.makeDir(OS.Path.join(OS.Constants.Path.localProfileDir, PERSONALITY_PROVIDER_DIR_NAME));
     const path = OS.Path.join(OS.Constants.Path.localProfileDir, PERSONALITY_PROVIDER_DIR_NAME, filename);
-    return OS.File.remove(path, {ignoreAbsent: true});
+
+    await OS.File.remove(path, {ignoreAbsent: true});
+    return OS.File.removeEmptyDir(OS.Path.join(OS.Constants.Path.localProfileDir, PERSONALITY_PROVIDER_DIR_NAME), { ignoreAbsent: true });
   }
 
   async getAttachment(record) {

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -97,7 +97,6 @@ this.PersonalityProvider = class PersonalityProvider {
    * Downloads the attachment to disk assuming the dir already exists
    * and any existing files matching the filename are clobbered.
    */
-  /* istanbul ignore next */
   async _downloadAttachment(record) {
     const {attachment: {location, filename}} = record;
     const remoteFilePath = (await baseAttachmentsURL) + location;

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -113,7 +113,7 @@ this.PersonalityProvider = class PersonalityProvider {
     } catch (error) {
       Cu.reportError(`Failed to load ${filepath}: ${error.message}`);
     }
-    return null;
+    return {};
   }
 
   async init(callback) {
@@ -166,15 +166,15 @@ this.PersonalityProvider = class PersonalityProvider {
    * A Recipe is a set of instructions on how to processes a RecipeExecutor.
    */
   async getRecipe() {
-    if (!this.recipe || !this.recipe.length) {
+    if (!this.recipes || !this.recipes.length) {
       const start = perfService.absNow();
-      this.recipe = await this.getFromRemoteSettings(RECIPE_NAME);
+      this.recipes = await this.getFromRemoteSettings(RECIPE_NAME);
       this.dispatch(ac.PerfEvent({
         event: "PERSONALIZATION_V2_GET_RECIPE_DURATION",
         value: Math.round(perfService.absNow() - start),
       }));
     }
-    return this.recipe[0];
+    return this.recipes[0];
   }
 
   /**

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -97,6 +97,7 @@ this.PersonalityProvider = class PersonalityProvider {
    * Downloads the attachment to disk assuming the dir already exists
    * and any existing files matching the filename are clobbered.
    */
+  /* istanbul ignore next */
   async _downloadAttachment(record) {
     const {attachment: {location, filename}} = record;
     const remoteFilePath = (await baseAttachmentsURL) + location;

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -194,7 +194,6 @@ this.PersonalityProvider = class PersonalityProvider {
 
   async getFromRemoteSettings(name) {
     const result = await RemoteSettings(name).get();
-    console.log(result, "==============");
     return Promise.all(result.map(async record => ({...await this.getAttachment(record), recordKey: record.key})));
   }
 

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -122,17 +122,11 @@ this.PersonalityProvider = class PersonalityProvider {
     const localFilePath = OS.Path.join(PERSONALITY_PROVIDER_DIR, filename);
 
     let retry = 0;
-    console.log("exists???", await OS.File.exists(localFilePath));
-    while ((!await OS.File.exists(localFilePath) ||
-        await OS.File.stat(localFilePath).size !== size ||
-        getHash(await this._getFileStr(localFilePath)) !== hash) &&
-        (retry++ < retries)) {
-      console.log("?????????????????????");
-      try {
-        await this._downloadAttachment(record);
-      } catch (e) {
-        console.log(e);
-      }
+    while ((retry++ < retries) &&
+        (!await OS.File.exists(localFilePath) ||
+        (await OS.File.stat(localFilePath)).size !== size ||
+        getHash(await this._getFileStr(localFilePath)) !== hash)) {
+      await this._downloadAttachment(record);
     }
   }
 
@@ -200,6 +194,7 @@ this.PersonalityProvider = class PersonalityProvider {
 
   async getFromRemoteSettings(name) {
     const result = await RemoteSettings(name).get();
+    console.log(result, "==============");
     return Promise.all(result.map(async record => ({...await this.getAttachment(record), recordKey: record.key})));
   }
 

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -122,11 +122,17 @@ this.PersonalityProvider = class PersonalityProvider {
     const localFilePath = OS.Path.join(PERSONALITY_PROVIDER_DIR, filename);
 
     let retry = 0;
+    console.log("exists???", await OS.File.exists(localFilePath));
     while ((!await OS.File.exists(localFilePath) ||
         await OS.File.stat(localFilePath).size !== size ||
         getHash(await this._getFileStr(localFilePath)) !== hash) &&
         (retry++ < retries)) {
-      await this._downloadAttachment(record);
+      console.log("?????????????????????");
+      try {
+        await this._downloadAttachment(record);
+      } catch (e) {
+        console.log(e);
+      }
     }
   }
 

--- a/test/unit/lib/FilterAdult.test.js
+++ b/test/unit/lib/FilterAdult.test.js
@@ -1,20 +1,29 @@
 import {filterAdult} from "lib/FilterAdult.jsm";
+import {GlobalOverrider} from "test/unit/utils";
 
 describe("filterAdult", () => {
   let hashStub;
   let hashValue;
+  let globals;
 
   beforeEach(() => {
+    globals = new GlobalOverrider();
     hashStub = {
       finish: sinon.stub().callsFake(() => hashValue),
       init: sinon.stub(),
       update: sinon.stub(),
     };
-    global.Cc["@mozilla.org/security/hash;1"] = {
-      createInstance() {
-        return hashStub;
+    globals.set("Cc", {
+      "@mozilla.org/security/hash;1": {
+        createInstance() {
+          return hashStub;
+        },
       },
-    };
+    });
+  });
+
+  afterEach(() => {
+    globals.restore();
   });
 
   it("should default to include on unexpected urls", () => {

--- a/test/unit/lib/PersistentCache.test.js
+++ b/test/unit/lib/PersistentCache.test.js
@@ -25,6 +25,9 @@ describe("PersistentCache", () => {
 
     cache = new PersistentCache(filename);
   });
+  afterEach(() => {
+    globals.restore();
+  });
 
   describe("#get", () => {
     it("tries to read the file on the first get", async () => {

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -382,9 +382,7 @@ describe("Personality Provider", () => {
       assert(instance.deleteAttachment.withArgs("update-old-2").calledOnce);
     });
     it("should write a file from _downloadAttachment", async () => {
-      const fetchStub = globals.sandbox.stub();
-      globals.set("fetch", fetchStub);
-      fetchStub.resolves({
+      const fetchStub = globals.sandbox.stub(global, "fetch").resolves({
         ok: true,
         arrayBuffer: async () => {},
       });
@@ -397,9 +395,7 @@ describe("Personality Provider", () => {
       assert.calledWith(writeAtomicStub, "/filename", new Uint8Array(), {tmpPath: "/filename.tmp"});
     });
     it("should call reportError from _downloadAttachment if not valid response", async () => {
-      const fetchStub = globals.sandbox.stub();
-      globals.set("fetch", fetchStub);
-      fetchStub.resolves({ok: false});
+      globals.sandbox.stub(global, "fetch").resolves({ok: false});
       globals.sandbox.spy(global.Cu, "reportError");
 
       await instance._downloadAttachment({attachment: {location: "location", filename: "filename"}});

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -464,18 +464,12 @@ describe("Personality Provider", () => {
     it("should return JSON when calling getAttachment", async () => {
       sinon.stub(instance, "maybeDownloadAttachment").returns(Promise.resolve());
       sinon.stub(instance, "_getFileStr").returns(Promise.resolve("{}"));
-      const parseSpy = globals.sandbox.spy(JSON, "parse");
       const reportErrorStub = globals.sandbox.stub(global.Cu, "reportError");
       globals.sandbox.stub(global.OS.Path, "join").callsFake((first, second) => first + second);
-      globals.set("JSON", {
-        parse: parseSpy,
-      });
       const record = {attachment: {filename: "filename"}};
       let returnValue = await instance.getAttachment(record);
 
       assert.notCalled(reportErrorStub);
-      assert.calledOnce(parseSpy);
-      assert.calledWith(parseSpy, "{}");
       assert.calledOnce(instance._getFileStr);
       assert.calledWith(instance._getFileStr, "/filename");
       assert.calledOnce(instance.maybeDownloadAttachment);

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -381,6 +381,22 @@ describe("Personality Provider", () => {
       assert(instance.deleteAttachment.withArgs("update-old-1").calledOnce);
       assert(instance.deleteAttachment.withArgs("update-old-2").calledOnce);
     });
+    it("should write a file from _downloadAttachment", async () => {
+      const fetchStub = globals.sandbox.stub(global, "fetch").resolves({
+        ok: true,
+        arrayBuffer: async () => {},
+      });
+
+      const writeAtomicStub = globals.sandbox.stub(global.OS.File, "writeAtomic").resolves(Promise.resolve());
+      globals.sandbox.stub(global.OS.Path, "join").callsFake((first, second) => first + second);
+      await instance._downloadAttachment({attachment: {location: "location", filename: "filename"}});
+
+      const fetchArgs = fetchStub.firstCall.args;
+      assert.equal(fetchArgs[0], "/location");
+      const writeArgs = writeAtomicStub.firstCall.args;
+      assert.equal(writeArgs[0], "/filename");
+      assert.equal(writeArgs[2].tmpPath, "/filename.tmp");
+    });
     it("should call reportError from _downloadAttachment if not valid response", async () => {
       globals.sandbox.stub(global, "fetch").resolves({ok: false});
       globals.sandbox.spy(global.Cu, "reportError");

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -63,12 +63,7 @@ describe("Personality Provider", () => {
       },
     });
     globals.set("fetch", fetchStub);
-
-    globals.set("Services", {
-      prefs: {
-        getCharPref: pref => pref,
-      },
-    });
+    globals.sandbox.stub(global.Services.prefs, "getCharPref").callsFake(pref => pref);
 
     ({PersonalityProvider} = injector({
       "lib/NaiveBayesTextTagger.jsm": {NaiveBayesTextTagger: NaiveBayesTextTaggerStub},
@@ -401,10 +396,6 @@ describe("Personality Provider", () => {
         Path: {join: (first, second) => first + second},
       });
       writeAtomicStub.resolves(Promise.resolve());
-      await instance._downloadAttachment({attachment: {location: "location", filename: "filename"}});
-
-      assert.calledWith(fetchStub, "/location", {headers: new Headers()});
-      assert.calledWith(writeAtomicStub, "/filename", new Uint8Array(), {tmpPath: "/filename.tmp"});
     });
     it("should call reportError from _downloadAttachment if not valid response", async () => {
       const fetchStub = globals.sandbox.stub();

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -389,6 +389,9 @@ describe("Personality Provider", () => {
 
       const writeAtomicStub = globals.sandbox.stub(global.OS.File, "writeAtomic").resolves(Promise.resolve());
       globals.sandbox.stub(global.OS.Path, "join").callsFake((first, second) => first + second);
+
+      globals.set("Uint8Array", class Uint8Array {});
+
       await instance._downloadAttachment({attachment: {location: "location", filename: "filename"}});
 
       const fetchArgs = fetchStub.firstCall.args;

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -381,19 +381,6 @@ describe("Personality Provider", () => {
       assert(instance.deleteAttachment.withArgs("update-old-1").calledOnce);
       assert(instance.deleteAttachment.withArgs("update-old-2").calledOnce);
     });
-    it("should write a file from _downloadAttachment", async () => {
-      const fetchStub = globals.sandbox.stub(global, "fetch").resolves({
-        ok: true,
-        arrayBuffer: async () => {},
-      });
-
-      const writeAtomicStub = globals.sandbox.stub(global.OS.File, "writeAtomic").resolves(Promise.resolve());
-      globals.sandbox.stub(global.OS.Path, "join").callsFake((first, second) => first + second);
-      await instance._downloadAttachment({attachment: {location: "location", filename: "filename"}});
-
-      assert.calledWith(fetchStub, "/location", {headers: new Headers()});
-      assert.calledWith(writeAtomicStub, "/filename", new Uint8Array(), {tmpPath: "/filename.tmp"});
-    });
     it("should call reportError from _downloadAttachment if not valid response", async () => {
       globals.sandbox.stub(global, "fetch").resolves({ok: false});
       globals.sandbox.spy(global.Cu, "reportError");

--- a/test/unit/lib/PersonalityProvider.test.js
+++ b/test/unit/lib/PersonalityProvider.test.js
@@ -465,13 +465,10 @@ describe("Personality Provider", () => {
       sinon.stub(instance, "maybeDownloadAttachment").returns(Promise.resolve());
       sinon.stub(instance, "_getFileStr").returns(Promise.resolve("{}"));
       const parseSpy = globals.sandbox.spy(JSON, "parse");
-      const reportErrorStub = globals.sandbox.stub();
+      const reportErrorStub = globals.sandbox.stub(global.Cu, "reportError");
       globals.sandbox.stub(global.OS.Path, "join").callsFake((first, second) => first + second);
       globals.set("JSON", {
         parse: parseSpy,
-      });
-      globals.set("Cu", {
-        reportError: reportErrorStub,
       });
       const record = {attachment: {filename: "filename"}};
       let returnValue = await instance.getAttachment(record);

--- a/test/unit/lib/TopStoriesFeed.test.js
+++ b/test/unit/lib/TopStoriesFeed.test.js
@@ -134,10 +134,15 @@ describe("Top Stories Feed", () => {
     });
     it("should report error for invalid configuration", () => {
       globals.sandbox.spy(global.Cu, "reportError");
-      sectionsManagerStub.sections.set("topstories", {options: {api_key_pref: "invalid"}});
+      sectionsManagerStub.sections.set("topstories", {
+        options: {
+         api_key_pref: "invalid",
+         stories_endpoint: "https://invalid.com/?apiKey=$apiKey",
+        },
+      });
       instance.init();
 
-      assert.called(Cu.reportError);
+      assert.calledWith(Cu.reportError, "Problem initializing top stories feed: An API key was specified but none configured: https://invalid.com/?apiKey=$apiKey");
     });
     it("should report error for missing api key", () => {
       globals.sandbox.spy(global.Cu, "reportError");

--- a/test/unit/lib/TopStoriesFeed.test.js
+++ b/test/unit/lib/TopStoriesFeed.test.js
@@ -136,8 +136,8 @@ describe("Top Stories Feed", () => {
       globals.sandbox.spy(global.Cu, "reportError");
       sectionsManagerStub.sections.set("topstories", {
         options: {
-         api_key_pref: "invalid",
-         stories_endpoint: "https://invalid.com/?apiKey=$apiKey",
+          api_key_pref: "invalid",
+          stories_endpoint: "https://invalid.com/?apiKey=$apiKey",
         },
       });
       instance.init();

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -93,10 +93,12 @@ const TEST_GLOBAL = {
   },
   OS: {
     Path: {
-      join() {return "/"}
+      join() {
+        return "/";
+      },
     },
     Constants: {
-      Path: "/"
+      Path: "/",
     },
   },
   PlacesUtils: {

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -109,6 +109,14 @@ const TEST_GLOBAL = {
     },
   },
   OS: {
+    File: {
+      writeAtomic() {},
+      makeDir() {},
+      stat() {},
+      exists() {},
+      remove() {},
+      removeEmptyDir() {},
+    },
     Path: {
       join() {
         return "/";

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -69,9 +69,26 @@ const TEST_GLOBAL = {
       markPageAsTyped() {},
       removeObserver() {},
     },
+    "@mozilla.org/io/string-input-stream;1": {
+      createInstance() {
+        return {};
+      },
+    },
+    "@mozilla.org/security/hash;1": {
+      createInstance() {
+        return {
+          init() {},
+          updateFromStream() {},
+          finish() {
+            return "0";
+          },
+        };
+      },
+    },
     "@mozilla.org/updates/update-checker;1": {createInstance() {}},
   },
   Ci: {
+    nsICryptoHash: {},
     nsIHttpChannel: {REFERRER_POLICY_UNSAFE_URL: 5},
     nsITimer: {TYPE_ONE_SHOT: 1},
     nsIWebProgressListener: {LOCATION_CHANGE_SAME_DOCUMENT: 1},
@@ -98,7 +115,9 @@ const TEST_GLOBAL = {
       },
     },
     Constants: {
-      Path: "/",
+      Path: {
+        localProfileDir: "/",
+      },
     },
   },
   PlacesUtils: {
@@ -224,7 +243,17 @@ const TEST_GLOBAL = {
   EventEmitter,
   ShellService: {isDefaultBrowser: () => true},
   FilterExpressions: {eval() { return Promise.resolve(false); }},
-  RemoteSettings() { return {get() { return Promise.resolve([]); }, on() {}}; },
+  RemoteSettings(name) {
+    return {
+      get() {
+        if (name === "attachment") {
+          return Promise.resolve([{attachment: {}}]);
+        }
+        return Promise.resolve([]);
+      },
+      on() {},
+    };
+  },
   Localization: class {},
 };
 overrider.set(TEST_GLOBAL);

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -91,6 +91,14 @@ const TEST_GLOBAL = {
       executePlacesQuery: async (sql, options) => ({sql, options}),
     },
   },
+  OS: {
+    Path: {
+      join() {return "/"}
+    },
+    Constants: {
+      Path: "/"
+    },
+  },
   PlacesUtils: {
     get bookmarks() {
       return TEST_GLOBAL.Cc["@mozilla.org/browser/nav-bookmarks-service;1"];
@@ -145,6 +153,7 @@ const TEST_GLOBAL = {
       setStringPref() {},
       getIntPref() {},
       getBoolPref() {},
+      getCharPref() {},
       setBoolPref() {},
       setIntPref() {},
       getBranch() {},
@@ -213,7 +222,7 @@ const TEST_GLOBAL = {
   EventEmitter,
   ShellService: {isDefaultBrowser: () => true},
   FilterExpressions: {eval() { return Promise.resolve(false); }},
-  RemoteSettings() { return {get() { return Promise.resolve([]); }}; },
+  RemoteSettings() { return {get() { return Promise.resolve([]); }, on() {}}; },
   Localization: class {},
 };
 overrider.set(TEST_GLOBAL);


### PR DESCRIPTION
To test:
1. Make a new profile, but don't log into it.
2. Go into that profile's dir, and paste in a places.sqlite from an existing profile to get a good chunk of history to work with.
3. Create a user.js file with this in it:
```
user_pref("services.settings.server", "https://kinto.dev.mozaws.net/v1");
user_pref("services.settings.verify_signature", false);
```
4. Now run the profile.
5. In the browser debugger, paste in `Services.obs.notifyObservers(null, "idle-daily");`
6. Make an insignificant change to the pref browser.newtabpage.activity-stream.feeds.section.topstories.options to trigger a fresh cache.

Expected: you should now be seeing personalized stories on about:home.