### PR TITLE
(nobug) - Center Card images

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -34,6 +34,7 @@ $excerpt-line-height: 20;
     padding-top: 50%; // 2:1 aspect ratio
     background-repeat: no-repeat;
     background-size: cover;
+    background-position: center;
   }
 
   .meta {

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -49,6 +49,7 @@
       background-repeat: no-repeat;
       background-size: cover;
       background-color: $grey-30;
+      background-position: center;
     }
 
     .meta {


### PR DESCRIPTION
2/3 Hero Before
<img width="642" alt="screenshot 2019-01-23 at 20 26 06" src="https://user-images.githubusercontent.com/810040/51633852-8de2c200-1f4a-11e9-90e7-9e0fdda2d33a.png">
2/3 Hero After
<img width="637" alt="screenshot 2019-01-23 at 20 26 13" src="https://user-images.githubusercontent.com/810040/51633854-8de2c200-1f4a-11e9-950b-bb561048f510.png">
Hero Before
<img width="636" alt="screenshot 2019-01-23 at 21 04 26" src="https://user-images.githubusercontent.com/810040/51633856-8e7b5880-1f4a-11e9-9a6c-2d6f2d79e6bf.png">
Hero After
<img width="642" alt="screenshot 2019-01-23 at 21 04 20" src="https://user-images.githubusercontent.com/810040/51633855-8e7b5880-1f4a-11e9-8ea0-0a2094084f90.png">

There are changes to the Card component as well but it's very hard to notice the difference with a side by side photo, it's easier to toggle the property when reviewing and notice the difference. Example:

Before
<img width="240" alt="screenshot 2019-01-23 at 21 11 09" src="https://user-images.githubusercontent.com/810040/51634039-15303580-1f4b-11e9-9cf3-a3f023056c43.png">

After
<img width="242" alt="screenshot 2019-01-23 at 21 11 15" src="https://user-images.githubusercontent.com/810040/51634040-15303580-1f4b-11e9-9c5e-a2ba95e0ec0f.png">
