### PR TITLE
Fix Bug 1517327 - Search telemetry failures not caught by taskcluster

### DIFF
--- a/mochitest.sh
+++ b/mochitest.sh
@@ -18,11 +18,14 @@ cd /mozilla-central && ./mach build \
   && ./mach test browser/components/newtab/test/browser --headless \
   && ./mach test browser/components/newtab/test/xpcshell \
   && ./mach test --log-tbpl test_run_log \
-  browser_parsable_css \
-  browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
-  browser/components/preferences/in-content/tests/browser_newtab_menu.js \
-  browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
-  browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js \
+    browser/base/content/test/about/browser_aboutHome_search_telemetry.js \
+    browser/base/content/test/static/browser_parsable_css.js \
+    browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
+    browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
+    browser/components/preferences/in-content/tests/browser_newtab_menu.js \
+    browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js \
+    browser/components/search/test/browser/browser_google_behavior.js \
+    browser/modules/test/browser/browser_UsageTelemetry_content.js \
   && ! grep -q TEST-UNEXPECTED test_run_log \
   && ! ./mach test all_files_referenced | grep activity-stream \
   && RUN_FIND_DUPES=1 ./mach package


### PR DESCRIPTION
Directly fixing test failures (turning off `handoffToAwesomebar` pref in `browser.ini`s) as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1516272 export, so probably don't want to merge this yet…