### PR TITLE
 Port Bug 1524688: Part 61 - Convert AboutNewTabService to static registration. r=mconley

### DIFF
--- a/AboutNewTabService.jsm
+++ b/AboutNewTabService.jsm
@@ -6,7 +6,6 @@
 
 "use strict";
 
-const {XPCOMUtils} = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const {AppConstants} = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
 const {E10SUtils} = ChromeUtils.import("resource://gre/modules/E10SUtils.jsm");
@@ -361,4 +360,4 @@ AboutNewTabService.prototype = {
   },
 };
 
-var EXPORTED_SYMBOLS = ["AboutNewTabService"];
+const EXPORTED_SYMBOLS = ["AboutNewTabService"];

--- a/AboutNewTabService.jsm
+++ b/AboutNewTabService.jsm
@@ -361,4 +361,4 @@ AboutNewTabService.prototype = {
   },
 };
 
-this.NSGetFactory = XPCOMUtils.generateNSGetFactory([AboutNewTabService]);
+var EXPORTED_SYMBOLS = ["AboutNewTabService"];

--- a/NewTabComponents.manifest
+++ b/NewTabComponents.manifest
@@ -1,2 +1,0 @@
-component {dfcd2adc-7867-4d3a-ba70-17501f208142} aboutNewTabService.js
-contract @mozilla.org/browser/aboutnewtab-service;1 {dfcd2adc-7867-4d3a-ba70-17501f208142}

--- a/components.conf
+++ b/components.conf
@@ -1,0 +1,14 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Classes = [
+    {
+        'cid': '{dfcd2adc-7867-4d3a-ba70-17501f208142}',
+        'contract_ids': ['@mozilla.org/browser/aboutnewtab-service;1'],
+        'jsm': 'resource:///modules/AboutNewTabService.jsm',
+        'constructor': 'AboutNewTabService',
+    },
+]

--- a/moz.build
+++ b/moz.build
@@ -19,9 +19,12 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'browser-newtab'
 
-EXTRA_COMPONENTS += [
-    'aboutNewTabService.js',
-    'NewTabComponents.manifest',
+EXTRA_JS_MODULES += [
+    'AboutNewTabService.jsm',
+]
+
+XPCOM_MANIFESTS += [
+    'components.conf',
 ]
 
 JAR_MANIFESTS += ['jar.mn']


### PR DESCRIPTION
https://hg.mozilla.org/mozilla-central/rev/8276ffc51b70

r?@ncloudioj Almost a plain copy but there was a rename frmo aboutNewTabService.js to AboutNewTabService.jsm. Also, needed to fix a couple lint errors.