### PR TITLE
(nobug) package-lock update to https link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3035,7 +3035,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Small change that shows up on a new npm install (npm v.6.4.1)