### PR TITLE
Bug 1527397 – Refactor Hero's full width layout

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -74,8 +74,10 @@ export class Hero extends React.PureComponent {
               <div className="img" style={{backgroundImage: `url(${heroRec.image_src})`}} />
             </div>
             <div className="meta">
-              <header>{heroRec.title}</header>
-              <p className="excerpt">{heroRec.excerpt}</p>
+              <div className="header-and-excerpt">
+                <header>{heroRec.title}</header>
+                <p className="excerpt">{heroRec.excerpt}</p>
+              </div>
               {heroRec.context ? (
                 <p className="context">{heroRec.context}</p>
               ) : (

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -153,6 +153,16 @@ $card-header-in-hero-line-height: 20;
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 24px;
+    padding: 20px 0;
+
+    &.ds-hero-border {
+      border-top: $border-secondary;
+
+      .ds-card:nth-child(-n+2) {
+        border-bottom: $border-secondary;
+        margin-bottom: 20px;
+      }
+    }
 
     .wrapper {
       border-top: 0;
@@ -182,7 +192,7 @@ $card-header-in-hero-line-height: 20;
 
     .cards {
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(2, 1fr);
       grid-column-gap: 24px;
     }
   }

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -16,7 +16,7 @@ $card-header-in-hero-line-height: 20;
   }
 
   .excerpt {
-    @include limit-visibile-lines(4, 23, 15);
+    @include limit-visibile-lines(3, 20, 14);
     margin: 4px 0 8px;
   }
 
@@ -90,7 +90,7 @@ $card-header-in-hero-line-height: 20;
 
     .meta {
       header {
-        @include limit-visibile-lines(2, 28, 22);
+        @include limit-visibile-lines(4, 28, 22);
         color: $grey-90;
       }
 
@@ -150,32 +150,32 @@ $card-header-in-hero-line-height: 20;
   .ds-column-10 &,
   .ds-column-11 &,
   .ds-column-12 & {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 24px;
+
     .wrapper {
-      display: flex;
-      align-items: flex-start;
-      flex-direction: row-reverse;
+      border-top: 0;
+      border-bottom: 0;
+      margin: 0;
+      padding: 0;
 
       .img-wrapper {
-        width: 67%;
         margin: 0;
       }
 
       .img {
+        margin-bottom: 16px;
         height: 0;
         padding-top: 50%; // 2:1 aspect ratio
       }
 
       .meta {
-        width: 33%;
         padding: 0 24px 0 0;
 
         header {
-          @include limit-visibile-lines(6, 28, 22);
-          margin: 0 0 4px;
-        }
-
-        p {
-          line-height: 1.6;
+          @include limit-visibile-lines(3, 28, 22);
+          margin: 0 0 8px;
         }
       }
     }

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -89,6 +89,10 @@ $card-header-in-hero-line-height: 20;
     }
 
     .meta {
+      display: block;
+      flex-direction: column;
+      justify-content: space-between;
+
       header {
         @include limit-visibile-lines(4, 28, 22);
         color: $grey-90;
@@ -130,6 +134,7 @@ $card-header-in-hero-line-height: 20;
       .meta {
         grid-column: 1;
         grid-row: 1;
+        display: flex;
       }
 
       .img {
@@ -181,11 +186,16 @@ $card-header-in-hero-line-height: 20;
       }
 
       .meta {
+        display: flex;
         padding: 0 24px 0 0;
 
         header {
           @include limit-visibile-lines(3, 28, 22);
           margin: 0 0 8px;
+        }
+
+        .source {
+          margin: 0;
         }
       }
     }


### PR DESCRIPTION
Repro steps:

- Set `browser.newtabpage.activity-stream.discoverystream.config` to `{"enabled":true,"show_spocs":true,"layout_endpoint":"https://getpocket.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=dev-test-all"}`
- Compare Hero layouts in build to those in the [Figma](https://www.figma.com/file/HAk87Z6QBcu6YxBIoXN6LJcU/Firefox-Home-Modules?node-id=9%3A15)