### PR TITLE
Bug 1525366 - Show user preference for SPOCs if Discoverystream is on

### DIFF
--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -286,8 +286,19 @@ this.AboutPreferences = class AboutPreferences {
       createAppend("label", discoveryGroup)
         .appendChild(document.createElementNS(HTML_NS, "h2"))
         .textContent = formatString("prefs_content_discovery_header");
-      createAppend("description", discoveryGroup)
-        .textContent = formatString("prefs_content_discovery_description");
+      const descriptionHbox = createAppend("hbox", discoveryGroup);
+      const discoveryGroupDescription = createAppend("description", descriptionHbox);
+      discoveryGroupDescription.textContent = formatString("prefs_content_discovery_description");
+      discoveryGroupDescription.classList.add("tail-with-learn-more");
+
+      // Add the Learn more link in the description
+      const topstoriesSection = prefStructure.find(s => s.id === "topstories");
+      const learnMoreURL = topstoriesSection && topstoriesSection.learnMore.link.href;
+      const link = createAppend("label", descriptionHbox);
+      link.classList.add("learn-sponsored");
+      link.classList.add("text-link");
+      link.setAttribute("href", learnMoreURL);
+      link.textContent = formatString("prefs_topstories_sponsored_learn_more");
 
       if (discoveryStreamConfig.show_spocs && sponsoredStoriesCheckbox) {
         sponsoredStoriesCheckbox.remove();

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -18,6 +18,7 @@ const HTML_NS = "http://www.w3.org/1999/xhtml";
 
 const PREFERENCES_LOADED_EVENT = "home-pane-loaded";
 const DISCOVERY_STREAM_CONFIG_PREF_NAME = "browser.newtabpage.activity-stream.discoverystream.config";
+const PREF_SHOW_SPONSORED = "showSponsored";
 
 // These "section" objects are formatted in a way to be similar to the ones from
 // SectionsManager to construct the preferences view.
@@ -105,7 +106,7 @@ this.AboutPreferences = class AboutPreferences {
 
   async observe(window) {
     this.renderPreferences(window, await this.strings, [...PREFS_BEFORE_SECTIONS,
-      ...this.store.getState().Sections, ...PREFS_AFTER_SECTIONS], this.store.getState().DiscoveryStream.config.enabled);
+      ...this.store.getState().Sections, ...PREFS_AFTER_SECTIONS], this.store.getState().DiscoveryStream.config);
   }
 
   /**
@@ -133,7 +134,7 @@ this.AboutPreferences = class AboutPreferences {
    * Render preferences to an about:preferences content window with the provided
    * strings and preferences structure.
    */
-  renderPreferences({document, Preferences, gHomePane}, strings, prefStructure, discoveryStreamEnabled) {
+  renderPreferences({document, Preferences, gHomePane}, strings, prefStructure, discoveryStreamConfig) {
     // Helper to create a new element and append it
     const createAppend = (tag, parent) => parent.appendChild(
       document.createXULElement(tag));
@@ -268,7 +269,7 @@ this.AboutPreferences = class AboutPreferences {
       });
     });
 
-    if (discoveryStreamEnabled) {
+    if (discoveryStreamConfig.enabled) {
       // If Discovery Stream is enabled hide Home Content options
       contentsGroup.style.visibility = "hidden";
 
@@ -280,6 +281,13 @@ this.AboutPreferences = class AboutPreferences {
         .textContent = formatString("prefs_content_discovery_header");
       createAppend("description", discoveryGroup)
         .textContent = formatString("prefs_content_discovery_description");
+
+      if (discoveryStreamConfig.show_spocs) {
+        const discoveryDetails = createAppend("vbox", discoveryGroup);
+        const subcheck = createAppend("checkbox", discoveryDetails);
+        subcheck.setAttribute("label", formatString("prefs_sponsored_stories_status_label"));
+        linkPref(subcheck, PREF_SHOW_SPONSORED, "bool");
+      }
 
       const contentDiscoveryButton = document.createElementNS(HTML_NS, "button");
       contentDiscoveryButton.classList.add("contentDiscoveryButton");

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -168,6 +168,10 @@ this.AboutPreferences = class AboutPreferences {
       `href="data:text/css,${encodeURIComponent(CUSTOM_CSS)}" type="text/css"`),
       document.documentElement);
 
+    // Both Topstories and Discovery Stream need to toggle the same pref but
+    // we can't have two elements linked to the same pref so we reuse the same.
+    let sponsoredStoriesCheckbox = null;
+
     // Insert a new group immediately after the homepage one
     const homeGroup = document.getElementById("homepageGroup");
     const contentsGroup = homeGroup.insertAdjacentElement("afterend", homeGroup.cloneNode());
@@ -266,6 +270,9 @@ this.AboutPreferences = class AboutPreferences {
         subcheck.classList.add("indent");
         subcheck.setAttribute("label", formatString(nested.titleString));
         linkPref(subcheck, nested.name, "bool");
+        if (nested.name === "showSponsored") {
+          sponsoredStoriesCheckbox = subcheck;
+        }
       });
     });
 
