### PR TITLE
Bug 1527980 - Add devtools for resetting and picking a layout variant

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -155,5 +155,10 @@
   .ds-component {
     margin-bottom: 20px;
   }
+
+  .optOutNote {
+    font-size: 12px;
+    margin-inline-start: 4px;
+  }
 }
 


### PR DESCRIPTION
![screen shot 2019-02-14 at 1 46 03 pm](https://user-images.githubusercontent.com/1455535/52810754-4b9c3480-3061-11e9-9777-057cda8228d7.png)

Testing enabled / opt-out:
1. Turn on new tab devtools: Set `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` to `true`.
2. Navigate to about:newtab#devtools-ds
3. Make sure the enabled checkbox is checked. Ensure discovery stream is visible on another tab.
4. Go to about:preferences#home and click the "Turn off discovery stream" button.
5. On about:newtab#devtools-ds, ensure that the enabled checkbox is now unchecked and you see the message "(Note: User has opted-out. Check this box to reset)" next to the checkbox.
6. Check the enabled box. Ensure that discovery stream now shows up again on a new tab page and the opt-out message has disappeared next to the checkbox.

Testing layout variants.
1. On about:newtab#devtools-ds, ensure discovery stream is enabled.
2. Check the "basic" radio box. Ensure you see a 3-card layout on new tab.
3. Check the "dev-test-all" radio box. Ensure you see a long layout with many elements.
4. On about:config, try changing the `browser.newtabpage.activity-stream.discoverystream.config` pref to include `layout_variant=basic` in the endpoint.
5. Check that on about:newtab#devtools-ds the basic radio checkbox is now checked.