### PR TITLE
Bug 1519342 - Show Onboarding card after RTAMO addon install

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -159,6 +159,8 @@ export class ASRouterUISurface extends React.PureComponent {
       case "CLEAR_MESSAGE":
         if (action.data.id === this.state.message.id) {
           this.setState({message: {}});
+          // Remove any styles related to the RTAMO message
+          document.body.classList.remove("welcome", "hide-main", "amo");
         }
         break;
       case "CLEAR_PROVIDER":

--- a/content-src/asrouter/templates/ReturnToAMO/ReturnToAMO.jsx
+++ b/content-src/asrouter/templates/ReturnToAMO/ReturnToAMO.jsx
@@ -14,8 +14,6 @@ export class ReturnToAMO extends React.PureComponent {
 
   onClickAddExtension() {
     this.props.onAction(this.props.content.primary_button.action);
-    this.props.onBlock();
-    document.body.classList.remove("welcome", "hide-main", "amo");
   }
 
   onBlockButton() {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -908,6 +908,7 @@ class _ASRouter {
     }
   }
 
+  // Ensure we switch to the Onboarding message after RTAMO addon was installed
   _updateOnboardingState() {
     let addonInstallObs = (subject, topic) => {
       Services.obs.removeObserver(addonInstallObs, "webextension-install-notify");

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -253,7 +253,9 @@ const MessageLoaderUtils = {
                                                           null, null, null, null, amTelemetryInfo);
       await AddonManager.installAddonFromWebpage("application/x-xpinstall", browser,
         systemPrincipal, install);
-    } catch (e) {}
+    } catch (e) {
+      Cu.reportError(e);
+    }
   },
 
   /**
@@ -906,6 +908,15 @@ class _ASRouter {
     }
   }
 
+  _updateOnboardingState() {
+    let addonInstallObs = (subject, topic) => {
+      Services.obs.removeObserver(addonInstallObs, "webextension-install-notify");
+      this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_MESSAGE", data: {id: "RETURN_TO_AMO_1"}});
+      this.blockMessageById("RETURN_TO_AMO_1");
+    };
+    Services.obs.addObserver(addonInstallObs, "webextension-install-notify");
+  }
+
   _loadSnippetsWhitelistHosts() {
     let additionalHosts = [];
     const whitelistPrefValue = Services.prefs.getStringPref(SNIPPETS_ENDPOINT_WHITELIST, "");
@@ -1025,6 +1036,7 @@ class _ASRouter {
         UITour.showMenu(target.browser.ownerGlobal, action.data.args);
         break;
       case ra.INSTALL_ADDON_FROM_URL:
+        this._updateOnboardingState();
         await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);
         break;
       case ra.SHOW_FIREFOX_ACCOUNTS:


### PR DESCRIPTION
Note: if there is a network connection issue and install fails the message is not blocked. I think this behavior makes sense, the user can retry as opposed to now when the message goes away forever after the first click regardless of outcome.

Testing:
1. Enable RTAMO steps here
  * enable `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled`
  * set `browser.newtabpage.activity-stream.asrouter.providers.onboarding` to `{"id":"onboarding","type":"local","localProvider":"OnboardingMessageProvider","enabled":true,"exclude":[]}`
  * navigate to `about:newtab#devtools-targeting` and scroll to the bottom
  * click `Force attribution`
  * navigate to `about:welcome` and confirm that the RTAMO message is shown
2. Install the addon and ensure the switch to the 3 onboarding messages happens after addon install finishes.
  * [visual explanation here, slides 11-12](https://docs.google.com/presentation/d/1blJHV5RQnU0qEEXP56JOkmMBscWf2RVnne3DuAs5IMg/edit#slide=id.g3fb6ce4a35_0_0)
3. Ensure the message is blocked afterwards
  * Shows up as blocked in `about:newtab#devtools`
