### PR TITLE
Fix Bug 1502266 - Verify that Update Checker is available before crea…

### DIFF
--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -63,7 +63,7 @@ function CachedTargetingGetter(property, options = null, updateInterval = FRECEN
 }
 
 function CheckBrowserNeedsUpdate(updateInterval = FRECENT_SITES_UPDATE_INTERVAL) {
-  const UpdateChecker = Cc["@mozilla.org/updates/update-checker;1"].createInstance(Ci.nsIUpdateChecker);
+  const UpdateChecker = Cc["@mozilla.org/updates/update-checker;1"];
   const checker = {
     _lastUpdated: 0,
     _value: null,
@@ -91,8 +91,9 @@ function CheckBrowserNeedsUpdate(updateInterval = FRECENT_SITES_UPDATE_INTERVAL)
           QueryInterface: ChromeUtils.generateQI(["nsIUpdateCheckListener"]),
         };
 
-        if (now - this._lastUpdated >= updateInterval) {
-          UpdateChecker.checkForUpdates(updateServiceListener, true);
+        if (UpdateChecker && (now - this._lastUpdated >= updateInterval)) {
+          const checkerInstance = UpdateChecker.createInstance(Ci.nsIUpdateChecker);
+          checkerInstance.checkForUpdates(updateServiceListener, true);
           this._lastUpdated = now;
         } else {
           resolve(this._value);


### PR DESCRIPTION
…ting an instance

I tried doing an early return `reject` if UpdateChecker is undefined but our lint rules force all code paths to `return` making it incompatible with the event based `checkForUpdates`.

This way we return `null` if UpdateChecker is undefined. I interpret that as: if you can't do an update `needsUpdate` should just report you are up to date.

> there are compile-time options to disable it [Update Checker].

Probably special enterprise builds, either way not in the snippet target audience.