### PR TITLE
Bug 1521886 - update thicknesss/color of ds-list horizontal rules

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -3,7 +3,12 @@ $item-font-size: 13;
 $item-line-height: 20;
 
 .ds-list-border {
-  border: 1px solid $grey-40-36;
+  border: 1px solid $grey-30;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+
+  padding-top: 1px;
 
   // Instead of using margin, we need to use these to override stuff that comes
   // by default from <hr>.
@@ -88,8 +93,8 @@ $item-line-height: 20;
 // Unfortunately the border needs to go _above_ the row gap as currently
 // set up, which means that some refactoring will be required to do this.
 .ds-list-item:nth-child(-n+3) { // all but the last three items
-  border-bottom: 2px solid $grey-40-36;
-  margin-bottom: -2px;  // cancel out the 2 pixels we used for the border
+  border-bottom: 1px solid $grey-30;
+  margin-bottom: -1px;  // cancel out the pixel we used for the border
 
   padding-bottom: 2px;
 }

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -3,10 +3,8 @@ $item-font-size: 13;
 $item-line-height: 20;
 
 .ds-list-border {
-  border: 1px solid $grey-30;
-  border-left: 0;
-  border-right: 0;
-  border-bottom: 0;
+  border: 0;
+  border-top: $border-secondary;
 
   padding-top: 1px;
 
@@ -93,7 +91,7 @@ $item-line-height: 20;
 // Unfortunately the border needs to go _above_ the row gap as currently
 // set up, which means that some refactoring will be required to do this.
 .ds-list-item:nth-child(-n+3) { // all but the last three items
-  border-bottom: 1px solid $grey-30;
+  border-bottom: $border-secondary;
   margin-bottom: -1px;  // cancel out the pixel we used for the border
 
   padding-bottom: 2px;

--- a/content-src/styles/_variables.scss
+++ b/content-src/styles/_variables.scss
@@ -29,7 +29,6 @@ $grey-10-95: rgba($grey-10, 0.95);
 $grey-20-60: rgba($grey-20, 0.6);
 $grey-20-80: rgba($grey-20, 0.8);
 $grey-30-60: rgba($grey-30, 0.6);
-$grey-40-36: rgba($grey-40, 0.36);
 $grey-60-60: rgba($grey-60, 0.6);
 $grey-60-70: rgba($grey-60, 0.7);
 $grey-80-95: rgba($grey-80, 0.95);


### PR DESCRIPTION
How to test:

* go to about:config
* search for stream.config
* set that preference to {"enabled":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}
* open a new tab

Inspect the long horizontal rule at the top of the one of the list.  Also inspect the shorter line (which is implemented as a border) above one of the .ds-items.  Both should be 1 pixel thick, and the color of the lines should be #D7D7DB (which is the same as rgb(215, 215, 219)).
