### PR TITLE
Fix Bug 1502332 - Add message filtering based on targeting expression and parameters

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -115,12 +115,11 @@ export class ASRouterAdmin extends React.PureComponent {
 
   handleMessageFiltering(event) {
     if (this.state.jexlMessageFilter) {
-      return this.clearJEXLMessageFiltering();
+      this.clearJEXLMessageFiltering();
+    } else {
+      this.setState({jexlMessageFilter: true});
+      this.state.messages.forEach(({id, targeting}) => targeting && this.handleExpressionEval(event, id, targeting));
     }
-
-    this.setState({jexlMessageFilter: true});
-    this.state.messages.forEach(({id, targeting}) => targeting && this.handleExpressionEval(event, id, targeting));
-    return null;
   }
 
   onChangeTargetingParameters(event) {
@@ -135,8 +134,8 @@ export class ASRouterAdmin extends React.PureComponent {
       updatedParameters[name] = value;
       try {
         JSON.parse(value);
+        target.setCustomValidity("");
       } catch ({message}) {
-        console.log(`Error parsing value of parameter ${name}`); // eslint-disable-line no-console
         targetingParametersError = {id: name};
         target.setCustomValidity(message);
         target.reportValidity();
@@ -180,6 +179,9 @@ export class ASRouterAdmin extends React.PureComponent {
   }
 
   onChangeMessageFilter(event) {
+    if (this.state.jexlMessageFilter) {
+      this.clearJEXLMessageFiltering();
+    }
     this.setState({messageFilter: event.target.value});
   }
 
@@ -227,7 +229,6 @@ export class ASRouterAdmin extends React.PureComponent {
   }
 
   clearJEXLMessageFiltering(event) {
-    event.target.setCustomValidity("");
     this.setState({jexlMessageFilter: false, jexlMatchingMessages: []});
   }
 
@@ -272,10 +273,16 @@ export class ASRouterAdmin extends React.PureComponent {
     if (!this.state.providers) {
       return null;
     }
+    const options = this.state.providers.map(provider => (<option key={provider.id} value={provider.id}>{provider.id}</option>));
+    let selected = this.state.messageFilter;
+    if (this.state.jexlMessageFilter) {
+      selected = "JEXL Targeting";
+      options.push(<option key="jexlMessageFilter" value={selected}>{selected}</option>);
+    }
     return (<React.Fragment>
-      <p>Show messages from <select value={this.state.messageFilter} onChange={this.onChangeMessageFilter}>
+      <p>Show messages from <select value={selected} onChange={this.onChangeMessageFilter}>
       <option value="all">all providers</option>
-      {this.state.providers.map(provider => (<option key={provider.id} value={provider.id}>{provider.id}</option>))}
+        {options}
       </select></p>
       <p>
         Filter all messages based on the targeting parameters below

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -1,3 +1,11 @@
+%inputs-shared {
+  background: $white;
+  border: $input-border;
+  margin: 8px 0;
+  padding: 8px;
+  width: 100%;
+  font-size: 15px;
+}
 
 .asrouter-admin {
   $border-color: var(--newtab-border-secondary-color);
@@ -24,6 +32,32 @@
   table {
     border-collapse: collapse;
     width: 100%;
+  }
+
+  textarea {
+    @extend %inputs-shared;
+  }
+
+  input {
+    &[type='text'] {
+      @extend %inputs-shared;
+
+      &:focus {
+        border: $input-border-active;
+        box-shadow: var(--newtab-textbox-focus-boxshadow);
+      }
+
+      &[disabled] {
+        border: $input-border;
+        box-shadow: none;
+        opacity: 0.4;
+      }
+
+      &.errorState {
+        border: $input-error-border;
+        box-shadow: $input-error-boxshadow;
+      }
+    }
   }
 
   .sourceLabel {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -555,13 +555,13 @@ class _ASRouter {
     return ASRouterTargeting.findMatchingMessage({messages, trigger, context, onError: this._handleTargetingError});
   }
 
-  async evaluateExpression(target, {expression, context}) {
+  async evaluateExpression(target, {id, expression, context}) {
     const channel = target || this.messageChannel;
     let evaluationStatus;
     try {
-      evaluationStatus = {result: await ASRouterTargeting.isMatch(expression, context), success: true};
+      evaluationStatus = {result: await ASRouterTargeting.isMatch(expression, context), success: true, id};
     } catch (e) {
-      evaluationStatus = {result: e.message, success: false};
+      evaluationStatus = {result: e.message, success: false, id};
     }
 
     channel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "ADMIN_SET_STATE", data: {...this.state, evaluationStatus}});


### PR DESCRIPTION
This will go through all the messages and filter out those that have a targeting expression that does not match the current values of the targeting parameters. Updating those parameters allows to check which messages match.
<img width="569" alt="grafik" src="https://user-images.githubusercontent.com/810040/48074204-53ce1380-e1d8-11e8-85e6-3a06c9c33352.png">

Some improvements to the inputs
<img width="557" alt="grafik" src="https://user-images.githubusercontent.com/810040/48074305-8a0b9300-e1d8-11e8-89d6-f4f38a745268.png">


It adds some improvements to the error states
<img width="593" alt="grafik" src="https://user-images.githubusercontent.com/810040/48074276-7ceea400-e1d8-11e8-9ae4-e3ca5cb1c684.png">

