### PR TITLE
Bug 1515078 - Use PreferenceExperiments API to unenroll from Pocket Newtab experiment

### DIFF
--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -286,14 +286,15 @@ this.AboutPreferences = class AboutPreferences {
         .addEventListener("click", async () => {
           const activeExperiments = await PreferenceExperiments.getAllActive();
           const experiment = activeExperiments.find(exp => exp.preferenceName === DISCOVERY_STREAM_CONFIG_PREF_NAME);
+          // Unconditionally update the UI for a fast user response and in
+          // order to help with testing
+          discoveryGroup.style.display = "none";
+          contentsGroup.style.visibility = "visible";
           if (experiment) {
             await PreferenceExperiments.stop(experiment.name, {
               resetValue: true,
               reason: "individual-opt-out",
             });
-
-            discoveryGroup.style.display = "none";
-            contentsGroup.style.visibility = "visible";
           }
         }, {once: true});
     }

--- a/test/unit/lib/AboutPreferences.test.js
+++ b/test/unit/lib/AboutPreferences.test.js
@@ -312,18 +312,24 @@ describe("AboutPreferences Feed", () => {
         // Stream is enabled
         assert.propertyVal(node.style, "visibility", "hidden");
       });
-      it("should toggle the Discovery Stream pref on button click", () => {
+      it("should toggle the Discovery Stream pref on button click", async () => {
         DiscoveryStream = {config: {enabled: true}};
-        const stub = sandbox.stub(Services.prefs, "clearUserPref");
+        const PreferenceExperimentsStub = {
+          getAllActive: sandbox.stub().resolves([{name: "discoverystream", preferenceName: "browser.newtabpage.activity-stream.discoverystream.config"}]),
+          stop: sandbox.stub().resolves(),
+        };
+        globals.set("PreferenceExperiments", PreferenceExperimentsStub);
 
         testRender();
 
         assert.calledOnce(node.addEventListener);
 
-        node.addEventListener.firstCall.args[1]();
+        // Trigger the button click listener
+        await node.addEventListener.firstCall.args[1]();
 
-        assert.calledOnce(stub);
-        assert.calledWithExactly(stub, "browser.newtabpage.activity-stream.discoverystream.config");
+        assert.calledOnce(PreferenceExperimentsStub.getAllActive);
+        assert.calledOnce(PreferenceExperimentsStub.stop);
+        assert.calledWithExactly(PreferenceExperimentsStub.stop, "discoverystream", {resetValue: true, reason: "individual-opt-out"});
       });
     });
   });


### PR DESCRIPTION
[`"individual-opt-out"`](https://searchfox.org/mozilla-central/rev/bee8cf15c901b9f4b0c074c9977da4bbebc506e3/toolkit/components/normandy/content/about-studies/about-studies.js#189) is the telemetry event name used when unenrolling from an experiment on the `about:studies` page. We could change that to something specific to `about:preferences` if we're interested in the data.

I was not familiar with how Normandy chooses users and toggles preferences. Specifically what happens if we roll out from 1% to 5% but before the second rollout some users voluntarily leave the experiment.
> because of the sampling characteristics of Normandy, if you increase from 1% to 5%, the additional 4% are guaranteed to be distinct from the original 1%