### PR TITLE
Bug 1528966

### DIFF
--- a/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
+++ b/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
@@ -166,6 +166,26 @@
         }
       ]
     },
+    "descriptionDetails": {
+      "description": "Additional information and steps on how to use",
+      "type": "object",
+      "properties": {
+        "steps": {
+          "description": "Array of messages or string_ids",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "string_id": {
+                "type": "string",
+                "description": "Id of string to localized addon description"
+              }
+            }
+          }
+        }
+      },
+      "required": ["steps"]
+    },
     "buttons": {
       "description": "The label and functionality for the buttons in the pop-over.",
       "type": "object",

--- a/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
+++ b/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
@@ -15,6 +15,10 @@
     }
   },
   "properties": {
+    "category": {
+      "type": "string",
+      "description": "Attribute used for different groups of messages from the same provider"
+    },
     "bucket_id": {
       "type": "string",
       "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
@@ -319,5 +323,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["bucket_id", "notification_text", "heading_text", "text", "buttons"]
+  "required": ["category", "bucket_id", "notification_text", "heading_text", "text", "buttons"]
 }

--- a/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
+++ b/content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json
@@ -184,7 +184,8 @@
                 "type": "string",
                 "description": "Id of string to localized addon description"
               }
-            }
+            },
+            "required": ["string_id"]
           }
         }
       },

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -949,7 +949,7 @@ This reports the user's interaction with Activity Stream Router.
   "source": "CFR",
   // message_id could be the ID of the recommendation, such as "wikipedia_addon"
   "message_id": "wikipedia_addon",
-  "event": "[INSTALL | BLOCK | DISMISS | RATIONALE | LEARN_MORE | CLICK_DOORHANGER | MANAGE]"
+  "event": "[INSTALL | PIN | BLOCK | DISMISS | RATIONALE | LEARN_MORE | CLICK_DOORHANGER | MANAGE]"
 }
 ```
 
@@ -965,7 +965,7 @@ This reports the user's interaction with Activity Stream Router.
   // message_id should be a bucket ID in the release channel, we may not use the
   // individual ID, such as addon ID, per legal's request
   "message_id": "bucket_id",
-  "event": "[INSTALL | BLOCK | DISMISS | RATIONALE | LEARN_MORE | CLICK_DOORHANGER | MANAGE]"
+  "event": "[INSTALL | PIN | BLOCK | DISMISS | RATIONALE | LEARN_MORE | CLICK_DOORHANGER | MANAGE]"
 }
 ```
 

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -315,7 +315,14 @@ const CFR_MESSAGES = [
         label: {string_id: "cfr-doorhanger-extension-sumo-link"},
         sumo_path: REDDIT_ENHANCEMENT_PARAMS.sumo_path,
       },
