### PR TITLE
Bug 1510335 - Set theme variant using query parameter

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -4,6 +4,7 @@ import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content
 import {generateMessages} from "./rich-text-strings";
 import {ImpressionsWrapper} from "./components/ImpressionsWrapper/ImpressionsWrapper";
 import {LocalizationProvider} from "fluent-react";
+import {NEWTAB_DARK_THEME} from "content-src/lib/constants";
 import {OnboardingMessage} from "./templates/OnboardingMessage/OnboardingMessage";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -61,11 +62,15 @@ export const ASRouterUtils = {
         return {
           url: endpoint.href,
           snippetId: params.get("snippetId"),
+          theme: this.getPreviewTheme(),
         };
       } catch (e) {}
     }
 
     return null;
+  },
+  getPreviewTheme() {
+    return new URLSearchParams(window.location.href.slice(window.location.href.indexOf("theme"))).get("theme");
   },
 };
 
@@ -183,6 +188,9 @@ export class ASRouterUISurface extends React.PureComponent {
     addLocaleData(global.document.documentElement.lang);
 
     const endpoint = ASRouterUtils.getPreviewEndpoint();
+    if (endpoint && endpoint.theme === "dark") {
+      global.window.dispatchEvent(new CustomEvent("LightweightTheme:Set", {detail: {data: NEWTAB_DARK_THEME}}));
+    }
     ASRouterUtils.addListener(this.onMessageFromParent);
 
     // If we are loading about:welcome we want to trigger the onboarding messages

--- a/content-src/lib/constants.js
+++ b/content-src/lib/constants.js
@@ -1,1 +1,27 @@
 export const IS_NEWTAB = global.document && global.document.documentURI === "about:newtab";
+export const NEWTAB_DARK_THEME = {
+  "ntp_background": {
+    "r": 42,
+    "g": 42,
+    "b": 46,
+    "a": 1,
+  },
+  "ntp_text": {
+    "r": 249,
+    "g": 249,
+    "b": 250,
+    "a": 1,
+  },
+  "sidebar": {
+    "r": 56,
+    "g": 56,
+    "b": 61,
+    "a": 1,
+  },
+  "sidebar_text": {
+    "r": 249,
+    "g": 249,
+    "b": 250,
+    "a": 1,
+  },
+};

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -116,6 +116,19 @@ describe("ASRouterUISurface", () => {
     assert.isFalse(wrapper.find(".snippets-preview-banner").exists());
   });
 
+  it("should dispatch an event to select the correct theme", () => {
+    const stub = sandbox.stub(window, "dispatchEvent");
+    sandbox.stub(ASRouterUtils, "getPreviewEndpoint").returns({theme: "dark"});
+
+    wrapper = mount(<ASRouterUISurface document={fakeDocument} />);
+
+    assert.calledOnce(stub);
+    assert.property(stub.firstCall.args[0].detail.data, "ntp_background");
+    assert.property(stub.firstCall.args[0].detail.data, "ntp_text");
+    assert.property(stub.firstCall.args[0].detail.data, "sidebar");
+    assert.property(stub.firstCall.args[0].detail.data, "sidebar_text");
+  });
+
   describe("snippets", () => {
     it("should send correct event and source when snippet is blocked", () => {
       wrapper.setState({message: FAKE_MESSAGE});


### PR DESCRIPTION
Based on Giorgos' request https://bugzilla.mozilla.org/show_bug.cgi?id=1510335#c4

Specify the theme variant in a query parameter `about:newtab?endpoint=...&theme=dark`

Initially tried using the `LightweightThemeManager.jsm` to pass down the theme variables but it turns out they [specify values using hex format](https://searchfox.org/mozilla-central/rev/4763b8d576ce52625d245d1ab6d9404ea025b026/browser/components/BrowserGlue.jsm#1089) but the content theme manager [expects rgba](https://searchfox.org/mozilla-central/rev/4763b8d576ce52625d245d1ab6d9404ea025b026/browser/base/content/contentTheme.js#145).  
None of the modules export functions to convert so I ended up adding the dark theme values we need to `./constants.js`

f?