### PR TITLE
 Bug 1515026 - Add telemetry event for learn more button 

### DIFF
--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -71,6 +71,8 @@ export class SubmitFormSnippet extends React.PureComponent {
   }
 
   expandSnippet() {
+    this.props.sendUserActionTelemetry({event: "CLICK_BUTTON", value: "scene1-button-learn-more", id: this.props.UISurface});
+
     this.setState({
       expanded: true,
       signupSuccess: false,

--- a/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
+++ b/test/unit/asrouter/templates/SubmitFormSnippet.test.jsx
@@ -141,6 +141,13 @@ describe("SubmitFormSnippet", () => {
       assert.isTrue(wrapper.state().expanded);
       assert.isTrue(wrapper.find("form").exists());
     });
+    it("should submit telemetry when the action button is clicked", () => {
+      assert.isFalse(wrapper.find("form").exists());
+
+      wrapper.find(".ASRouterButton").simulate("click");
+
+      assert.equal(wrapper.props().sendUserActionTelemetry.firstCall.args[0].value, "scene1-button-learn-more");
+    });
     it("should submit form data when submitted", () => {
       sandbox.stub(window, "fetch").resolves(fetchOk);
       wrapper.setState({expanded: true});


### PR DESCRIPTION
In order to test this
1. Set a breakpoint [in the TelemetryFeed](https://github.com/mozilla/activity-stream/blob/c90b29e394d1977121d031cc72652382ff9e29d6/lib/TelemetryFeed.jsm#L469)
2. Trigger `FXA_SNIPPET_TEST_1` from `about:newtab#asrouter`
3. Click the `Get connected with sync` button which should trigger the breakpoint
4. The `event_object` should contain `value: "scene1-button-learn-more"`