### PR TITLE
Bug 1519775 - Make one and two-column lists work

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -161,11 +161,13 @@ export class _DiscoveryStreamBase extends React.PureComponent {
       case "HorizontalRule":
         return (<HorizontalRule />);
       case "List":
-        rows = this.extractRows(component, MAX_ROWS_LIST);
+        rows = this.extractRows(component,
+          Math.min(component.properties.items, MAX_ROWS_LIST));
         return (
           <ImpressionStats rows={rows} dispatch={this.props.dispatch} source={component.type}>
             <List
               feed={component.feed}
+              items={component.properties.items}
               type={component.type}
               header={component.header} />
           </ImpressionStats>

--- a/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
+++ b/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
@@ -19,7 +19,7 @@
 
   // "Full width layout"
   .ds-column-9 &,
-  .dscolumn-10 &,
+  .ds-column-10 &,
   .ds-column-11 &,
   .ds-column-12 & {
     grid-template-columns: repeat(4, 1fr);

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -28,13 +28,31 @@ $item-line-height: 20;
 
 .ds-list {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-row-gap: 18px;
+  grid-row-gap: 24px;
   grid-column-gap: 24px;
 
   // reset some stuff from <ul>.  Should maybe be hoisted when we have better
   // regression detection?
   padding-inline-start: 0;
+
+  // "2/3 width layout"
+  .ds-column-5 &,
+  .ds-column-6 &,
+  .ds-column-7 &,
+  .ds-column-8 & {
+    grid-template-columns: repeat(2, 1fr);
+    grid-row-gap: 24px;
+  }
+
+  // "Full width layout"
+  .ds-column-9 &,
+  .ds-column-10 &,
+  .ds-column-11 &,
+  .ds-column-12 & {
+    grid-template-columns: repeat(3, 1fr);
+    grid-row-gap: 18px;
+  }
+
 }
 
 // XXX this is gross, and attaches the bottom-border to the item above.


### PR DESCRIPTION
Looking for a quick-turnaround review so I can get this (layout-breaking) bug in before the impending export and tidy up individual bits of the lists later.  Whoever wants this, feel free to take it!

How to test:

 * go to about:config
 * search for stream.config
 * set that preference to {"enabled":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}
 * open a new tab

The various trending stories should all be appropriate widths.

Things to note:

* some horizontal rules above or below individual stories may be incorrectly there or incorrectly missing.  https://bugzilla.mozilla.org/show_bug.cgi?id=1521119 has been filed.

Known bugs are already captured as dependents of the ds-list-component bug: https://bugzilla.mozilla.org/showdependencytree.cgi?id=1514020&hide_resolved=0

