### PR TITLE
Bug 1520849 - Add error boundary for DiscoveryStream

### DIFF
--- a/content-src/components/Base/Base.jsx
+++ b/content-src/components/Base/Base.jsx
@@ -171,7 +171,10 @@ export class BaseContent extends React.PureComponent {
                   <ManualMigration />
                 </div>
                 }
-              {isDiscoveryStream ? <DiscoveryStreamBase /> : <Sections />}
+              {isDiscoveryStream ? (
+                <ErrorBoundary className="borderless-error">
+                  <DiscoveryStreamBase />
+                </ErrorBoundary>) : <Sections />}
               <PrefsButton onClick={this.openPreferences} />
             </div>
             <ConfirmDialog />

--- a/content-src/components/ErrorBoundary/_ErrorBoundary.scss
+++ b/content-src/components/ErrorBoundary/_ErrorBoundary.scss
@@ -10,6 +10,10 @@
   justify-items: center;
   line-height: $error-fallback-line-height;
 
+  &.borderless-error {
+    box-shadow: none;
+  }
+
   a {
     color: var(--newtab-text-conditional-color);
     text-decoration: underline;


### PR DESCRIPTION
Adds a simple error boundary for DiscoveryStream.

To test this, you will need to apply this patch:
```diff
diff --git a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
index 6d946618..cc13d287 100644
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -193,6 +193,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
   }
 
   render() {
+    throw new Error("Oops!");
     const {layoutRender} = this.props.DiscoveryStream;
     const styles = [];
     return (
```

Ensure you can still use search with this error being thrown.