### PR TITLE
Bug 1513311 - Allow remote custom CSS to adjust section and/or card styles

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -19,7 +19,32 @@ const MAX_ROWS_HERO = 5;
 const MAX_ROWS_LISTS = 5;
 const MAX_ROWS_CARDGRID = 8;
 
+const ALLOWED_CSS_URL_PREFIXES = ["chrome://", "resource://", "https://img-getpocket.cdn.mozilla.net/"];
+const DUMMY_CSS_SELECTOR = "DUMMY#CSS.SELECTOR";
+
+/**
+ * Validate a CSS declaration. The values are assumed to be normalized by CSSOM.
+ */
+export function isAllowedCSS(property, value) {
+  // Bug 1454823: INTERNAL properties, e.g., -moz-context-properties, are
+  // exposed but their values aren't resulting in getting nothing. Fortunately,
+  // we don't care about validating the values of the current set of properties.
+  if (value === undefined) {
+    return true;
+  }
+
+  // Make sure all urls are of the allowed protocols/prefixes
+  const urls = value.match(/url\("[^"]+"\)/g);
+  return !urls || urls.every(url => ALLOWED_CSS_URL_PREFIXES.some(prefix =>
+    url.slice(5).startsWith(prefix)));
+}
+
 export class _DiscoveryStreamBase extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onStyleMount = this.onStyleMount.bind(this);
+  }
+
   extractRows(component, limit) {
     if (component.data && component.data.recommendations) {
       const items = Math.min(limit, component.properties.items || component.data.recommendations.length);
@@ -27,6 +52,54 @@ export class _DiscoveryStreamBase extends React.PureComponent {
     }
 
     return [];
+  }
+
+  onStyleMount(style) {
+    // Unmounting style gets rid of old styles, so nothing else to do
+    if (!style) {
+      return;
+    }
+
+    const {sheet} = style;
+    const styles = JSON.parse(style.dataset.styles);
+    styles.forEach((row, rowIndex) => {
+      row.forEach((component, componentIndex) => {
+        // Nothing to do without optional styles overrides
+        if (!component) {
+          return;
+        }
+
+        Object.entries(component).forEach(([selectors, declarations]) => {
+          // Start with a dummy rule to validate declarations and selectors
+          sheet.insertRule(`${DUMMY_CSS_SELECTOR} {}`);
+          const [rule] = sheet.cssRules;
+
+          // Validate declarations and remove any offenders. CSSOM silently
+          // discards invalid entries, so here we apply extra restrictions.
+          rule.style = declarations;
+          [...rule.style].forEach(property => {
+            const value = rule.style[property];
+            if (!isAllowedCSS(property, value)) {
+              console.error(`Bad CSS declaration ${property}: ${value}`); // eslint-disable-line no-console
+              rule.style.removeProperty(property);
+            }
+          });
+
+          // Set the actual desired selectors scoped to the component
+          const prefix = `.ds-layout > .ds-column:nth-child(${rowIndex + 1}) > :nth-child(${componentIndex + 1})`;
+          // NB: Splitting on "," doesn't work with strings with commas, but
+          // we're okay with not supporting those selectors
+          rule.selectorText = selectors.split(",").map(selector => prefix +
+            // Assume :pseudo-classes are for component instead of descendant
+            (selector[0] === ":" ? "" : " ") + selector).join(",");
+
+          // CSSOM silently ignores bad selectors, so we'll be noisy instead
+          if (rule.selectorText === DUMMY_CSS_SELECTOR) {
+            console.error(`Bad CSS selector ${selectors}`); // eslint-disable-line no-console
+          }
+        });
+      });
+    });
   }
 
   renderComponent(component) {
@@ -81,19 +154,29 @@ export class _DiscoveryStreamBase extends React.PureComponent {
     }
   }
 
+  renderStyles(styles) {
+    // Use json string as both the key and styles to render so React knows when
+    // to unmount and mount a new instance for new styles.
+    const json = JSON.stringify(styles);
+    return (<style key={json} data-styles={json} ref={this.onStyleMount} />);
+  }
+
   render() {
     const {layoutRender} = this.props.DiscoveryStream;
+    const styles = [];
     return (
       <div className="discovery-stream ds-layout">
         {layoutRender.map((row, rowIndex) => (
           <div key={`row-${rowIndex}`} className={`ds-column ds-column-${row.width}`}>
-            {row.components.map((component, componentIndex) => (
-              <div key={`component-${componentIndex}`}>
+            {row.components.map((component, componentIndex) => {
+              styles[rowIndex] = [...styles[rowIndex] || [], component.styles];
+              return (<div key={`component-${componentIndex}`}>
                 {this.renderComponent(component)}
-              </div>
-            ))}
+              </div>);
+            })}
           </div>
         ))}
+        {this.renderStyles(styles)}
       </div>
     );
   }

--- a/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
@@ -1,0 +1,35 @@
+import {isAllowedCSS} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
+
+describe("<isAllowedCSS>", () => {
+  it("should allow colors", () => {
+    assert.isTrue(isAllowedCSS("color", "red"));
+  });
+
+  it("should allow resource urls", () => {
+    assert.isTrue(isAllowedCSS("background-image", `url("resource://activity-stream/data/content/assets/glyph-info-16.svg")`));
+  });
+
+  it("should allow chrome urls", () => {
+    assert.isTrue(isAllowedCSS("background-image", `url("chrome://browser/skin/history.svg")`));
+  });
+
+  it("should allow allowed https urls", () => {
+    assert.isTrue(isAllowedCSS("background-image", `url("https://img-getpocket.cdn.mozilla.net/media/image.png")`));
+  });
+
+  it("should disallow other https urls", () => {
+    assert.isFalse(isAllowedCSS("background-image", `url("https://mozilla.org/media/image.png")`));
+  });
+
+  it("should disallow other protocols", () => {
+    assert.isFalse(isAllowedCSS("background-image", `url("ftp://mozilla.org/media/image.png")`));
+  });
+
+  it("should allow allowed multiple valid urls", () => {
+    assert.isTrue(isAllowedCSS("background-image", `url("https://img-getpocket.cdn.mozilla.net/media/image.png"), url("chrome://browser/skin/history.svg")`));
+  });
+
+  it("should disallow if any invaild", () => {
+    assert.isFalse(isAllowedCSS("background-image", `url("chrome://browser/skin/history.svg"), url("ftp://mozilla.org/media/image.png")`));
+  });
+});


### PR DESCRIPTION
r?@ScottDowne This assumes an optional `styles` property on a component.

If you set `browser.newtabpage.activity-stream.discoverystream.config` to
```
{"enabled":true,"layout_endpoint":"data:,%7B%22layout%22%3A%5B%7B%22width%22%3A12%2C%22components%22%3A%5B%7B%22styles%22%3A%7B%22%22%3A%22background%3Aurl(https%3A%2F%2Fmozilla.org)%3Btransition%3Abackground-color%201s%22%2C%22%3Ahover%22%3A%22background-color%3Argba(0%2C0%2C255%2C.5)%22%2C%22%7B%7D%22%3A%22top%3A0%22%2C%22*%22%3A%22color%3Ared%22%2C%22p%22%3A%22transform%3Arotate(180deg)%3Btext-transform%3Auppercase%22%2C%22.ds-header%3A%3Abefore%2Cp%3Anth-child(3)%3A%3Abefore%22%3A%22content%3A'%F0%9F%91%8D'%22%7D%2C%22type%22%3A%22Hero%22%2C%22header%22%3A%7B%22title%22%3A%22Recommended%20by%20Pocket%22%7D%2C%22feed%22%3A%7B%22url%22%3A%22https%3A%2F%2Fgetpocket.cdn.mozilla.net%2Fv3%2Ffirefox%2Fglobal-recs%3Fversion%3D3%26consumer_key%3D40249-e88c401e1b1f2242d9e441c4%26locale_lang%3Den-US%22%7D%2C%22properties%22%3A%7B%7D%7D%5D%7D%5D%7D"}
```
(which is this json)
```json
{"layout":[{"width":12,"components":[{"styles":{"":"background:url(https://mozilla.org);transition:background-color 1s",":hover":"background-color:rgba(0,0,255,.5)","{}":"top:0","*":"color:red","p":"transform:rotate(180deg);text-transform:uppercase",".ds-header::before,p:nth-child(3)::before":"content:'\uD83D\uDC4D'"},"type":"Hero","header":{"title":"Recommended by Pocket"},"feed":{"url":"https:\/\/getpocket.cdn.mozilla.net\/v3\/firefox\/global-recs?version=3&consumer_key=40249-e88c401e1b1f2242d9e441c4&locale_lang=en-US"},"properties":{}}]}]}

{
	"": "background:url(https://mozilla.org);transition:background-color 1s",
	":hover": "background-color:rgba(0,0,255,.5)",
	"{}": "top:0",
	"*": "color:red",
	"p": "transform:rotate(180deg);text-transform:uppercase",
	".ds-header::before,p:nth-child(3)::before": "content:'\uD83D\uDC4D'"
}
```
Should see something like…
![screen shot 2019-01-16 at 5 06 01 pm](https://user-images.githubusercontent.com/438537/51288701-3bd1f780-19b2-11e9-8c58-fa48a91a7b5e.png)

(Don't forget to try hovering!)

Here's the generated CSS:
```css
.ds-layout > .ds-column:nth-child(1) > :nth-child(1) .ds-header::before, .ds-layout > .ds-column:nth-child(1) > :nth-child(1) p:nth-child(3)::before { content: \"👍\"; }
.ds-layout > .ds-column:nth-child(1) > :nth-child(1) p { transform: rotate(180deg); text-transform: uppercase; }
.ds-layout > .ds-column:nth-child(1) > :nth-child(1) * { color: red; }
DUMMY#CSS.SELECTOR { top: 0px; }
.ds-layout > .ds-column:nth-child(1) > :nth-child(1):hover { background-color: rgba(0, 0, 255, 0.5); }
.ds-layout > .ds-column:nth-child(1) > :nth-child(1) { background-color: rgba(0, 0, 0, 0); background-position: 0% 0%; background-repeat: repeat; background-attachment: scroll; background-size: auto; background-origin: padding-box; background-clip: border-box; transition: background-color 1s ease 0s; }
```

As of right now, the server isn't returning the right response at https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-styles