### PR TITLE
Bug 1522551 - Mock experiment enrollment via ASRouter debug

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -111,9 +111,11 @@ export class ASRouterAdminInner extends React.PureComponent {
     this.onChangeTargetingParameters = this.onChangeTargetingParameters.bind(this);
     this.onChangeAttributionParameters = this.onChangeAttributionParameters.bind(this);
     this.setAttribution = this.setAttribution.bind(this);
+    this.setExperimentPref = this.setExperimentPref.bind(this);
     this.onCopyTargetingParams = this.onCopyTargetingParams.bind(this);
     this.onPasteTargetingParams = this.onPasteTargetingParams.bind(this);
     this.onNewTargetingParams = this.onNewTargetingParams.bind(this);
+    this.onChangeExperimentParameter = this.onChangeExperimentParameter.bind(this);
     this.state = {
       messageFilter: "all",
       evaluationStatus: {},
@@ -125,6 +127,10 @@ export class ASRouterAdminInner extends React.PureComponent {
         source: "addons.mozilla.org",
         campaign: "non-fx-button",
         content: "iridium@particlecore.github.io",
+      },
+      experimentParameters: {
+        preferenceName: "browser.newtabpage.activity-stream.discoverystream.config",
+        preferenceValue: "",
       },
     };
   }
@@ -198,6 +204,17 @@ export class ASRouterAdminInner extends React.PureComponent {
         expression: this.refs.expressionInput.value,
         context,
       },
+    });
+  }
+
+  onChangeExperimentParameter(event) {
+    const {name, value} = event.target;
+
+    this.setState(({experimentParameters}) => {
+      const updatedParameters = {...experimentParameters};
+      updatedParameters[name] = value;
+
+      return {experimentParameters: updatedParameters};
     });
   }
 
@@ -471,6 +488,10 @@ export class ASRouterAdminInner extends React.PureComponent {
     ASRouterUtils.sendMessage({type: "FORCE_ATTRIBUTION", data: this.state.attributionParameters});
   }
 
+  setExperimentPref() {
+    ASRouterUtils.sendMessage({type: "FORCE_EXPERIMENT", data: this.state.experimentParameters});
+  }
+
   renderPocketStory(story) {
     return (<tr className="message-item" key={story.guid}>
       <td className="message-id"><span>{story.guid} <br /></span></td>
@@ -524,6 +545,28 @@ export class ASRouterAdminInner extends React.PureComponent {
       </div>);
   }
 
+  renderExperimentsParameters() {
+    return (
+      <div>
+        <h2>Preference Experiment</h2>
+        <p>Simulate a Normady experiment enrollment that sets the value of a preference</p>
+        <table>
+          <tr>
+            <td>Preference name</td>
+            <td><input type="text" name="preferenceName" onChange={this.onChangeExperimentParameter} value={this.state.experimentParameters.preferenceName} /></td>
+          </tr>
+          <tr>
+            <td>Preference value</td>
+            <td><input type="text" name="preferenceValue" onChange={this.onChangeExperimentParameter} value={this.state.experimentParameters.preferenceValue} /></td>
+          </tr>
+          <tr>
+            <td><button className="ASRouterButton primary button" onClick={this.setExperimentPref}>Force Preference Experiment</button></td>
+          </tr>
+        </table>
+      </div>
+    );
+  }
+
   getSection() {
     const [section] = this.props.location.routes;
     switch (section) {
@@ -533,6 +576,7 @@ export class ASRouterAdminInner extends React.PureComponent {
           <button className="button" onClick={this.expireCache}>Expire Cache</button> (This expires the cache in ASR Targeting for bookmarks and top sites)
           {this.renderTargetingParameters()}
           {this.renderAttributionParamers()}
+          {this.renderExperimentsParameters()}
         </React.Fragment>);
       case "pocket":
         return (<React.Fragment>

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1056,6 +1056,32 @@ describe("ASRouter", () => {
     });
   });
 
+  describe("#onMessage: FORCE_EXPERIMENT", () => {
+    it("should call forceExperimentEnrollment", async () => {
+      const stub = sandbox.stub(Router, "forceExperimentEnrollment");
+      const msg = fakeAsyncMessage({type: "FORCE_EXPERIMENT"});
+
+      await Router.onMessage(msg);
+
+      assert.calledOnce(stub);
+    });
+    it("should run a PreferenceExperimentAction", async () => {
+      const runRecipeStub = sandbox.stub().resolves();
+      const finalizeStub = sandbox.stub().resolves();
+      class PrefExpStub {
+        async runRecipe() { return runRecipeStub(); }
+        async finalize() { return finalizeStub(); }
+      }
+      globals.set("PreferenceExperimentAction", PrefExpStub);
+      const msg = fakeAsyncMessage({type: "FORCE_EXPERIMENT", data: {}});
+
+      await Router.onMessage(msg);
+
+      assert.calledOnce(runRecipeStub);
+      assert.calledOnce(finalizeStub);
+    });
+  });
+
   describe("_triggerHandler", () => {
     it("should call #onMessage with the correct trigger", () => {
       sinon.spy(Router, "onMessage");


### PR DESCRIPTION
In order to test this:
0. With the Pocket Newtab experience disabled.
1. `about:newtab#devtools-targeting`
2. Under `Preference Experiment` for `Preference value` paste in
  * `{"enabled":true,"show_spocs":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=basic"}`
3. Click `Force Preference Experiment`
4. [verify] Open a new tab and Pocket Newtab should be enabled.
5. [verify] Go to `about:preferences` and in the Home tab when you click the button to leave the experiment you should get back to the previous experience (Pocket Newtab disabled).

This method will work for any preference value that we want to simulate a Normady experiment pref change.