### PR TITLE
Bug 1521203 - Ensure appropriate resource requests for endpoints (layout, feed, spoc)

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -239,6 +239,10 @@ const PREFS_CONFIG = new Map([
       });
     },
   }],
+  ["discoverystream.endpoints", {
+    title: "Endpoint prefixes (comma-separated) that are allowed to be requested",
+    value: "https://getpocket.cdn.mozilla.net/",
+  }],
   ["discoverystream.optOut.0", {
     title: "Opt out of new layout v0",
     value: false,

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -19,6 +19,7 @@ const SPOCS_FEEDS_UPDATE_TIME = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_RECS_EXPIRE_TIME = 60 * 60 * 1000; // 1 hour
 const MAX_LIFETIME_CAP = 500; // Guard against misconfiguration on the server
 const PREF_CONFIG = "discoverystream.config";
+const PREF_ENDPOINTS = "discoverystream.endpoints";
 const PREF_OPT_OUT = "discoverystream.optOut.0";
 const PREF_SHOW_SPONSORED = "showSponsored";
 const PREF_SPOC_IMPRESSIONS = "discoverystream.spoc.impressions";
@@ -88,17 +89,20 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       return null;
     }
     try {
+      // Make sure the requested endpoint is allowed
+      const allowed = this.store.getState().Prefs.values[PREF_ENDPOINTS].split(",");
+      if (!allowed.some(prefix => endpoint.startsWith(prefix))) {
+        throw new Error(`Not one of allowed prefixes (${allowed})`);
+      }
+
       const response = await fetch(endpoint, {credentials: "omit"});
       if (!response.ok) {
-        // istanbul ignore next
-        throw new Error(`${endpoint} returned unexpected status: ${response.status}`);
+        throw new Error(`Unexpected status (${response.status})`);
       }
       return response.json();
     } catch (error) {
-      // istanbul ignore next
       Cu.reportError(`Failed to fetch ${endpoint}: ${error.message}`);
     }
-    // istanbul ignore next
     return null;
   }
 

--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -5,6 +5,7 @@ support-files =
   head.js
 prefs =
   browser.newtabpage.activity-stream.debug=false
+  browser.newtabpage.activity-stream.discoverystream.endpoints=data:
 
 [browser_activity_stream_strings.js]
 [browser_as_load_location.js]


### PR DESCRIPTION
r?@ScottDowne This adds a prefix check based on a string pref. I was thinking maybe just a plain boolean but that loses out on some flexibility if we ever needed to change the pref to something else for Release users…

Also, I guess we'll need to let people know to set the pref to something like "http" if using custom endpoints.