### PR TITLE
Fix Bug 1511165 - about:welcome addon card on windows says "addon name"

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -808,14 +808,6 @@ class _ASRouter {
       message = await this._findMessage(msgs, trigger);
     }
 
-    if (message && message.template === "return_to_amo_overlay") {
-      // If we failed to get this info, we do not want to show this message
-      if (!message.content.primary_button.action.data.url ||
-          !message.content.addon_icon) {
-        return;
-      }
-    }
-
     if (previewMsgs.length) {
       // We don't want to cache preview messages, remove them after we selected the message to show
       await this.setState(state => ({

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -44,8 +44,6 @@ const MAX_MESSAGE_LIFETIME_CAP = 100;
 const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider, CFRMessageProvider, SnippetsTestMessageProvider};
 const STARTPAGE_VERSION = "6";
 
-const ADDONS_API_URL = "https://services.addons.mozilla.org/api/v3/addons/addon";
-
 const MessageLoaderUtils = {
   STARTPAGE_VERSION,
   REMOTE_LOADER_CACHE_KEY: "RemoteLoaderCache",
@@ -799,25 +797,6 @@ class _ASRouter {
     return impressions;
   }
 
-  async _fetchAddonInfo() {
-    let data = {};
-    const {content} = await AttributionCode.getAttrDataAsync();
-    if (!content) {
-      return data;
-    }
-    try {
-      const response = await fetch(`${ADDONS_API_URL}/${content}`);
-      if (response.status !== 204 && response.ok) {
-        const json = await response.json();
-        data.url = json.current_version.files[0].url;
-        data.iconURL = json.icon_url;
-      }
-    } catch (e) {
-      Cu.reportError("Failed to get the latest add-on version for Return to AMO");
-    }
-    return data;
-  }
-
   async sendNextMessage(target, trigger) {
     const msgs = this._getUnblockedMessages();
     let message = null;
@@ -829,17 +808,12 @@ class _ASRouter {
       message = await this._findMessage(msgs, trigger);
     }
 
-    // We need some addon info if we are showing return to amo overlay, so fetch
-    // that, and update the message accordingly
     if (message && message.template === "return_to_amo_overlay") {
-      const {url, iconURL} = await this._fetchAddonInfo();
-
       // If we failed to get this info, we do not want to show this message
-      if (!url || !iconURL) {
+      if (!message.content.primary_button.action.data.url ||
+          !message.content.addon_icon) {
         return;
       }
-      message.content.addon_icon = iconURL;
-      message.content.primary_button.action.data.url = url;
     }
 
     if (previewMsgs.length) {

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -26,12 +26,16 @@ async function getAddonInfo() {
       }
     }
     const [addon] = await AddonRepository.getAddonsByIDs([content]);
+    if (addon.sourceURI.scheme !== "https") {
+      return null;
+    }
     return {
       name: addon.name,
       url: addon.sourceURI.spec,
       iconURL: addon.icons["64"] || addon.icons["32"],
     };
   } catch (e) {
+    Cu.reportError("Failed to get the latest add-on version for Return to AMO");
     return null;
   }
 }

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -29,7 +29,7 @@ async function getAddonInfo() {
     return {
       name: addon.name,
       url: addon.sourceURI.spec,
-      iconURL: addon.icons["64"],
+      iconURL: addon.icons["64"] || addon.icons["32"],
     };
   } catch (e) {
     return null;

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -200,13 +200,20 @@ const OnboardingMessageProvider = {
       // We need some addon info if we are showing return to amo overlay, so fetch
       // that, and update the message accordingly
       if (msg.template === "return_to_amo_overlay") {
-        const addonInfo = await getAddonInfo();
-        if (!addonInfo) {
+        try {
+          const {name, iconURL, url} = await getAddonInfo();
+          // If we do not have all the data from the AMO api to indicate to the user
+          // what they are installing we don't want to show the message
+          if (!name || !iconURL || !url) {
+            continue;
+          }
+
+          msg.content.text.args["addon-name"] = name;
+          msg.content.addon_icon = iconURL;
+          msg.content.primary_button.action.data.url = url;
+        } catch (e) {
           continue;
         }
-        msg.content.text.args["addon-name"] = addonInfo.name;
-        msg.content.addon_icon = addonInfo.iconURL;
-        msg.content.primary_button.action.data.url = addonInfo.url;
       }
 
       const [primary_button_string, title_string, text_string] = await L10N.formatMessages([

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -150,14 +150,14 @@ const ONBOARDING_MESSAGES = async () => ([
     content: {
       header: {string_id: "onboarding-welcome-header"},
       title: {string_id: "return-to-amo-sub-header"},
-      addon_icon: null, // to be dynamically filled in, in ASRouter.jsm
+      addon_icon: null,
       icon: "gift-extension",
       text: {string_id: "return-to-amo-addon-header", args: {"addon-name": null}},
       primary_button: {
         label: {string_id: "return-to-amo-extension-button"},
         action: {
           type: "INSTALL_ADDON_FROM_URL",
-          data: {url: null}, // to be dynamically filled in, in ASRouter.jsm
+          data: {url: null},
         },
       },
       secondary_button: {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -797,15 +797,6 @@ describe("ASRouter", () => {
       it("should have previousSessionEnd in the message context", () => {
         assert.propertyVal(Router._getMessagesContext(), "previousSessionEnd", 100);
       });
-      it("should return early and not send a message if we failed to get addon info for return to amo template", async () => {
-        let message = [
-          {id: "foo1", template: "return_to_amo_overlay", trigger: {id: "foo"}, content: {addon_icon: null, primary_button: {action: {data: {url: null}}}, title: "Foo1", body: "Foo123-1"}},
-        ];
-        await Router.setState({messages: message});
-        sandbox.spy(Router, "_sendMessageToTarget");
-        await Router.sendNextMessage({sendAsyncMessage: sandbox.stub()}, {id: "foo"});
-        assert.notCalled(Router._sendMessageToTarget);
-      });
     });
 
     describe("#onMessage: OVERRIDE_MESSAGE", () => {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -797,57 +797,14 @@ describe("ASRouter", () => {
       it("should have previousSessionEnd in the message context", () => {
         assert.propertyVal(Router._getMessagesContext(), "previousSessionEnd", 100);
       });
-      it("should update parameters of the message if the template is return to amo", async () => {
-        let message = [
-          {id: "foo1", template: "return_to_amo_overlay", trigger: {id: "foo"}, content: {addon_icon: null, primary_button: {action: {data: {url: null}}}, title: "Foo1", body: "Foo123-1"}},
-        ];
-        await Router.setState({messages: message});
-        sandbox.stub(Router, "_fetchAddonInfo").returns({url: "foo.com", iconURL: "url/foo.ico"});
-        await Router.sendNextMessage({sendAsyncMessage: sandbox.stub()}, {id: "foo"});
-        const msg = await Router._findMessage(message, {id: "foo"});
-        assert.calledOnce(Router._fetchAddonInfo);
-        assert.equal(msg.content.addon_icon, message[0].content.addon_icon);
-        assert.equal(msg.content.primary_button.action.data.url, message[0].content.primary_button.action.data.url);
-      });
       it("should return early and not send a message if we failed to get addon info for return to amo template", async () => {
         let message = [
           {id: "foo1", template: "return_to_amo_overlay", trigger: {id: "foo"}, content: {addon_icon: null, primary_button: {action: {data: {url: null}}}, title: "Foo1", body: "Foo123-1"}},
         ];
         await Router.setState({messages: message});
-        sandbox.stub(Router, "_fetchAddonInfo").returns({});
         sandbox.spy(Router, "_sendMessageToTarget");
         await Router.sendNextMessage({sendAsyncMessage: sandbox.stub()}, {id: "foo"});
-        assert.calledOnce(Router._fetchAddonInfo);
         assert.notCalled(Router._sendMessageToTarget);
-      });
-    });
-
-    describe("#_fetchAddonInfo", () => {
-      it("should fetch the addon url and the icon for the addon", async () => {
-        fetchStub
-          .withArgs("https://services.addons.mozilla.org/api/v3/addons/addon/addonID")
-          .resolves({ok: true, status: 200, json: () => Promise.resolve({icon_url: "url/foo.ico", current_version: {files: [{url: "foo.com"}]}})});
-        const {url, iconURL} = await Router._fetchAddonInfo();
-        assert.equal(url, "foo.com");
-        assert.equal(iconURL, "url/foo.ico");
-      });
-      it("should return empty object if AttributionCode doesn't return anything", async () => {
-        fakeAttributionCode.getAttrDataAsync = () => (Promise.resolve({content: null}));
-        fetchStub
-          .withArgs("https://services.addons.mozilla.org/api/v3/addons/addon/addonID")
-          .resolves({ok: true, status: 200, json: () => Promise.resolve({icon_url: "url/foo.ico", current_version: {files: [{url: "foo.com"}]}})});
-        const data = await Router._fetchAddonInfo();
-        assert.deepEqual(data, {});
-      });
-      it("should throw if we failed to get the addon version", async () => {
-        fetchStub
-          .withArgs("https://services.addons.mozilla.org/api/v3/addons/addon/addonID")
-          .rejects();
-        sandbox.stub(Cu, "reportError");
-        const data = await Router._fetchAddonInfo();
-
-        assert.calledOnce(Cu.reportError);
-        assert.deepEqual(data, {});
       });
     });
 

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -121,8 +121,10 @@ describe("OnboardingMessage", () => {
     globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
     globals.set("AddonRepository", {getAddonsByIDs: sandbox.stub().rejects()});
 
-    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const msgs = await OnboardingMessageProvider.getUntranslatedMessages();
     const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
-    assert.lengthOf(translatedMessages, 0);
+    const returnToAMOMsgs = translatedMessages.filter(({id}) => id === "RETURN_TO_AMO_1");
+    assert.lengthOf(translatedMessages, msgs.length - 1);
+    assert.lengthOf(returnToAMOMsgs, 0);
   });
 });

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -84,8 +84,8 @@ describe("OnboardingMessage", () => {
   });
   it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
     const fakeContent = "foo%bar.org";
-    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo"}, icons: {64: null}}]});
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo", scheme: "https"}, icons: {64: null}}]});
 
     const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
     const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
@@ -93,8 +93,8 @@ describe("OnboardingMessage", () => {
   });
   it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
     const fakeContent = "foo%bar.org";
-    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: null}, icons: {64: "icon"}}]});
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: null, scheme: "https"}, icons: {64: "icon"}}]});
 
     const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
     const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
@@ -102,8 +102,17 @@ describe("OnboardingMessage", () => {
   });
   it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
     const fakeContent = "foo%bar.org";
-    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: null, sourceURI: {spec: "foo"}, icons: {64: "icon"}}]});
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: null, sourceURI: {spec: "foo", scheme: "https"}, icons: {64: "icon"}}]});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.lengthOf(translatedMessages, 0);
+  });
+  it("should skip return_to_amo_overlay if addon scheme is not https", async () => {
+    const fakeContent = "foo%bar.org";
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo", scheme: "http"}, icons: {64: "icon"}}]});
 
     const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
     const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -32,6 +32,7 @@ describe("OnboardingMessage", () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
     globals.set("FxAccountsConfig", {promiseEmailFirstURI: sandbox.stub().resolves("some/url")});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo"}, icons: {64: "icon"}}]});
   });
   afterEach(() => {
     sandbox.restore();
@@ -51,25 +52,50 @@ describe("OnboardingMessage", () => {
   it("should decode the content field (double decoding)", async () => {
     const fakeContent = "foo%2540bar.org";
     globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content}]});
 
-    const [returnToAMOMsg] = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
-    assert.propertyVal(returnToAMOMsg.content.text.args, "addon-name", "foo@bar.org");
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const [translatedMessage] = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.propertyVal(translatedMessage.content.text.args, "addon-name", "foo@bar.org");
   });
   it("should catch any decoding exceptions", async () => {
     const fakeContent = "foo%bar.org";
     globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content}]});
 
