### PR TITLE
Bug 1525391 - Collect telemetry for request time and cache age for Pocket

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -739,6 +739,78 @@ These report any failures during domain affinity v2 calculations, and where it f
 }
 ```
 
+### Discovery Stream performance pings
+
+#### Request time of layout feed in ms
+
+```js
+{
+  "action": "activity_stream_performance_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": "LAYOUT_REQUEST_TIME",
+  "value": 42
+}
+```
+
+#### Request time of SPOCS feed in ms
+
+```js
+{
+  "action": "activity_stream_performance_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": "SPOCS_REQUEST_TIME",
+  "value": 42
+}
+```
+
+#### Request time of component feed feed in ms
+
+```js
+{
+  "action": "activity_stream_performance_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": "COMPONENT_FEED_REQUEST_TIME",
+  "value": 42
+}
+```
+
+#### Request time of total Discovery Stream feed in ms
+
+```js
+{
+  "action": "activity_stream_performance_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": "DS_FEED_TOTAL_REQUEST_TIME",
+  "value": 136
+}
+```
+
+#### Cache age of Discovery Stream feed in second
+
+```js
+{
+  "action": "activity_stream_performance_event",
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": "DS_CACHE_AGE_IN_SEC",
+  "value": 1800 // 30 minutes
+}
+```
+
 ## Undesired event pings
 
 These pings record the undesired events happen in the addon for further investigation.

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -5,6 +5,7 @@
 
 const {XPCOMUtils} = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
+ChromeUtils.defineModuleGetter(this, "perfService", "resource://activity-stream/common/PerfService.jsm");
 
 const {actionTypes: at, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm");
 const {PersistentCache} = ChromeUtils.import("resource://activity-stream/lib/PersistentCache.jsm");
@@ -137,8 +138,10 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     const cachedData = await this.cache.get() || {};
     let {layout} = cachedData;
     if (this.isExpired({cachedData, key: "layout", isStartup})) {
+      const start = perfService.absNow();
       const layoutResponse = await this.fetchFromEndpoint(this.config.layout_endpoint);
       if (layoutResponse && layoutResponse.layout) {
+        this.layoutRequestTime = Math.round(perfService.absNow() - start);
         layout = {
           lastUpdated: Date.now(),
           spocs: layoutResponse.spocs,
@@ -236,10 +239,17 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       return;
     }
 
+    // Reset the flag that indicates whether or not at least one API request
+    // was issued to fetch the component feed in `getComponentFeed()`.
+    this.componentFeedFetched = false;
+    const start = perfService.absNow();
     const {newFeedsPromises, newFeeds} = this.buildFeedPromises(DiscoveryStream.layout, isStartup);
 
     // Each promise has a catch already built in, so no need to catch here.
     await Promise.all(newFeedsPromises);
+    if (this.componentFeedFetched) {
+      this.componentFeedRequestTime = Math.round(perfService.absNow() - start);
+    }
     await this.cache.set("feeds", newFeeds);
     sendUpdate({type: at.DISCOVERY_STREAM_FEEDS_UPDATE, data: newFeeds});
   }
@@ -252,8 +262,10 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       spocs = cachedData.spocs;
       if (this.isExpired({cachedData, key: "spocs", isStartup})) {
         const endpoint = this.store.getState().DiscoveryStream.spocs.spocs_endpoint;
+        const start = perfService.absNow();
         const spocsResponse = await this.fetchFromEndpoint(endpoint);
         if (spocsResponse) {
+          this.spocsRequestTime = Math.round(perfService.absNow() - start);
           spocs = {
             lastUpdated: Date.now(),
             data: spocsResponse,
@@ -343,6 +355,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     if (this.isExpired({cachedData, key: "feed", url: feedUrl, isStartup})) {
       const feedResponse = await this.fetchFromEndpoint(feedUrl);
       if (feedResponse) {
+        this.componentFeedFetched = true;
         feed = {
           lastUpdated: Date.now(),
           data: feedResponse,
@@ -399,8 +412,88 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     this.loaded = true;
   }
 
+  /**
+   * Reports the cache age in second for Discovery Stream.
+   */
+  async reportCacheAge() {
+    const cachedData = await this.cache.get() || {};
+    const {layout, spocs, feeds} = cachedData;
+    let cacheAge = Date.now();
+    let updated = false;
+
+    if (layout && layout.lastUpdated && layout.lastUpdated < cacheAge) {
+      updated = true;
+      cacheAge = layout.lastUpdated;
+    }
+
+    if (spocs && spocs.lastUpdated && spocs.lastUpdated < cacheAge) {
+      updated = true;
+      cacheAge = spocs.lastUpdated;
+    }
+
+    if (feeds) {
+      Object.keys(feeds).forEach(url => {
+        const feed = feeds[url];
+        if (feed.lastUpdated && feed.lastUpdated < cacheAge) {
+          updated = true;
+          cacheAge = feed.lastUpdated;
+        }
+      });
+    }
+
+    if (updated) {
+      this.store.dispatch(ac.PerfEvent({
+        event: "DS_CACHE_AGE_IN_SEC",
+        value: Math.round((Date.now() - cacheAge) / 1000),
+      }));
+    }
+  }
+
+  /**
+   * Reports various time durations when the feed is requested from endpoint for
+   * the first time. This could happen on the browser start-up, or the pref changes
+   * of discovery stream.
+   *
+   * Metrics to be reported:
+   *   - Request time for layout endpoint
+   *   - Request time for feed endpoint
+   *   - Request time for spoc endpoint
+   *   - Total request time for data completeness
+   */
+  reportRequestTime() {
+    if (this.layoutRequestTime) {
+      this.store.dispatch(ac.PerfEvent({
+        event: "LAYOUT_REQUEST_TIME",
+        value: this.layoutRequestTime,
+      }));
+    }
+    if (this.spocsRequestTime) {
+      this.store.dispatch(ac.PerfEvent({
+        event: "SPOCS_REQUEST_TIME",
+        value: this.spocsRequestTime,
+      }));
+    }
+    if (this.componentFeedRequestTime) {
+      this.store.dispatch(ac.PerfEvent({
+        event: "COMPONENT_FEED_REQUEST_TIME",
+        value: this.componentFeedRequestTime,
+      }));
+    }
+    if (this.totalRequestTime) {
+      this.store.dispatch(ac.PerfEvent({
+        event: "DS_FEED_TOTAL_REQUEST_TIME",
+        value: this.totalRequestTime,
+      }));
+    }
+  }
+
   async enable() {
+    // Note that cache age needs to be reported prior to refreshAll.
+    await this.reportCacheAge();
+    const start = perfService.absNow();
     await this.refreshAll({updateOpenTabs: true, isStartup: true});
+    this.totalRequestTime = Math.round(perfService.absNow() - start);
+    this.reportRequestTime();
   }
 
   async disable() {
@@ -408,6 +501,10 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     // Reset reducer
     this.store.dispatch(ac.BroadcastToContent({type: at.DISCOVERY_STREAM_LAYOUT_RESET}));
     this.loaded = false;
+    this.layoutRequestTime = undefined;
+    this.spocsRequestTime = undefined;
+    this.componentFeedRequestTime = undefined;
+    this.totalRequestTime = undefined;
   }
 
   async clearCache() {

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -188,6 +188,19 @@ describe("DiscoveryStreamFeed", () => {
         assert.equal(args[0].length, 3);
       }
     );
+
+    it("should not record the request time if no fetch request was issued", async () => {
+      const fakeComponents = {components: []};
+      const fakeLayout = [fakeComponents, {components: [{}]}, {}];
+      fakeDiscoveryStream = {DiscoveryStream: {layout: fakeLayout}};
+      fakeCache = {feeds: {"foo.com": {"lastUpdated": Date.now(), "data": "data"}}};
+      sandbox.stub(feed.cache, "get").returns(Promise.resolve(fakeCache));
+      feed.componentFeedRequestTime = undefined;
+
+      await feed.loadComponentFeeds(feed.store.dispatch);
+
+      assert.isUndefined(feed.componentFeedRequestTime);
+    });
   });
 
   describe("#getComponentFeed", () => {
@@ -590,10 +603,14 @@ describe("DiscoveryStreamFeed", () => {
       sandbox.stub(feed.cache, "set").returns(Promise.resolve());
       setPref(CONFIG_PREF_NAME, {enabled: true});
       sandbox.stub(feed, "loadLayout").returns(Promise.resolve());
+      sandbox.stub(feed, "reportCacheAge").resolves();
+      sandbox.spy(feed, "reportRequestTime");
 
       await feed.onAction({type: at.INIT});
 
       assert.calledOnce(feed.loadLayout);
+      assert.calledOnce(feed.reportCacheAge);
+      assert.calledOnce(feed.reportRequestTime);
       assert.isTrue(feed.loaded);
     });
   });
@@ -872,7 +889,7 @@ describe("DiscoveryStreamFeed", () => {
       Object.defineProperty(feed, "showSpocs", {get: () => true});
     });
 
-    it("should call layout, component, spocs update functions", async () => {
+    it("should call layout, component, spocs update and telemetry reporting functions", async () => {
       await feed.refreshAll();
 
       assert.calledOnce(feed.loadLayout);
@@ -983,6 +1000,79 @@ describe("DiscoveryStreamFeed", () => {
         assert.calledTwice(feed.store.dispatch);
         assert.equal(feed.store.dispatch.firstCall.args[0].type, at.DISCOVERY_STREAM_FEEDS_UPDATE);
       });
+    });
+  });
+
+  describe("#reportCacheAge", () => {
+    let cache;
+    const cacheAge = 30;
+    beforeEach(() => {
+      cache = {
+        layout: {lastUpdated: Date.now() - 10 * 1000},
+        feeds: {"foo.com": {lastUpdated: Date.now() - cacheAge * 1000}},
+        spocs: {lastUpdated: Date.now() - 20 * 1000},
+      };
+      sandbox.stub(feed.cache, "get").resolves(cache);
+    });
+
+    it("should report the oldest lastUpdated date as the cache age", async () => {
+      sandbox.spy(feed.store, "dispatch");
+      feed.loaded = false;
+      await feed.reportCacheAge();
+
+      assert.calledOnce(feed.store.dispatch);
+
+      const [action] = feed.store.dispatch.firstCall.args;
+      assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
+      assert.equal(action.data.event, "DS_CACHE_AGE_IN_SEC");
+      assert.isAtLeast(action.data.value, cacheAge);
+      feed.loaded = true;
+    });
+  });
+
+  describe("#reportRequestTime", () => {
+    let cache;
+    const cacheAge = 30;
+    beforeEach(() => {
+      cache = {
+        layout: {lastUpdated: Date.now() - 10 * 1000},
+        feeds: {"foo.com": {lastUpdated: Date.now() - cacheAge * 1000}},
+        spocs: {lastUpdated: Date.now() - 20 * 1000},
+      };
+      sandbox.stub(feed.cache, "get").resolves(cache);
+    });
+
+    it("should report all the request times", async () => {
+      sandbox.spy(feed.store, "dispatch");
+      feed.loaded = false;
+      feed.layoutRequestTime = 1000;
+      feed.spocsRequestTime = 2000;
+      feed.componentFeedRequestTime = 3000;
+      feed.totalRequestTime = 5000;
+      feed.reportRequestTime();
+
+      assert.equal(feed.store.dispatch.callCount, 4);
+
+      let [action] = feed.store.dispatch.getCall(0).args;
+      assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
+      assert.equal(action.data.event, "LAYOUT_REQUEST_TIME");
+      assert.equal(action.data.value, 1000);
+
+      [action] = feed.store.dispatch.getCall(1).args;
+      assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
+      assert.equal(action.data.event, "SPOCS_REQUEST_TIME");
+      assert.equal(action.data.value, 2000);
+
+      [action] = feed.store.dispatch.getCall(2).args;
+      assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
+      assert.equal(action.data.event, "COMPONENT_FEED_REQUEST_TIME");
+      assert.equal(action.data.value, 3000);
+
+      [action] = feed.store.dispatch.getCall(3).args;
+      assert.equal(action.type, at.TELEMETRY_PERFORMANCE_EVENT);
+      assert.equal(action.data.event, "DS_FEED_TOTAL_REQUEST_TIME");
+      assert.equal(action.data.value, 5000);
+      feed.loaded = true;
     });
   });
 });


### PR DESCRIPTION
This adds various metrics to measure:

* the request time to fetch layout, spocs, and component feed on browser start-up and pref change. It won't record telemetry 1) if the cache is not expired, 2) subsequent loads after the first fetch  
* the total duration for the data completeness on browser start-up, which includes fetches to the endpoints, cache loads, and other data preparation
* cache age in second, which will be calculated based on the oldest `lastUpdated` in the cache file