### PR TITLE
Fix Bug 1504754 - Debug noscripts version of new tab page fail to load

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -152,10 +152,8 @@ function writeFiles(name, destPath, filesMap, {html, state}, options) {
 
 const STATIC_FILES = new Map([
   ["activity-stream-debug.html", ({options}) => templateHTML(options)],
-  ["activity-stream-debug-noscripts.html", ({options}) => templateHTML(Object.assign({}, options, {noscripts: true}))],
   ["activity-stream-initial-state.js", ({state}) => templateJs("gActivityStreamPrerenderedState", "static", state)],
   ["activity-stream-prerendered-debug.html", ({html, options}) => templateHTML(options, html)],
-  ["activity-stream-prerendered-debug-noscripts.html", ({html, options}) => templateHTML(Object.assign({}, options, {noscripts: true}), html)],
 ]);
 
 const LOCALIZED_FILES = new Map([

--- a/test/xpcshell/test_AboutNewTabService.js
+++ b/test/xpcshell/test_AboutNewTabService.js
@@ -42,9 +42,11 @@ function setExpectedUrlsWithScripts() {
 
 function setExpectedUrlsWithoutScripts() {
   ACTIVITY_STREAM_PRERENDER_URL = "resource://activity-stream/prerendered/en-US/activity-stream-prerendered-noscripts.html";
-  ACTIVITY_STREAM_PRERENDER_DEBUG_URL = "resource://activity-stream/prerendered/static/activity-stream-prerendered-debug-noscripts.html";
   ACTIVITY_STREAM_URL = "resource://activity-stream/prerendered/en-US/activity-stream-noscripts.html";
-  ACTIVITY_STREAM_DEBUG_URL = "resource://activity-stream/prerendered/static/activity-stream-debug-noscripts.html";
+
+  // Debug urls are the same as non-debug because debug scripts load dynamically
+  ACTIVITY_STREAM_PRERENDER_DEBUG_URL = ACTIVITY_STREAM_PRERENDER_URL;
+  ACTIVITY_STREAM_DEBUG_URL = ACTIVITY_STREAM_URL;
 }
 
 function nextChangeNotificationPromise(aNewURL, testMessage) {


### PR DESCRIPTION
r?@k88hudson Instead of packaging the file that was being built, don't bother building a -debug-noscripts.html because it's the same as -noscripts.html files that are already packaged and localized. Turns out the dynamic script loader already supports using -dev scripts, so we just needed to fix the url being loaded.

Eventually when privileged content process is the only way to load new tab, a bit of code can be simplified and cleaned up. But until then, we have the static debug with-scripts and dynamic debug no-scripts.