### PR TITLE
Bug 1520854 - make text color in AS work again in dark theme

### DIFF
--- a/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
+++ b/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
@@ -1,5 +1,5 @@
-
-.outer-wrapper a {
+.outer-wrapper .discovery-stream.ds-layout a {
+  // XXX note that this only looks right in the light theme
   color: $grey-90;
 }
 


### PR DESCRIPTION
How to test:

* In a clean profile, set your computer's OS to use dark theme (on Mac, this is System Preferences -> General).
* Open a new tab
* For the pocket cards, the title and excepts should be a legible light grey

Then, to ensure that this fix hasn't regressed the original thing it was intended to address.

* Reset your computer's OS theme use a light theme
* go to about:config
* search for stream.config
* set that preference to {"enabled":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}
* open a new tab

Verify that the text in the title of the Trending Stories list items is #0C0C0D
