### PR TITLE
fix(styles): Remove title alignment that affect other sections for now

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/SectionTitle/_SectionTitle.scss
+++ b/content-src/components/DiscoveryStreamComponents/SectionTitle/_SectionTitle.scss
@@ -1,7 +1,4 @@
 .section-title {
-  text-align: center;
-  width: 100%;
-
   ul {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
r? @ScottDowne or @gvn 

Before:
![screen shot 2019-01-04 at 1 44 14 pm](https://user-images.githubusercontent.com/438537/50712603-f95e0180-1026-11e9-9f24-392826424111.png)

After:
![screen shot 2019-01-04 at 1 43 37 pm](https://user-images.githubusercontent.com/438537/50712608-fd8a1f00-1026-11e9-8499-127e1e3e5fbd.png)
