### PR TITLE
Release uplift: Bug 1504165 - Two Sponsored cards are wrongly displayed after i…

### DIFF
--- a/common/Reducers.jsm
+++ b/common/Reducers.jsm
@@ -270,7 +270,10 @@ function Sections(prevState = INITIAL_STATE.Sections, action) {
             const rows = Array.from(action.data.rows);
             section.rows.forEach((card, index) => {
               if (card.pinned) {
-                rows.splice(index, 0, card);
+                // Only add it if it's not already there.
+                if (rows[index].guid !== card.guid) {
+                  rows.splice(index, 0, card);
+                }
               }
             });
             return Object.assign({}, section, initialized, Object.assign({}, action.data, {rows}));

--- a/test/unit/common/Reducers.test.js
+++ b/test/unit/common/Reducers.test.js
@@ -333,7 +333,12 @@ describe("Reducers", () => {
       let updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.deepEqual(updatedSection.rows, [ROW]);
 
-      const PINNED_ROW = {id: "pinned", pinned: true};
+      const PINNED_ROW = {id: "pinned", pinned: true, guid: "pinned"};
+      newState = Sections(newState, {type: at.SECTION_UPDATE, data: Object.assign({rows: [PINNED_ROW]}, {id: "foo_bar_2"})});
+      updatedSection = newState.find(section => section.id === "foo_bar_2");
+      assert.deepEqual(updatedSection.rows, [PINNED_ROW]);
+
+      // Updating the section again should not duplicate pinned cards
       newState = Sections(newState, {type: at.SECTION_UPDATE, data: Object.assign({rows: [PINNED_ROW]}, {id: "foo_bar_2"})});
       updatedSection = newState.find(section => section.id === "foo_bar_2");
       assert.deepEqual(updatedSection.rows, [PINNED_ROW]);


### PR DESCRIPTION
…ncreasing the number of Pocket recommendation rows