### PR TITLE
Bug 1519243 - Split title component into two, the new one is navigation

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -4,6 +4,7 @@ import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
 import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
 import {ImpressionStats} from "content-src/components/DiscoveryStreamImpressionStats/ImpressionStats";
 import {List} from "content-src/components/DiscoveryStreamComponents/List/List";
+import {Navigation} from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
 import React from "react";
 import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
 import {selectLayoutRender} from "content-src/lib/selectLayoutRender";
@@ -130,7 +131,9 @@ export class _DiscoveryStreamBase extends React.PureComponent {
       case "TopSites":
         return (<TopSites />);
       case "SectionTitle":
-        return (<SectionTitle />);
+        return (<SectionTitle header={component.header} />);
+      case "Navigation":
+        return (<Navigation links={component.properties.links} alignment={component.properties.alignment} />);
       case "CardGrid":
         rows = this.extractRows(component, MAX_ROWS_CARDGRID);
         return (

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -131,9 +131,16 @@ export class _DiscoveryStreamBase extends React.PureComponent {
       case "TopSites":
         return (<TopSites />);
       case "SectionTitle":
-        return (<SectionTitle header={component.header} />);
+        return (
+          <SectionTitle
+            header={component.header} />
+        );
       case "Navigation":
-        return (<Navigation links={component.properties.links} alignment={component.properties.alignment} />);
+        return (
+          <Navigation
+            links={component.properties.links}
+            alignment={component.properties.alignment} />
+        );
       case "CardGrid":
         rows = this.extractRows(component, MAX_ROWS_CARDGRID);
         return (

--- a/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
+++ b/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
@@ -1,8 +1,3 @@
-.outer-wrapper .discovery-stream.ds-layout a {
-  // XXX note that this only looks right in the light theme
-  color: $grey-90;
-}
-
 .discovery-stream.ds-layout {
   $columns: 12;
   display: grid;

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -53,6 +53,10 @@ $item-line-height: 20;
     grid-row-gap: 18px;
   }
 
+  a {
+    // XXX note that this only looks right in the light theme
+    color: $grey-90;
+  }
 }
 
 // XXX this is gross, and attaches the bottom-border to the item above.

--- a/content-src/components/DiscoveryStreamComponents/Navigation/Navigation.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/Navigation.jsx
@@ -11,12 +11,10 @@ export class Navigation extends React.PureComponent {
   render() {
     const {links} = this.props || [];
     const {alignment} = this.props || "centered";
-    const moreRecs = links.pop();
     return (
       <span className={`ds-navigation ds-navigation-${alignment}`}>
         <ul>
           {links && links.map(t => <Topic key={t.name} url={t.url} name={t.name} />)}
-          {moreRecs ? <li><a href={moreRecs.url} className="ds-more-recommendations">{moreRecs.name}</a></li> : null }
         </ul>
       </span>
     );

--- a/content-src/components/DiscoveryStreamComponents/Navigation/Navigation.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/Navigation.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export class Topic extends React.PureComponent {
+  render() {
+    const {url, name} = this.props;
+    return (<li><a key={name} href={url}>{name}</a></li>);
+  }
+}
+
+export class Navigation extends React.PureComponent {
+  render() {
+    const {links} = this.props || [];
+    const {alignment} = this.props || "centered";
+    const moreRecs = links.pop();
+    return (
+      <span className={`ds-navigation ds-navigation-${alignment}`}>
+        <ul>
+          {links && links.map(t => <Topic key={t.name} url={t.url} name={t.name} />)}
+          {moreRecs ? <li><a href={moreRecs.url} className="ds-more-recommendations">{moreRecs.name}</a></li> : null }
+        </ul>
+      </span>
+    );
+  }
+}

--- a/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
@@ -39,23 +39,7 @@
       &:active,
       &:visited {
         color: $blue-70;
-
-        &.ds-more-recommendations::after {
-          fill: $blue-70;
-        }
       }
     }
-  }
-
-  .ds-more-recommendations::after {
-    background: url('../data/content/assets/topic-show-more-12.svg') no-repeat center center;
-    content: '';
-    -moz-context-properties: fill;
-    fill: var(--newtab-link-primary-color);
-    display: inline-block;
-    height: 16px;
-    margin-inline-start: 5px;
-    vertical-align: top;
-    width: 12px;
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
@@ -26,7 +26,24 @@
     }
 
     a {
-      color: $blue-60;
+      &:hover {
+        // text-decoration: underline; didn't quite match comps.
+        border-bottom: 1px solid var(--newtab-link-primary-color);
+
+        &:active,
+        &:visited {
+          border-bottom: 1px solid $blue-70;
+        }
+      }
+
+      &:active,
+      &:visited {
+        color: $blue-70;
+
+        &.ds-more-recommendations::after {
+          fill: $blue-70;
+        }
+      }
     }
   }
 
@@ -34,7 +51,7 @@
     background: url('../data/content/assets/topic-show-more-12.svg') no-repeat center center;
     content: '';
     -moz-context-properties: fill;
-    fill: $blue-60;
+    fill: var(--newtab-link-primary-color);
     display: inline-block;
     height: 16px;
     margin-inline-start: 5px;

--- a/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
@@ -5,7 +5,7 @@
   }
 
   &.ds-navigation-right-aligned {
-    text-align: right;
+    text-align: end;
   }
 
   ul {

--- a/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/_Navigation.scss
@@ -1,0 +1,44 @@
+.ds-navigation {
+
+  &.ds-navigation-centered {
+    text-align: center;
+  }
+
+  &.ds-navigation-right-aligned {
+    text-align: right;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  ul li {
+    display: inline-block;
+
+    &::after {
+      content: '•';
+      padding: 8px;
+    }
+
+    &:last-child::after {
+      content: none;
+    }
+
+    a {
+      color: $blue-60;
+    }
+  }
+
+  .ds-more-recommendations::after {
+    background: url('../data/content/assets/topic-show-more-12.svg') no-repeat center center;
+    content: '';
+    -moz-context-properties: fill;
+    fill: $blue-60;
+    display: inline-block;
+    height: 16px;
+    margin-inline-start: 5px;
+    vertical-align: top;
+    width: 12px;
+  }
+}

--- a/content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle.jsx
+++ b/content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle.jsx
@@ -1,22 +1,13 @@
 import React from "react";
 
-export class Topic extends React.PureComponent {
-  render() {
-    const {url, name} = this.props;
-    return (<li><a key={name} href={url}>{name}</a></li>);
-  }
-}
-
 export class SectionTitle extends React.PureComponent {
   render() {
-    const {topics} = this.props;
+    const {header: {title, subtitle}} = this.props;
     return (
-      <span className="ds-section-title">
-        <ul>
-          {topics && topics.map(t => <Topic key={t.name} url={t.url} name={t.name} />)}
-          <li><a className="ds-more-recommendations">More Recommendations</a></li>
-        </ul>
-      </span>
+      <div className="ds-section-title">
+        <div className="title">{title}</div>
+        {subtitle ? <div className="subtitle">{subtitle}</div> : null}
+      </div>
     );
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/SectionTitle/_SectionTitle.scss
+++ b/content-src/components/DiscoveryStreamComponents/SectionTitle/_SectionTitle.scss
@@ -1,30 +1,15 @@
 .ds-section-title {
-  ul {
-    margin: 0;
-    padding: 0;
+  text-align: center;
+
+  .title {
+    line-height: 48px;
+    font-size: 36px;
+    color: $grey-90;
   }
 
-  ul li {
-    display: inline-block;
-
-    &::after {
-      content: '•';
-      padding: 8px;
-    }
-
-    &:last-child::after {
-      content: none;
-    }
-  }
-
-  .ds-more-recommendations::after {
-    background: url('../data/content/assets/topic-show-more-12.svg') no-repeat center center;
-    content: '';
-    -moz-context-properties: fill;
-    display: inline-block;
-    height: 16px;
-    margin-inline-start: 5px;
-    vertical-align: top;
-    width: 12px;
+  .subtitle {
+    line-height: 24px;
+    font-size: 15px;
+    color: $grey-50;
   }
 }

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -151,6 +151,7 @@ input {
 @import '../components/DiscoveryStreamComponents/Hero/Hero';
 @import '../components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule';
 @import '../components/DiscoveryStreamComponents/List/List';
+@import '../components/DiscoveryStreamComponents/Navigation/Navigation';
 @import '../components/DiscoveryStreamComponents/SectionTitle/SectionTitle';
 @import '../components/DiscoveryStreamComponents/TopSites/TopSites';
 @import '../components/DiscoveryStreamComponents/DSCard/DSCard';


### PR DESCRIPTION
I've been testing with this: https://gist.githubusercontent.com/ScottDowne/84457bf09597afe67926cca558f20d22/raw/e42431c06c21867388468e8ab734b394c32f9a77/title-nav

changing out things as I need.