### PR TITLE
Bug 1527945 - Disable sync on .get() for Tippytop

### DIFF
--- a/lib/FaviconFeed.jsm
+++ b/lib/FaviconFeed.jsm
@@ -153,7 +153,10 @@ this.FaviconFeed = class FaviconFeed {
    * Get the site tippy top data from Remote Settings.
    */
   async getSite(domain) {
-    const sites = await this.tippyTop.get({filters: {domain}});
+    const sites = await this.tippyTop.get({
+      filters: {domain},
+      syncIfEmpty: false,
+    });
     return sites.length ? sites[0] : null;
   }
 


### PR DESCRIPTION
Will requires [Bug 1528704](https://bugzilla.mozilla.org/show_bug.cgi?id=1528704) to be taken into account by Remote Settings