### PR TITLE
Bug 1445352 - Add code coverage for .jsx files

### DIFF
--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -115,7 +115,7 @@ module.exports = function(config) {
           },
           {
             enforce: "post",
-            test: /\.jsm?$/,
+            test: /\.js[mx]?$/,
             loader: "istanbul-instrumenter-loader",
             options: {esModules: true},
             include: [

--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -51,10 +51,36 @@ module.exports = function(config) {
       // This will make karma fail if coverage reporting is less than the minimums here
       thresholds: !isTDD && {
         global: {
+          statements: 93,
+          lines: 93.1,
+          functions: 89.7,
+          branches: 87.8,
+        },
+        each: {
           statements: 100,
           lines: 100,
           functions: 100,
-          branches: 90,
+          branches: 66,
+          overrides: {
+            "content-src/components/DiscoveryStreamComponents/**/*.jsx": {
+              statements: 0,
+              lines: 0,
+              functions: 0,
+              branches: 0,
+            },
+            "content-src/asrouter/**/*.jsx": {
+              statements: 57,
+              lines: 58,
+              functions: 60,
+              branches: 50,
+            },
+            "content-src/components/**/*.jsx": {
+              statements: 0,
+              lines: 0,
+              functions: 0,
+              branches: 0,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
I broke down our frontend code into 3 different patterns/categories and added thresholds for each of them.
```javascript
// All DS components
"content-src/components/DiscoveryStreamComponents/**/*.jsx"
// All asrouter components
"content-src/asrouter/**/*.jsx"
// Everything else
"content-src/components/**/*.jsx"
```
Coverage varies among these categories: asrouter baseline is now around 50% while some DS components have no tests making the baseline be 0.

The issue I ran into is that `karma-coverage-istanbul-reporter` does not implement a [`excludes` (or similar) filter for the `global`](https://github.com/mattlewis92/karma-coverage-istanbul-reporter/blob/df3d5df236e6abd18911a8c0783e6a11dfd98bf9/src/reporter.js#L125-L138) threshold declarations. This means that the `global` requirements include the `.jsx` numbers and overall bring our global numbers down.
A solution to this issue might be to switch to [`karma-coverage`](https://github.com/karma-runner/karma-coverage). I don't know the benefits and trade-offs but the configuration file allows for the same options and in addition [you can have an excludes field for the global threshold](https://github.com/karma-runner/karma-coverage/blob/15f8b1278bcc620d5b6f16233f51bf28f091ea60/docs/configuration.md#check).

This PR is based on top of #4845 
