### PR TITLE
Bug 1503897 - Upgrade merge sub-dependency to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7680,10 +7680,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
     },
     "micromatch": {
       "version": "2.3.11",
@@ -10250,7 +10249,7 @@
         "known-css-properties": "0.3.0",
         "lodash.capitalize": "4.2.1",
         "lodash.kebabcase": "4.1.1",
-        "merge": "1.2.0",
+        "merge": "^1.2.0",
         "path-is-absolute": "1.0.1",
         "util": "0.10.3"
       },


### PR DESCRIPTION
1.2.0 has a reported security vulnerability

See: https://nvd.nist.gov/vuln/detail/CVE-2018-16469