### PR TITLE
Bug 1506225  - Support blocking by campaign

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -198,7 +198,7 @@ export class ASRouterAdmin extends React.PureComponent {
 
   renderMessageItem(msg) {
     const isCurrent = msg.id === this.state.lastMessageId;
-    const isBlocked = this.state.messageBlockList.includes(msg.id);
+    const isBlocked = this.state.messageBlockList.includes(msg.id) || this.state.messageBlockList.includes(msg.campaign);
     const impressions = this.state.messageImpressions[msg.id] ? this.state.messageImpressions[msg.id].length : 0;
 
     let itemClassName = "message-item";

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -673,6 +673,7 @@ class _ASRouter {
     let {state} = this;
     return state.messages.filter(item =>
       !state.messageBlockList.includes(item.id) &&
+      (!item.campaign || !state.messageBlockList.includes(item.campaign)) &&
       !state.providerBlockList.includes(item.provider)
     );
   }
@@ -829,10 +830,20 @@ class _ASRouter {
     const idsToBlock = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
 
     await this.setState(state => {
-      const messageBlockList = [...state.messageBlockList, ...idsToBlock];
-      // When a message is blocked, its impressions should be cleared as well
+      const messageBlockList = [...state.messageBlockList];
       const messageImpressions = {...state.messageImpressions};
-      idsToBlock.forEach(id => delete messageImpressions[id]);
+
+      idsToBlock.forEach(id => {
+        const message = state.messages.find(m => m.id === id);
+        const idToBlock = (message && message.campaign) ? message.campaign : id;
+        if (!messageBlockList.includes(idToBlock)) {
+          messageBlockList.push(idToBlock);
+        }
+
+        // When a message is blocked, its impressions should be cleared as well
+        delete messageImpressions[id];
+      });
+
       this._storage.set("messageBlockList", messageBlockList);
       return {messageBlockList, messageImpressions};
     });
@@ -990,7 +1001,9 @@ class _ASRouter {
       case "UNBLOCK_MESSAGE_BY_ID":
         await this.setState(state => {
           const messageBlockList = [...state.messageBlockList];
-          messageBlockList.splice(messageBlockList.indexOf(action.data.id), 1);
+          const message = state.messages.find(m => m.id === action.data.id);
+          const idToUnblock = (message && message.campaign) ? message.campaign : action.data.id;
+          messageBlockList.splice(messageBlockList.indexOf(idToUnblock), 1);
           this._storage.set("messageBlockList", messageBlockList);
           return {messageBlockList};
         });

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -9,6 +9,18 @@ const MESSAGES = () => ([
   {
     "id": "SIMPLE_TEST_1",
     "template": "simple_snippet",
+    "campaign": "test_campaign_blocking",
+    "content": {
+      "icon": TEST_ICON,
+      "text": "<syncLink>Sync it, link it, take it with you</syncLink>. All this and more with a Firefox Account.",
+      "links": {"syncLink": {"url": "https://www.mozilla.org/en-US/firefox/accounts"}},
+      "block_button_text": "Block",
+    },
+  },
+  {
+    "id": "SIMPLE_TEST_1_SAME_CAMPAIGN",
+    "template": "simple_snippet",
+    "campaign": "test_campaign_blocking",
     "content": {
       "icon": TEST_ICON,
       "text": "<syncLink>Sync it, link it, take it with you</syncLink>. All this and more with a Firefox Account.",

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -385,6 +385,19 @@ describe("ASRouter", () => {
       assert.calledOnce(targetStub.sendAsyncMessage);
       assert.equal(Router.state.lastMessageId, ALL_MESSAGE_IDS[0]);
     });
+    it("should not return a message from a blocked campaign", async () => {
+      // Block all messages except the first
+      await Router.setState(() => ({
+        messages: [{id: "foo", campaign: "foocampaign"}, {id: "bar"}],
+        messageBlockList: ["foocampaign"],
+      }));
+      const targetStub = {sendAsyncMessage: sandbox.stub()};
+
+      await Router.sendNextMessage(targetStub);
+
+      assert.calledOnce(targetStub.sendAsyncMessage);
+      assert.equal(Router.state.lastMessageId, "bar");
+    });
     it("should not return a message from a blocked provider", async () => {
       // There are only two providers; block the FAKE_LOCAL_PROVIDER, leaving
       // only FAKE_REMOTE_PROVIDER unblocked, which provides only one message
@@ -552,6 +565,19 @@ describe("ASRouter", () => {
         assert.isTrue(Router.state.messageBlockList.includes("foo"));
         assert.calledWith(channel.sendAsyncMessage, PARENT_TO_CHILD_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "foo"}});
       });
+      it("should add the campaign to the messageBlockList instead of id if .campaign is specified and not select messages of that campaign again", async () => {
+        await Router.setState({
+          messages: [
+            {id: "1", campaign: "foocampaign"},
+            {id: "2", campaign: "foocampaign"},
+          ],
+        });
+        const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "1"}});
+        await Router.onMessage(msg);
+
+        assert.isTrue(Router.state.messageBlockList.includes("foocampaign"));
+        assert.isEmpty(Router._getUnblockedMessages());
+      });
       it("should not broadcast CLEAR_MESSAGE if preventDismiss is true", async () => {
         const msg = fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "foo", preventDismiss: true}});
         await Router.onMessage(msg);
@@ -601,6 +627,14 @@ describe("ASRouter", () => {
         await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));
 
         assert.isFalse(Router.state.messageBlockList.includes("foo"));
+      });
+      it("should remove the campaign from the messageBlockList if it is defined", async () => {
+        await Router.setState({messages: [{id: "1", campaign: "foo"}]});
+        await Router.onMessage(fakeAsyncMessage({type: "BLOCK_MESSAGE_BY_ID", data: {id: "1"}}));
+        assert.isTrue(Router.state.messageBlockList.includes("foo"), "blocklist has campaign id");
+        await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "1"}}));
+
+        assert.isFalse(Router.state.messageBlockList.includes("foo"), "campaign id removed from blocklist");
       });
       it("should save the messageBlockList", async () => {
         await Router.onMessage(fakeAsyncMessage({type: "UNBLOCK_MESSAGE_BY_ID", data: {id: "foo"}}));


### PR DESCRIPTION
To test this: 

1. Open about:newtab#asrouter
2. Show snippets test provider messages
3. click "Show" next to `SIMPLE_TEST_1_SAME_CAMPAIGN`
4. On the actual snippet that appears, click the x to close/block the snippet
5. Ensure that BOTH `SIMPLE_TEST_1_SAME_CAMPAIGN` and `SIMPLE_TEST_1` are now blocked
6. Restart, ensure they are still blocked
7. Try unblocking one, ensure both are unblocked