### PR TITLE
Fix Bug 1515026 - Send telemetry ping for dismiss events

### DIFF
--- a/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
+++ b/content-src/asrouter/components/SnippetBase/SnippetBase.jsx
@@ -5,6 +5,7 @@ export class SnippetBase extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onBlockClicked = this.onBlockClicked.bind(this);
+    this.onDismissClicked = this.onDismissClicked.bind(this);
   }
 
   onBlockClicked() {
@@ -15,6 +16,14 @@ export class SnippetBase extends React.PureComponent {
     this.props.onBlock();
   }
 
+  onDismissClicked() {
+    if (this.props.provider !== "preview") {
+      this.props.sendUserActionTelemetry({event: "DISMISS", id: this.props.UISurface});
+    }
+
+    this.props.onDismiss();
+  }
+
   renderDismissButton() {
     if (this.props.footerDismiss) {
       return (
@@ -22,7 +31,7 @@ export class SnippetBase extends React.PureComponent {
           <div className="footer-content">
             <button
               className="ASRouterButton secondary"
-              onClick={this.props.onDismiss}>
+              onClick={this.onDismissClicked}>
               {this.props.content.scene2_dismiss_button_text}
             </button>
           </div>

--- a/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
@@ -121,6 +121,13 @@ describe("SubmitFormSnippet", () => {
 
       assert.calledOnce(wrapper.props().onDismiss);
     });
+    it("should send a DISMISS event ping", () => {
+      wrapper.setState({expanded: true});
+
+      wrapper.find(".ASRouterButton.secondary").simulate("click");
+
+      assert.equal(wrapper.props().sendUserActionTelemetry.firstCall.args[0].event, "DISMISS");
+    });
     it("should render hidden inputs + email input", () => {
       wrapper.setState({expanded: true});
 


### PR DESCRIPTION
In the previous snippets implementation the dismiss button had the same behavior as the block button and sent the same telemetry ping. We took a decision to make `dismiss` only remove the snippet for a particular impression (but not block it so that it might show up later) but we never had a different telemetry event for it.