### PR TITLE
Fix Bug 1509810 - Add missing defaults for snippet templates

### DIFF
--- a/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
+++ b/content-src/asrouter/components/SnippetBase/_SnippetBase.scss
@@ -31,8 +31,6 @@
   input {
     &[type='checkbox'] {
       margin-inline-start: 0;
-      height: 16px;
-      width: 16px;
     }
   }
 

--- a/content-src/asrouter/templates/EOYSnippet/EOYSnippet.jsx
+++ b/content-src/asrouter/templates/EOYSnippet/EOYSnippet.jsx
@@ -41,8 +41,14 @@ class EOYSnippetBase extends React.PureComponent {
       color: this.props.content.button_color,
       backgroundColor: this.props.content.button_background_color,
     };
+    const donationURLParams = [];
+    const paramsStartIndex = this.props.content.donation_form_url.indexOf("?");
+    for (const entry of new URLSearchParams(this.props.content.donation_form_url.slice(paramsStartIndex)).entries()) {
+      donationURLParams.push(entry);
+    }
 
     return (<form className="EOYSnippetForm" action={this.props.content.donation_form_url} method={this.props.form_method} onSubmit={this.handleSubmit} ref="form">
+      {donationURLParams.map(([key, value], idx) => <input type="hidden" name={key} value={value} key={idx} />)}
       {fieldNames.map((field, idx) => {
         const button_name = `donation_amount_${field}`;
         const amount = this.props.content[button_name];

--- a/content-src/asrouter/templates/EOYSnippet/_EOYSnippet.scss
+++ b/content-src/asrouter/templates/EOYSnippet/_EOYSnippet.scss
@@ -43,17 +43,6 @@
 
   .monthly-checkbox-container {
     width: 100%;
-
-    input {
-      &[type='checkbox'] {
-        width: 24px;
-        height: 24px;
-      }
-    }
-
-    label {
-      vertical-align: super;
-    }
   }
 
   .donation-form-url {

--- a/content-src/asrouter/templates/FXASignupSnippet/FXASignupSnippet.jsx
+++ b/content-src/asrouter/templates/FXASignupSnippet/FXASignupSnippet.jsx
@@ -10,6 +10,7 @@ export const FXASignupSnippet = props => {
     scene1_button_label: schema.properties.scene1_button_label.default,
     scene2_email_placeholder_text: schema.properties.scene2_email_placeholder_text.default,
     scene2_button_label: schema.properties.scene2_button_label.default,
+    scene2_dismiss_button_text: schema.properties.scene2_dismiss_button_text.default,
     ...props.content,
     hidden_inputs: {
       action: "email",

--- a/content-src/asrouter/templates/FXASignupSnippet/FXASignupSnippet.jsx
+++ b/content-src/asrouter/templates/FXASignupSnippet/FXASignupSnippet.jsx
@@ -6,7 +6,6 @@ export const FXASignupSnippet = props => {
   const userAgent = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
   const firefox_version = userAgent ? parseInt(userAgent[1], 10) : 0;
   const extendedContent = {
-    form_action: "https://accounts.firefox.com/",
     scene1_button_label: schema.properties.scene1_button_label.default,
     scene2_email_placeholder_text: schema.properties.scene2_email_placeholder_text.default,
     scene2_button_label: schema.properties.scene2_button_label.default,
@@ -28,5 +27,6 @@ export const FXASignupSnippet = props => {
   return (<SubmitFormSnippet
     {...props}
     content={extendedContent}
+    form_action={"https://accounts.firefox.com/"}
     form_method="GET" />);
 };

--- a/content-src/asrouter/templates/FXASignupSnippet/FXASignupSnippet.schema.json
+++ b/content-src/asrouter/templates/FXASignupSnippet/FXASignupSnippet.schema.json
@@ -87,7 +87,7 @@
           "enum": ["sync"]
         },
         "utm_content": {
-          "type": "string",
+          "type": "number",
           "description": "Firefox version number"
         },
         "utm_source": {

--- a/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
+++ b/content-src/asrouter/templates/NewsletterSnippet/NewsletterSnippet.jsx
@@ -8,6 +8,7 @@ export const NewsletterSnippet = props => {
     scene2_email_placeholder_text: schema.properties.scene2_email_placeholder_text.default,
     scene2_button_label: schema.properties.scene2_button_label.default,
     scene2_dismiss_button_text: schema.properties.scene2_dismiss_button_text.default,
+    scene2_newsletter: schema.properties.scene2_newsletter.default,
     ...props.content,
     hidden_inputs: {
       newsletters: props.content.scene2_newsletter || schema.properties.scene2_newsletter.default,

--- a/content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet.schema.json
+++ b/content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet.schema.json
@@ -65,11 +65,6 @@
       "type": "string",
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
     },
-    "scene2_email_placeholder_text": {
-      "type": "string",
-      "description": "Value to show while input is empty.",
-      "default": "Your email here"
-    },
     "scene2_button_label": {
       "type": "string",
       "description": "Label for form submit button",

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -78,6 +78,7 @@ const MESSAGES = () => ([
       "scene1_button_color": "#712b00",
       "scene1_button_background_color": "#ff9400",
       "scene2_title": "Let's do this!",
+      "locale": "en-CA",
       "scene2_dismiss_button_text": "Dismiss",
       "scene2_text": "Sign up for the Mozilla newsletter and we will keep you updated on how you can help.",
       "scene2_privacy_html": "I'm okay with Mozilla handling my info as explained in this <privacyLink>Privacy Notice</privacyLink>.",
@@ -129,7 +130,6 @@ const MESSAGES = () => ([
       "scene2_email_placeholder_text": "Your email",
       "scene2_button_label": "Continue",
       "scene2_dismiss_button_text": "Dismiss",
-      "form_action": "https://basket.mozilla.org/subscribe.json",
     },
   },
   {

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -180,7 +180,7 @@ const MESSAGES = () => ([
       "donation_amount_second": 25,
       "donation_amount_third": 10,
       "donation_amount_fourth": 5,
-      "donation_form_url": "https://donate.mozilla.org",
+      "donation_form_url": "https://donate.mozilla.org/pl/?utm_source=desktop-snippet&amp;utm_medium=snippet&amp;utm_campaign=donate&amp;utm_term=7556",
       "text": "Big corporations want to restrict how we access the web. Fake news is making it harder for us to find the truth. Online bullies are silencing inspired voices. The <em>not-for-profit Mozilla Foundation</em> fights for a healthy internet with programs like our Tech Policy Fellowships and Internet Health Report; <b>will you donate today</b>?",
     },
   },

--- a/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
+++ b/test/unit/asrouter/templates/NewsletterSnippet.test.jsx
@@ -37,5 +37,36 @@ describe("NewsletterSnippet", () => {
       wrapper.find(".ASRouterButton").simulate("click");
       assert.equal(wrapper.find(".mainInput").instance().type, "email");
     });
+
+    it("should have all of the default fields", () => {
+      const defaults = {
+        id: "foo123",
+        content: {},
+        onBlock() {},
+        onDismiss: sandbox.stub(),
+        sendUserActionTelemetry: sandbox.stub(),
+        onAction: sandbox.stub(),
+      };
+      const wrapper = mount(<NewsletterSnippet {...defaults} />);
+      // SendToDeviceSnippet is a wrapper around SubmitFormSnippet
+      const {props} = wrapper.children().get(0);
+
+      // the `locale` properties gets used as part of hidden_fields so we
+      // check for it separately
+      const properties = {...schema.properties};
+      const {locale} = properties;
+      delete properties.locale;
+
+      const defaultProperties = Object.keys(properties)
+        .filter(prop => properties[prop].default);
+      assert.lengthOf(defaultProperties, 5);
+      defaultProperties.forEach(prop => assert.propertyVal(props.content, prop, properties[prop].default));
+
+      const defaultHiddenProperties = Object.keys(schema.properties.hidden_inputs.properties)
+        .filter(prop => schema.properties.hidden_inputs.properties[prop].default);
+      assert.lengthOf(defaultHiddenProperties, 1);
+      defaultHiddenProperties.forEach(prop => assert.propertyVal(props.content.hidden_inputs, prop, schema.properties.hidden_inputs.properties[prop].default));
+      assert.propertyVal(props.content.hidden_inputs, "lang", locale.default);
+    });
   });
 });

--- a/test/unit/asrouter/templates/SendToDeviceSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SendToDeviceSnippet.test.jsx
@@ -1,6 +1,6 @@
 import {mount} from "enzyme";
 import React from "react";
-import schema from "content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json";
+import schema from "content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet.schema.json";
 import {SendToDeviceSnippet} from "content-src/asrouter/templates/SendToDeviceSnippet/SendToDeviceSnippet";
 import {SnippetsTestMessageProvider} from "lib/SnippetsTestMessageProvider.jsm";
 
@@ -72,14 +72,14 @@ describe("SendToDeviceSnippet", () => {
     // SendToDeviceSnippet is a wrapper around SubmitFormSnippet
     const {props} = wrapper.children().get(0);
 
-    assert.propertyVal(props.content, "scene1_button_label", "Learn more");
-    assert.propertyVal(props.content, "scene2_dismiss_button_text", "Dismiss");
-    assert.propertyVal(props.content, "scene2_button_label", "Send");
-    assert.propertyVal(props.content, "scene2_input_placeholder", "Your email here");
-    assert.propertyVal(props.content, "locale", "en-US");
-    assert.propertyVal(props.content, "country", "us");
-    assert.propertyVal(props.content, "include_sms", false);
-    assert.propertyVal(props.content, "message_id_email", "");
+    const defaultProperties = Object.keys(schema.properties)
+      .filter(prop => schema.properties[prop].default);
+    assert.lengthOf(defaultProperties, 6);
+    defaultProperties.forEach(prop => assert.propertyVal(props.content, prop, schema.properties[prop].default));
+
+    const defaultHiddenProperties = Object.keys(schema.properties.hidden_inputs.properties)
+      .filter(prop => schema.properties.hidden_inputs.properties[prop].default);
+    assert.lengthOf(defaultHiddenProperties, 0);
   });
 
   describe("form input", () => {


### PR DESCRIPTION
This addresses 1509810 and 1509851.

I also updated the tests to create assertions out of every schema property with a `default` field so that we don't miss them anymore. Meanwhile I found some minor inconsistencies which I also updated.

Regarding `donation_form_url` it looks like setting `form_action` to a URL with GET parameters will drop those parameters on form submit. Workaround was to convert those parameters to `input[type=hidden]`. This needs an update on the snippets side: the url needs to contain a `?` so we know where the paramters begin in the url. This doesn't seem to be an issue and support in the legacy implementation as well https://github.com/mozmeao/snippets/blob/94b18ab63703ad339b24db206e065061aaf0b30f/activity-stream/mofo-eoy-2017.html#L293 cc @glogiotatidis 