### PR TITLE
Bug 1529334 - Blocking/unblocking CFR doesn't clear impressions

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -874,6 +874,7 @@ class _ASRouter {
       });
 
       this._storage.set("messageBlockList", messageBlockList);
+      this._storage.set("messageImpressions", messageImpressions);
       return {messageBlockList, messageImpressions};
     });
   }


### PR DESCRIPTION
I don't think this ever worked:
When we're turning CFR off we call `cleanupImpressions` that calls `_cleanupImpressionsForItems` and updates the store with the new impression numbers.
When we block we never called `store.set` for impressions.