### PR TITLE
Fix Bug 1506600 - Show snippet title on a new line

### DIFF
--- a/content-src/asrouter/components/Button/_Button.scss
+++ b/content-src/asrouter/components/Button/_Button.scss
@@ -2,12 +2,12 @@
   font-weight: bold;
   white-space: nowrap;
   border-radius: 2px;
-  border: 1px solid var(--newtab-border-secondary-color);
-  background-color: var(--newtab-button-secondary-color);
+  border: 1px solid $grey-30;
+  background-color: $grey-10;
   font-family: inherit;
   padding: 8px 15px;
   margin-inline-start: 12px;
-  color: $grey-90-80;
+  color: inherit;
   cursor: pointer;
 
   .tall & {
@@ -21,9 +21,14 @@
   }
 
   &.secondary {
-    background: var(--newtab-button-secondary-color);
-    border: 1px solid var(--newtab-border-primary-color);
     font-size: 14px;
     font-weight: 600;
+  }
+}
+
+[lwt-newtab-brighttext] {
+  .ASRouterButton {
+    background-color: $grey-60;
+    border: 1px solid $grey-10-10;
   }
 }

--- a/content-src/asrouter/components/Button/_Button.scss
+++ b/content-src/asrouter/components/Button/_Button.scss
@@ -7,7 +7,7 @@
   font-family: inherit;
   padding: 8px 15px;
   margin-inline-start: 12px;
-  color: inherit;
+  color: $grey-90-80;
   cursor: pointer;
 
   .tall & {

--- a/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
+++ b/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
@@ -15,10 +15,13 @@
   a {
     cursor: pointer;
     color: var(--newtab-link-primary-color);
-    text-decoration: underline;
 
     [lwt-newtab-brighttext] & {
       font-weight: bold;
+    }
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 

--- a/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
+++ b/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
@@ -45,9 +45,9 @@
       padding-inline-end: $section-horizontal-padding;
     }
 
-    max-width: $wrapper-max-width-large;
+    max-width: $wrapper-max-width-large + ($section-horizontal-padding * 2);
     @media (min-width: $break-point-widest) {
-      max-width: $wrapper-max-width-widest;
+      max-width: $wrapper-max-width-widest + ($section-horizontal-padding * 2);
     }
   }
 

--- a/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -49,6 +49,7 @@
   }
 
   .title {
+    display: inline;
     font-size: inherit;
     margin: 0;
   }

--- a/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
+++ b/content-src/asrouter/templates/SimpleSnippet/_SimpleSnippet.scss
@@ -49,7 +49,6 @@
   }
 
   .title {
-    display: inline;
     font-size: inherit;
     margin: 0;
   }

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -9,13 +9,21 @@ export class SubmitFormSnippet extends React.PureComponent {
     super(props);
     this.expandSnippet = this.expandSnippet.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleSubmitAttempt = this.handleSubmitAttempt.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
     this.state = {
       expanded: false,
+      submitAttempted: false,
       signupSubmitted: false,
       signupSuccess: false,
       disableForm: false,
     };
+  }
+
+  handleSubmitAttempt() {
+    if (!this.state.submitAttempted) {
+      this.setState({submitAttempted: true});
+    }
   }
 
   async handleSubmit(event) {
@@ -137,7 +145,7 @@ export class SubmitFormSnippet extends React.PureComponent {
     return (<input
       ref="mainInput"
       type={this.props.inputType || "email"}
-      className="mainInput"
+      className={`mainInput${(this.state.submitAttempted ? "" : " clean")}`}
       name="email"
       required={true}
       placeholder={placholder}
@@ -160,7 +168,7 @@ export class SubmitFormSnippet extends React.PureComponent {
           {this.renderHiddenFormInputs()}
           <div>
             {this.renderInput()}
-            <button type="submit" className="ASRouterButton primary" ref="formSubmitBtn">{content.scene2_button_label}</button>
+            <button type="submit" className="ASRouterButton primary" onClick={this.handleSubmitAttempt} ref="formSubmitBtn">{content.scene2_button_label}</button>
           </div>
           {this.renderFormPrivacyNotice() || this.renderDisclaimer()}
         </form>

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -151,7 +151,7 @@ export class SubmitFormSnippet extends React.PureComponent {
     return (<SnippetBase {...this.props} className={containerClass} footerDismiss={true}>
         {content.scene2_icon ? <div className="scene2Icon"><img src={content.scene2_icon} /></div> : null}
         <div className="message">
-          {content.scene2_title ? <h3 className="scene2Title">{content.scene2_title}</h3> : null}
+          {content.scene2_title ? <h3 className="scene2Title">{`${content.scene2_title} `}</h3> : null}
           <p>
             <RichText scene2_text={content.scene2_text} localization_id="scene2_text" />
           </p>

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -151,9 +151,8 @@ export class SubmitFormSnippet extends React.PureComponent {
     return (<SnippetBase {...this.props} className={containerClass} footerDismiss={true}>
         {content.scene2_icon ? <div className="scene2Icon"><img src={content.scene2_icon} /></div> : null}
         <div className="message">
+          {content.scene2_title ? <h3 className="scene2Title">{content.scene2_title}</h3> : null}
           <p>
-            {content.scene2_title ? <h3 className="scene2Title">{content.scene2_title}</h3> : null}
-            {" "}
             <RichText scene2_text={content.scene2_text} localization_id="scene2_text" />
           </p>
         </div>

--- a/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
+++ b/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
@@ -10,6 +10,7 @@
 
   p {
     margin: 0;
+    display: inline;
   }
 
   &.send_to_device_snippet {
@@ -18,6 +19,14 @@
     .message {
       font-size: 16px;
       margin-bottom: 20px;
+    }
+
+    .scene2Title {
+      display: block;
+      font-size: 24px;
+      font-weight: 400;
+      text-align: center;
+      margin: 0 0 10px;
     }
   }
 
@@ -42,10 +51,9 @@
   }
 
   .scene2Title {
-    font-size: 24px;
-    margin: 0 0 10px;
-    font-weight: 400;
-    text-align: center;
+    display: inline;
+    font-size: inherit;
+    font-weight: bold;
   }
 
   form {

--- a/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
+++ b/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
@@ -113,6 +113,13 @@
       font-size: 14px;
       width: 50%;
 
+      &.clean {
+        &:invalid,
+        &:required {
+          box-shadow: none;
+        }
+      }
+
       &:focus {
         border: $input-border-active;
         box-shadow: var(--newtab-textbox-focus-boxshadow);

--- a/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
+++ b/content-src/asrouter/templates/SubmitFormSnippet/_SubmitFormSnippet.scss
@@ -42,10 +42,10 @@
   }
 
   .scene2Title {
-    font-size: inherit;
-    margin: 0;
-    font-weight: bold;
-    display: inline;
+    font-size: 24px;
+    margin: 0 0 10px;
+    font-weight: 400;
+    text-align: center;
   }
 
   form {


### PR DESCRIPTION
<img width="784" alt="grafik" src="https://user-images.githubusercontent.com/810040/48723222-f2696400-ec1d-11e8-9d1a-d1153874d4f1.png">

<img width="912" alt="grafik" src="https://user-images.githubusercontent.com/810040/48723758-65270f00-ec1f-11e8-9ab3-8f8e55dcdc11.png">

<img width="442" alt="grafik" src="https://user-images.githubusercontent.com/810040/48723620-0366a500-ec1f-11e8-9556-e46e40eb98e4.png">

Maybe update the message providers for simple snippets to show the difference between title and using a `b` or `strong` to reproduce the previous inline title?

The margin between scene2icon and scene2title is addressed in #4565 
