### PR TITLE
Bug 1521888 - add padding between ds-list-item-text and the image to the right, as per spec

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -141,6 +141,7 @@ $item-line-height: 20;
     box-sizing: border-box;
     display: none;
     height: $image-size;
+    margin-inline-start: $item-font-size * 1px;
     min-height: $image-size;
     min-width: $image-size;
     object-fit: cover;


### PR DESCRIPTION
This is on top of #4702. r?@piatra or @dmose 

Before:
![screen shot 2019-01-22 at 8 00 43 pm](https://user-images.githubusercontent.com/438537/51583146-016dcc00-1e84-11e9-8dbc-04361bba2e83.png)

After:
![screen shot 2019-01-22 at 8 04 33 pm](https://user-images.githubusercontent.com/438537/51583151-0599e980-1e84-11e9-8b48-b99960637766.png)

And just to see the non-images not affected.. all together!
![screen shot 2019-01-22 at 8 22 03 pm](https://user-images.githubusercontent.com/438537/51583158-164a5f80-1e84-11e9-89b3-c481f4c637bb.png)
