### PR TITLE
Bug 1515078 - Add opt out UX in about:preferences for Pocket Newtab

### DIFF
--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -66,7 +66,7 @@ const CUSTOM_CSS = `
   margin-top: 0;
   margin-bottom: 0;
 }
-#homeContentsGroup .contentDiscoveryButton {
+#discoveryContentsGroup .contentDiscoveryButton {
   margin-inline-start: 0;
 }
 `;
@@ -267,7 +267,7 @@ this.AboutPreferences = class AboutPreferences {
         contentsGroup.style.visibility = "hidden";
 
         const discoveryGroup = homeGroup.insertAdjacentElement("afterend", homeGroup.cloneNode());
-        discoveryGroup.id = "homeContentsGroup";
+        discoveryGroup.id = "discoveryContentsGroup";
         discoveryGroup.setAttribute("data-subcategory", "contents");
         createAppend("label", discoveryGroup)
           .appendChild(document.createElementNS(HTML_NS, "h2"))

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -260,7 +260,6 @@ this.AboutPreferences = class AboutPreferences {
       });
     });
 
-    console.log("DiscoveryStream enabled", discoveryStreamEnabled);
     if (discoveryStreamEnabled) {
       // If Discovery Stream is enabled hide Home Content options
       contentsGroup.style.visibility = "hidden";

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -66,6 +66,9 @@ const CUSTOM_CSS = `
   margin-top: 0;
   margin-bottom: 0;
 }
+#homeContentsGroup .contentDiscoveryButton {
+  margin-inline-start: 0;
+}
 `;
 
 this.AboutPreferences = class AboutPreferences {
@@ -97,7 +100,7 @@ this.AboutPreferences = class AboutPreferences {
 
   async observe(window) {
     this.renderPreferences(window, await this.strings, [...PREFS_BEFORE_SECTIONS,
-      ...this.store.getState().Sections, ...PREFS_AFTER_SECTIONS]);
+      ...this.store.getState().Sections, ...PREFS_AFTER_SECTIONS], this.store.getState().Prefs);
   }
 
   /**
@@ -125,7 +128,7 @@ this.AboutPreferences = class AboutPreferences {
    * Render preferences to an about:preferences content window with the provided
    * strings and preferences structure.
    */
-  renderPreferences({document, Preferences, gHomePane}, strings, prefStructure) {
+  renderPreferences({document, Preferences, gHomePane}, strings, prefStructure, ASPreferences) {
     // Helper to create a new element and append it
     const createAppend = (tag, parent) => parent.appendChild(
       document.createXULElement(tag));
@@ -256,6 +259,36 @@ this.AboutPreferences = class AboutPreferences {
         linkPref(subcheck, nested.name, "bool");
       });
     });
+
+    try {
+      const discoveryStreamPref = JSON.parse(ASPreferences.values["discoverystream.config"]);
+      if (discoveryStreamPref.enabled) {
+        // If Discovery Stream is enabled hide Home Content options
+        contentsGroup.style.visibility = "hidden";
+
+        const discoveryGroup = homeGroup.insertAdjacentElement("afterend", homeGroup.cloneNode());
+        discoveryGroup.id = "homeContentsGroup";
+        discoveryGroup.setAttribute("data-subcategory", "contents");
+        createAppend("label", discoveryGroup)
+          .appendChild(document.createElementNS(HTML_NS, "h2"))
+          .textContent = formatString("prefs_content_discovery_header");
+        createAppend("description", discoveryGroup)
+          .textContent = formatString("prefs_content_discovery_description");
+
+        const contentDiscoveryButton = document.createElementNS(HTML_NS, "button");
+        contentDiscoveryButton.classList.add("contentDiscoveryButton");
+        contentDiscoveryButton.textContent = formatString("prefs_content_discovery_button");
+        createAppend("hbox", discoveryGroup)
+          .appendChild(contentDiscoveryButton)
+          .addEventListener("click", () => {
+            discoveryGroup.style.display = "none";
+            contentsGroup.style.visibility = "visible";
+            Services.prefs.clearUserPref("browser.newtabpage.activity-stream.discoverystream.config");
+          }, {once: true});
+      }
+    } catch (e) {
+      Cu.reportError("Could not parse discoverystream.config pref");
+    }
 
     // Update the visibility of the Restore Defaults btn based on checked prefs
     gHomePane.toggleRestoreDefaultsBtn();

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -13,6 +13,7 @@ XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 const HTML_NS = "http://www.w3.org/1999/xhtml";
 
 const PREFERENCES_LOADED_EVENT = "home-pane-loaded";
+const DISCOVERY_STREAM_CONFIG_PREF_NAME = "browser.newtabpage.activity-stream.discoverystream.config";
 
 // These "section" objects are formatted in a way to be similar to the ones from
 // SectionsManager to construct the preferences view.
