### PR TITLE
Fix Bug 1504754 - Debug noscripts version of new tab page need to be packaged

### DIFF
--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -183,7 +183,7 @@ export class TopSiteLink extends React.PureComponent {
     }
     return (<li className={topSiteOuterClassName} onDrop={this.onDragEvent} onDragOver={this.onDragEvent} onDragEnter={this.onDragEvent} onDragLeave={this.onDragEvent} {...draggableProps}>
       <div className="top-site-inner">
-         <a href={!link.searchTopSite && link.url} tabIndex="0" onKeyPress={this.onKeyPress} onClick={onClick} draggable={true}>
+         <a href={link.searchTopSite ? undefined : link.url} tabIndex="0" onKeyPress={this.onKeyPress} onClick={onClick} draggable={true}>
             <div className="tile" aria-hidden={true} data-fallback={letterFallback}>
               <div className={imageClassName} style={imageStyle} />
               {link.searchTopSite && <div className="top-site-icon search-topsite" />}

--- a/jar.mn
+++ b/jar.mn
@@ -41,7 +41,9 @@ browser.jar:
 #endif
   res/activity-stream/prerendered/static/activity-stream-initial-state.js (./prerendered/static/activity-stream-initial-state.js)
 #ifndef RELEASE_OR_BETA
+  res/activity-stream/prerendered/static/activity-stream-debug-noscripts.html (./prerendered/static/activity-stream-debug-noscripts.html)
   res/activity-stream/prerendered/static/activity-stream-debug.html (./prerendered/static/activity-stream-debug.html)
+  res/activity-stream/prerendered/static/activity-stream-prerendered-debug-noscripts.html (./prerendered/static/activity-stream-prerendered-debug-noscripts.html)
   res/activity-stream/prerendered/static/activity-stream-prerendered-debug.html (./prerendered/static/activity-stream-prerendered-debug.html)
 #endif
   res/activity-stream/prerendered/ (./prerendered/locales/*)

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -358,7 +358,7 @@ describe("<TopSiteLink>", () => {
   it("should not add the url to the href if it a search shortcut", () => {
     link.searchTopSite = true;
     const wrapper = shallow(<TopSiteLink link={link} />);
-    assert.isFalse(wrapper.find("a").props().href);
+    assert.isUndefined(wrapper.find("a").props().href);
   });
   it("should have rtl direction automatically set for text", () => {
     const wrapper = shallow(<TopSiteLink link={link} />);


### PR DESCRIPTION
r?@sarracini Package the files that are already there with jar.mn. Also fixed a react dev warning that I saw when making sure noscripts loaded:
```
Warning: Received `false` for a non-boolean attribute `href`.

If you want to write it to the DOM, pass a string instead: href="false" or href={value.toString()}.

If you used to conditionally omit it with href={condition && value}, pass href={condition ? value : undefined} instead.
    in a (created by TopSiteLink)
    in div (created by TopSiteLink)
…```