### PR TITLE
Bug 1503693 - CFR button should persist in the URL bar until excused

### DIFF
--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -380,7 +380,8 @@ class PageAction {
 }
 
 function isHostMatch(browser, host) {
-  return browser.documentURI.spec === host;
+  return (browser.documentURI.scheme.startsWith("http") &&
+    browser.documentURI.host === host);
 }
 
 const CFRPageActions = {

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -340,9 +340,7 @@ class PageAction {
       accessKey: secondaryBtnStrings[0].attributes.accesskey,
       callback: () => {
         this.dispatchUserAction(secondary[0].action);
-        this.hide();
         this._sendTelemetry({message_id: id, bucket_id: content.bucket_id, event: "DISMISS"});
-        RecommendationMap.delete(browser);
       },
     }, {
       label: secondaryBtnStrings[1].label,
@@ -358,9 +356,7 @@ class PageAction {
       accessKey: secondaryBtnStrings[2].attributes.accesskey,
       callback: () => {
         this.dispatchUserAction(secondary[2].action);
-        this.hide();
         this._sendTelemetry({message_id: id, bucket_id: content.bucket_id, event: "MANAGE"});
-        RecommendationMap.delete(browser);
       },
     }];
 
@@ -384,8 +380,7 @@ class PageAction {
 }
 
 function isHostMatch(browser, host) {
-  return (browser.documentURI.scheme.startsWith("http") &&
-    browser.documentURI.host === host);
+  return browser.documentURI.spec === host;
 }
 
 const CFRPageActions = {
@@ -409,6 +404,11 @@ const CFRPageActions = {
         // The browser has a recommendation specified with this host, so show
         // the page action
         pageAction.show(recommendation);
+      } else if (recommendation.retain) {
+        // Keep the recommendation first time the user navigates away just in
+        // case they will go back to the previous page
+        pageAction.hide();
+        recommendation.retain = false;
       } else {
         // The user has navigated away from the specified host in the given
         // browser, so the recommendation is no longer valid and should be removed
@@ -451,7 +451,7 @@ const CFRPageActions = {
     // If we are forcing via the Admin page, the browser comes in a different format
     const win = browser.browser.ownerGlobal;
     const {id, content} = recommendation;
-    RecommendationMap.set(browser.browser, {id, content});
+    RecommendationMap.set(browser.browser, {id, retain: true, content});
     if (!PageActionMap.has(win)) {
       PageActionMap.set(win, new PageAction(win, dispatchToASRouter));
     }
@@ -476,7 +476,7 @@ const CFRPageActions = {
       return false;
     }
     const {id, content} = recommendation;
-    RecommendationMap.set(browser, {id, host, content});
+    RecommendationMap.set(browser, {id, host, retain: true, content});
     if (!PageActionMap.has(win)) {
       PageActionMap.set(win, new PageAction(win, dispatchToASRouter));
     }

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -523,8 +523,9 @@ describe("CFRPageActions", () => {
             event: "DISMISS",
           },
         });
-        // Should remove the recommendation
-        assert.isFalse(CFRPageActions.RecommendationMap.has(fakeBrowser));
+        // Don't remove the recommendation on `DISMISS` action
+        assert.isTrue(CFRPageActions.RecommendationMap.has(fakeBrowser));
+        assert.notCalled(pageAction.hide);
       });
       it("should send right telemetry for BLOCK secondary action", async () => {
         await pageAction._handleClick();
@@ -571,8 +572,9 @@ describe("CFRPageActions", () => {
             event: "MANAGE",
           },
         });
-        // Should remove the recommendation
-        assert.isFalse(CFRPageActions.RecommendationMap.has(fakeBrowser));
+        // Don't remove the recommendation on `MANAGE` action
+        assert.isTrue(CFRPageActions.RecommendationMap.has(fakeBrowser));
+        assert.notCalled(pageAction.hide);
       });
       it("should call PopupNotifications.show with the right arguments", async () => {
         await pageAction._handleClick();

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -511,7 +511,6 @@ describe("CFRPageActions", () => {
         sandbox.spy(pageAction, "hide");
         CFRPageActions.RecommendationMap.set(fakeBrowser, {});
         secondaryAction.callback();
-        assert.calledOnce(pageAction.hide);
         // Should send telemetry
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
@@ -554,13 +553,12 @@ describe("CFRPageActions", () => {
       });
       it("should send right telemetry for MANAGE secondary action", async () => {
         await pageAction._handleClick();
-        const blockAction = global.PopupNotifications.show.firstCall.args[5][2]; // eslint-disable-line prefer-destructuring
+        const manageAction = global.PopupNotifications.show.firstCall.args[5][2]; // eslint-disable-line prefer-destructuring
 
-        assert.deepEqual(blockAction.label, {value: "Secondary Button 3", attributes: {accesskey: "g"}});
+        assert.deepEqual(manageAction.label, {value: "Secondary Button 3", attributes: {accesskey: "g"}});
         sandbox.spy(pageAction, "hide");
         CFRPageActions.RecommendationMap.set(fakeBrowser, {});
-        blockAction.callback();
-        assert.calledOnce(pageAction.hide);
+        manageAction.callback();
         // Should send telemetry
         assert.calledWith(dispatchStub, {
           type: "DOORHANGER_TELEMETRY",
@@ -646,6 +644,26 @@ describe("CFRPageActions", () => {
         fakeBrowser.documentURI.host = someOtherFakeHost;
         assert.isTrue(CFRPageActions.RecommendationMap.has(fakeBrowser));
         CFRPageActions.updatePageActions(fakeBrowser);
+        assert.calledOnce(PageAction.prototype.hide);
+        assert.isFalse(CFRPageActions.RecommendationMap.has(fakeBrowser));
+      });
+      it("should not call `delete` if retain is true", () => {
+        savedRec.retain = true;
+        fakeBrowser.documentURI.host = "subdomain.mozilla.com";
+        assert.isTrue(CFRPageActions.RecommendationMap.has(fakeBrowser));
+
+        CFRPageActions.updatePageActions(fakeBrowser);
+        assert.propertyVal(savedRec, "retain", false);
+        assert.calledOnce(PageAction.prototype.hide);
+        assert.isTrue(CFRPageActions.RecommendationMap.has(fakeBrowser));
+      });
+      it("should call `delete` if retain is false", () => {
+        savedRec.retain = false;
+        fakeBrowser.documentURI.host = "subdomain.mozilla.com";
+        assert.isTrue(CFRPageActions.RecommendationMap.has(fakeBrowser));
+
+        CFRPageActions.updatePageActions(fakeBrowser);
+        assert.propertyVal(savedRec, "retain", false);
         assert.calledOnce(PageAction.prototype.hide);
         assert.isFalse(CFRPageActions.RecommendationMap.has(fakeBrowser));
       });


### PR DESCRIPTION
You can't really test this from ASRouter debug because we check for `https`.
Besides the changes mentioned in the bug in order to implement `and going back to the page where they remember seeing it in order to recover the message` I added an extra field `retain` that delays deleting the recommendation by 1 navigation step.
Trigger the CFR message, navigate away and then click back.
The puzzle piece icon will still be present on the original page where the message was shown.
When navigating away a second time the recommendation will be permanently deleted.