### PR TITLE
Bug 1521615 - Dry out header css for reusage usage with top sites.

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -107,7 +107,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
 
     switch (component.type) {
       case "TopSites":
-        return (<TopSites />);
+        return (<TopSites header={component.header} />);
       case "SectionTitle":
         return (<SectionTitle />);
       case "CardGrid":

--- a/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
+++ b/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
@@ -27,4 +27,11 @@
     display: grid;
     grid-row-gap: var(--gridRowGap);
   }
+
+  .ds-header {
+    font-size: 17px;
+    line-height: 24px;
+    color: $grey-90;
+    margin: 16px 0;
+  }
 }

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -1,10 +1,3 @@
-.ds-header {
-  font-size: 17px;
-  line-height: 24px;
-  color: $grey-90;
-  margin: 16px 0;
-}
-
 .ds-hero {
   .img {
     border: 0.5px solid $black-10;

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -68,7 +68,7 @@ export function _List(props) {
 
   return (
     <div>
-      <h3 className="ds-list-title">{props.header && props.header.title}</h3>
+      {props.header && props.header.title ? <div className="ds-header">{props.header.title}</div> : null }
       <hr className="ds-list-border" />
       <ul className="ds-list">{recMarkup}</ul>
     </div>

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -2,21 +2,6 @@
 $item-font-size: 13;
 $item-line-height: 20;
 
-.ds-list-title {
-  color: $grey-90;
-
-  // reset these, which come from the browser's <hr> implementation
-  margin-block-start: 0;
-  margin-block-end: 0;
-
-  // Since we don't have a border, we use padding instead of margin in order to
-  // defeat margin collapsing.
-  padding: 8px 0;
-
-  line-height: 24px;
-  font-size: 17px;
-}
-
 .ds-list-border {
   border: 1px solid $grey-40-36;
 

--- a/content-src/components/DiscoveryStreamComponents/TopSites/TopSites.jsx
+++ b/content-src/components/DiscoveryStreamComponents/TopSites/TopSites.jsx
@@ -4,8 +4,15 @@ import React from "react";
 
 export class _TopSites extends React.PureComponent {
   render() {
+    const header = this.props.header || {};
     return (
       <div className="ds-top-sites">
+        {header.title ? (
+          <div className="ds-header">
+            <span className="icon icon-small-spacer icon-topsites" />
+            <span>{header.title}</span>
+          </div>
+        ) : null}
         <OldTopSites />
       </div>
     );


### PR DESCRIPTION
To test:

1. Ensure the new tab is the regular version by default.
2. In `about:config`, change  `browser.newtabpage.activity-stream.discoverystream.config` to be `{"enabled":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}`
3. Ensure new tab is rendering components with readable headers for List, Hero, and top sites.
4. Reset the pref, ensure everything is back to normal.