### PR TITLE
Bug 1520853 - update default search shortcuts config for Fx66

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -176,14 +176,8 @@ const PREFS_CONFIG = new Map([
         return "";
       }
       const searchShortcuts = [];
-      if (geo === "CN") {
-        searchShortcuts.push("baidu");
-      } else if (["BY", "KZ", "RU", "TR"].includes(geo)) {
-        searchShortcuts.push("yandex");
-      } else {
+      if (["DE", "FR", "GB", "IT", "JP", "US"].includes(geo)) {
         searchShortcuts.push("google");
-      }
-      if (["AT", "DE", "FR", "GB", "IT", "JP", "US"].includes(geo)) {
         searchShortcuts.push("amazon");
       }
       return searchShortcuts.join(",");

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -176,8 +176,14 @@ const PREFS_CONFIG = new Map([
         return "";
       }
       const searchShortcuts = [];
-      if (["DE", "FR", "GB", "IT", "JP", "US"].includes(geo)) {
+      if (geo === "CN") {
+        searchShortcuts.push("baidu");
+      } else if (["BY", "KZ", "RU", "TR"].includes(geo)) {
+        searchShortcuts.push("yandex");
+      } else {
         searchShortcuts.push("google");
+      }
+      if (["DE", "FR", "GB", "IT", "JP", "US"].includes(geo)) {
         searchShortcuts.push("amazon");
       }
       return searchShortcuts.join(",");

--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -163,7 +163,7 @@ this.TopSitesFeed = class TopSitesFeed {
       const shouldPin = this.store.getState().Prefs.values[SEARCH_SHORTCUTS_SEARCH_ENGINES_PREF]
         .split(",")
         .map(getSearchProvider)
-        .filter(s => s);
+        .filter(s => s && s.shortURL !== this._currentSearchHostname);
 
       // If we've previously inserted all search shortcuts return early
       if (shouldPin.every(shortcut => prevInsertedShortcuts.includes(shortcut.shortURL))) {

--- a/test/browser/browser_topsites_contextMenu_options.js
+++ b/test/browser/browser_topsites_contextMenu_options.js
@@ -58,8 +58,8 @@ test_newtab({
   before: setDefaultTopSites,
   test: async function searchTopSites_dismiss() {
     const siteSelector = ".search-shortcut";
-    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(siteSelector).length === 2,
-      "2 search topsites are loaded by default");
+    await ContentTaskUtils.waitForCondition(() => content.document.querySelectorAll(siteSelector).length === 1,
+      "1 search topsites is loaded by default");
 
     const contextMenuItems = content.openContextMenuAndGetOptions(siteSelector);
     is(contextMenuItems.length, 2, "Search TopSites should only have Unpin and Dismiss");

--- a/test/browser/browser_topsites_section.js
+++ b/test/browser/browser_topsites_section.js
@@ -126,7 +126,7 @@ test_newtab({
     await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".search-shortcut .title.pinned"), "Wait for pinned search topsites");
 
     const searchTopSites = content.document.querySelectorAll(".title.pinned");
-    ok(searchTopSites.length >= 2, "There should be at least 2 search topsites");
+    ok(searchTopSites.length >= 1, "There should be at least 2 search topsites");
 
     searchTopSites[0].click();
 

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -1343,6 +1343,12 @@ describe("Top Sites Feed", () => {
         assert.deepEqual(fakeNewTabUtils.pinnedLinks.links[6], {url: "https://amazon.com", searchTopSite: true, label: "@amazon"});
       });
 
+      it("should not pin shortcuts for the current default search engine", async () => {
+        feed._currentSearchHostname = "google";
+        await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);
+        assert.deepEqual(fakeNewTabUtils.pinnedLinks.links[3], {url: "https://amazon.com", searchTopSite: true, label: "@amazon"});
+      });
+
       it("should only pin the first shortcut if there's only one available slot", async () => {
         fakeNewTabUtils.pinnedLinks.links[3] = {url: ""};
         await feed._maybeInsertSearchShortcuts(fakeNewTabUtils.pinnedLinks.links);


### PR DESCRIPTION
This enables @amazon in only 6 countries: DE, FR, GB, IT, JP, US

And it skips pinning a shortcut if it matches your current default search engine.

To verify, I fired up a local clean build and it only pinned Amazon instead of both Google and Amazon.