### PR TITLE
Bug 1521915 - replace DiscoveryStream three-period ellipses with a single unicode ellipsis character

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -1,6 +1,7 @@
 import {actionCreators as ac} from "common/Actions.jsm";
 import {DSCard} from "../DSCard/DSCard.jsx";
 import React from "react";
+import {truncateText} from "content-src/lib/truncate-text";
 
 export class Hero extends React.PureComponent {
   constructor(props) {
@@ -36,7 +37,6 @@ export class Hero extends React.PureComponent {
 
     let [heroRec, ...otherRecs] = data.recommendations.slice(0, this.props.items);
     this.heroRec = heroRec;
-    let truncateText = (text, cap) => `${text.substring(0, cap)}${text.length > cap ? `...` : ``}`;
 
     // Note that `{index + 1}` is necessary below for telemetry since we treat heroRec as index 0.
     let cards = otherRecs.map((rec, index) => (
@@ -49,7 +49,7 @@ export class Hero extends React.PureComponent {
         index={index + 1}
         type={this.props.type}
         dispatch={this.props.dispatch}
-        context={truncateText(rec.context || "", 22)}
+        context={truncateText(rec.context, 22)}
         source={truncateText(rec.domain, 22)} />
     ));
 

--- a/content-src/lib/truncate-text.js
+++ b/content-src/lib/truncate-text.js
@@ -1,0 +1,3 @@
+export function truncateText(text = "", cap) {
+  return text.substring(0, cap).trim() + (text.length > cap ? "…" : "");
+}

--- a/test/unit/content-src/lib/truncate-text.test.js
+++ b/test/unit/content-src/lib/truncate-text.test.js
@@ -1,0 +1,37 @@
+import {truncateText} from "content-src/lib/truncate-text";
+
+describe("truncateText", () => {
+  it("should accept nothing", () => {
+    assert.equal(truncateText(), "");
+  });
+
+  it("should give back string with no truncating", () => {
+    const str = "hello";
+
+    assert.equal(truncateText(str), str);
+  });
+
+  it("should give back short string for long cap", () => {
+    const str = "hello";
+
+    assert.equal(truncateText(str, 100), str);
+  });
+
+  it("should give back string for exact cap", () => {
+    const str = "hello";
+
+    assert.equal(truncateText(str, str.length), str);
+  });
+
+  it("should cap off long string with ellipsis", () => {
+    const str = "hello world";
+
+    assert.equal(truncateText(str, 5), "hello…");
+  });
+
+  it("should avoid putting ellipsis after whitespace", () => {
+    const str = "hello             world";
+
+    assert.equal(truncateText(str, 10), "hello…");
+  });
+});


### PR DESCRIPTION
r?@piatra or @gvn Moved `truncateText` to its own file with tests. Made it slightly smarter about whitespace. Oh and switched to `…`