### PR TITLE
Bug 1520259 - Add space for devtools fixed sidebar

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -2,14 +2,16 @@
 .asrouter-admin {
   $border-color: var(--newtab-border-secondary-color);
   $monospace: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
+  $sidebar-width: 240px;
   margin: 0 auto;
   font-size: 14px;
-
+  padding-left: $sidebar-width;
   display: flex;
 
   .sidebar {
+    inset-inline-start: 0;
     position: fixed;
-    width: 240px;
+    width: $sidebar-width;
     padding: 30px 20px;
 
     ul {


### PR DESCRIPTION
Test plan:

1. Ensure you have devtools enabled via [these instructions](https://docs.google.com/document/d/1iySmNA2tBl3ApLuJtP7UBlPwNx9sH1SmK-jG6exvMQ0/edit#heading=h.3zj0kjmo4xno)
2. Make your window size ~500px wide
3. Visit about:newtab#devtools-ds. Ensure you can use the enabled/disabled checkbox on the DiscoveryStream section and that devtools are no longer covered by the sidebar