### PR TITLE
Bug 1521860 - Ensure we don't use object spread syntax with data from server

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -60,8 +60,16 @@ export function _List(props) {
 
   const recs = feed.data.recommendations;
 
-  let recMarkup = recs.slice(props.recStartingPoint, props.items).map((rec, index) => (
-    <ListItem {...rec} key={`ds-list-item-${index}`} index={index} type={props.type} dispatch={props.dispatch} />)
+  let recMarkup = recs.slice(0, props.items).map((rec, index) => (
+    <ListItem key={`ds-list-item-${index}`}
+      index={index}
+      type={props.type}
+      id={rec.id}
+      title={rec.title}
+      image_src={rec.image_src}
+      url={rec.url}
+      domain={rec.domain}
+      dispatch={props.dispatch} />)
   );
 
   const listStyles = [

--- a/content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle.jsx
+++ b/content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle.jsx
@@ -2,11 +2,16 @@ import React from "react";
 
 export class SectionTitle extends React.PureComponent {
   render() {
-    const {header: {title, subtitle}} = this.props;
+    const {header} = this.props;
+
+    if (!header) {
+      return null;
+    }
+
     return (
       <div className="ds-section-title">
-        <div className="title">{title}</div>
-        {subtitle ? <div className="subtitle">{subtitle}</div> : null}
+        <div className="title">{header.title}</div>
+        {header.subtitle ? <div className="subtitle">{header.subtitle}</div> : null}
       </div>
     );
   }

--- a/content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle.jsx
+++ b/content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle.jsx
@@ -2,16 +2,11 @@ import React from "react";
 
 export class SectionTitle extends React.PureComponent {
   render() {
-    const {header} = this.props;
-
-    if (!header) {
-      return null;
-    }
-
+    const {header: {title, subtitle}} = this.props;
     return (
       <div className="ds-section-title">
-        <div className="title">{header.title}</div>
-        {header.subtitle ? <div className="subtitle">{header.subtitle}</div> : null}
+        <div className="title">{title}</div>
+        {subtitle ? <div className="subtitle">{subtitle}</div> : null}
       </div>
     );
   }


### PR DESCRIPTION
This is the only occurrence I could still find. For future work how should we handle this? Do we prevent rendering or should we provide default props with an appropriate shape that allows destructuring? 