### PR TITLE
Bug 1524322 – Add Message component

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -1,5 +1,6 @@
 import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
 import {connect} from "react-redux";
+import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
 import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
 import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
 import {ImpressionStats} from "content-src/components/DiscoveryStreamImpressionStats/ImpressionStats";
@@ -127,6 +128,15 @@ export class _DiscoveryStreamBase extends React.PureComponent {
     switch (component.type) {
       case "TopSites":
         return (<TopSites header={component.header} />);
+      case "Message":
+        return (
+          <DSMessage
+            title={component.header && component.header.title}
+            subtitle={component.header && component.header.subtitle}
+            link_text={component.header && component.header.link_text}
+            link_url={component.header && component.header.link_url}
+            icon={component.header && component.header.icon} />
+        );
       case "SectionTitle":
         return (
           <SectionTitle

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
@@ -4,8 +4,13 @@ export class DSMessage extends React.PureComponent {
   render() {
     return (
       <div className="ds-message">
-        {this.props.title && (<header className="title">{this.props.title}</header>)}
-        {this.props.subtitle && (
+        {this.props.title && (
+          <header className="title">
+            {this.props.icon && (<img src={this.props.icon}/>)}
+            <span>{this.props.title}</span>
+          </header>
+        )}
+        {(this.props.subtitle || this.props.link_text && this.props.link_url) && (
           <p className="subtitle">
             {this.props.subtitle && (<span>{this.props.subtitle}</span>)}
             {this.props.link_text && this.props.link_url && (<a href={this.props.link_url}>{this.props.link_text}</a>)}

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
@@ -2,21 +2,24 @@ import React from "react";
 
 export class DSMessage extends React.PureComponent {
   render() {
+    let hasSubtitleAndOrLink = this.props.link_text && this.props.link_url;
+    hasSubtitleAndOrLink = hasSubtitleAndOrLink || this.props.subtitle;
+
     return (
       <div className="ds-message">
         {this.props.title && (
           <header className="title">
-            {this.props.icon && (<img src={this.props.icon}/>)}
+            {this.props.icon && (<img src={this.props.icon} />)}
             <span>{this.props.title}</span>
           </header>
         )}
-        {(this.props.subtitle || this.props.link_text && this.props.link_url) && (
+        { hasSubtitleAndOrLink && (
           <p className="subtitle">
             {this.props.subtitle && (<span>{this.props.subtitle}</span>)}
             {this.props.link_text && this.props.link_url && (<a href={this.props.link_url}>{this.props.link_text}</a>)}
           </p>
         )}
       </div>
-     )
+    );
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
@@ -19,7 +19,7 @@ export class DSMessage extends React.PureComponent {
             {this.props.link_text && this.props.link_url && (<a href={this.props.link_url}>{this.props.link_text}</a>)}
           </p>
         )}
-        <hr class="ds-hr"/>
+        <hr className="ds-hr" />
       </div>
     );
   }

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
@@ -19,6 +19,7 @@ export class DSMessage extends React.PureComponent {
             {this.props.link_text && this.props.link_url && (<a href={this.props.link_url}>{this.props.link_text}</a>)}
           </p>
         )}
+        <hr class="ds-hr"/>
       </div>
     );
   }

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export class DSMessage extends React.PureComponent {
+  render() {
+    return (
+      <div className="ds-message">
+        {this.props.title && (<header className="title">{this.props.title}</header>)}
+        {this.props.subtitle && (
+          <p className="subtitle">
+            {this.props.subtitle && (<span>{this.props.subtitle}</span>)}
+            {this.props.link_text && this.props.link_url && (<a href={this.props.link_url}>{this.props.link_text}</a>)}
+          </p>
+        )}
+      </div>
+     )
+  }
+}

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
@@ -1,0 +1,19 @@
+.ds-message {
+  .title {
+    line-height: 24px;
+    font-size: 17px;
+    color: $grey-90;
+    font-weight: 600;
+  }
+
+  .subtitle {
+    line-height: 20px;
+    font-size: 13px;
+    color: $grey-50;
+    margin: 0;
+
+    a::before {
+      content: ' ';
+    }
+  }
+}

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
@@ -1,9 +1,20 @@
 .ds-message {
   .title {
-    line-height: 24px;
-    font-size: 17px;
-    color: $grey-90;
-    font-weight: 600;
+    display: flex;
+    align-items: center;
+
+    img {
+      width: 16px;
+      height: 16px;
+      margin: 0 6px 0 0;
+    }
+
+    span {
+      line-height: 24px;
+      font-size: 17px;
+      color: $grey-90;
+      font-weight: 600;
+    }
   }
 
   .subtitle {
@@ -12,8 +23,13 @@
     color: $grey-50;
     margin: 0;
 
-    a::before {
+    span::after {
       content: ' ';
+    }
+
+    a:hover,
+    a:focus {
+      text-decoration: underline;
     }
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
@@ -1,4 +1,6 @@
 .ds-message {
+  margin: 8px 0 0;
+
   .title {
     display: flex;
     align-items: center;
@@ -19,7 +21,7 @@
 
   .subtitle {
     line-height: 20px;
-    font-size: 13px;
+    font-size: 14px;
     color: $grey-50;
     margin: 0;
 
@@ -31,5 +33,9 @@
     a:focus {
       text-decoration: underline;
     }
+  }
+
+  .ds-hr {
+    margin: 16px 0 8px 0;
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/_DSMessage.scss
@@ -36,6 +36,6 @@
   }
 
   .ds-hr {
-    margin: 16px 0 8px 0;
+    margin: 16px 0 8px;
   }
 }

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -155,6 +155,7 @@ input {
 @import '../components/DiscoveryStreamComponents/SectionTitle/SectionTitle';
 @import '../components/DiscoveryStreamComponents/TopSites/TopSites';
 @import '../components/DiscoveryStreamComponents/DSCard/DSCard';
+@import '../components/DiscoveryStreamComponents/DSMessage/DSMessage';
 
 // AS Router
 @import '../asrouter/components/Button/Button';


### PR DESCRIPTION
1. Set `browser.newtabpage.activity-stream.discoverystream.config` to `{"enabled":true,"show_spocs":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}`
2. Verify that Message component layout matches [comp](https://bug1524322.bmoattachments.org/attachment.cgi?id=9040475)
