### PR TITLE
Bug 1517713 - [RTL] Localized "Search the Web" string is LTR'd

### DIFF
--- a/content-src/components/Search/_Search.scss
+++ b/content-src/components/Search/_Search.scss
@@ -173,7 +173,7 @@ $glyph-forward: url('chrome://browser/skin/forward.svg');
 
   .fake-textbox {
     opacity: 0.54;
-    text-align: left;
+    text-align: start;
   }
 
   .fake-caret {


### PR DESCRIPTION
r?@k88hudson 

Before:
![screen shot 2019-01-04 at 1 54 39 pm](https://user-images.githubusercontent.com/438537/50712996-5908dc80-1028-11e9-8430-dc5cf3fb1113.png)

After:
![screen shot 2019-01-04 at 1 54 30 pm](https://user-images.githubusercontent.com/438537/50713002-5dcd9080-1028-11e9-9830-5a572c79958f.png)
