### PR TITLE
Followup Bug 1521084 - Add default pref for impressions so it gets into redux state

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -226,6 +226,10 @@ const PREFS_CONFIG = new Map([
     title: "Opt out of new layout v0",
     value: false,
   }],
+  ["discoverystream.spoc.impressions", {
+    title: "Track spoc impressions",
+    value: "{}",
+  }],
   ["darkModeMessage", {
     title: "Boolean flag that decides whether to show the dark Mode message or not.",
     value: IS_NIGHTLY_OR_UNBRANDED_BUILD,


### PR DESCRIPTION
This was regressed by #4754. Not sure if this needs a bug for uplift as we probably won't be uplifting the regressing bug (opt out handling for default on in nightly). But I suppose if we do uplift it, this should be uplifted with it together.

r?@k88hudson or @piatra Not sure if we should long term just make PrefsFeed track/dispatch any pref under the branch instead of only accepting those that were set by default… ?