### PR TITLE
Bug 1520898 - Display spoc context.

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid.jsx
+++ b/content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid.jsx
@@ -22,6 +22,7 @@ export class CardGrid extends React.PureComponent {
         id={rec.id}
         index={index}
         type={this.props.type}
+        context={rec.context}
         dispatch={this.props.dispatch}
         source={rec.domain} />
     ));

--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -32,7 +32,11 @@ export class DSCard extends React.PureComponent {
         <div className="meta">
           <header className="title">{this.props.title}</header>
           <p className="excerpt">{this.props.excerpt}</p>
-          <p className="source">{this.props.source}</p>
+          {this.props.context ? (
+            <p className="context">{this.props.context}</p>
+          ) : (
+            <p className="source">{this.props.source}</p>
+          )}
         </div>
       </a>
     );

--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -60,4 +60,8 @@ $excerpt-line-height: 20;
     color: $grey-50;
     margin: 8px 0;
   }
+
+  .context {
+    color: $teal-70;
+  }
 }

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -49,6 +49,7 @@ export class Hero extends React.PureComponent {
         index={index + 1}
         type={this.props.type}
         dispatch={this.props.dispatch}
+        context={truncateText(rec.context || "", 22)}
         source={truncateText(`TODO: SOURCE`, 22)} />
     ));
 
@@ -63,7 +64,11 @@ export class Hero extends React.PureComponent {
             <div className="meta">
               <header>{truncateText(heroRec.title, 28)}</header>
               <p>{truncateText(heroRec.excerpt, 114)}</p>
-              <p>{truncateText(`TODO: SOURCE`, 22)}</p>
+              {heroRec.context ? (
+                <p className="context">{truncateText(heroRec.context, 22)}</p>
+              ) : (
+                <p>{truncateText(`TODO: SOURCE`, 22)}</p>
+              )}
             </div>
           </a>
           <div className="cards">

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -66,6 +66,10 @@
 
       p {
         font-size: 13px;
+
+        &.context {
+          color: $teal-70;
+        }
       }
     }
   }
@@ -85,7 +89,6 @@
         padding-top: 100%; // 1:1 aspect ratio
       }
     }
-
 
     .cards {
       display: grid;


### PR DESCRIPTION


Testing instructions.

1. Ensure the new tab is the regular version by default.
2. In `about:config`, change  `browser.newtabpage.activity-stream.discoverystream.config` to be `{"enabled":true,"layout_endpoint":"https://gist.githubusercontent.com/ScottDowne/e8ad372bc57ed3feba0bf02f89473fc9/raw/74daf564fea3e41e1ef24c39b18690623679182b/mrspocs"}`
3. Ensure new tab is rendering a bunch of spocs with the text "Sponsored by..." in a few. Specifically, it's in the last two on the card grid, and the first and last on the hero.
4. Reset the pref, ensure everything is back to normal.