### PR TITLE
Move to pref branch for ASR

### DIFF
--- a/content-src/asrouter/README.md
+++ b/content-src/asrouter/README.md
@@ -5,24 +5,29 @@
 Name | Used for | Type | Example value
 ---  | ---      | ---  | ---
 `whitelistHosts` | Whitelist a host in order to fetch messages from its endpoint | `[String]` |  `["gist.github.com", "gist.githubusercontent.com", "localhost:8000"]`
-`messageProviders` | Message provider options | `Object` | [see below](#message-providers)
+`providers.snippets` | Message provider options for snippets | `Object` | [see below](#message-providers)
+`providers.cfr` | Message provider options for cfr | `Object` | [see below](#message-providers)
+`providers.onboarding` | Message provider options for onboarding | `Object` | [see below](#message-providers)
 
-### Message providers
+### Message providers examples
 
 ```json
-[
-   {
-      "id" : "onboarding",
-      "type" : "local",
-      "localProvider" : "OnboardingMessageProvider"
-   },
-   {
-      "type" : "remote",
-      "url" : "https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json",
-      "updateCycleInMs" : 14400000,
-      "id" : "snippets"
-   }
-]
+{
+  "id" : "snippets",
+  "type" : "remote",
+  "enabled": true,
+  "url" : "https://snippets.cdn.mozilla.net/us-west/bundles/bundle_d6d90fb9098ce8b45e60acf601bcb91b68322309.json",
+  "updateCycleInMs" : 14400000
+}
+```
+
+```json
+{
+  "id" : "onboarding",
+  "enabled": true,
+  "type" : "local",
+  "localProvider" : "OnboardingMessageProvider"
+}
 ```
 
 ## Admin Interface

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -244,7 +244,8 @@ export class ASRouterAdmin extends React.PureComponent {
         <td className="min" />
         <td className="min">Provider ID</td>
         <td>Source</td>
-        <td>Last Updated</td>
+        <td className="min">Cohort</td>
+        <td className="min">Last Updated</td>
       </tr>
     </thead>);
   }
@@ -263,11 +264,7 @@ export class ASRouterAdmin extends React.PureComponent {
 
         let label = "local";
         if (provider.type === "remote") {
-          let displayUrl = "";
-          try {
-            displayUrl = `(${new URL(info.url).hostname})`;
-          } catch (err) {}
-          label = (<span>endpoint <a target="_blank" href={info.url}>{displayUrl}</a></span>);
+          label = (<span>endpoint (<a className="providerUrl" target="_blank" href={info.url}>{info.url}</a>)</span>);
         } else if (provider.type === "remote-settings") {
           label = `remote settings (${provider.bucket})`;
         }
@@ -288,6 +285,7 @@ export class ASRouterAdmin extends React.PureComponent {
           <td>{isTestProvider ? <input type="checkbox" disabled={true} readOnly={true} checked={true} /> : <input type="checkbox" data-provider={provider.id} checked={isUserEnabled && isSystemEnabled} onChange={this.handleEnabledToggle} />}</td>
           <td>{provider.id}</td>
           <td><span className={`sourceLabel${(isUserEnabled && isSystemEnabled) ? "" : " isDisabled"}`}>{label}</span></td>
+          <td>{provider.cohort}</td>
           <td style={{whiteSpace: "nowrap"}}>{info.lastUpdated ? new Date(info.lastUpdated).toLocaleString() : ""}</td>
         </tr>);
       })}

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -91,6 +91,10 @@
     }
   }
 
+  .providerUrl {
+    font-size: 12px;
+  }
+
   pre {
     background: var(--newtab-textbox-background-color);
     margin: 0;

--- a/content-src/lib/snippets.js
+++ b/content-src/lib/snippets.js
@@ -247,10 +247,6 @@ export class SnippetsProvider {
     }
   }
 
