### PR TITLE
Bug 1519774 - implement lists without images

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -165,6 +165,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           <ImpressionStats rows={rows} dispatch={this.props.dispatch} source={component.type}>
             <List
               feed={component.feed}
+              hasImages={component.properties.has_images}
               hasNumbers={component.properties.has_numbers}
               items={component.properties.items}
               type={component.type}

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -68,6 +68,7 @@ export function _List(props) {
 
   const listStyles = [
     "ds-list",
+    props.hasImages ? "ds-list-images" : "",
     props.hasNumbers ? "ds-list-numbers" : "",
   ];
   return (
@@ -80,6 +81,7 @@ export function _List(props) {
 }
 
 _List.defaultProps = {
+  hasImages: false, // Display images for each item
   hasNumbers: false, // Display numbers for each item
   items: 6, // Number of stories to display.  TODO: get from endpoint
 };

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -44,6 +44,12 @@ $item-line-height: 20;
   }
 }
 
+.ds-list-images {
+  .ds-list-item .ds-list-image {
+    display: block;
+  }
+}
+
 .ds-list-numbers {
   $counter-whitespace: ($item-line-height - $item-font-size) * 1px;
   $counter-size: ($item-font-size) * 2px + $counter-whitespace;
@@ -128,6 +134,7 @@ $item-line-height: 20;
   }
 
   .ds-list-image {
+    display: none;
     width: 72px;
     height: 72px;
     object-fit: cover;


### PR DESCRIPTION
This is on top of #4698 so look at https://github.com/mozilla/activity-stream/commit/ee3568cb140997bd82b1ae1dfb32e8ae0994c01a . r?@ScottDowne or @dmose 

No images and with images (+ numbers)
![screen shot 2019-01-22 at 11 54 06 am](https://user-images.githubusercontent.com/438537/51561617-91882300-1e3c-11e9-8bdb-9c6c5d19515d.png)
