### PR TITLE
Followup Bug 1522832 - Restore header-and-excerpt div

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -74,8 +74,10 @@ export class Hero extends React.PureComponent {
               <div className="img" style={{backgroundImage: `url(${heroRec.image_src})`}} />
             </div>
             <div className="meta">
-              <header>{heroRec.title}</header>
-              <p className="excerpt">{heroRec.excerpt}</p>
+              <div className="header-and-excerpt">
+                <header>{heroRec.title}</header>
+                <p className="excerpt">{heroRec.excerpt}</p>
+              </div>
               {heroRec.context ? (
                 <p className="context">{heroRec.context}</p>
               ) : (

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -94,6 +94,7 @@ $card-header-in-hero-line-height: 20;
       header {
         @include limit-visibile-lines(4, 28, 22);
         color: $grey-90;
+        margin-bottom: 8px;
       }
 
       .context {
@@ -189,7 +190,6 @@ $card-header-in-hero-line-height: 20;
 
         header {
           @include limit-visibile-lines(3, 28, 22);
-          margin: 0 0 8px;
         }
 
         .source {


### PR DESCRIPTION
Fixes regression from https://github.com/mozilla/activity-stream/pull/4743/files#diff-cf1c6bc5f41ffdc4fb0575d6987f3311L77