### PR TITLE
bug 1520893 - Display spocs

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -39,6 +39,27 @@ export function isAllowedCSS(property, value) {
     url.slice(5).startsWith(prefix)));
 }
 
+function maybeInjectSpocs(data, spocs) {
+  if (!data || !spocs.positions || !spocs.positions.length) {
+    return data;
+  }
+
+  const recommendations = [...data.recommendations];
+
+  for (let position of spocs.positions) {
+    const {result} = position;
+    if (result) {
+      // Insert spoc into the desired index.
+      recommendations.splice(position.index, 0, result);
+    }
+  }
+
+  return {
+    ...data,
+    recommendations,
+  };
+}
+
 export class _DiscoveryStreamBase extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -116,7 +137,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           <ImpressionStats rows={rows} dispatch={this.props.dispatch} source={component.type}>
             <CardGrid
               title={component.header && component.header.title}
-              data={component.data}
+              data={maybeInjectSpocs(component.data, component.spocs)}
               feed={component.feed}
               border={component.properties.border}
               type={component.type}
@@ -130,7 +151,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           <ImpressionStats rows={rows} dispatch={this.props.dispatch} source={component.type}>
             <Hero
               title={component.header && component.header.title}
-              data={component.data}
+              data={maybeInjectSpocs(component.data, component.spocs)}
               border={component.properties.border}
               type={component.type}
               dispatch={this.props.dispatch}

--- a/content-src/lib/selectLayoutRender.js
+++ b/content-src/lib/selectLayoutRender.js
@@ -1,19 +1,5 @@
 import {createSelector} from "reselect";
 
-function calculateSpocs(component, spocs) {
-  let spocIndex = 0;
-  return component.spocs.positions.map(position => {
-    const rickRoll = Math.random();
-    if (spocs.data.spocs[spocIndex] && rickRoll <= component.spocs.probability) {
-      return {
-        ...position,
-        result: spocs.data.spocs[spocIndex++],
-      };
-    }
-    return position;
-  });
-}
-
 export const selectLayoutRender = createSelector(
   // Selects layout, feeds, spocs so that we only recompute if
   // any of these values change.
@@ -26,6 +12,21 @@ export const selectLayoutRender = createSelector(
   // Adds data to each component from feeds. This function only re-runs if one of the inputs change.
   // TODO: calculate spocs
   function layoutRender(layout, feeds, spocs) {
+    let spocIndex = 0;
+
+    function calculateSpocs(component) {
+      return component.spocs.positions.map(position => {
+        const rickRoll = Math.random();
+        if (spocs.data.spocs[spocIndex] && rickRoll <= component.spocs.probability) {
+          return {
+            ...position,
+            result: spocs.data.spocs[spocIndex++],
+          };
+        }
+        return position;
+      });
+    }
+
     return layout.map(row => ({
       ...row,
 
@@ -40,7 +41,7 @@ export const selectLayoutRender = createSelector(
         if (component.spocs && spocs.data.spocs && spocs.data.spocs.length) {
           component.spocs = {
             ...component.spocs,
-            positions: calculateSpocs(component, spocs),
+            positions: calculateSpocs(component),
           };
         }
 


### PR DESCRIPTION
To test:

1. set your browser.newtabpage.activity-stream.discoverystream.config pref to `{"enabled":true,"layout_endpoint":"https://gist.githubusercontent.com/ScottDowne/1be633daea7d1ce65a8ca903a3be9ae9/raw/3d51663327126879f6fa1c6b3e7730e7805c9e1e/spocs"}`
2. Load a new tab, take note of the 3rd card in both the card grid and hero grid.
3. Refresh a couple times, noting the 3rd card in each refresh.

Expected: The third position on each hero and card component has a 50% chance to be a spoc.

There are 4 combinations based on the rolls you get.

1. where both rolls fail, and in this case you see the same card in both positions in both components because they share the same feed.

2. where the card component rolls a spoc and the hero does not.

3. where hero has a spoc and card doesn't.

4. And finally where they both have spocs.

We need to ensure when they both display a spoc, it's not the same spoc.

Dunno the best way to determine which card is what because I'm using live feed data. At the moment I'm writing this the card is from "theatlantic.com" and the two available spocs are from "thepointsguy.com" and have different images.