### PR TITLE
(nobug): Report JEXL syntax errors in ASRouter Admin

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -239,13 +239,14 @@ export class ASRouterAdmin extends React.PureComponent {
   renderTargetingParameters() {
     // There was no error and the result is truthy
     const success = this.state.evaluationStatus.success && !!this.state.evaluationStatus.result;
+    const result = JSON.stringify(this.state.evaluationStatus.result, null, 2) || "undefined";
 
     return (<table><tbody>
       <tr><td><h2>Evaluate JEXL expression</h2></td></tr>
       <tr>
         <td>
           <p><textarea ref="expressionInput" rows="10" cols="60" placeholder="Evaluate JEXL expressions and mock parameters by changing their values below" /></p>
-          <p>Status: <span ref="evaluationStatus">{success ? "✅" : "❌"}, Result: {JSON.stringify(this.state.evaluationStatus.result, null, 2)}</span></p>
+          <p>Status: <span ref="evaluationStatus">{success ? "✅" : "❌"}, Result: {result}</span></p>
         </td>
         <td>
            <button className="ASRouterButton secondary" onClick={this.handleExpressionEval}>Evaluate</button>

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -239,7 +239,7 @@ export class ASRouterAdmin extends React.PureComponent {
   renderTargetingParameters() {
     // There was no error and the result is truthy
     const success = this.state.evaluationStatus.success && !!this.state.evaluationStatus.result;
-    const result = JSON.stringify(this.state.evaluationStatus.result, null, 2) || "undefined";
+    const result = JSON.stringify(this.state.evaluationStatus.result, null, 2) || "(Empty result)";
 
     return (<table><tbody>
       <tr><td><h2>Evaluate JEXL expression</h2></td></tr>

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -561,7 +561,7 @@ class _ASRouter {
     try {
       evaluationStatus = {result: await ASRouterTargeting.isMatch(expression, context), success: true};
     } catch (e) {
-      evaluationStatus = {result: e, success: false};
+      evaluationStatus = {result: e.message, success: false};
     }
 
     channel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: {...this.state, evaluationStatus}});


### PR DESCRIPTION
I added `|| "undefined"` because targeting parameters typos wouldn't output anything in the Result field.

<img width="497" alt="grafik" src="https://user-images.githubusercontent.com/810040/47845306-92209880-ddbc-11e8-9ee0-52ef4210c2a9.png">
<img width="489" alt="grafik" src="https://user-images.githubusercontent.com/810040/47845316-98167980-ddbc-11e8-9d12-2209c41abae8.png">
<img width="489" alt="grafik" src="https://user-images.githubusercontent.com/810040/47845332-a2387800-ddbc-11e8-9750-83083ac7652c.png">