-  _noSnippetFallback() {
-    // TODO
-  }
-
   _showRemoteSnippets() {
     const snippetsEl = document.getElementById(this.elementId);
     const payload = this.snippetsMap.get("snippets");
@@ -272,6 +268,8 @@ export class SnippetsProvider {
     // eslint-disable-next-line no-unsanitized/property
     snippetsEl.innerHTML = payload;
 
+    this._logIfDevtools("Successfully added snippets.");
+
     // Scripts injected by innerHTML are inactive, so we have to relocate them
     // through DOM manipulation to activate their contents.
     for (const scriptEl of snippetsEl.getElementsByTagName("script")) {
@@ -290,6 +288,13 @@ export class SnippetsProvider {
     }
   }
 
+  // istanbul ignore next
+  _logIfDevtools(text) {
+    if (this.devtoolsEnabled) {
+      console.log("Legacy snippets:", text); // eslint-disable-line no-console
+    }
+  }
+
   /**
    * init - Fetch the snippet payload and show snippets
    *
@@ -304,7 +309,10 @@ export class SnippetsProvider {
       appData: {},
       elementId: "snippets",
       connect: true,
+      devtoolsEnabled: false,
     }, options);
+
+    this._logIfDevtools("Initializing...");
 
     // Add listener so we know when snippets are blocked on other pages
     if (global.RPMAddMessageListener) {
@@ -337,12 +345,14 @@ export class SnippetsProvider {
     try {
       this._showRemoteSnippets();
     } catch (e) {
-      this._noSnippetFallback(e);
+      this._logIfDevtools("Problem inserting remote snippets!");
+      console.error(e); // eslint-disable-line no-console
     }
 
     window.dispatchEvent(new Event(SNIPPETS_ENABLED_EVENT));
 
     this.initialized = true;
+    this._logIfDevtools("Finished initializing.");
   }
 
   uninit() {
@@ -397,11 +407,7 @@ export function addSnippetsSubscriber(store) {
       location.hash !== "#asrouter"
     ) {
       initializing = true;
-      await snippets.init({appData: state.Snippets});
-      // istanbul ignore if
-      if (state.Prefs.values["asrouter.devtoolsEnabled"]) {
-        console.log("Legacy snippets initialized"); // eslint-disable-line no-console
-      }
+      await snippets.init({appData: state.Snippets, devtoolsEnabled: state.Prefs.values["asrouter.devtoolsEnabled"]});
       initializing = false;
 
     /** If we should remove snippets... */

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -5,13 +5,13 @@
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-const PROVIDER_PREF = "browser.newtabpage.activity-stream.asrouter.messageProviders";
+const PROVIDER_PREF_BRANCH = "browser.newtabpage.activity-stream.asrouter.providers.";
 const DEVTOOLS_PREF = "browser.newtabpage.activity-stream.asrouter.devtoolsEnabled";
 
 const DEFAULT_STATE = {
   _initialized: false,
   _providers: null,
-  _providerPref: PROVIDER_PREF,
+  _providerPrefBranch: PROVIDER_PREF_BRANCH,
   _devtoolsEnabled: null,
   _devtoolsPref: DEVTOOLS_PREF,
 };
@@ -35,17 +35,24 @@ class _ASRouterPreferences {
   }
 
   _getProviderConfig() {
-    try {
-      return JSON.parse(Services.prefs.getStringPref(this._providerPref, ""));
-    } catch (e) {
-      Cu.reportError(`Could not parse ASRouter preference. Try resetting ${this._providerPref} in about:config.`);
-    }
-    return null;
+    const prefList = Services.prefs.getChildList(this._providerPrefBranch);
+    return prefList.reduce((filtered, pref) => {
+      let value;
+      try {
+        value = JSON.parse(Services.prefs.getStringPref(pref, ""));
+      } catch (e) {
+        Cu.reportError(`Could not parse ASRouter preference. Try resetting ${pref} in about:config.`);
+      }
+      if (value) {
+        filtered.push(value);
+      }
+      return filtered;
+    }, []);
   }
 
   get providers() {
     if (!this._initialized || this._providers === null) {
-      const config = this._getProviderConfig() || [];
+      const config = this._getProviderConfig();
       const providers = config.map(provider => Object.freeze(provider));
       if (this.devtoolsEnabled) {
         providers.unshift(TEST_PROVIDER);
@@ -58,26 +65,19 @@ class _ASRouterPreferences {
 
   enableOrDisableProvider(id, value) {
     const providers = this._getProviderConfig();
-    if (!providers) {
-      Cu.reportError(`Cannot enable/disable providers if ${this._providerPref} is unparseable.`);
-      return;
-    }
-    if (!providers.find(p => p.id === id)) {
-      Cu.reportError(`Cannot set enabled state for '${id}' because it does not exist in ${this._providerPref}`);
+    const config = providers.find(p => p.id === id);
+    if (!config) {
+      Cu.reportError(`Cannot set enabled state for '${id}' because the pref ${this._providerPrefBranch}${id} does not exist or is not correctly formatted.`);
       return;
     }
 
-    const newConfig = providers.map(provider => {
-      if (provider.id === id) {
-        return {...provider, enabled: value};
-      }
-      return provider;
-    });
-    Services.prefs.setStringPref(this._providerPref, JSON.stringify(newConfig));
+    Services.prefs.setStringPref(this._providerPrefBranch + id, JSON.stringify({...config, enabled: value}));
   }
 
   resetProviderPref() {
-    Services.prefs.clearUserPref(this._providerPref);
+    for (const pref of Services.prefs.getChildList(this._providerPrefBranch)) {
+      Services.prefs.clearUserPref(pref);
+    }
     for (const id of Object.keys(USER_PREFERENCES)) {
       Services.prefs.clearUserPref(USER_PREFERENCES[id]);
     }
@@ -101,14 +101,11 @@ class _ASRouterPreferences {
   }
 
   observe(aSubject, aTopic, aPrefName) {
-    switch (aPrefName) {
-      case this._providerPref:
-        this._providers = null;
-        break;
-      case this._devtoolsPref:
-        this._providers = null;
-        this._devtoolsEnabled = null;
-        break;
+    if (aPrefName && aPrefName.startsWith(this._providerPrefBranch)) {
+      this._providers = null;
+    } else if (aPrefName === this._devtoolsPref) {
+      this._providers = null;
+      this._devtoolsEnabled = null;
     }
     this._callbacks.forEach(cb => cb(aPrefName));
   }
@@ -147,7 +144,7 @@ class _ASRouterPreferences {
     if (this._initialized) {
       return;
     }
-    Services.prefs.addObserver(this._providerPref, this);
+    Services.prefs.addObserver(this._providerPrefBranch, this);
     Services.prefs.addObserver(this._devtoolsPref, this);
     for (const id of Object.keys(USER_PREFERENCES)) {
       Services.prefs.addObserver(USER_PREFERENCES[id], this);
@@ -157,7 +154,7 @@ class _ASRouterPreferences {
 
   uninit() {
     if (this._initialized) {
-      Services.prefs.removeObserver(this._providerPref, this);
+      Services.prefs.removeObserver(this._providerPrefBranch, this);
       Services.prefs.removeObserver(this._devtoolsPref, this);
       for (const id of Object.keys(USER_PREFERENCES)) {
         Services.prefs.removeObserver(USER_PREFERENCES[id], this);

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -202,33 +202,34 @@ const PREFS_CONFIG = new Map([
     title: "Does the user allow CFR recommendations?",
     value: true,
   }],
-  ["asrouter.messageProviders", {
-    title: "Configuration for ASRouter message providers",
-
-    /**
-     * Each provider must have a unique id and a type of "local" or "remote".
-     * Local providers must specify the name of an ASRouter message provider.
-     * Remote providers must specify a `url` and an `updateCycleInMs`.
-     * Each provider must also have an `enabled` boolean.
-     */
-    value: JSON.stringify([{
+  ["asrouter.providers.onboarding", {
+    title: "Configuration for onboarding provider",
+    value: JSON.stringify({
       id: "onboarding",
       type: "local",
       localProvider: "OnboardingMessageProvider",
       enabled: true,
-    }, {
+    }),
+  }],
+  ["asrouter.providers.snippets", {
+    title: "Configuration for snippets provider",
+    value: JSON.stringify({
       id: "snippets",
       type: "remote",
       url: "https://snippets.cdn.mozilla.net/%STARTPAGE_VERSION%/%NAME%/%VERSION%/%APPBUILDID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/",
       updateCycleInMs: ONE_HOUR_IN_MS * 4,
       enabled: false,
-    }, {
+    }),
+  }],
+  ["asrouter.providers.cfr", {
+    title: "Configuration for CFR provider",
+    value: JSON.stringify({
       id: "cfr",
       type: "local",
       localProvider: "CFRMessageProvider",
       enabled: IS_NIGHTLY_OR_UNBRANDED_BUILD,
       cohort: IS_NIGHTLY_OR_UNBRANDED_BUILD ? "nightly" : "",
-    }]),
+    }),
   }],
 ]);
 

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -227,8 +227,8 @@ const PREFS_CONFIG = new Map([
       id: "cfr",
       type: "local",
       localProvider: "CFRMessageProvider",
-      enabled: IS_NIGHTLY_OR_UNBRANDED_BUILD,
-      cohort: IS_NIGHTLY_OR_UNBRANDED_BUILD ? "nightly" : "",
+      frequency: {custom: [{period: "daily", cap: 1}]},
+      enabled: true,
     }),
   }],
 ]);

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -218,7 +218,7 @@ const PREFS_CONFIG = new Map([
       type: "remote",
       url: "https://snippets.cdn.mozilla.net/%STARTPAGE_VERSION%/%NAME%/%VERSION%/%APPBUILDID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/",
       updateCycleInMs: ONE_HOUR_IN_MS * 4,
-      enabled: false,
+      enabled: UpdateUtils.getUpdateChannel(true) === "nightly",
     }),
   }],
   ["asrouter.providers.cfr", {

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -40,58 +40,6 @@ const REDDIT_ENHANCEMENT_PARAMS = {
 
 const CFR_MESSAGES = [
   {
-    id: "FACEBOOK_CONTAINER_1",
-    template: "cfr_doorhanger",
-    content: {
-      bucket_id: "CFR_M1",
-      notification_text: {string_id: "cfr-doorhanger-extension-notification"},
-      heading_text: {string_id: "cfr-doorhanger-extension-heading"},
-      info_icon: {
-        label: {string_id: "cfr-doorhanger-extension-sumo-link"},
-        sumo_path: FACEBOOK_CONTAINER_PARAMS.sumo_path,
-      },
-      addon: {
-        id: "954390",
-        title: "Facebook Container",
-        icon: "resource://activity-stream/data/content/assets/cfr_fb_container.png",
-        rating: 4.6,
-        users: 299019,
-        author: "Mozilla",
-        amo_url: "https://addons.mozilla.org/en-US/firefox/addon/facebook-container/",
-      },
-      text: "Stop Facebook from tracking your activity across the web. Use Facebook the way you normally do without annoying ads following you around.",
-      buttons: {
-        primary: {
-          label: {string_id: "cfr-doorhanger-extension-ok-button"},
-          action: {
-            type: "INSTALL_ADDON_FROM_URL",
-            data: {url: null},
-          },
-        },
-        secondary: [{
-          label: {string_id: "cfr-doorhanger-extension-cancel-button"},
-          action: {type: "CANCEL"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-never-show-recommendation"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-manage-settings-button"},
-          action: {
-            type: "OPEN_PREFERENCES_PAGE",
-            data: {category: "general-cfr", origin: "CFR"},
-          },
-        }],
-      },
-    },
-    frequency: {lifetime: 1},
-    targeting: `
-      localeLanguageCode == "en" &&
-      (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
-      (xpinstallEnabled == true) &&
-      (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
-      (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${FACEBOOK_CONTAINER_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
-    trigger: {id: "openURL", params: FACEBOOK_CONTAINER_PARAMS.open_urls},
-  },
-  {
     id: "FACEBOOK_CONTAINER_3",
     template: "cfr_doorhanger",
     content: {
@@ -137,63 +85,10 @@ const CFR_MESSAGES = [
     frequency: {lifetime: 3},
     targeting: `
       localeLanguageCode == "en" &&
-      (providerCohorts.cfr == "three_per_day") &&
       (xpinstallEnabled == true) &&
       (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(FACEBOOK_CONTAINER_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${FACEBOOK_CONTAINER_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: FACEBOOK_CONTAINER_PARAMS.open_urls},
-  },
-  {
-    id: "GOOGLE_TRANSLATE_1",
-    template: "cfr_doorhanger",
-    content: {
-      bucket_id: "CFR_M1",
-      notification_text: {string_id: "cfr-doorhanger-extension-notification"},
-      heading_text: {string_id: "cfr-doorhanger-extension-heading"},
-      info_icon: {
-        label: {string_id: "cfr-doorhanger-extension-sumo-link"},
-        sumo_path: GOOGLE_TRANSLATE_PARAMS.sumo_path,
-      },
-      addon: {
-        id: "445852",
-        title: "To Google Translate",
-        icon: "resource://activity-stream/data/content/assets/cfr_google_translate.png",
-        rating: 4.1,
-        users: 313474,
-        author: "Juan Escobar",
-        amo_url: "https://addons.mozilla.org/en-US/firefox/addon/to-google-translate/",
-      },
-      text: "Instantly translate any webpage text. Simply highlight the text, right-click to open the context menu, and choose a text or aural translation.",
-      buttons: {
-        primary: {
-          label: {string_id: "cfr-doorhanger-extension-ok-button"},
-          action: {
-            type: "INSTALL_ADDON_FROM_URL",
-            data: {url: null},
-          },
-        },
-        secondary: [{
-          label: {string_id: "cfr-doorhanger-extension-cancel-button"},
-          action: {type: "CANCEL"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-never-show-recommendation"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-manage-settings-button"},
-          action: {
-            type: "OPEN_PREFERENCES_PAGE",
-            data: {category: "general-cfr", origin: "CFR"},
-          },
-        }],
-      },
-    },
-    frequency: {lifetime: 1},
-    targeting: `
-      localeLanguageCode == "en" &&
-      (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
-      (xpinstallEnabled == true) &&
-      (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
-      (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${GOOGLE_TRANSLATE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
-    trigger: {id: "openURL", params: GOOGLE_TRANSLATE_PARAMS.open_urls},
   },
   {
     id: "GOOGLE_TRANSLATE_3",
@@ -241,63 +136,10 @@ const CFR_MESSAGES = [
     frequency: {lifetime: 3},
     targeting: `
       localeLanguageCode == "en" &&
-      (providerCohorts.cfr == "three_per_day") &&
       (xpinstallEnabled == true) &&
       (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(GOOGLE_TRANSLATE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${GOOGLE_TRANSLATE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: GOOGLE_TRANSLATE_PARAMS.open_urls},
-  },
-  {
-    id: "YOUTUBE_ENHANCE_1",
-    template: "cfr_doorhanger",
-    content: {
-      bucket_id: "CFR_M1",
-      notification_text: {string_id: "cfr-doorhanger-extension-notification"},
-      heading_text: {string_id: "cfr-doorhanger-extension-heading"},
-      info_icon: {
-        label: {string_id: "cfr-doorhanger-extension-sumo-link"},
-        sumo_path: YOUTUBE_ENHANCE_PARAMS.sumo_path,
-      },
-      addon: {
-        id: "700308",
-        title: "Enhancer for YouTube\u2122",
-        icon: "resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png",
-        rating: 4.8,
-        users: 357328,
-        author: "Maxime RF",
-        amo_url: "https://addons.mozilla.org/en-US/firefox/addon/enhancer-for-youtube/",
-      },
-      text: "Take control of your YouTube experience. Automatically block annoying ads, set playback speed and volume, remove annotations, and more.",
-      buttons: {
-        primary: {
-          label: {string_id: "cfr-doorhanger-extension-ok-button"},
-          action: {
-            type: "INSTALL_ADDON_FROM_URL",
-            data: {url: null},
-          },
-        },
-        secondary: [{
-          label: {string_id: "cfr-doorhanger-extension-cancel-button"},
-          action: {type: "CANCEL"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-never-show-recommendation"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-manage-settings-button"},
-          action: {
-            type: "OPEN_PREFERENCES_PAGE",
-            data: {category: "general-cfr", origin: "CFR"},
-          },
-        }],
-      },
-    },
-    frequency: {lifetime: 1},
-    targeting: `
-      localeLanguageCode == "en" &&
-      (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
-      (xpinstallEnabled == true) &&
-      (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
-      (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${YOUTUBE_ENHANCE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
-    trigger: {id: "openURL", params: YOUTUBE_ENHANCE_PARAMS.open_urls},
   },
   {
     id: "YOUTUBE_ENHANCE_3",
@@ -345,63 +187,10 @@ const CFR_MESSAGES = [
     frequency: {lifetime: 3},
     targeting: `
       localeLanguageCode == "en" &&
-      (providerCohorts.cfr == "three_per_day") &&
       (xpinstallEnabled == true) &&
       (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(YOUTUBE_ENHANCE_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${YOUTUBE_ENHANCE_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: YOUTUBE_ENHANCE_PARAMS.open_urls},
-  },
-  {
-    id: "WIKIPEDIA_CONTEXT_MENU_SEARCH_1",
-    template: "cfr_doorhanger",
-    content: {
-      bucket_id: "CFR_M1",
-      notification_text: {string_id: "cfr-doorhanger-extension-notification"},
-      heading_text: {string_id: "cfr-doorhanger-extension-heading"},
-      info_icon: {
-        label: {string_id: "cfr-doorhanger-extension-sumo-link"},
-        sumo_path: WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.sumo_path,
-      },
-      addon: {
-        id: "659026",
-        title: "Wikipedia Context Menu Search",
-        icon: "resource://activity-stream/data/content/assets/cfr_wiki_search.png",
-        rating: 4.9,
-        users: 3095,
-        author: "Nick Diedrich",
-        amo_url: "https://addons.mozilla.org/en-US/firefox/addon/wikipedia-context-menu-search/",
-      },
-      text: "Get to a Wikipedia page fast, from anywhere on the web. Just highlight any webpage text and right-click to open the context menu to start a Wikipedia search.",
-      buttons: {
-        primary: {
-          label: {string_id: "cfr-doorhanger-extension-ok-button"},
-          action: {
-            type: "INSTALL_ADDON_FROM_URL",
-            data: {url: null},
-          },
-        },
-        secondary: [{
-          label: {string_id: "cfr-doorhanger-extension-cancel-button"},
-          action: {type: "CANCEL"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-never-show-recommendation"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-manage-settings-button"},
-          action: {
-            type: "OPEN_PREFERENCES_PAGE",
-            data: {category: "general-cfr", origin: "CFR"},
-          },
-        }],
-      },
-    },
-    frequency: {lifetime: 1},
-    targeting: `
-      localeLanguageCode == "en" &&
-      (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
-      (xpinstallEnabled == true) &&
-      (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
-      (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
-    trigger: {id: "openURL", params: WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls},
   },
   {
     id: "WIKIPEDIA_CONTEXT_MENU_SEARCH_3",
@@ -449,63 +238,10 @@ const CFR_MESSAGES = [
     frequency: {lifetime: 3},
     targeting: `
       localeLanguageCode == "en" &&
-      (providerCohorts.cfr == "three_per_day") &&
       (xpinstallEnabled == true) &&
       (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
     trigger: {id: "openURL", params: WIKIPEDIA_CONTEXT_MENU_SEARCH_PARAMS.open_urls},
-  },
-  {
-    id: "REDDIT_ENHANCEMENT_1",
-    template: "cfr_doorhanger",
-    content: {
-      bucket_id: "CFR_M1",
-      notification_text: {string_id: "cfr-doorhanger-extension-notification"},
-      heading_text: {string_id: "cfr-doorhanger-extension-heading"},
-      info_icon: {
-        label: {string_id: "cfr-doorhanger-extension-sumo-link"},
-        sumo_path: REDDIT_ENHANCEMENT_PARAMS.sumo_path,
-      },
-      addon: {
-        id: "387429",
-        title: "Reddit Enhancement Suite",
-        icon: "resource://activity-stream/data/content/assets/cfr_reddit_enhancement.png",
-        rating: 4.6,
-        users: 258129,
-        author: "honestbleeps",
-        amo_url: "https://addons.mozilla.org/en-US/firefox/addon/reddit-enhancement-suite/",
-      },
-      text: "New features include Inline Image Viewer, Never Ending Reddit (never click 'next page' again), Keyboard Navigation, Account Switcher, and User Tagger.",
-      buttons: {
-        primary: {
-          label: {string_id: "cfr-doorhanger-extension-ok-button"},
-          action: {
-            type: "INSTALL_ADDON_FROM_URL",
-            data: {url: null},
-          },
-        },
-        secondary: [{
-          label: {string_id: "cfr-doorhanger-extension-cancel-button"},
-          action: {type: "CANCEL"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-never-show-recommendation"},
-        }, {
-          label: {string_id: "cfr-doorhanger-extension-manage-settings-button"},
-          action: {
-            type: "OPEN_PREFERENCES_PAGE",
-            data: {category: "general-cfr", origin: "CFR"},
-          },
-        }],
-      },
-    },
-    frequency: {lifetime: 1},
-    targeting: `
-      localeLanguageCode == "en" &&
-      (providerCohorts.cfr in ["one_per_day", "nightly"]) &&
-      (xpinstallEnabled == true) &&
-      (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
-      (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${REDDIT_ENHANCEMENT_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,
-    trigger: {id: "openURL", params: REDDIT_ENHANCEMENT_PARAMS.open_urls},
   },
   {
     id: "REDDIT_ENHANCEMENT_3",
@@ -553,7 +289,6 @@ const CFR_MESSAGES = [
     frequency: {lifetime: 3},
     targeting: `
       localeLanguageCode == "en" &&
-      (providerCohorts.cfr == "three_per_day") &&
       (xpinstallEnabled == true) &&
       (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.existing_addons)} intersect addonsInfo.addons|keys)|length == 0 &&
       (${JSON.stringify(REDDIT_ENHANCEMENT_PARAMS.open_urls)} intersect topFrecentSites[.frecency >= ${REDDIT_ENHANCEMENT_PARAMS.min_frecency}]|mapToProperty('host'))|length > 0`,

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -399,9 +399,12 @@ add_task(async function check_sync() {
 });
 
 add_task(async function check_provider_cohorts() {
-  await pushPrefs(["browser.newtabpage.activity-stream.asrouter.messageProviders", JSON.stringify([{id: "onboarding", messages: [], enabled: true, cohort: "foo"}, {id: "cfr", messages: [], cohort: "bar"}])]);
-  is(await ASRouterTargeting.Environment.providerCohorts.onboarding, "foo");
-  is(await ASRouterTargeting.Environment.providerCohorts.cfr, "bar");
+  await pushPrefs(["browser.newtabpage.activity-stream.asrouter.providers.onboarding", JSON.stringify({id: "onboarding", messages: [], enabled: true, cohort: "foo"})]);
+  await pushPrefs(["browser.newtabpage.activity-stream.asrouter.providers.cfr", JSON.stringify({id: "cfr", enabled: true, cohort: "bar"})]);
+  is(await ASRouterTargeting.Environment.providerCohorts.onboarding, "foo",
+    "should have cohort foo for onboarding");
+  is(await ASRouterTargeting.Environment.providerCohorts.cfr, "bar",
+    "should have cohort bar for cfr");
 });
 
 add_task(async function check_xpinstall_enabled() {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -18,7 +18,7 @@ import {CFRPageActions} from "lib/CFRPageActions.jsm";
 import {GlobalOverrider} from "test/unit/utils";
 import ProviderResponseSchema from "content-src/asrouter/schemas/provider-response.schema.json";
 
-const MESSAGE_PROVIDER_PREF_NAME = "browser.newtabpage.activity-stream.asrouter.messageProviders";
+const MESSAGE_PROVIDER_PREF_NAME = "browser.newtabpage.activity-stream.asrouter.providers.snippets";
 const FAKE_PROVIDERS = [FAKE_LOCAL_PROVIDER, FAKE_REMOTE_PROVIDER, FAKE_REMOTE_SETTINGS_PROVIDER];
 const ALL_MESSAGE_IDS = [...FAKE_LOCAL_MESSAGES, ...FAKE_REMOTE_MESSAGES].map(message => message.id);
 const FAKE_BUNDLE = [FAKE_LOCAL_MESSAGES[1], FAKE_LOCAL_MESSAGES[2]];

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -1,13 +1,13 @@
 import {_ASRouterPreferences, ASRouterPreferences as ASRouterPreferencesSingleton, TEST_PROVIDER} from "lib/ASRouterPreferences.jsm";
 const FAKE_PROVIDERS = [{id: "foo"}, {id: "bar"}];
 
-const PROVIDER_PREF = "browser.newtabpage.activity-stream.asrouter.messageProviders";
+const PROVIDER_PREF_BRANCH = "browser.newtabpage.activity-stream.asrouter.providers.";
 const DEVTOOLS_PREF = "browser.newtabpage.activity-stream.asrouter.devtoolsEnabled";
 const SNIPPETS_USER_PREF = "browser.newtabpage.activity-stream.feeds.snippets";
 const CFR_USER_PREF = "browser.newtabpage.activity-stream.asrouter.userprefs.cfr";
 
 /** NUMBER_OF_PREFS_TO_OBSERVE includes:
- *  1. asrouter.messageProvider
+ *  1. asrouter.providers. pref branch
  *  2. asrouter.devtoolsEnabled
  *  3. browser.newtabpage.activity-stream.feeds.snippets (user preference - snippets)
  *  4. browser.newtabpage.activity-stream.asrouter.userprefs.cfr (user preference - cfr)
@@ -20,17 +20,34 @@ describe("ASRouterPreferences", () => {
   let addObserverStub;
   let stringPrefStub;
   let boolPrefStub;
+
   beforeEach(() => {
     ASRouterPreferences = new _ASRouterPreferences();
 
     sandbox = sinon.sandbox.create();
     addObserverStub = sandbox.stub(global.Services.prefs, "addObserver");
-    stringPrefStub =  sandbox.stub(global.Services.prefs, "getStringPref").withArgs(PROVIDER_PREF).returns(JSON.stringify(FAKE_PROVIDERS));
+    stringPrefStub =  sandbox.stub(global.Services.prefs, "getStringPref");
+    FAKE_PROVIDERS.forEach(provider => {
+      stringPrefStub.withArgs(`${PROVIDER_PREF_BRANCH}${provider.id}`).returns(JSON.stringify(provider));
+    });
+    sandbox.stub(global.Services.prefs, "getChildList")
+      .withArgs(PROVIDER_PREF_BRANCH).returns(FAKE_PROVIDERS.map(provider => `${PROVIDER_PREF_BRANCH}${provider.id}`));
+
     boolPrefStub = sandbox.stub(global.Services.prefs, "getBoolPref").returns(false);
   });
+
   afterEach(() => {
     sandbox.restore();
   });
+
+  function getPrefNameForProvider(providerId) {
+    return `${PROVIDER_PREF_BRANCH}${providerId}`;
+  }
+
+  function setPrefForProvider(providerId, value) {
+    stringPrefStub.withArgs(getPrefNameForProvider(providerId)).returns(JSON.stringify(value));
+  }
+
   it("ASRouterPreferences should be an instance of _ASRouterPreferences", () => {
     assert.instanceOf(ASRouterPreferencesSingleton, _ASRouterPreferences);
   });
@@ -75,7 +92,7 @@ describe("ASRouterPreferences", () => {
       ASRouterPreferences.uninit();
 
       assert.callCount(removeStub, NUMBER_OF_PREFS_TO_OBSERVE);
-      assert.calledWith(removeStub, PROVIDER_PREF);
+      assert.calledWith(removeStub, PROVIDER_PREF_BRANCH);
       assert.calledWith(removeStub, DEVTOOLS_PREF);
       assert.isEmpty(ASRouterPreferences._callbacks);
     });
@@ -86,14 +103,16 @@ describe("ASRouterPreferences", () => {
 
       const result = ASRouterPreferences.providers;
       assert.deepEqual(result, FAKE_PROVIDERS);
-      assert.calledOnce(stringPrefStub);
+      // once per pref
+      assert.calledTwice(stringPrefStub);
     });
     it("should return the cached value the second time .providers is accessed", () => {
       ASRouterPreferences.init();
       const [, secondCall] = [ASRouterPreferences.providers, ASRouterPreferences.providers];
 
       assert.deepEqual(secondCall, FAKE_PROVIDERS);
-      assert.calledOnce(stringPrefStub);
+      // once per pref
+      assert.calledTwice(stringPrefStub);
     });
     it("should just parse the pref each time if ASRouterPreferences hasn't been initialized yet", () => {
       // Intentionally not initialized
@@ -101,13 +120,13 @@ describe("ASRouterPreferences", () => {
 
       assert.deepEqual(firstCall, FAKE_PROVIDERS);
       assert.deepEqual(secondCall, FAKE_PROVIDERS);
-      assert.calledTwice(stringPrefStub);
+      assert.callCount(stringPrefStub, 4);
     });
-    it("should return [] if the pref was not parsable", () => {
-      stringPrefStub.withArgs(PROVIDER_PREF).returns("not json");
+    it("should skip the pref without throwing if a pref is not parsable", () => {
+      stringPrefStub.withArgs(`${PROVIDER_PREF_BRANCH}foo`).returns("not json");
       ASRouterPreferences.init();
 
-      assert.deepEqual(ASRouterPreferences.providers, []);
+      assert.deepEqual(ASRouterPreferences.providers, [{id: "bar"}]);
     });
     it("should include TEST_PROVIDER if devtools is turned on", () => {
       boolPrefStub.withArgs(DEVTOOLS_PREF).returns(true);
@@ -176,21 +195,21 @@ describe("ASRouterPreferences", () => {
   describe("#enableOrDisableProvider", () => {
     it("should enable an existing provider if second param is true", () => {
       const setStub = sandbox.stub(global.Services.prefs, "setStringPref");
-      stringPrefStub.withArgs(PROVIDER_PREF).returns(JSON.stringify([{id: "foo", enabled: false}, {id: "bar", enabled: false}]));
+      setPrefForProvider("foo", {id: "foo", enabled: false});
       assert.isFalse(ASRouterPreferences.providers[0].enabled);
 
       ASRouterPreferences.enableOrDisableProvider("foo", true);
 
-      assert.calledWith(setStub, PROVIDER_PREF, JSON.stringify([{id: "foo", enabled: true}, {id: "bar", enabled: false}]));
+      assert.calledWith(setStub, getPrefNameForProvider("foo"), JSON.stringify({id: "foo", enabled: true}));
     });
     it("should disable an existing provider if second param is false", () => {
       const setStub = sandbox.stub(global.Services.prefs, "setStringPref");
-      stringPrefStub.withArgs(PROVIDER_PREF).returns(JSON.stringify([{id: "foo", enabled: true}, {id: "bar", enabled: true}]));
+      setPrefForProvider("foo", {id: "foo", enabled: true});
       assert.isTrue(ASRouterPreferences.providers[0].enabled);
 
       ASRouterPreferences.enableOrDisableProvider("foo", false);
 
-      assert.calledWith(setStub, PROVIDER_PREF, JSON.stringify([{id: "foo", enabled: false}, {id: "bar", enabled: true}]));
+      assert.calledWith(setStub, getPrefNameForProvider("foo"), JSON.stringify({id: "foo", enabled: false}));
     });
     it("should not throw if the id does not exist", () => {
       assert.doesNotThrow(() => {
@@ -198,7 +217,7 @@ describe("ASRouterPreferences", () => {
       });
     });
     it("should not throw if pref is not parseable", () => {
-      stringPrefStub.withArgs(PROVIDER_PREF).returns("not valid");
+      stringPrefStub.withArgs(getPrefNameForProvider("foo")).returns("not valid");
       assert.doesNotThrow(() => {
         ASRouterPreferences.enableOrDisableProvider("foo", true);
       });
@@ -219,29 +238,36 @@ describe("ASRouterPreferences", () => {
     it("should reset the pref and user prefs", () => {
       const resetStub = sandbox.stub(global.Services.prefs, "clearUserPref");
       ASRouterPreferences.resetProviderPref();
-      assert.calledWith(resetStub, PROVIDER_PREF);
+      FAKE_PROVIDERS.forEach(provider => {
+        assert.calledWith(resetStub, getPrefNameForProvider(provider.id));
+      });
       assert.calledWith(resetStub, SNIPPETS_USER_PREF);
+      assert.calledWith(resetStub, CFR_USER_PREF);
     });
   });
   describe("observer, listeners", () => {
     it("should invalidate .providers when the pref is changed", () => {
-      const testProviders = [{id: "newstuff"}];
+      const testProvider = {id: "newstuff"};
+      const newProviders = [...FAKE_PROVIDERS, testProvider];
 
       ASRouterPreferences.init();
 
       assert.deepEqual(ASRouterPreferences.providers, FAKE_PROVIDERS);
-      stringPrefStub.withArgs(PROVIDER_PREF).returns(JSON.stringify(testProviders));
-      ASRouterPreferences.observe(null, null, PROVIDER_PREF);
+      stringPrefStub.withArgs(getPrefNameForProvider(testProvider.id)).returns(JSON.stringify(testProvider));
+      global.Services.prefs.getChildList
+        .withArgs(PROVIDER_PREF_BRANCH).returns(newProviders.map(provider => getPrefNameForProvider(provider.id)));
+      ASRouterPreferences.observe(null, null, getPrefNameForProvider(testProvider.id));
 
       // Cache should be invalidated so we access the new value of the pref now
-      assert.deepEqual(ASRouterPreferences.providers, testProviders);
+      assert.deepEqual(ASRouterPreferences.providers, newProviders);
     });
     it("should invalidate .devtoolsEnabled and .providers when the pref is changed", () => {
       ASRouterPreferences.init();
 
       assert.isFalse(ASRouterPreferences.devtoolsEnabled);
       boolPrefStub.withArgs(DEVTOOLS_PREF).returns(true);
-      stringPrefStub.withArgs(PROVIDER_PREF).returns("[]");
+      global.Services.prefs.getChildList
+        .withArgs(PROVIDER_PREF_BRANCH).returns([]);
       ASRouterPreferences.observe(null, null, DEVTOOLS_PREF);
 
       // Cache should be invalidated so we access the new value of the pref now
@@ -256,8 +282,8 @@ describe("ASRouterPreferences", () => {
       ASRouterPreferences.addListener(callback1);
       ASRouterPreferences.addListener(callback2);
 
-      ASRouterPreferences.observe(null, null, PROVIDER_PREF);
-      assert.calledWith(callback1, PROVIDER_PREF);
+      ASRouterPreferences.observe(null, null, getPrefNameForProvider("foo"));
+      assert.calledWith(callback1, getPrefNameForProvider("foo"));
 
       ASRouterPreferences.observe(null, null, DEVTOOLS_PREF);
       assert.calledWith(callback2, DEVTOOLS_PREF);
@@ -267,8 +293,8 @@ describe("ASRouterPreferences", () => {
       ASRouterPreferences.init();
       ASRouterPreferences.addListener(callback);
 
-      ASRouterPreferences.observe(null, null, PROVIDER_PREF);
-      assert.calledWith(callback, PROVIDER_PREF);
+      ASRouterPreferences.observe(null, null, getPrefNameForProvider("foo"));
+      assert.calledWith(callback, getPrefNameForProvider("foo"));
 
       callback.reset();
       ASRouterPreferences.removeListener(callback);

--- a/test/unit/asrouter/CFRMessageProvider.test.js
+++ b/test/unit/asrouter/CFRMessageProvider.test.js
@@ -10,22 +10,15 @@ const REGULAR_IDS = [
 ];
 
 describe("CFRMessageProvider", () => {
-  it("should have a total of 10 messages", () => {
-    assert.lengthOf(messages, 10);
+  it("should have a total of 5 messages", () => {
+    assert.lengthOf(messages, 5);
   });
-  it("should two variants for each of the five regular addons", () => {
+  it("should have one message each for the five regular addons", () => {
     for (const id of REGULAR_IDS) {
-      const cohort1 = messages.find(msg => msg.id === `${id}_1`);
-      assert.ok(cohort1, `contains one day cohort for ${id}`);
-      assert.deepEqual(cohort1.frequency, {lifetime: 1}, "one day cohort has the right frequency cap");
-      assert.include(cohort1.targeting, `(providerCohorts.cfr in ["one_per_day", "nightly"])`);
-
       const cohort3 = messages.find(msg => msg.id === `${id}_3`);
       assert.ok(cohort3, `contains three day cohort for ${id}`);
       assert.deepEqual(cohort3.frequency, {lifetime: 3}, "three day cohort has the right frequency cap");
-      assert.include(cohort3.targeting, `(providerCohorts.cfr == "three_per_day")`);
-
-      assert.deepEqual(cohort1.content, cohort3.content, "cohorts should have the same content");
+      assert.notInclude(cohort3.targeting, `providerCohorts.cfr`);
     }
   });
   it("should always have xpinstallEnabled as targeting if it is an addon", () => {

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -140,6 +140,7 @@ const TEST_GLOBAL = {
       removeObserver() {},
       getPrefType() {},
       clearUserPref() {},
+      getChildList() { return []; },
       getStringPref() {},
       setStringPref() {},
       getIntPref() {},


### PR DESCRIPTION
This patch moves our various configurations to a pref branch for ASR rather than a single prefs to support the shield roll-out mechanism. It also turns on snippets in nightly and CFR for all channels.

Please test with the following steps:

1. With a temp-profile/new profile, turn on the devtoolsEnabled pref and visit about:newtab#asrouter
2. Ensure CFR is on by default and the 3-lifetime cap variant is the default
3. Try turning different providers on/off.
4. With ASR snippets disabled, ensure legacy snippets are properly loaded in about:newtab by opening the console.
5. With ASR snippets enabled, ensure you see actual content on new tab pages. 


