### PR TITLE
Port Bug 1525134 - Remove remote url from browser_discovery_styles.js r=andreio

### DIFF
--- a/test/browser/browser_discovery_styles.js
+++ b/test/browser/browser_discovery_styles.js
@@ -64,7 +64,9 @@ test_newtab({
         components: [{
           type: "HorizontalRule",
           styles: {
-            "hr": `background-image: url(https://example.com/background);
+            // NB: Use display: none to avoid network requests to unfiltered urls
+            "hr": `display: none;
+                   background-image: url(https://example.com/background);
                    content: url(chrome://browser/content);
                    cursor: url(  resource://activity-stream/cursor  ), auto;
                    list-style-image: url('https://img-getpocket.cdn.mozilla.net/list');`,


### PR DESCRIPTION
Against master to get other ports so automation is hopefully green. Locally looks good without seeing:

```
Entering test bound test_url_filtering
FATAL ERROR: Non-local network connections are disabled and a connection attempt to img-getpocket.cdn.mozilla.net (23.210.237.36) was made.
You should only access hostnames available via the test networking proxy (if running mochitests) or from a test-specific httpd.js server (if running xpcshell tests). Browser services should be disabled or redirected to a local server.
[GFX1-]: Receive IPC close with reason=AbnormalShutdown
Exiting due to channel error.
…
ERROR TEST-UNEXPECTED-FAIL | browser/components/newtab/test/browser/browser_discovery_styles.js | application terminated with exit code 1
```