@@ -281,7 +282,7 @@ this.AboutPreferences = class AboutPreferences {
         .addEventListener("click", () => {
           discoveryGroup.style.display = "none";
           contentsGroup.style.visibility = "visible";
-          Services.prefs.clearUserPref("browser.newtabpage.activity-stream.discoverystream.config");
+          Services.prefs.clearUserPref(DISCOVERY_STREAM_CONFIG_PREF_NAME);
         }, {once: true});
     }
 

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -91,6 +91,11 @@ section_disclaimer_topstories_buttontext=Okay, got it
 # what is shown for the homepage, new windows, and new tabs.
 prefs_home_header=Firefox Home Content
 prefs_home_description=Choose what content you want on your Firefox Home screen.
+
+prefs_content_discovery_header=Firefox Home
+prefs_content_discovery_description=Content Discovery in Firefox Home allows you to discover high-quality, relevant articles from across the web.
+prefs_content_discovery_button=Turn Off Content Discovery
+
 # LOCALIZATION NOTE (prefs_section_rows_option): This is a semi-colon list of
 # plural forms used in a drop down of multiple row options (1 row, 2 rows).
 # See: http://developer.mozilla.org/en/docs/Localization_and_Plurals

--- a/test/unit/lib/AboutPreferences.test.js
+++ b/test/unit/lib/AboutPreferences.test.js
@@ -130,27 +130,31 @@ describe("AboutPreferences Feed", () => {
     let prefStructure;
     let Preferences;
     let gHomePane;
+    let discoveryStreamExperiment;
     const testRender = () => instance.renderPreferences({
       document: {
         createXULElement: sandbox.stub().returns(node),
         createProcessingInstruction: sandbox.stub(),
-        createElementNS: sandbox.stub().callsFake((NS, el) => document.createElement(el)),
+        createElementNS: sandbox.stub().callsFake((NS, el) => node),
         getElementById: sandbox.stub().returns(node),
         insertBefore: sandbox.stub().returnsArg(0),
       },
       Preferences,
       gHomePane,
-    }, strings, prefStructure);
+    }, strings, prefStructure, {values: {"discoverystream.config": discoveryStreamExperiment}});
     beforeEach(() => {
       node = {
         appendChild: sandbox.stub().returnsArg(0),
+        addEventListener: sandbox.stub(),
         classList: {add: sandbox.stub()},
         cloneNode: sandbox.stub().returnsThis(),
         insertAdjacentElement: sandbox.stub().returnsArg(1),
         setAttribute: sandbox.stub(),
+        style: {},
       };
       strings = {};
       prefStructure = [];
+      discoveryStreamExperiment = JSON.stringify({enabled: false});
       Preferences = {
         add: sandbox.stub(),
         get: sandbox.stub().returns({}),
@@ -286,6 +290,51 @@ describe("AboutPreferences Feed", () => {
         testRender();
 
         assert.calledOnce(gHomePane.toggleRestoreDefaultsBtn);
+      });
+    });
+    describe("#DiscoveryStream", () => {
+      it("should not render the Discovery Stream section", () => {
+        discoveryStreamExperiment = JSON.stringify({enabled: false});
+
+        testRender();
+
+        assert.isFalse(node.textContent.includes("prefs_content_discovery"));
+      });
+      it("should render the Discovery Stream section", () => {
+        discoveryStreamExperiment = JSON.stringify({enabled: true});
+        const spy = sandbox.spy(instance, "renderPreferences");
+
+        testRender();
+
+        const documentStub = spy.firstCall.args[0].document;
+
+        assert.equal(node.textContent, "prefs_content_discovery_button");
+        assert.calledWith(documentStub.createElementNS, "http://www.w3.org/1999/xhtml", "button");
+        // node points to contentsGroup, style is set to hidden if Discovery
+        // Stream is enabled
+        assert.propertyVal(node.style, "visibility", "hidden");
+      });
+      it("should toggle the Discovery Stream pref on button click", () => {
+        discoveryStreamExperiment = JSON.stringify({enabled: true});
+        const stub = sandbox.stub(Services.prefs, "clearUserPref");
+
+        testRender();
+
+        assert.calledOnce(node.addEventListener);
+
+        node.addEventListener.firstCall.args[1]();
+
+        assert.calledOnce(stub);
+        assert.calledWithExactly(stub, "browser.newtabpage.activity-stream.discoverystream.config");
+      });
+      it("should guard against invalid JSON", () => {
+        sandbox.stub(Cu, "reportError");
+
+        discoveryStreamExperiment = {enabled: true};
+
+        testRender();
+
+        assert.calledOnce(Cu.reportError);
       });
     });
   });


### PR DESCRIPTION
In order to test this 
* set `browser.newtabpage.activity-stream.discoverystream.config` to have `enable` set to true
* navigate to `about:preferences#home`

