### PR TITLE
Fix Bug 1517745 - Remove arrow from search bar when hand-off enabled

### DIFF
--- a/content-src/components/Search/Search.jsx
+++ b/content-src/components/Search/Search.jsx
@@ -122,7 +122,6 @@ export class _Search extends React.PureComponent {
             title={this.props.intl.formatMessage({id: "search_web_placeholder"})}>
             <div className="fake-textbox">{this.props.intl.formatMessage({id: "search_web_placeholder"})}</div>
             <div className="fake-caret" />
-            <div className="fake-button" />
           </button>
           {/*
             This dummy and hidden input below is so we can load ContentSearchUIController.

--- a/content-src/components/Search/_Search.scss
+++ b/content-src/components/Search/_Search.scss
@@ -196,24 +196,6 @@ $glyph-forward: url('chrome://browser/skin/forward.svg');
       display: block;
     }
   }
-
-  .fake-button {
-    background: $glyph-forward no-repeat center center;
-    background-size: 16px 16px;
-    border: 0;
-    border-radius: 0 $border-radius $border-radius 0;
-    -moz-context-properties: fill;
-    fill: var(--newtab-search-icon-color);
-    height: 100%;
-    inset-inline-end: 0;
-    position: absolute;
-    top: 1px;
-    width: $search-button-width;
-
-    &:dir(rtl) {
-      transform: scaleX(-1);
-    }
-  }
 }
 
 @media (min-height: 701px) {


### PR DESCRIPTION
Before:
<img width="784" alt="screen shot 2019-01-07 at 1 27 03 pm" src="https://user-images.githubusercontent.com/36629/50785925-0d507000-1280-11e9-91fa-dc77743360e5.png">

After:
<img width="804" alt="screen shot 2019-01-07 at 1 27 30 pm" src="https://user-images.githubusercontent.com/36629/50785932-117c8d80-1280-11e9-8770-0c7518cc1ab6.png">

With hand-off disabled:
<img width="813" alt="screen shot 2019-01-07 at 1 27 47 pm" src="https://user-images.githubusercontent.com/36629/50785935-17726e80-1280-11e9-862a-aed3bc7185f4.png">
