### PR TITLE
Fix Bug 1514890 - Change installation source for addons installed from ActivityStream

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -220,9 +220,8 @@ const MessageLoaderUtils = {
       const aUri = Services.io.newURI(url);
       const systemPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
 
-      // AddonManager installation source associated to the addons installed from activitystream
-      // (See Bug 1496167 for a rationale).
-      const amTelemetryInfo = {source: "activitystream"};
+      // AddonManager installation source associated to the addons installed from activitystream's CFR
+      const amTelemetryInfo = {source: "amo"};
       const install = await AddonManager.getInstallForURL(aUri.spec, "application/x-xpinstall", null,
                                                           null, null, null, null, amTelemetryInfo);
       await AddonManager.installAddonFromWebpage("application/x-xpinstall", browser,

--- a/test/unit/asrouter/MessageLoaderUtils.test.js
+++ b/test/unit/asrouter/MessageLoaderUtils.test.js
@@ -256,7 +256,7 @@ describe("MessageLoaderUtils", () => {
       // Verify that the expected installation source has been passed to the getInstallForURL
       // method (See Bug 1496167 for a rationale).
       assert.calledWithExactly(getInstallStub, "foo.com", "application/x-xpinstall", null,
-                               null, null, null, null, {source: "activitystream"});
+                               null, null, null, null, {source: "amo"});
     });
     it("should not call the Addons API on invalid URLs", async () => {
       sandbox.stub(global.Services.scriptSecurityManager, "getSystemPrincipal").throws();


### PR DESCRIPTION
This PR is a follow up related to the changes previously applied in #4467, per Bug 1514890 we would like to change the installation source associated to addons installed from ActivityStream.