### PR TITLE
(nobug) – Reverting #4707

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -55,7 +55,7 @@
     .meta {
       header {
         font-size: 22px;
-        color: $black;
+        color: $grey-90;
       }
 
       p {


### PR DESCRIPTION
Figma was inconsistent. `$grey-90` is what's actually intended.