### PR TITLE
Fix Bug 1506592 - Broken image icon for empty sections

### DIFF
--- a/content-src/components/Sections/Sections.jsx
+++ b/content-src/components/Sections/Sections.jsx
@@ -235,8 +235,8 @@ export class Section extends React.PureComponent {
           <div className="section-empty-state">
             <div className="empty-state">
               {emptyState.icon && emptyState.icon.startsWith("moz-extension://") ?
-                <img className="empty-state-icon icon" style={{"background-image": `url('${emptyState.icon}')`}} /> :
-                <img className={`empty-state-icon icon icon-${emptyState.icon}`} />}
+                <span className="empty-state-icon icon" style={{"background-image": `url('${emptyState.icon}')`}} /> :
+                <span className={`empty-state-icon icon icon-${emptyState.icon}`} />}
               <p className="empty-state-message">
                 {getFormattedMessage(emptyState.message)}
               </p>


### PR DESCRIPTION
Changed these to be spans. We still want background-image property because we use `-moz-context-properties` to set the color.
Suggestion from https://bugzilla.mozilla.org/show_bug.cgi?id=1506592#c13

![screen shot 2018-11-14 at 12 38 56](https://user-images.githubusercontent.com/810040/48480416-44674f80-e802-11e8-9d15-c4b7e5f8cce4.png)
![screen shot 2018-11-14 at 12 39 22](https://user-images.githubusercontent.com/810040/48480417-44674f80-e802-11e8-9f94-2104698a1eda.png)

Before:

![screen shot 2018-11-14 at 12 43 55](https://user-images.githubusercontent.com/810040/48480513-990aca80-e802-11e8-8a41-c6d486f0b7eb.png)

