### PR TITLE
Bug 1533089 - HTTP Referer not set when clicking articles

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -30,7 +30,11 @@ export class DSCard extends React.PureComponent {
   render() {
     return (
       <div className="ds-card">
-        <SafeAnchor className="ds-card-link" url={this.props.url} onLinkClick={this.onLinkClick}>
+        <SafeAnchor
+          className="ds-card-link"
+          dispatch={this.props.dispatch}
+          onLinkClick={this.onLinkClick}
+          url={this.props.url}>
           <div className="img-wrapper">
             <div className="img" style={{backgroundImage: `url(${this.props.image_src}`}} />
           </div>

--- a/content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu.jsx
@@ -63,7 +63,12 @@ export class _DSLinkMenu extends React.PureComponent {
           onUpdate={this.onMenuUpdate}
           onShow={this.onMenuShow}
           options={TOP_STORIES_CONTEXT_MENU_OPTIONS}
-          site={{url: this.props.url, title: this.props.title, type: this.props.type}} />
+          site={{
+            referrer: "https://getpocket.com/recommendations",
+            title: this.props.title,
+            type: this.props.type,
+            url: this.props.url,
+          }} />
       }
     </div>);
   }

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -71,7 +71,11 @@ export class Hero extends React.PureComponent {
         <div className="ds-header">{this.props.title}</div>
         <div className={`ds-hero ds-hero-${this.props.border}`}>
           <div className="ds-hero-item">
-            <SafeAnchor url={heroRec.url} className="wrapper" onLinkClick={this.onLinkClick}>
+            <SafeAnchor
+              className="wrapper"
+              dispatch={this.props.dispatch}
+              onLinkClick={this.onLinkClick}
+              url={heroRec.url}>
               <div className="img-wrapper">
                 <div className="img" style={{backgroundImage: `url(${heroRec.image_src})`}} />
               </div>

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -35,7 +35,11 @@ export class ListItem extends React.PureComponent {
   render() {
     return (
       <li className="ds-list-item">
-        <SafeAnchor url={this.props.url} className="ds-list-item-link" onLinkClick={this.onLinkClick}>
+        <SafeAnchor
+          className="ds-list-item-link"
+          dispatch={this.props.dispatch}
+          onLinkClick={this.onLinkClick}
+          url={this.props.url}>
           <div className="ds-list-item-text">
             <div>
               <div className="ds-list-item-title">{this.props.title}</div>

--- a/content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor.jsx
+++ b/content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor.jsx
@@ -1,6 +1,34 @@
+import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import React from "react";
 
 export class SafeAnchor extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick(event) {
+    // Use dispatch instead of normal link click behavior to include referrer
+    if (this.props.dispatch) {
+      event.preventDefault();
+      const {altKey, button, ctrlKey, metaKey, shiftKey} = event;
+      this.props.dispatch(ac.OnlyToMain({
+        type: at.OPEN_LINK,
+        data: {
+          event: {altKey, button, ctrlKey, metaKey, shiftKey},
+          referrer: "https://getpocket.com/recommendations",
+          // Use the anchor's url, which could have been cleaned up
+          url: event.currentTarget.href,
+        },
+      }));
+    }
+
+    // Propagate event if there's a handler
+    if (this.props.onLinkClick) {
+      this.props.onLinkClick(event);
+    }
+  }
+
   safeURI(url) {
     let protocol = null;
     try {
@@ -19,9 +47,9 @@ export class SafeAnchor extends React.PureComponent {
   }
 
   render() {
-    const {url, className, onLinkClick} = this.props;
+    const {url, className} = this.props;
     return (
-      <a href={this.safeURI(url)} className={className} onClick={onLinkClick}>
+      <a href={this.safeURI(url)} className={className} onClick={this.onClick}>
         {this.props.children}
       </a>
     );


### PR DESCRIPTION
r?@punamdahiya Resolves merge conflicts between #4818 (on master) and #4831 (on central) by adding referrer to the site object for DSLinkMenu and adding dispatch to SafeAnchor article uses.