### PR TITLE
Backport Bug 1472212 - Update URLs to include the noscripts version in xpcshell and browser tests for newtab. r=Mardak

### DIFF
--- a/aboutNewTabService.js
+++ b/aboutNewTabService.js
@@ -108,6 +108,7 @@ AboutNewTabService.prototype = {
       case "nsPref:changed":
         if (data === PREF_SEPARATE_PRIVILEGED_CONTENT_PROCESS) {
           this._privilegedContentProcess = Services.prefs.getBoolPref(PREF_SEPARATE_PRIVILEGED_CONTENT_PROCESS);
+          this.notifyChange();
         } else if (data === PREF_ACTIVITY_STREAM_PRERENDER_ENABLED) {
           this._activityStreamPrerender = Services.prefs.getBoolPref(PREF_ACTIVITY_STREAM_PRERENDER_ENABLED);
           this.notifyChange();

--- a/test/browser/browser_packaged_as_locales.js
+++ b/test/browser/browser_packaged_as_locales.js
@@ -4,7 +4,9 @@ XPCOMUtils.defineLazyServiceGetter(this, "aboutNewTabService",
                                    "nsIAboutNewTabService");
 
 // Tests are by default run with non-debug en-US configuration
-const DEFAULT_URL = "resource://activity-stream/prerendered/en-US/activity-stream-prerendered.html";
+const DEFAULT_URL = SpecialPowers.getBoolPref("browser.tabs.remote.separatePrivilegedContentProcess")
+  ? "resource://activity-stream/prerendered/en-US/activity-stream-prerendered-noscripts.html"
+  : "resource://activity-stream/prerendered/en-US/activity-stream-prerendered.html";
 
 /**
  * Temporarily change the app locale to get the localized activity stream url

--- a/test/browser/browser_packaged_as_locales.js
+++ b/test/browser/browser_packaged_as_locales.js
@@ -4,9 +4,9 @@ XPCOMUtils.defineLazyServiceGetter(this, "aboutNewTabService",
                                    "nsIAboutNewTabService");
 
 // Tests are by default run with non-debug en-US configuration
-const DEFAULT_URL = SpecialPowers.getBoolPref("browser.tabs.remote.separatePrivilegedContentProcess")
-  ? "resource://activity-stream/prerendered/en-US/activity-stream-prerendered-noscripts.html"
-  : "resource://activity-stream/prerendered/en-US/activity-stream-prerendered.html";
+const DEFAULT_URL = SpecialPowers.getBoolPref("browser.tabs.remote.separatePrivilegedContentProcess") ?
+  "resource://activity-stream/prerendered/en-US/activity-stream-prerendered-noscripts.html" :
+  "resource://activity-stream/prerendered/en-US/activity-stream-prerendered.html";
 
 /**
  * Temporarily change the app locale to get the localized activity stream url


### PR DESCRIPTION
Waiting on TC to see it green. Also the backport failed eslint so there's an extra commit there.