@@ -282,7 +289,11 @@ this.AboutPreferences = class AboutPreferences {
       createAppend("description", discoveryGroup)
         .textContent = formatString("prefs_content_discovery_description");
 
-      if (discoveryStreamConfig.show_spocs) {
+      if (discoveryStreamConfig.show_spocs && sponsoredStoriesCheckbox) {
+        sponsoredStoriesCheckbox.remove();
+        sponsoredStoriesCheckbox.classList.remove("indent");
+        discoveryGroup.appendChild(sponsoredStoriesCheckbox);
+      } else if (discoveryStreamConfig.show_spocs) {
         const discoveryDetails = createAppend("vbox", discoveryGroup);
         const subcheck = createAppend("checkbox", discoveryDetails);
         subcheck.setAttribute("label", formatString("prefs_sponsored_stories_status_label"));
@@ -302,6 +313,11 @@ this.AboutPreferences = class AboutPreferences {
           // order to help with testing
           discoveryGroup.style.display = "none";
           contentsGroup.style.visibility = "visible";
+          if (sponsoredStoriesCheckbox) {
+            sponsoredStoriesCheckbox.remove();
+            sponsoredStoriesCheckbox.classList.add("indent");
+            document.querySelector("[data-subcategory='topstories'] .indent").appendChild(sponsoredStoriesCheckbox);
+          }
           if (experiment) {
             await PreferenceExperiments.stop(experiment.name, {
               resetValue: true,

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -270,7 +270,7 @@ this.AboutPreferences = class AboutPreferences {
         subcheck.classList.add("indent");
         subcheck.setAttribute("label", formatString(nested.titleString));
         linkPref(subcheck, nested.name, "bool");
-        if (nested.name === "showSponsored") {
+        if (nested.name === PREF_SHOW_SPONSORED) {
           sponsoredStoriesCheckbox = subcheck;
         }
       });
@@ -294,6 +294,7 @@ this.AboutPreferences = class AboutPreferences {
         sponsoredStoriesCheckbox.classList.remove("indent");
         discoveryGroup.appendChild(sponsoredStoriesCheckbox);
       } else if (discoveryStreamConfig.show_spocs) {
+        // If there is no element to reuse create one
         const discoveryDetails = createAppend("vbox", discoveryGroup);
         const subcheck = createAppend("checkbox", discoveryDetails);
         subcheck.setAttribute("label", formatString("prefs_sponsored_stories_status_label"));
@@ -314,9 +315,11 @@ this.AboutPreferences = class AboutPreferences {
           discoveryGroup.style.display = "none";
           contentsGroup.style.visibility = "visible";
           if (sponsoredStoriesCheckbox) {
+            // If we reused the checkbox element we need to restore it
             sponsoredStoriesCheckbox.remove();
             sponsoredStoriesCheckbox.classList.add("indent");
-            document.querySelector("[data-subcategory='topstories'] .indent").appendChild(sponsoredStoriesCheckbox);
+            const topstoriesDetails = document.querySelector("[data-subcategory='topstories'] .indent");
+            topstoriesDetails.appendChild(sponsoredStoriesCheckbox);
           }
           if (experiment) {
             await PreferenceExperiments.stop(experiment.name, {

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -641,7 +641,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
             break;
           // Check if spocs was disabled. Remove them if they were.
           case PREF_SHOW_SPONSORED:
-            await this.loadSpocs();
+            await this.loadSpocs(update => this.store.dispatch(ac.BroadcastToContent(update)));
             break;
         }
         break;

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -105,6 +105,7 @@ prefs_topsites_description=The sites you visit most
 prefs_topstories_description2=Great content from around the web, personalized for you
 prefs_topstories_options_sponsored_label=Sponsored Stories
 prefs_topstories_sponsored_learn_more=Learn more
+prefs_sponsored_stories_status_label=Show sponsored stories
 prefs_highlights_description=A selection of sites that you’ve saved or visited
 prefs_highlights_options_visited_label=Visited Pages
 prefs_highlights_options_download_label=Most Recent Download

--- a/test/unit/lib/AboutPreferences.test.js
+++ b/test/unit/lib/AboutPreferences.test.js
@@ -145,7 +145,7 @@ describe("AboutPreferences Feed", () => {
       },
       Preferences,
       gHomePane,
-    }, strings, prefStructure, DiscoveryStream.config.enabled);
+    }, strings, prefStructure, DiscoveryStream.config);
     beforeEach(() => {
       node = {
         appendChild: sandbox.stub().returnsArg(0),
@@ -298,7 +298,7 @@ describe("AboutPreferences Feed", () => {
     describe("#DiscoveryStream", () => {
       let PreferenceExperimentsStub;
       beforeEach(() => {
-        DiscoveryStream = {config: {enabled: true}};
+        DiscoveryStream = {config: {enabled: true, show_spocs: false}};
         PreferenceExperimentsStub = {
           getAllActive: sandbox.stub().resolves([{name: "discoverystream", preferenceName: "browser.newtabpage.activity-stream.discoverystream.config"}]),
           stop: sandbox.stub().resolves(),
@@ -344,6 +344,24 @@ describe("AboutPreferences Feed", () => {
         assert.calledOnce(PreferenceExperimentsStub.getAllActive);
         assert.calledOnce(PreferenceExperimentsStub.stop);
         assert.calledWithExactly(PreferenceExperimentsStub.stop, "discoverystream", {resetValue: true, reason: "individual-opt-out"});
+      });
+      it("should render the spocs opt out checkbox if show_spocs is true", () => {
+        const spy = sandbox.spy(instance, "renderPreferences");
+        DiscoveryStream = {config: {enabled: true, show_spocs: true}};
+        testRender();
+
+        const {createXULElement} = spy.firstCall.args[0].document;
+        assert.calledWith(createXULElement, "checkbox");
+        assert.calledWith(Preferences.add, {id: "browser.newtabpage.activity-stream.showSponsored", type: "bool"});
+      });
+      it("should not render the spocs opt out checkbox if show_spocs is false", () => {
+        const spy = sandbox.spy(instance, "renderPreferences");
+        DiscoveryStream = {config: {enabled: true, show_spocs: false}};
+        testRender();
+
+        const {createXULElement} = spy.firstCall.args[0].document;
+        assert.neverCalledWith(createXULElement, "checkbox");
+        assert.neverCalledWith(Preferences.add, {id: "browser.newtabpage.activity-stream.showSponsored", type: "bool"});
       });
     });
   });

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -793,6 +793,20 @@ describe("DiscoveryStreamFeed", () => {
     });
   });
 
+  describe("#onAction: PREF_SHOW_SPONSORED", () => {
+    it("should call loadSpocs when preference changes", async () => {
+      sandbox.stub(feed, "loadSpocs").resolves();
+      sandbox.stub(feed.store, "dispatch");
+
+      await feed.onAction({type: at.PREF_CHANGED, data: {name: "showSponsored"}});
+
+      assert.calledOnce(feed.loadSpocs);
+      const [dispatchFn] = feed.loadSpocs.firstCall.args;
+      dispatchFn({});
+      assert.calledWith(feed.store.dispatch, ac.BroadcastToContent({}));
+    });
+  });
+
   describe("#isExpired", () => {
     it("should throw if the key is not valid", () => {
       assert.throws(() => {


### PR DESCRIPTION
The issue I ran into while implementing this: 

tldr 2 checkboxes linking to the same preference (`showSponsored`) doesn't work.

Currently in `about:preferences` we hide the default prefs (via CSS) and append the experiment preferences. In this bug we add a checkbox (for the experiment prefs) to toggle spocs. This checkbox links to the same pref as TopStories section (`.showSponsored`) essentially having 2 checkboxes linking to the same preference, [which is not allowed](https://searchfox.org/mozilla-central/rev/5e3bffe964110b8d1885b4236b8abd5c94d8f609/toolkit/content/preferencesBindings.js#35).

And there doesn't seem to be a way to unlink a binding between an element and a pref so my solution was to just reload the page if the user leaves the experiment. 
I could also reach into `Preferences._all` and remove it and the listener but at that point I would be implementing the missing `Preferences.remove` method.
I'm open to suggestions to improve this.