-    const [returnToAMOMsg] = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
-    assert.propertyVal(returnToAMOMsg.content.text.args, "addon-name", fakeContent);
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const [translatedMessage] = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.propertyVal(translatedMessage.content.text.args, "addon-name", fakeContent);
   });
   it("should ignore attribution from sources other than mozilla.org", async () => {
     const fakeContent = "foo%bar.org";
     globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.allizom.org"})});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content}]});
 
     const [returnToAMOMsg] = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
     assert.propertyVal(returnToAMOMsg.content.text.args, "addon-name", null);
+  });
+  it("should correctly add all addon information to the message after translation", async () => {
+    const fakeContent = "foo%2540bar.org";
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent, source: "addons.mozilla.org"})});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const [translatedMessage] = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.propertyVal(translatedMessage.content.text.args, "addon-name", "foo@bar.org");
+    assert.propertyVal(translatedMessage.content, "addon_icon", "icon");
+    assert.propertyVal(translatedMessage.content.primary_button.action.data, "url", "foo");
+  });
+  it("should skip return_to_amo_overlay if getAddonInfo fails", async () => {
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().rejects()});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.lengthOf(translatedMessages, 0);
+  });
+  it("should catch any exceptions fetching the addon information", async () => {
+    const fakeContent = "foo%bar.org";
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
+    globals.set("AddonRepository", {getAddonsByIDs: sandbox.stub().rejects()});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.lengthOf(translatedMessages, 0);
   });
 });

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -32,7 +32,7 @@ describe("OnboardingMessage", () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
     globals.set("FxAccountsConfig", {promiseEmailFirstURI: sandbox.stub().resolves("some/url")});
-    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo"}, icons: {64: "icon"}}]});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo", scheme: "https"}, icons: {64: "icon"}}]});
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -82,6 +82,33 @@ describe("OnboardingMessage", () => {
     assert.propertyVal(translatedMessage.content, "addon_icon", "icon");
     assert.propertyVal(translatedMessage.content.primary_button.action.data, "url", "foo");
   });
