### PR TITLE
Bug 1534278 –  Remove Extra borders on Hero cards on Dark theme

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -72,7 +72,7 @@ $card-header-in-hero-line-height: 20;
     padding: 16px 0;
     height: 100%;
 
-    @at-root .ds-hero-no-border .wrapper {
+    @at-root .ds-hero-no-border .ds-hero-item .wrapper {
       border-top: 0;
       border-bottom: 0;
       padding: 0 0 8px;

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -22,11 +22,6 @@ $card-header-in-hero-line-height: 20;
     margin: 4px 0 8px;
   }
 
-  .ds-list {
-    border-top: 0;
-    padding-top: 0;
-  }
-
   .ds-card {
     border: 0;
     padding-bottom: 20px;
@@ -61,7 +56,6 @@ $card-header-in-hero-line-height: 20;
   // "1/3 width layout" (aka "Mobile First")
   .wrapper {
     @include ds-border-top;
-    @include ds-border-bottom;
     @include dark-theme-only {
       color: $grey-30;
     }
@@ -69,7 +63,7 @@ $card-header-in-hero-line-height: 20;
     color: $grey-50;
     display: block;
     margin: 12px 0 16px;
-    padding: 16px 0;
+    padding: 16px 0 0;
     height: 100%;
 
     @at-root .ds-hero-no-border .ds-hero-item .wrapper {

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -63,7 +63,7 @@ $card-header-in-hero-line-height: 20;
     color: $grey-50;
     display: block;
     margin: 12px 0 16px;
-    padding: 16px 0 0;
+    padding-top: 16px;
     height: 100%;
 
     @at-root .ds-hero-no-border .ds-hero-item .wrapper {

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -132,7 +132,6 @@ $item-line-height: 20;
 }
 
 .ds-list-borders {
-  @include ds-border-top;
   grid-row-gap: $bordered-spacing;
   padding-top: $bordered-spacing;
 

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -132,6 +132,7 @@ $item-line-height: 20;
 }
 
 .ds-list-borders {
+  @include ds-border-top;
   grid-row-gap: $bordered-spacing;
   padding-top: $bordered-spacing;
 

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -17,7 +17,7 @@
 }
 
 @mixin dark-theme-only {
-  [lwt-newtab-brighttext]:not(.force-light-theme) & {
+  [lwt-newtab-brighttext] & {
     @content;
   }
 }


### PR DESCRIPTION
Repro: https://bugzilla.mozilla.org/show_bug.cgi?id=1534278#c0