### PR TITLE
Bug 1517525 - Spelling issue for Reducers.test.js initial state

### DIFF
--- a/test/unit/common/Reducers.test.js
+++ b/test/unit/common/Reducers.test.js
@@ -606,7 +606,7 @@ describe("Reducers", () => {
       assert.propertyVal(state, "version", data.version);
     });
     it("should reset to the initial state on a SNIPPETS_RESET action", () => {
-      const state = Snippets({initalized: true, foo: "bar"}, {type: at.SNIPPETS_RESET});
+      const state = Snippets({initialized: true, foo: "bar"}, {type: at.SNIPPETS_RESET});
       assert.equal(state, INITIAL_STATE.Snippets);
     });
     it("should set the new blocklist on SNIPPET_BLOCKED", () => {


### PR DESCRIPTION
The test is not affected because [0] on `SNIPPETS_RESET` the reducer always returns `INITIAL_STATE.Snippets` regardless of the initial state passed in the args.

[0] https://github.com/mozilla/activity-stream/blob/c90b29e394d1977121d031cc72652382ff9e29d6/common/Reducers.jsm#L420-L421