### PR TITLE
Bug 1534934 - Investigate multiple CFR triggers being called at the s…

### DIFF
--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -590,6 +590,10 @@ const CFRPageActions = {
     if (browser !== win.gBrowser.selectedBrowser || !isHostMatch(browser, host)) {
       return false;
     }
+    if (RecommendationMap.has(browser)) {
+      // Don't replace an existing message
+      return false;
+    }
     const {id, content} = recommendation;
     RecommendationMap.set(browser, {id, host, retain: true, content});
     if (!PageActionMap.has(win)) {

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -85,9 +85,7 @@ function trigger_cfr_panel(browser, trigger, {action = {type: "FOO"}, heading_te
     delete recommendation.content.addon;
   }
 
-  registerCleanupFunction(() => {
-    clearNotifications();
-  });
+  clearNotifications();
 
   return CFRPageActions.addRecommendation(
     browser,

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -69,11 +69,21 @@ function checkCFRAddonsElements(notification) {
   Assert.ok(notification.querySelector("#cfr-notification-author"), "Panel should have author info");
 }
 
+function clearNotifications() {
+  for (let notification of PopupNotifications._currentNotifications) {
+    notification.remove();
+  }
+}
+
 function trigger_cfr_panel(browser, trigger, {action = {type: "FOO"}, heading_text, category = "cfrAddons"} = {}) { // a fake action type will result in the action being ignored
   const recommendation = createDummyRecommendation({action, category, heading_text});
   if (category !== "cfrAddons") {
     delete recommendation.content.addon;
   }
+
+  registerCleanupFunction(() => {
+    clearNotifications();
+  });
 
   return CFRPageActions.addRecommendation(
     browser,

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -73,6 +73,10 @@ function clearNotifications() {
   for (let notification of PopupNotifications._currentNotifications) {
     notification.remove();
   }
+
+  // Clicking the primary action also removes the notification
+  Assert.equal(PopupNotifications._currentNotifications.length, 0,
+    "Should have removed the notification");
 }
 
 function trigger_cfr_panel(browser, trigger, {action = {type: "FOO"}, heading_text, category = "cfrAddons"} = {}) { // a fake action type will result in the action being ignored

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -1,4 +1,5 @@
 import {CFRPageActions, PageAction} from "lib/CFRPageActions.jsm";
+import {FAKE_RECOMMENDATION} from "./constants";
 import {GlobalOverrider} from "test/unit/utils";
 
 describe("CFRPageActions", () => {
@@ -41,50 +42,7 @@ describe("CFRPageActions", () => {
     sandbox = sinon.createSandbox();
     clock = sandbox.useFakeTimers();
 
-    fakeRecommendation = {
-      id: "fake_id",
-      content: {
-        category: "cfrDummy",
-        bucket_id: "fake_bucket_id",
-        notification_text: "Fake Notification Text",
-        info_icon: {
-          label: "Fake Info Icon Label",
-          sumo_path: "a_help_path_fragment",
-        },
-        heading_text: "Fake Heading Text",
-        addon:  {
-          title: "Fake Addon Title",
-          author: "Fake Addon Author",
-          icon: "a_path_to_some_icon",
-          rating: 4.2,
-          users: 1234,
-          amo_url: "a_path_to_amo",
-        },
-        descriptionDetails: {
-          steps: [{string_id: "cfr-features-step1"}],
-        },
-        text: "Here is the recommendation text body",
-        buttons: {
-          primary: {
-            label: {string_id: "primary_button_id"},
-            action: {
-              id: "primary_action",
-              data: {},
-            },
-          },
-          secondary: [{
-            label: {string_id: "secondary_button_id"},
-            action: {id: "secondary_action"},
-          }, {
-            label: {string_id: "secondary_button_id_2"},
-            action: {id: "secondary_action"},
-          }, {
-            label: {string_id: "secondary_button_id_3"},
-            action: {id: "secondary_action"},
-          }],
-        },
-      },
-    };
+    fakeRecommendation = {...FAKE_RECOMMENDATION};
     fakeHost = "mozilla.org";
     fakeBrowser = {
       documentURI: {
@@ -789,6 +747,40 @@ describe("CFRPageActions", () => {
         assert.equal(recommendation.content.buttons.primary.action.id, fakeRecommendation.content.buttons.primary.action.id);
 
         delete fakeRecommendation.template;
+      });
+      describe("simultaneous recommendations", () => {
+        it("should prevent a second message if one is currently displayed", async () => {
+          const secondMessage = {...fakeRecommendation, id: "second_message"};
+          let messageAdded = await CFRPageActions.addRecommendation(fakeBrowser, fakeHost, fakeRecommendation, dispatchStub);
+
+          assert.isTrue(messageAdded);
+          assert.deepInclude(CFRPageActions.RecommendationMap.get(fakeBrowser), {
+            id: fakeRecommendation.id,
+            host: fakeHost,
+            content: fakeRecommendation.content,
+          });
+
+          messageAdded = await CFRPageActions.addRecommendation(fakeBrowser, fakeHost, secondMessage, dispatchStub);
+          // Adding failed
+          assert.isFalse(messageAdded);
+          // First message is still there
+          assert.deepInclude(CFRPageActions.RecommendationMap.get(fakeBrowser), {
+            id: fakeRecommendation.id,
+            host: fakeHost,
+            content: fakeRecommendation.content,
+          });
+        });
+        it("should send impressions just for the first message", async () => {
+          const secondMessage = {...fakeRecommendation, id: "second_message"};
+          await CFRPageActions.addRecommendation(fakeBrowser, fakeHost, fakeRecommendation, dispatchStub);
+          await CFRPageActions.addRecommendation(fakeBrowser, fakeHost, secondMessage, dispatchStub);
+
+          // Doorhanger telemetry + Impression for just 1 message
+          assert.calledTwice(dispatchStub);
+          const [firstArgs] = dispatchStub.firstCall.args;
+          const [secondArgs] = dispatchStub.secondCall.args;
+          assert.equal(firstArgs.data.id, secondArgs.data.message_id);
+        });
       });
     });
 

--- a/test/unit/asrouter/constants.js
+++ b/test/unit/asrouter/constants.js
@@ -20,6 +20,52 @@ export const FAKE_REMOTE_PROVIDER = {id: "remotey", type: "remote", url: "http:/
 
 export const FAKE_REMOTE_SETTINGS_PROVIDER = {id: "remotey-settingsy", type: "remote-settings", bucket: "bucketname", enabled: true};
 
+export const FAKE_RECOMMENDATION = {
+  id: "fake_id",
+  template: "cfr_doorhanger",
+  content: {
+    category: "cfrDummy",
+    bucket_id: "fake_bucket_id",
+    notification_text: "Fake Notification Text",
+    info_icon: {
+      label: "Fake Info Icon Label",
+      sumo_path: "a_help_path_fragment",
+    },
+    heading_text: "Fake Heading Text",
+    addon:  {
+      title: "Fake Addon Title",
+      author: "Fake Addon Author",
+      icon: "a_path_to_some_icon",
+      rating: 4.2,
+      users: 1234,
+      amo_url: "a_path_to_amo",
+    },
+    descriptionDetails: {
+      steps: [{string_id: "cfr-features-step1"}],
+    },
+    text: "Here is the recommendation text body",
+    buttons: {
+      primary: {
+        label: {string_id: "primary_button_id"},
+        action: {
+          id: "primary_action",
+          data: {},
+        },
+      },
+      secondary: [{
+        label: {string_id: "secondary_button_id"},
+        action: {id: "secondary_action"},
+      }, {
+        label: {string_id: "secondary_button_id_2"},
+        action: {id: "secondary_action"},
+      }, {
+        label: {string_id: "secondary_button_id_3"},
+        action: {id: "secondary_action"},
+      }],
+    },
+  },
+};
+
 // Stubs methods on RemotePageManager
 export class FakeRemotePageManager {
   constructor() {


### PR DESCRIPTION
…ame time

I've made it so that it rejects a second `addRecommendation` call for the same browser. That map entry [is removed](https://github.com/mozilla/activity-stream/blob/348fd7ec68f44311d5da64af29a2fbb147c417a7/lib/CFRPageActions.jsm#L530) when the user navigates away.
I've kept the `_DUMMY` messages in case it might useful to test this in the review process but I didn't end up using them for mochitests so I want to remove before landing.
