### PR TITLE
Bug 1533089 - HTTP Referer not set when clicking articles

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -28,7 +28,11 @@ export class DSCard extends React.PureComponent {
 
   render() {
     return (
-      <SafeAnchor url={this.props.url} className="ds-card" onLinkClick={this.onLinkClick}>
+      <SafeAnchor
+        className="ds-card"
+        dispatch={this.props.dispatch}
+        onLinkClick={this.onLinkClick}
+        url={this.props.url}>
         <div className="img-wrapper">
           <div className="img" style={{backgroundImage: `url(${this.props.image_src}`}} />
         </div>

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -69,7 +69,11 @@ export class Hero extends React.PureComponent {
       <div>
         <div className="ds-header">{this.props.title}</div>
         <div className={`ds-hero ds-hero-${this.props.border}`}>
-          <SafeAnchor url={heroRec.url} className="wrapper" onLinkClick={this.onLinkClick}>
+          <SafeAnchor
+            className="wrapper"
+            dispatch={this.props.dispatch}
+            onLinkClick={this.onLinkClick}
+            url={heroRec.url}>
             <div className="img-wrapper">
               <div className="img" style={{backgroundImage: `url(${heroRec.image_src})`}} />
             </div>

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -34,7 +34,11 @@ export class ListItem extends React.PureComponent {
   render() {
     return (
       <li className="ds-list-item">
-        <SafeAnchor url={this.props.url} className="ds-list-item-link" onLinkClick={this.onLinkClick}>
+        <SafeAnchor
+          className="ds-list-item-link"
+          dispatch={this.props.dispatch}
+          onLinkClick={this.onLinkClick}
+          url={this.props.url}>
           <div className="ds-list-item-text">
             <div>
               <div className="ds-list-item-title">{this.props.title}</div>

--- a/content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor.jsx
+++ b/content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor.jsx
@@ -1,6 +1,34 @@
+import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import React from "react";
 
 export class SafeAnchor extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick(event) {
+    // Use dispatch instead of normal link click behavior to include referrer
+    if (this.props.dispatch) {
+      event.preventDefault();
+      const {altKey, button, ctrlKey, metaKey, shiftKey} = event;
+      this.props.dispatch(ac.OnlyToMain({
+        type: at.OPEN_LINK,
+        data: {
+          event: {altKey, button, ctrlKey, metaKey, shiftKey},
+          referrer: "https://getpocket.com/recommendations",
+          // Use the anchor's url, which could have been cleaned up
+          url: event.currentTarget.href,
+        },
+      }));
+    }
+
+    // Propagate event if there's a handler
+    if (this.props.onLinkClick) {
+      this.props.onLinkClick(event);
+    }
+  }
+
   safeURI(url) {
     let protocol = null;
     try {
@@ -19,9 +47,9 @@ export class SafeAnchor extends React.PureComponent {
   }
 
   render() {
-    const {url, className, onLinkClick} = this.props;
+    const {url, className} = this.props;
     return (
-      <a href={this.safeURI(url)} className={className} onClick={onLinkClick}>
+      <a href={this.safeURI(url)} className={className} onClick={this.onClick}>
         {this.props.children}
       </a>
     );


### PR DESCRIPTION
r?@k88hudson or @punamdahiya Tested with https://gist.githubusercontent.com/punamdahiya/44f78e2f338cbf95f5c28d31faed4639/raw/1c61974ca8ebd02431512d9425031e3a9c8e04f4/test-message-feed.json which has a "bill gates" article with javascript uri. Still sends telemetry that a click was attempted but doesn't open the link. Other links open fine with referrer:
![screen shot 2019-03-06 at 11 42 35 am](https://user-images.githubusercontent.com/438537/53909226-15b9f280-4006-11e9-84fa-1fdd9ed225a9.png)

And for spoc:
![screen shot 2019-03-06 at 11 43 27 am](https://user-images.githubusercontent.com/438537/53909197-0175f580-4006-11e9-962d-d9d959f09c02.png)

Also checked that links for navigation don't send referrer:
![screen shot 2019-03-06 at 11 44 18 am](https://user-images.githubusercontent.com/438537/53909246-1fdbf100-4006-11e9-93e4-0e0e8a627838.png)
