### PR TITLE
Fix Bug 1496241 - Activity Stream doesn't honor default preference set via Autoconfig (and policy)

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -461,7 +461,7 @@ this.ActivityStream = class ActivityStream {
       // If there's an existing value and it has changed, that means we need to
       // overwrite the default with the new value.
       if (prefConfig.value !== undefined && prefConfig.value !== newValue) {
-        this._defaultPrefs.setDefaultPref(pref, newValue);
+        this._defaultPrefs.set(pref, newValue);
       }
 
       prefConfig.value = newValue;

--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -30,7 +30,6 @@
 //     sandbox.stub(as.store, "init");
 //     sandbox.stub(as.store, "uninit");
 //     sandbox.stub(as._defaultPrefs, "init");
-//     sandbox.stub(as._defaultPrefs, "reset");
 //   });
 
 //   afterEach(() => sandbox.restore());

--- a/test/unit/lib/ActivityStreamPrefs.test.js
+++ b/test/unit/lib/ActivityStreamPrefs.test.js
@@ -1,4 +1,3 @@
-const ACTIVITY_STREAM_PREF_BRANCH = "browser.newtabpage.activity-stream.";
 import {DefaultPrefs, Prefs} from "lib/ActivityStreamPrefs.jsm";
 
 const TEST_PREF_CONFIG = new Map([
@@ -18,15 +17,6 @@ describe("ActivityStreamPrefs", () => {
       assert.property(p, "get");
       assert.property(p, "set");
       assert.property(p, "observe");
-    });
-    describe(".branchName", () => {
-      it("should return the activity stream branch by default", () => {
-        assert.equal(p.branchName, ACTIVITY_STREAM_PREF_BRANCH);
-      });
-      it("should return the custom branch name if it was passed to the constructor", () => {
-        p = new Prefs("foo");
-        assert.equal(p.branchName, "foo");
-      });
     });
     describe("#observeBranch", () => {
       let listener;
@@ -82,43 +72,38 @@ describe("ActivityStreamPrefs", () => {
       beforeEach(() => {
         sandbox = sinon.sandbox.create();
         defaultPrefs = new DefaultPrefs(TEST_PREF_CONFIG);
-        sinon.spy(defaultPrefs.branch, "setBoolPref");
-        sinon.spy(defaultPrefs.branch, "setStringPref");
-        sinon.spy(defaultPrefs.branch, "setIntPref");
+        sinon.stub(defaultPrefs, "set");
       });
       afterEach(() => {
         sandbox.restore();
       });
       it("should initialize a boolean pref", () => {
         defaultPrefs.init();
-        assert.calledWith(defaultPrefs.branch.setBoolPref, "foo", true);
+        assert.calledWith(defaultPrefs.set, "foo", true);
+      });
+      it("should not initialize a pref if a default exists", () => {
+        defaultPrefs.prefs.foo = false;
+
+        defaultPrefs.init();
+
+        assert.neverCalledWith(defaultPrefs.set, "foo", true);
       });
       it("should initialize a string pref", () => {
         defaultPrefs.init();
-        assert.calledWith(defaultPrefs.branch.setStringPref, "bar", "BAR");
+        assert.calledWith(defaultPrefs.set, "bar", "BAR");
       });
       it("should initialize a integer pref", () => {
         defaultPrefs.init();
-        assert.calledWith(defaultPrefs.branch.setIntPref, "baz", 1);
+        assert.calledWith(defaultPrefs.set, "baz", 1);
       });
       it("should initialize a pref with value if Firefox is not a local build", () => {
         defaultPrefs.init();
-        assert.calledWith(defaultPrefs.branch.setStringPref, "qux", "foo");
+        assert.calledWith(defaultPrefs.set, "qux", "foo");
       });
       it("should initialize a pref with value_local_dev if Firefox is a local build", () => {
         sandbox.stub(global.AppConstants, "MOZILLA_OFFICIAL").value(false);
         defaultPrefs.init();
-        assert.calledWith(defaultPrefs.branch.setStringPref, "qux", "foofoo");
-      });
-    });
-    describe("#reset", () => {
-      it("should clear user preferences for each pref in the config", () => {
-        const defaultPrefs = new DefaultPrefs(TEST_PREF_CONFIG);
-        sinon.spy(defaultPrefs.branch, "clearUserPref");
-        defaultPrefs.reset();
-        for (const name of TEST_PREF_CONFIG.keys()) {
-          assert.calledWith(defaultPrefs.branch.clearUserPref, name);
-        }
+        assert.calledWith(defaultPrefs.set, "qux", "foofoo");
       });
     });
   });


### PR DESCRIPTION
r?@k88hudson This removes some test-only methods on `Prefs` and `DefaultPrefs` while making the latter extend `Preferences` like the former. This was to reuse the `get` method that knows how to get a preference by type because turns out just plain `getPrefType() == INVALID` is insufficient to correctly determine if there's a default preference value.