### PR TITLE
Bug 1522865 - Adjust list title weight and numbered circle

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -35,11 +35,7 @@ export class ListItem extends React.PureComponent {
       <li className="ds-list-item">
         <a className="ds-list-item-link" href={this.props.url} onClick={this.onLinkClick}>
           <div className="ds-list-item-text">
-            <div className="ds-list-item-title">
-              <b>
-                {this.props.title}
-              </b>
-            </div>
+            <div className="ds-list-item-title">{this.props.title}</div>
             {this.props.excerpt && <div className="ds-list-item-excerpt">{truncateText(this.props.excerpt, 90)}</div>}
             <div className="ds-list-item-info">{this.props.domain}</div>
           </div>

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -89,7 +89,7 @@ $item-line-height: 20;
 
 .ds-list-numbers {
   $counter-whitespace: ($item-line-height - $item-font-size) * 1px;
-  $counter-size: ($item-font-size) * 2px + $counter-whitespace;
+  $counter-size: 32px;
   $counter-padded-size: $counter-size + $counter-whitespace * 1.5;
 
   .ds-list-item {
@@ -185,6 +185,7 @@ $item-line-height: 20;
   }
 
   .ds-list-item-title {
+    font-weight: 600;
     margin-bottom: 8px;
   }
 


### PR DESCRIPTION
r?@ScottDowne or @dmose Gets rid of the <b> and just sets the weight correctly on the div. Sets a fixed circle size.