### PR TITLE
Bug 1522233 - Add styling for HorizonalRule

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -28,8 +28,8 @@
     color: $grey-50;
     margin: 18px 0;
     padding: 20px 0;
-    border-top: 1px solid transparentize($grey-40, 0.64);
-    border-bottom: 1px solid transparentize($grey-40, 0.64);
+    border-top: $border-secondary;
+    border-bottom: $border-secondary;
 
     &:hover .meta header {
       color: $blue-60;

--- a/content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule.jsx
+++ b/content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule.jsx
@@ -3,7 +3,7 @@ import React from "react";
 export class HorizontalRule extends React.PureComponent {
   render() {
     return (
-      <hr />
+      <hr className="ds-hr" />
     );
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/HorizontalRule/_HorizontalRule.scss
+++ b/content-src/components/DiscoveryStreamComponents/HorizontalRule/_HorizontalRule.scss
@@ -1,0 +1,5 @@
+.ds-hr {
+  border: 0;
+  height: 0;
+  border-top: $border-secondary;
+}


### PR DESCRIPTION
Sorry had to do this, it was hurting my eyes 😜 

Reference design: https://www.figma.com/file/B1eynmsVDYKdpDWZhP8xYBWq/User-Research-Layout-Prototypes

Test steps:
1. Set `browser.newtabpage.activity-stream.discoverystream.config` pref to: `
{"enabled":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}`
2. Check to make sure the horizontal line under the "Best of the Web" heading at the top is a light grey colour and 2px high.