### PR TITLE
Bug 1530359 - Handle URL redirects for CFR triggers

### DIFF
--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -152,7 +152,12 @@ this.ASRouterTriggerListeners = new Map([
     },
 
     onLocationChange(aBrowser, aWebProgress, aRequest, aLocationURI, aFlags) {
-      let host = aLocationURI ? aLocationURI.host : "";
+      let host;
+      try {
+        host = aLocationURI ? aLocationURI.host : "";
+      } catch (e) { // about: pages will throw errors
+        return;
+      }
       // Some websites trigger redirect events after they finish loading even
       // though the location remains the same. This results in onLocationChange
       // events to be fired twice.
@@ -273,7 +278,12 @@ this.ASRouterTriggerListeners = new Map([
     },
 
     onLocationChange(aBrowser, aWebProgress, aRequest, aLocationURI, aFlags) {
-      let host = aLocationURI ? aLocationURI.host : "";
+      let host;
+      try {
+        host = aLocationURI ? aLocationURI.host : "";
+      } catch (e) { // about: pages will throw errors
+        return;
+      }
       // Some websites trigger redirect events after they finish loading even
       // though the location remains the same. This results in onLocationChange
       // events to be fired twice.

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -38,12 +38,10 @@ const REDDIT_ENHANCEMENT_PARAMS = {
   min_frecency: 10000,
 };
 const PINNED_TABS_TARGET_SITES = [
-  "docs.google.com", "www.docs.google.com", "calendar.google.com",
-  "messenger.com", "www.messenger.com", "web.whatsapp.com", "mail.google.com",
-  "outlook.live.com", "facebook.com", "www.facebook.com", "twitter.com", "www.twitter.com",
-  "reddit.com", "www.reddit.com", "github.com", "www.github.com", "youtube.com", "www.youtube.com",
-  "feedly.com", "www.feedly.com", "drive.google.com", "amazon.com", "www.amazon.com",
-  "messages.android.com",
+  "docs.google.com", "calendar.google.com",
+  "messenger.com", "web.whatsapp.com", "mail.google.com", "outlook.live.com",
+  "facebook.com", "twitter.com", "twitter.com", "reddit.com", "github.com",
+  "youtube.com", "feedly.com", "drive.google.com", "amazon.com", "messages.android.com",
 ];
 
 const CFR_MESSAGES = [

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -38,10 +38,12 @@ const REDDIT_ENHANCEMENT_PARAMS = {
   min_frecency: 10000,
 };
 const PINNED_TABS_TARGET_SITES = [
-  "docs.google.com", "calendar.google.com",
-  "messenger.com", "web.whatsapp.com", "mail.google.com", "outlook.live.com",
-  "facebook.com", "twitter.com", "twitter.com", "reddit.com", "github.com",
-  "youtube.com", "feedly.com", "drive.google.com", "amazon.com", "messages.android.com",
+  "docs.google.com", "www.docs.google.com", "calendar.google.com",
+  "messenger.com", "www.messenger.com", "web.whatsapp.com", "mail.google.com",
+  "outlook.live.com", "facebook.com", "www.facebook.com", "twitter.com", "www.twitter.com",
+  "reddit.com", "www.reddit.com", "github.com", "www.github.com", "youtube.com", "www.youtube.com",
+  "feedly.com", "www.feedly.com", "drive.google.com", "amazon.com", "www.amazon.com",
+  "messages.android.com",
 ];
 
 const CFR_MESSAGES = [

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -183,7 +183,25 @@ describe("ASRouterTriggerListeners", () => {
         assert.calledOnce(newTriggerHandler);
         assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
-      it("should call triggerHandler for a redirect", async () => {
+      it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {
+        for (let trigger of [openURLListener, frequentVisitsListener]) {
+          const newTriggerHandler = sinon.stub();
+          await trigger.init(newTriggerHandler, hosts);
+
+          const browser = {};
+          const webProgress = {isTopLevel: true};
+          const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
+          const aRequest = {
+            QueryInterface: sandbox.stub().returns({
+              originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+            }),
+          };
+          trigger.onLocationChange(browser, webProgress, aRequest, aLocationURI);
+          assert.calledOnce(aRequest.QueryInterface);
+          assert.calledOnce(newTriggerHandler);
+        }
+      });
+      it("should call triggerHandler with the right arguments (redirect)", async () => {
         const newTriggerHandler = sinon.stub();
         await openURLListener.init(newTriggerHandler, hosts);
 
@@ -196,8 +214,6 @@ describe("ASRouterTriggerListeners", () => {
           }),
         };
         openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
-        assert.calledOnce(aRequest.QueryInterface);
-        assert.calledOnce(newTriggerHandler);
         assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
       it("should fail for subdomains (not redirect)", async () => {

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -200,6 +200,22 @@ describe("ASRouterTriggerListeners", () => {
         assert.calledOnce(newTriggerHandler);
         assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
+      it("should fail for subdomains (not redirect)", async () => {
+        const newTriggerHandler = sinon.stub();
+        await openURLListener.init(newTriggerHandler, hosts);
+
+        const browser = {};
+        const webProgress = {isTopLevel: true};
+        const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
+        const aRequest = {
+          QueryInterface: sandbox.stub().returns({
+            originalURI: {spec: "subdomain.mozilla.org", host: "subdomain.mozilla.org"},
+          }),
+        };
+        openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
+        assert.calledOnce(aRequest.QueryInterface);
+        assert.notCalled(newTriggerHandler);
+      });
     });
 
     describe("delayed startup finished", () => {

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -9,7 +9,7 @@ describe("ASRouterTriggerListeners", () => {
   const triggerHandler = () => {};
   const openURLListener = ASRouterTriggerListeners.get("openURL");
   const frequentVisitsListener = ASRouterTriggerListeners.get("frequentVisits");
-  const hosts = ["mozilla.com", "mozilla.org"];
+  const hosts = ["www.mozilla.com", "www.mozilla.org"];
 
   function resetEnumeratorStub(windows) {
     windowEnumeratorStub
@@ -178,10 +178,10 @@ describe("ASRouterTriggerListeners", () => {
 
         const browser = {};
         const webProgress = {isTopLevel: true};
-        const location = "mozilla.org";
+        const location = "www.mozilla.org";
         openURLListener.onLocationChange(browser, webProgress, undefined, {host: location});
         assert.calledOnce(newTriggerHandler);
-        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
       });
       it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {
         for (let trigger of [openURLListener, frequentVisitsListener]) {
@@ -193,7 +193,7 @@ describe("ASRouterTriggerListeners", () => {
           const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
           const aRequest = {
             QueryInterface: sandbox.stub().returns({
-              originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+              originalURI: {spec: "www.mozilla.org", host: "www.mozilla.org"},
             }),
           };
           trigger.onLocationChange(browser, webProgress, aRequest, aLocationURI);
@@ -210,11 +210,11 @@ describe("ASRouterTriggerListeners", () => {
         const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
         const aRequest = {
           QueryInterface: sandbox.stub().returns({
-            originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+            originalURI: {spec: "www.mozilla.org", host: "www.mozilla.org"},
           }),
         };
         openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
-        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
       });
       it("should fail for subdomains (not redirect)", async () => {
         const newTriggerHandler = sinon.stub();

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -9,7 +9,7 @@ describe("ASRouterTriggerListeners", () => {
   const triggerHandler = () => {};
   const openURLListener = ASRouterTriggerListeners.get("openURL");
   const frequentVisitsListener = ASRouterTriggerListeners.get("frequentVisits");
-  const hosts = ["www.mozilla.com", "www.mozilla.org"];
+  const hosts = ["mozilla.com", "mozilla.org"];
 
   function resetEnumeratorStub(windows) {
     windowEnumeratorStub
@@ -178,10 +178,27 @@ describe("ASRouterTriggerListeners", () => {
 
         const browser = {};
         const webProgress = {isTopLevel: true};
-        const location = "https://www.mozilla.org/something";
-        openURLListener.onLocationChange(browser, webProgress, undefined, {spec: location});
+        const location = "mozilla.org";
+        openURLListener.onLocationChange(browser, webProgress, undefined, {host: location});
         assert.calledOnce(newTriggerHandler);
-        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
+      });
+      it("should call triggerHandler for a redirect", async () => {
+        const newTriggerHandler = sinon.stub();
+        await openURLListener.init(newTriggerHandler, hosts);
+
+        const browser = {};
+        const webProgress = {isTopLevel: true};
+        const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
+        const aRequest = {
+          QueryInterface: sandbox.stub().returns({
+            originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+          }),
+        };
+        openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
+        assert.calledOnce(aRequest.QueryInterface);
+        assert.calledOnce(newTriggerHandler);
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
     });
 

--- a/test/unit/asrouter/CFRMessageProvider.test.js
+++ b/test/unit/asrouter/CFRMessageProvider.test.js
@@ -41,4 +41,9 @@ describe("CFRMessageProvider", () => {
       }
     }
   });
+  it("should contain `www.` version of the hosts", () => {
+    const pinTabMessage = messages.find(m => m.id === "PIN_TAB");
+
+    assert.isTrue(pinTabMessage.trigger.params.filter(host => host.startsWith("www.")).length > 0);
+  });
 });


### PR DESCRIPTION
The way I'm handling redirects is to additionally check the original request host against the hosts defined in the message.
For example if `de.quora.com` fails the initial check but we initially navigated to `quora.com` then the check will now pass.
This doesn't mean that `bar.mozilla.com` will match for `mozilla.com` because we check that `(originalLocation !== location)` before trying the second lookup so it's only for redirects when this check would return true.