### PR TITLE
Bug 1521891 - portrait images in list items should correctly cover 72x72 box

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -134,13 +134,16 @@ $item-line-height: 20;
   }
 
   .ds-list-image {
-    display: none;
-    width: 72px;
-    height: 72px;
-    object-fit: cover;
+    $image-size: 72px;
 
+    border-radius: 4px;
     border: 0.5px solid $black-12;
     box-sizing: border-box;
-    border-radius: 4px;
+    display: none;
+    height: $image-size;
+    min-height: $image-size;
+    min-width: $image-size;
+    object-fit: cover;
+    width: $image-size;
   }
 }


### PR DESCRIPTION
r?@piatra or @dmose 

Before
![screen shot 2019-01-22 at 8 00 53 pm](https://user-images.githubusercontent.com/438537/51582394-b605ee80-1e80-11e9-9d8e-d70b959f5181.png)

After
![screen shot 2019-01-22 at 8 00 43 pm](https://user-images.githubusercontent.com/438537/51582398-b8684880-1e80-11e9-9bd4-05f949a30e10.png)