-      text: "Get easy access to your most-used sites. Keep sites open in a tab (even when you restart).",
+      text: {string_id: "cfr-doorhanger-pintab-description"},
+      descriptionDetails: {
+        steps: [
+          {"string_id": "cfr-doorhanger-pintab-step1"},
+          {"string_id": "cfr-doorhanger-pintab-step2"},
+          {"string_id": "cfr-doorhanger-pintab-step3"},
+        ],
+      },
       buttons: {
         primary: {
           label: {string_id: "cfr-doorhanger-pintab-ok-button"},

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -306,7 +306,6 @@ const CFR_MESSAGES = [
     id: "PIN_TAB",
     template: "cfr_doorhanger",
     category: "cfrFeatures",
-    exclude: true,
     content: {
       bucket_id: "CFR_PIN_TAB",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -343,7 +343,8 @@ const CFR_MESSAGES = [
         }],
       },
     },
-    targeting: `!hasPinnedTabs && recentVisits[.timestamp > (currentDate|date - 3600 * 1000 * 1)]|length >= 1`,
+    frequency: {lifetime: 3},
+    targeting: `!hasPinnedTabs && recentVisits[.timestamp > (currentDate|date - 3600 * 1000 * 1)]|length >= 5`,
     trigger: {id: "frequentVisits", params: PINNED_TABS_TARGET_SITES},
   },
 ];

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -305,6 +305,7 @@ const CFR_MESSAGES = [
   {
     id: "PIN_TAB",
     template: "cfr_doorhanger",
+    exclude: true,
     content: {
       category: "cfrFeatures",
       bucket_id: "CFR_PIN_TAB",

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -43,8 +43,8 @@ const CFR_MESSAGES = [
   {
     id: "FACEBOOK_CONTAINER_3",
     template: "cfr_doorhanger",
-    category: "cfrAddons",
     content: {
+      category: "cfrAddons",
       bucket_id: "CFR_M1",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},
       heading_text: {string_id: "cfr-doorhanger-extension-heading"},
@@ -95,8 +95,8 @@ const CFR_MESSAGES = [
   {
     id: "GOOGLE_TRANSLATE_3",
     template: "cfr_doorhanger",
-    category: "cfrAddons",
     content: {
+      category: "cfrAddons",
       bucket_id: "CFR_M1",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},
       heading_text: {string_id: "cfr-doorhanger-extension-heading"},
@@ -147,8 +147,8 @@ const CFR_MESSAGES = [
   {
     id: "YOUTUBE_ENHANCE_3",
     template: "cfr_doorhanger",
-    category: "cfrAddons",
     content: {
+      category: "cfrAddons",
       bucket_id: "CFR_M1",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},
       heading_text: {string_id: "cfr-doorhanger-extension-heading"},
@@ -199,9 +199,9 @@ const CFR_MESSAGES = [
   {
     id: "WIKIPEDIA_CONTEXT_MENU_SEARCH_3",
     template: "cfr_doorhanger",
-    category: "cfrAddons",
     exclude: true,
     content: {
+      category: "cfrAddons",
       bucket_id: "CFR_M1",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},
       heading_text: {string_id: "cfr-doorhanger-extension-heading"},
@@ -252,9 +252,9 @@ const CFR_MESSAGES = [
   {
     id: "REDDIT_ENHANCEMENT_3",
     template: "cfr_doorhanger",
-    category: "cfrAddons",
     exclude: true,
     content: {
+      category: "cfrAddons",
       bucket_id: "CFR_M1",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},
       heading_text: {string_id: "cfr-doorhanger-extension-heading"},
@@ -305,8 +305,8 @@ const CFR_MESSAGES = [
   {
     id: "PIN_TAB",
     template: "cfr_doorhanger",
-    category: "cfrFeatures",
     content: {
+      category: "cfrFeatures",
       bucket_id: "CFR_PIN_TAB",
       notification_text: {string_id: "cfr-doorhanger-extension-notification"},
       heading_text: {string_id: "cfr-doorhanger-pintab-heading"},

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -284,6 +284,11 @@ class PageAction {
     const footerText = this.window.document.getElementById("cfr-notification-footer-text");
     const footerLink = this.window.document.getElementById("cfr-notification-footer-learn-more-link");
 
+    // Use the message category as a CSS selector to hide different parts of the
+    // notification template markup
+    this.window.document.getElementById("contextual-feature-recommendation-notification")
+      .setAttribute("data-notification-category", message.content.category);
+
     headerLabel.value = await this.getStrings(content.heading_text);
     headerLink.setAttribute("href", SUMO_BASE_URL + content.info_icon.sumo_path);
     headerLink.setAttribute(this.window.RTL_UI ? "left" : "right", 0);
@@ -300,6 +305,7 @@ class PageAction {
     if (content.addon) {
       await this._setAddonAuthorAndRating(this.window.document, content);
       panelTitle = await this.getStrings(content.addon.title);
+      options = {popupIconURL: content.addon.icon};
 
       footerLink.value = await this.getStrings({string_id: "cfr-doorhanger-extension-learn-more-link"});
       footerLink.setAttribute("href", content.addon.amo_url);
@@ -313,13 +319,6 @@ class PageAction {
         this._sendTelemetry({message_id: id, bucket_id: content.bucket_id, event: "INSTALL"});
         RecommendationMap.delete(browser);
       };
-
-      options = {
-        popupIconURL: content.addon.icon,
-        hideClose: true,
-        eventCallback: this._popupStateChange,
-      };
-
     } else {
       const stepsContainerId = "cfr-notification-feature-steps";
       primaryActionCallback = () => {
@@ -344,9 +343,6 @@ class PageAction {
         await this._l10n.translateElements([...stepsContainer.children]);
         footerText.parentNode.appendChild(stepsContainer);
       }
-
-      // Hide the section related to author information and rating
-      footerLink.parentNode.style.display = "none";
     }
 
     const primaryBtnStrings = await this.getStrings(primary.label);
@@ -397,14 +393,12 @@ class PageAction {
       "cfr",
       mainAction,
       secondaryActions,
-      options
+      {
+        ...options,
+        hideClose: true,
+        eventCallback: this._popupStateChange,
+      }
     );
-
-    // XXX Find a better way to do this
-    // This piece of content is added dinamically when PopupNotifications.show is called
-    if (!content.addon) {
-      this.window.document.querySelector(".popup-notification-body-container").setAttribute("hidden", true);
-    }
   }
 
   /**

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -320,6 +320,7 @@ class PageAction {
       };
     } else {
       const stepsContainerId = "cfr-notification-feature-steps";
+      let stepsContainer = this.window.document.getElementById(stepsContainerId);
       primaryActionCallback = () => {
         this._blockMessage(id);
         this.dispatchUserAction(primary.action);
@@ -328,20 +329,21 @@ class PageAction {
         RecommendationMap.delete(browser);
       };
       panelTitle = await this.getStrings(content.heading_text);
-      let stepsContainer = this.window.document.getElementById(stepsContainerId);
 
-      // Container for bullet point list
-      if (!stepsContainer) {
+      if (stepsContainer) { // If it exists we need to empty it
+        stepsContainer.remove();
+        stepsContainer = stepsContainer.cloneNode(false);
+      } else {
         stepsContainer = this.window.document.createElement("vbox");
         stepsContainer.setAttribute("id", stepsContainerId);
-        for (let step of content.descriptionDetails.steps) {
-          const li = this.window.document.createElement("li");
-          li.setAttribute("data-l10n-id", step.string_id);
-          stepsContainer.appendChild(li);
-        }
-        await this._l10n.translateElements([...stepsContainer.children]);
-        footerText.parentNode.appendChild(stepsContainer);
       }
+      footerText.parentNode.appendChild(stepsContainer);
+      for (let step of content.descriptionDetails.steps) {
+        const li = this.window.document.createElement("li");
+        this._l10n.setAttributes(li, step.string_id);
+        stepsContainer.appendChild(li);
+      }
+      await this._l10n.translateElements([...stepsContainer.children]);
     }
 
     const primaryBtnStrings = await this.getStrings(primary.label);

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -321,6 +321,7 @@ class PageAction {
       };
 
     } else {
+      const stepsContainerId = "cfr-notification-feature-steps";
       primaryActionCallback = () => {
         this._blockMessage(id);
         this.dispatchUserAction(primary.action);
@@ -329,12 +330,12 @@ class PageAction {
         RecommendationMap.delete(browser);
       };
       panelTitle = await this.getStrings(content.heading_text);
-      let stepsContainer = this.window.document.getElementById("feature-details-steps");
+      let stepsContainer = this.window.document.getElementById(stepsContainerId);
 
       // Container for bullet point list
       if (!stepsContainer) {
         stepsContainer = this.window.document.createElement("vbox");
-        stepsContainer.setAttribute("id", "feature-details-steps");
+        stepsContainer.setAttribute("id", stepsContainerId);
         for (let step of content.descriptionDetails.steps) {
           const li = this.window.document.createElement("li");
           li.setAttribute("data-l10n-id", step.string_id);

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -4,7 +4,7 @@
 "use strict";
 
 const {XPCOMUtils} = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
-const {Localization} = ChromeUtils.import("resource://gre/modules/Localization.jsm");
+const {DOMLocalization} = ChromeUtils.import("resource://gre/modules/DOMLocalization.jsm");
 const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 
@@ -52,7 +52,7 @@ class PageAction {
     this._showPopupOnClick = this._showPopupOnClick.bind(this);
     this.dispatchUserAction = this.dispatchUserAction.bind(this);
 
-    this._l10n = new Localization([
+    this._l10n = new DOMLocalization([
       "browser/newtab/asrouter.ftl",
     ]);
 
@@ -328,21 +328,23 @@ class PageAction {
         this._sendTelemetry({message_id: id, bucket_id: content.bucket_id, event: "PIN"});
         RecommendationMap.delete(browser);
       };
-
       panelTitle = await this.getStrings(content.heading_text);
-
       let stepsContainer = this.window.document.getElementById("feature-details-steps");
+
+      // Container for bullet point list
       if (!stepsContainer) {
         stepsContainer = this.window.document.createElement("vbox");
         stepsContainer.setAttribute("id", "feature-details-steps");
         for (let step of content.descriptionDetails.steps) {
           const li = this.window.document.createElement("li");
-          li.textContent = await this.getStrings(step);
+          li.setAttribute("data-l10n-id", step.string_id);
           stepsContainer.appendChild(li);
         }
+        await this._l10n.translateElements([...stepsContainer.children]);
         footerText.parentNode.appendChild(stepsContainer);
       }
 
+      // Hide the section related to author information and rating
       footerLink.parentNode.style.display = "none";
     }
 

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -283,6 +283,10 @@ class PageAction {
     const headerImage = this.window.document.getElementById("cfr-notification-header-image");
     const footerText = this.window.document.getElementById("cfr-notification-footer-text");
     const footerLink = this.window.document.getElementById("cfr-notification-footer-learn-more-link");
+    const {primary, secondary} = content.buttons;
+    let primaryActionCallback;
+    let options = {};
+    let panelTitle;
 
     // Use the message category as a CSS selector to hide different parts of the
     // notification template markup
@@ -294,11 +298,6 @@ class PageAction {
     headerLink.setAttribute(this.window.RTL_UI ? "left" : "right", 0);
     headerImage.setAttribute("tooltiptext", await this.getStrings(content.info_icon.label, "tooltiptext"));
     headerLink.onclick = () => this._sendTelemetry({message_id: id, bucket_id: content.bucket_id, event: "RATIONALE"});
-
-    let primaryActionCallback;
-    let options = {};
-    let panelTitle;
-    const {primary, secondary} = content.buttons;
 
     footerText.textContent = await this.getStrings(content.text);
 
@@ -346,6 +345,11 @@ class PageAction {
     }
 
     const primaryBtnStrings = await this.getStrings(primary.label);
+    const mainAction = {
+      label: primaryBtnStrings,
+      accessKey: primaryBtnStrings.attributes.accesskey,
+      callback: primaryActionCallback,
+    };
 
     // For each secondary action, get the strings and attributes
     const secondaryBtnStrings = [];
@@ -353,13 +357,6 @@ class PageAction {
       let label = await this.getStrings(button.label);
       secondaryBtnStrings.push({label, attributes: label.attributes});
     }
-
-    const mainAction = {
-      label: primaryBtnStrings,
-      accessKey: primaryBtnStrings.attributes.accesskey,
-      callback: primaryActionCallback,
-    };
-
     const secondaryActions = [{
       label: secondaryBtnStrings[0].label,
       accessKey: secondaryBtnStrings[0].attributes.accesskey,

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -411,6 +411,7 @@ describe("CFRPageActions", () => {
 
     describe("#_showPopupOnClick", () => {
       let translateElementsStub;
+      let setAttributesStub;
       beforeEach(async () => {
         CFRPageActions.PageActionMap.set(fakeBrowser.ownerGlobal, pageAction);
         await CFRPageActions.addRecommendation(fakeBrowser, fakeHost, fakeRecommendation, dispatchStub);
@@ -429,6 +430,8 @@ describe("CFRPageActions", () => {
           .callsFake(async ({args}) => `${args.total} users`); // eslint-disable-line max-nested-callbacks
 
         translateElementsStub = sandbox.stub().resolves();
+        setAttributesStub = sandbox.stub();
+        global.DOMLocalization.prototype.setAttributes = setAttributesStub;
         global.DOMLocalization.prototype.translateElements = translateElementsStub;
       });
 
@@ -617,14 +620,14 @@ describe("CFRPageActions", () => {
         delete fakeRecommendation.content.addon;
         await pageAction._showPopupOnClick();
 
-        assert.calledOnce(translateElementsStub);
-        assert.equal(translateElementsStub.firstCall.args[0][0].dataset.l10nId, fakeRecommendation.content.descriptionDetails.steps[0].string_id);
+        assert.calledOnce(setAttributesStub);
+        assert.calledWith(setAttributesStub, sinon.match.any, fakeRecommendation.content.descriptionDetails.steps[0].string_id);
       });
-      it("should hide popup-notification-body-container", async () => {
+      it("should set the correct data-notification-category", async () => {
         delete fakeRecommendation.content.addon;
         await pageAction._showPopupOnClick();
 
-        assert.equal(elements["popup-notification-body-container"].getAttribute("hidden"), "true");
+        assert.equal(elements["contextual-feature-recommendation-notification"].dataset.notificationCategory, fakeRecommendation.content.category);
       });
       it("should send PIN event on primary action click", async () => {
         sandbox.stub(pageAction, "_sendTelemetry");

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -40,6 +40,7 @@ describe("CFRPageActions", () => {
     fakeRecommendation = {
       id: "fake_id",
       content: {
+        category: "cfrDummy",
         bucket_id: "fake_bucket_id",
         notification_text: "Fake Notification Text",
         info_icon: {

--- a/test/unit/asrouter/templates/ExtensionDoorhanger.test.jsx
+++ b/test/unit/asrouter/templates/ExtensionDoorhanger.test.jsx
@@ -2,6 +2,7 @@ import {CFRMessageProvider} from "lib/CFRMessageProvider.jsm";
 import schema from "content-src/asrouter/templates/CFR/templates/ExtensionDoorhanger.schema.json";
 
 const DEFAULT_CONTENT = {
+  "category": "dummyCategory",
   "bucket_id": "some_bucket_id",
   "notification_text": "Recommendation",
   "heading_text": "Recommended Extension",
@@ -39,6 +40,7 @@ const DEFAULT_CONTENT = {
 };
 
 const L10N_CONTENT = {
+  "category": "dummyL10NCategory",
   "bucket_id": "some_bucket_id",
   "notification_text": {"string_id": "notification_text_id"},
   "heading_text": {"string_id": "heading_text_id"},


### PR DESCRIPTION
Phab changes https://phabricator.services.mozilla.com/D22084

This adds the new schema field `descriptionDetails`. 
Updated `_renderPopup` to handle the two different code paths for addons and features CFRs.
It will show the panel with the message content but not the image.

<img width="361" alt="image" src="https://user-images.githubusercontent.com/810040/53809514-c9f74280-3f4c-11e9-975c-4643d0a35e4e.png">

* Currently the Pin tab message still has `exclude: true`.