### PR TITLE
Bug 1519773 - implement image placeholder style for list items

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -25,16 +25,12 @@ $excerpt-line-height: 20;
 
   .img-wrapper {
     width: 100%;
-    border: 0.5px solid $black-10;
-    border-radius: 4px;
   }
 
   .img {
+    @include image-as-background;
     height: 0;
     padding-top: 50%; // 2:1 aspect ratio
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
   }
 
   .meta {

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -1,8 +1,6 @@
 .ds-hero {
   .img {
-    border: 0.5px solid $black-10;
-    box-sizing: border-box;
-    border-radius: 4px;
+    @include image-as-background;
   }
 
   .ds-card {
@@ -46,10 +44,6 @@
     .img {
       height: 0;
       padding-top: 50%; // 2:1 aspect ratio
-      background-repeat: no-repeat;
-      background-size: cover;
-      background-color: $grey-30;
-      background-position: center;
     }
 
     .meta {

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -41,7 +41,7 @@ export class ListItem extends React.PureComponent {
             </div>
             <div className="ds-list-item-info">{this.props.domain}</div>
           </div>
-          <img className="ds-list-image" src={this.props.image_src} />
+          <div className="ds-list-image" style={{backgroundImage: `url(${this.props.image_src})`}} />
         </a>
       </li>
     );

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -143,15 +143,12 @@ $item-line-height: 20;
   .ds-list-image {
     $image-size: 72px;
 
-    border-radius: 4px;
-    border: 0.5px solid $black-12;
-    box-sizing: border-box;
+    @include image-as-background;
     display: none;
     height: $image-size;
     margin-inline-start: $item-font-size * 1px;
     min-height: $image-size;
     min-width: $image-size;
-    object-fit: cover;
     width: $image-size;
   }
 

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -1,3 +1,14 @@
+// Shared styling of article images shown as background
+@mixin image-as-background {
+  background-color: var(--newtab-card-placeholder-color);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border-radius: 4px;
+  border: 0.5px solid $black-10;
+  box-sizing: border-box;
+}
+
 // Note: lineHeight and fontSize should be unitless but can be derived from pixel values
 @mixin limit-visibile-lines($line-count, $line-height, $font-size) {
   max-height: 1em * $line-count * $line-height / $font-size;

--- a/content-src/styles/_theme.scss
+++ b/content-src/styles/_theme.scss
@@ -71,6 +71,7 @@ body {
   --newtab-card-active-outline-color: #{$grey-30};
   --newtab-card-background-color: #{$white};
   --newtab-card-hairline-color: #{$black-10};
+  --newtab-card-placeholder-color: #{$grey-30};
   --newtab-card-shadow: 0 1px 4px 0 #{$grey-90-10};
 
   // Snippets
@@ -129,6 +130,7 @@ body {
     --newtab-card-active-outline-color: #{$grey-60};
     --newtab-card-background-color: #{$grey-70};
     --newtab-card-hairline-color: #{$grey-10-10};
+    --newtab-card-placeholder-color: #{$grey-60};
     --newtab-card-shadow: 0 1px 8px 0 #{$grey-90-20};
 
     // Snippets

--- a/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
@@ -76,10 +76,10 @@ describe("<ListItem> presentation component", () => {
     assert.lengthOf(anchors, 1);
   });
 
-  it("should include an img with a src of props.image_src", () => {
+  it("should include an background image of props.image_src", () => {
     const wrapper = shallow(<ListItem {...ValidListItemProps} />);
 
-    const anchors = wrapper.find(`img[src="${ValidListItemProps.image_src}"]`);
-    assert.lengthOf(anchors, 1);
+    const imageStyle = wrapper.find(".ds-list-image").prop("style");
+    assert.propertyVal(imageStyle, "backgroundImage", `url(${ValidListItemProps.image_src})`);
   });
 });


### PR DESCRIPTION
The duplication was hurting my eyes ;) r? @k88hudson Not sure if it's better as a mixin or a css class that each div additionally sets.. Also, turns out img with no image has some default border that can't be overridden??

Before
![screen shot 2019-01-23 at 1 30 27 pm](https://user-images.githubusercontent.com/438537/51638494-53a9fe00-1f13-11e9-8e01-baf73de1e073.png)

After
![screen shot 2019-01-23 at 1 31 15 pm](https://user-images.githubusercontent.com/438537/51638481-4d1b8680-1f13-11e9-8e03-1c0885b88c31.png)