+  it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
+    const fakeContent = "foo%bar.org";
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: "foo"}, icons: {64: null}}]});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.lengthOf(translatedMessages, 0);
+  });
+  it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
+    const fakeContent = "foo%bar.org";
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: content, sourceURI: {spec: null}, icons: {64: "icon"}}]});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.lengthOf(translatedMessages, 0);
+  });
+  it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
+    const fakeContent = "foo%bar.org";
+    globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().resolves({content: fakeContent})});
+    globals.set("AddonRepository", {getAddonsByIDs: ([content]) => [{name: null, sourceURI: {spec: "foo"}, icons: {64: "icon"}}]});
+
+    const msgs = (await OnboardingMessageProvider.getUntranslatedMessages()).filter(({id}) => id === "RETURN_TO_AMO_1");
+    const translatedMessages = await OnboardingMessageProvider.translateMessages(msgs);
+    assert.lengthOf(translatedMessages, 0);
+  });
   it("should skip return_to_amo_overlay if getAddonInfo fails", async () => {
     globals.set("AttributionCode", {getAttrDataAsync: sandbox.stub().rejects()});
 

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -265,7 +265,11 @@ const TEST_GLOBAL = {
       on() {},
     };
   },
-  Localization: class {},
+  Localization: class {
+    async formatMessages(stringsIds) {
+      return Promise.resolve(stringsIds.map(({id, args}) => ({value: {string_id: id, args}})));
+    }
+  },
 };
 overrider.set(TEST_GLOBAL);
 


### PR DESCRIPTION
In order to test this go to `about:newtab#asrouter` and use the force attribution button at the button of the page. After that navigate to `about:welcome` and you should get the onboarding message that prompts you to install the addon. You can change it to test with a different addon: you can use the following value for the `content` field (again on the `about:newtab#asrouter` page) `jid1-MnnxcxisBPnSXQ@jetpack` and this should force Privacy Badger as a message.

Requires #4587 to land first.

