### PR TITLE
Bug 1502971 - Enable ASR Snippets by default

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -221,7 +221,7 @@ const PREFS_CONFIG = new Map([
       type: "remote",
       url: "https://snippets.cdn.mozilla.net/%STARTPAGE_VERSION%/%NAME%/%VERSION%/%APPBUILDID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/",
       updateCycleInMs: ONE_HOUR_IN_MS * 4,
-      enabled: false,
+      enabled: true,
     }, {
       id: "cfr",
       type: "local",


### PR DESCRIPTION
To ensure this is working, make sure you have snippets running on a new profile with default ASR messageProvider settings.