### PR TITLE
Fix Bug 1509755 - Wait for browser initialization to finish before adding CFR trigger listeners

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -430,7 +430,7 @@ class _ASRouter {
       const unseenListeners = new Set(ASRouterTriggerListeners.keys());
       for (const {trigger} of newState.messages) {
         if (trigger && ASRouterTriggerListeners.has(trigger.id)) {
-          ASRouterTriggerListeners.get(trigger.id).init(this._triggerHandler, trigger.params);
+          await ASRouterTriggerListeners.get(trigger.id).init(this._triggerHandler, trigger.params);
           unseenListeners.delete(trigger.id);
         }
       }

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -24,6 +24,10 @@ this.ASRouterTriggerListeners = new Map([
     _triggerHandler: null,
     _hosts: null,
 
+    /**
+     * Wait for browser startup to finish to avoid accessing uninitialized
+     * properties
+     */
     async _checkStartupFinished(win) {
       if (!win.gBrowserInit.delayedStartupFinished) {
         await new Promise(resolve => {

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -24,11 +24,24 @@ this.ASRouterTriggerListeners = new Map([
     _triggerHandler: null,
     _hosts: null,
 
+    async _checkStartupFinished(win) {
+      if (!win.gBrowserInit.delayedStartupFinished) {
+        await new Promise(resolve => {
+          let delayedStartupObserver = () => {
+            Services.obs.removeObserver(delayedStartupObserver, "browser-delayed-startup-finished");
+            resolve();
+          };
+
+          Services.obs.addObserver(delayedStartupObserver, "browser-delayed-startup-finished");
+        });
+      }
+    },
+
     /*
      * If the listener is already initialised, `init` will replace the trigger
      * handler and add any new hosts to `this._hosts`.
      */
-    init(triggerHandler, hosts = []) {
+    async init(triggerHandler, hosts = []) {
       if (!this._initialized) {
         this.onLocationChange = this.onLocationChange.bind(this);
 
@@ -40,6 +53,7 @@ this.ASRouterTriggerListeners = new Map([
           if (win.closed || PrivateBrowsingUtils.isWindowPrivate(win)) {
             continue;
           }
+          await this._checkStartupFinished(win);
           win.gBrowser.addTabsProgressListener(this);
         }
 

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -31,9 +31,11 @@ this.ASRouterTriggerListeners = new Map([
     async _checkStartupFinished(win) {
       if (!win.gBrowserInit.delayedStartupFinished) {
         await new Promise(resolve => {
-          let delayedStartupObserver = () => {
-            Services.obs.removeObserver(delayedStartupObserver, "browser-delayed-startup-finished");
-            resolve();
+          let delayedStartupObserver = (subject, topic) => {
+            if (topic === "browser-delayed-startup-finished" && subject === win) {
+              Services.obs.removeObserver(delayedStartupObserver, "browser-delayed-startup-finished");
+              resolve();
+            }
           };
 
           Services.obs.addObserver(delayedStartupObserver, "browser-delayed-startup-finished");

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -135,6 +135,9 @@ describe("ASRouterTriggerListeners", () => {
         existingWindow.gBrowserInit.delayedStartupFinished = false;
         sandbox.stub(global.Services.obs, "addObserver").callsFake(fn => fn());
       });
+      afterEach(() => {
+        openURLListener.uninit();
+      });
 
       it("should wait for startup and then add the tabs listener", async () => {
         await openURLListener.init(triggerHandler, hosts);

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -20,7 +20,7 @@ describe("ASRouterTriggerListeners", () => {
     sandbox = sinon.createSandbox();
     registerWindowNotificationStub = sandbox.stub(global.Services.ww, "registerNotification");
     unregisterWindoNotificationStub = sandbox.stub(global.Services.ww, "unregisterNotification");
-    existingWindow = {gBrowser: {addTabsProgressListener: sandbox.stub(), removeTabsProgressListener: sandbox.stub()}};
+    existingWindow = {gBrowser: {addTabsProgressListener: sandbox.stub(), removeTabsProgressListener: sandbox.stub()}, gBrowserInit: {delayedStartupFinished: true}};
     windowEnumeratorStub = sandbox.stub(global.Services.wm, "getEnumerator");
     resetEnumeratorStub([existingWindow]);
     sandbox.spy(openURLListener, "init");
@@ -37,8 +37,8 @@ describe("ASRouterTriggerListeners", () => {
     });
 
     describe("#init", () => {
-      beforeEach(() => {
-        openURLListener.init(triggerHandler, hosts);
+      beforeEach(async () => {
+        await openURLListener.init(triggerHandler, hosts);
       });
       afterEach(() => {
         openURLListener.uninit();
@@ -77,8 +77,8 @@ describe("ASRouterTriggerListeners", () => {
     });
 
     describe("#uninit", () => {
-      beforeEach(() => {
-        openURLListener.init(triggerHandler, hosts);
+      beforeEach(async () => {
+        await openURLListener.init(triggerHandler, hosts);
         // Ensure that the window enumerator will return the existing window for uninit as well
         resetEnumeratorStub([existingWindow]);
         openURLListener.uninit();
@@ -113,9 +113,13 @@ describe("ASRouterTriggerListeners", () => {
     });
 
     describe("#onLocationChange", () => {
-      it("should call the ._triggerHandler with the right arguments", () => {
+      afterEach(() => {
+        openURLListener.uninit();
+      });
+
+      it("should call the ._triggerHandler with the right arguments", async () => {
         const newTriggerHandler = sinon.stub();
-        openURLListener.init(newTriggerHandler, hosts);
+        await openURLListener.init(newTriggerHandler, hosts);
 
         const browser = {};
         const webProgress = {isTopLevel: true};
@@ -123,6 +127,19 @@ describe("ASRouterTriggerListeners", () => {
         openURLListener.onLocationChange(browser, webProgress, undefined, {spec: location});
         assert.calledOnce(newTriggerHandler);
         assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
+      });
+    });
+
+    describe("delayed startup finished", () => {
+      beforeEach(() => {
+        existingWindow.gBrowserInit.delayedStartupFinished = false;
+        sandbox.stub(global.Services.obs, "addObserver").callsFake(fn => fn());
+      });
+
+      it("should wait for startup and then add the tabs listener", async () => {
+        await openURLListener.init(triggerHandler, hosts);
+
+        assert.calledOnce(existingWindow.gBrowser.addTabsProgressListener);
       });
     });
   });

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -133,7 +133,7 @@ describe("ASRouterTriggerListeners", () => {
     describe("delayed startup finished", () => {
       beforeEach(() => {
         existingWindow.gBrowserInit.delayedStartupFinished = false;
-        sandbox.stub(global.Services.obs, "addObserver").callsFake(fn => fn());
+        sandbox.stub(global.Services.obs, "addObserver").callsFake(fn => fn(existingWindow, "browser-delayed-startup-finished"));
       });
       afterEach(() => {
         openURLListener.uninit();


### PR DESCRIPTION
This should help us ensure we're not trying to add that listener too early in the startup process. 

I have a try run https://treeherder.mozilla.org/#/jobs?repo=try&revision=942859ad6573d7f6c7e203a8004685de685f0f8c&selectedJob=213978989 that shows a failure linking to the same issue but I think it's missclassified.
Checking the failure logs shows
```
TEST-UNEXPECTED-FAIL | browser/base/content/test/plugins/browser_CTP_drag_drop.js | leaked 1 window(s) until shutdown [url = http://127.0.0.1:8888/browser/browser/base/content/test/plugins/plugin_test.html]
```
This does not correspond to the failures associated with this bug(s) it should specifically mention `win.gBrowser is undefined;`