### PR TITLE
Bug 1530714 - Report ASRouter errors in ASRouterAdmin

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -152,7 +152,6 @@ export class ASRouterAdminInner extends React.PureComponent {
     this.onCopyTargetingParams = this.onCopyTargetingParams.bind(this);
     this.onPasteTargetingParams = this.onPasteTargetingParams.bind(this);
     this.onNewTargetingParams = this.onNewTargetingParams.bind(this);
-    this.renderErrorMessage = this.renderErrorMessage.bind(this);
     this.state = {
       messageFilter: "all",
       evaluationStatus: {},
@@ -563,12 +562,8 @@ export class ASRouterAdminInner extends React.PureComponent {
       </div>);
   }
 
-  reportErrorToConsole(error) {
-    return () => console.log(error); // eslint-disable-line no-console
-  }
-
   renderErrorMessage({timestamp, error}) {
-    return (<tr onClick={this.reportErrorToConsole(error)}>
+    return (<tr>
       <td>{error.message}</td>
       <td>{relativeTime(timestamp)}</td>
     </tr>);

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -562,21 +562,24 @@ export class ASRouterAdminInner extends React.PureComponent {
       </div>);
   }
 
-  renderErrorMessage({timestamp, error}) {
-    return (<tr>
+  renderErrorMessage({timestamp, error}, idx) {
+    return (<tr key={idx}>
       <td>{error.message}</td>
       <td>{relativeTime(timestamp)}</td>
     </tr>);
   }
 
   renderErrors() {
+    // sorts tA first if tA < tB, most recent timestamp will come first
+    const sortFn = (a, b) => a.timestamp - b.timestamp;
+
     if (this.state.errors && this.state.errors.length) {
       return (<table>
         <thead>
           <td>Message</td>
           <td>Timestamp</td>
         </thead>
-        {this.state.errors.map(this.renderErrorMessage)}
+        {this.state.errors.sort(sortFn).map(this.renderErrorMessage)}
         </table>);
     }
 

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -564,7 +564,7 @@ export class ASRouterAdminInner extends React.PureComponent {
 
   renderErrorMessage({id, errors}) {
     const providerId = <td rowSpan={errors.length}>{id}</td>;
-    return errors.map(({error, timestamp}, cellKey) => (<tr key={cellKey}>
+    return errors.reverse().map(({error, timestamp}, cellKey) => (<tr key={cellKey}>
       {cellKey === 0 ? providerId : null}
       <td>{error.message}</td>
       <td>{relativeTime(timestamp)}</td>
@@ -573,8 +573,6 @@ export class ASRouterAdminInner extends React.PureComponent {
   }
 
   renderErrors() {
-    // sorts tA first if tA < tB, most recent timestamp will come first
-    // const sortFn = (a, b) => a.timestamp - b.timestamp;
     const providersWithErrors = this.state.providers && this.state.providers
       .filter(p => p.errors && p.errors.length);
 

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -152,6 +152,7 @@ export class ASRouterAdminInner extends React.PureComponent {
     this.onCopyTargetingParams = this.onCopyTargetingParams.bind(this);
     this.onPasteTargetingParams = this.onPasteTargetingParams.bind(this);
     this.onNewTargetingParams = this.onNewTargetingParams.bind(this);
+    this.renderErrorMessage = this.renderErrorMessage.bind(this);
     this.state = {
       messageFilter: "all",
       evaluationStatus: {},
@@ -562,6 +563,31 @@ export class ASRouterAdminInner extends React.PureComponent {
       </div>);
   }
 
+  reportErrorToConsole(error) {
+    return () => console.log(error); // eslint-disable-line no-console
+  }
+
+  renderErrorMessage({timestamp, error}) {
+    return (<tr onClick={this.reportErrorToConsole(error)}>
+      <td>{error.message}</td>
+      <td>{relativeTime(timestamp)}</td>
+    </tr>);
+  }
+
+  renderErrors() {
+    if (this.state.errors && this.state.errors.length) {
+      return (<table>
+        <thead>
+          <td>Message</td>
+          <td>Timestamp</td>
+        </thead>
+        {this.state.errors.map(this.renderErrorMessage)}
+        </table>);
+    }
+
+    return <p>No errors</p>;
+  }
+
   getSection() {
     const [section] = this.props.location.routes;
     switch (section) {
@@ -582,6 +608,12 @@ export class ASRouterAdminInner extends React.PureComponent {
           <h2>Discovery Stream</h2>
           <DiscoveryStreamAdmin state={this.props.DiscoveryStream} otherPrefs={this.props.Prefs.values} dispatch={this.props.dispatch} />
         </React.Fragment>);
+      case "errors":
+        return (<React.Fragment>
+          <h2>ASRouter Errors</h2>
+          {this.renderErrors()}
+          </React.Fragment>
+        );
       default:
         return (<React.Fragment>
           <h2>Message Providers <button title="Restore all provider settings that ship with Firefox" className="button" onClick={this.resetPref}>Restore default prefs</button></h2>
@@ -602,6 +634,7 @@ export class ASRouterAdminInner extends React.PureComponent {
           <li><a href="#devtools-targeting">Targeting</a></li>
           <li><a href="#devtools-pocket">Pocket</a></li>
           <li><a href="#devtools-ds">Discovery Stream</a></li>
+          <li><a href="#devtools-errors">Errors</a></li>
         </ul>
       </aside>
       <main className="main-panel">

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -576,10 +576,14 @@ export class ASRouterAdminInner extends React.PureComponent {
     if (this.state.errors && this.state.errors.length) {
       return (<table>
         <thead>
-          <td>Message</td>
-          <td>Timestamp</td>
+          <tr>
+            <th>Message</th>
+            <th>Timestamp</th>
+          </tr>
         </thead>
-        {this.state.errors.sort(sortFn).map(this.renderErrorMessage)}
+        <tbody>
+          {this.state.errors.sort(sortFn).map(this.renderErrorMessage)}
+        </tbody>
         </table>);
     }
 

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -564,6 +564,7 @@ export class ASRouterAdminInner extends React.PureComponent {
 
   renderErrorMessage({id, errors}) {
     const providerId = <td rowSpan={errors.length}>{id}</td>;
+    // .reverse() so that the last error (most recent) is first
     return errors.reverse().map(({error, timestamp}, cellKey) => (<tr key={cellKey}>
       {cellKey === 0 ? providerId : null}
       <td>{error.message}</td>

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -565,12 +565,12 @@ export class ASRouterAdminInner extends React.PureComponent {
   renderErrorMessage({id, errors}) {
     const providerId = <td rowSpan={errors.length}>{id}</td>;
     // .reverse() so that the last error (most recent) is first
-    return errors.reverse().map(({error, timestamp}, cellKey) => (<tr key={cellKey}>
-      {cellKey === 0 ? providerId : null}
+    return errors.map(({error, timestamp}, cellKey) => (<tr key={cellKey}>
+      {cellKey === errors.length - 1 ? providerId : null}
       <td>{error.message}</td>
       <td>{relativeTime(timestamp)}</td>
       </tr>)
-    );
+    ).reverse();
   }
 
   renderErrors() {

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -562,28 +562,32 @@ export class ASRouterAdminInner extends React.PureComponent {
       </div>);
   }
 
-  renderErrorMessage({timestamp, error}, idx) {
-    return (<tr key={idx}>
+  renderErrorMessage({id, errors}) {
+    const providerId = <td rowSpan={errors.length}>{id}</td>;
+    return errors.map(({error, timestamp}, cellKey) => (<tr key={cellKey}>
+      {cellKey === 0 ? providerId : null}
       <td>{error.message}</td>
       <td>{relativeTime(timestamp)}</td>
-    </tr>);
+      </tr>)
+    );
   }
 
   renderErrors() {
     // sorts tA first if tA < tB, most recent timestamp will come first
-    const sortFn = (a, b) => a.timestamp - b.timestamp;
+    // const sortFn = (a, b) => a.timestamp - b.timestamp;
+    const providersWithErrors = this.state.providers && this.state.providers
+      .filter(p => p.errors && p.errors.length);
 
-    if (this.state.errors && this.state.errors.length) {
-      return (<table>
+    if (providersWithErrors && providersWithErrors.length) {
+      return (<table className="errorReporting">
         <thead>
           <tr>
+            <th>Provider ID</th>
             <th>Message</th>
             <th>Timestamp</th>
           </tr>
         </thead>
-        <tbody>
-          {this.state.errors.sort(sortFn).map(this.renderErrorMessage)}
-        </tbody>
+        <tbody>{providersWithErrors.map(this.renderErrorMessage)}</tbody>
         </table>);
     }
 

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -48,6 +48,20 @@
   table {
     border-collapse: collapse;
     width: 100%;
+
+    &.errorReporting {
+      tr {
+        border: 1px solid var(--newtab-textbox-background-color);
+      }
+
+      td {
+        padding: 4px;
+
+        &[rowspan] {
+          border: 1px solid var(--newtab-textbox-background-color);
+        }
+      }
+    }
   }
 
   .sourceLabel {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -133,6 +133,7 @@ const MessageLoaderUtils = {
           jsonResponse = await response.json();
         } catch (e) {
           MessageLoaderUtils.reportError(e);
+          return remoteMessages;
         }
         if (jsonResponse && jsonResponse.messages) {
           remoteMessages = jsonResponse.messages

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -124,10 +124,7 @@ const MessageLoaderUtils = {
       }
       if (
         response &&
-        // Empty response
-        response.status !== 204 &&
-        // Not modified
-        response.status !== 304 &&
+        (response.status >= 200 && response.status < 400) &&
         (response.ok || response.status === 302)
       ) {
         let jsonResponse;

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -128,13 +128,14 @@ const MessageLoaderUtils = {
         response.status !== 304 &&
         (response.ok || response.status === 302)
       ) {
+        let jsonResponse;
         try {
-          response = await response.json();
+          jsonResponse = await response.json();
         } catch (e) {
           MessageLoaderUtils.reportError(e);
         }
-        if (response.messages) {
-          remoteMessages = response.messages
+        if (jsonResponse && jsonResponse.messages) {
+          remoteMessages = jsonResponse.messages
             .map(msg => ({...msg, provider_url: provider.url}));
 
           // Cache the results if this isn't a preview URL.

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -116,7 +116,7 @@ const MessageLoaderUtils = {
 
       let response;
       try {
-        response = await fetch(provider.url, {headers});
+        response = await fetch(provider.url, {headers, credentials: "omit"});
       } catch (e) {
         MessageLoaderUtils.reportError(e);
       }

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -440,6 +440,7 @@ class _ASRouter {
     return [...this.state.errors, ...MessageLoaderUtils.errors]
       .map(({timestamp, error}) => ({
         timestamp,
+        // Can't send error object to content process
         error: {message: error.toString(), stack: error.stack},
       }
       ));

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -53,7 +53,7 @@ const MessageLoaderUtils = {
 
   reportError(e) {
     Cu.reportError(e);
-    this._errors = [{timestamp: new Date(), error: e}, ...this._errors];
+    this._errors.push({timestamp: new Date(), error: e});
   },
 
   get errors() {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -149,9 +149,11 @@ const MessageLoaderUtils = {
 
             storage.set(MessageLoaderUtils.REMOTE_LOADER_CACHE_KEY, {...allCached, [provider.id]: cacheInfo});
           }
+        } else {
+          MessageLoaderUtils.reportError(`No messages returned from ${provider.url}.`);
         }
       } else if (response) {
-        MessageLoaderUtils.reportError(`Invalid response status ${response.status}`);
+        MessageLoaderUtils.reportError(`Invalid response status ${response.status} from ${provider.url}.`);
       }
     }
     return remoteMessages;
@@ -436,7 +438,7 @@ class _ASRouter {
     return [...this.state.errors, ...MessageLoaderUtils.errors]
       .map(({timestamp, error}) => ({
         timestamp,
-        error: {message: error.message, stack: error.stack, fileName: error.fileName},
+        error: {message: error.toString(), stack: error.stack},
       }
       ));
   }

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -124,8 +124,8 @@ const MessageLoaderUtils = {
       }
       if (
         response &&
-        (response.status >= 200 && response.status < 400) &&
-        (response.ok || response.status === 302)
+        response.ok &&
+        (response.status >= 200 && response.status < 400)
       ) {
         let jsonResponse;
         try {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -24,6 +24,7 @@ const FAKE_PROVIDERS = [FAKE_LOCAL_PROVIDER, FAKE_REMOTE_PROVIDER, FAKE_REMOTE_S
 const ALL_MESSAGE_IDS = [...FAKE_LOCAL_MESSAGES, ...FAKE_REMOTE_MESSAGES].map(message => message.id);
 const FAKE_BUNDLE = [FAKE_LOCAL_MESSAGES[1], FAKE_LOCAL_MESSAGES[2]];
 const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+const FAKE_RESPONSE_HEADERS = {get() {}};
 
 // Creates a message object that looks like messages returned by
 // RemotePageManager listeners
@@ -94,7 +95,7 @@ describe("ASRouter", () => {
     clock = sandbox.useFakeTimers();
     fetchStub = sandbox.stub(global, "fetch")
       .withArgs("http://fake.com/endpoint")
-      .resolves({ok: true, status: 200, json: () => Promise.resolve({messages: FAKE_REMOTE_MESSAGES})});
+      .resolves({ok: true, status: 200, json: () => Promise.resolve({messages: FAKE_REMOTE_MESSAGES}), headers: FAKE_RESPONSE_HEADERS});
     getStringPrefStub = sandbox.stub(global.Services.prefs, "getStringPref");
 
     fakeAttributionCode = {
@@ -223,7 +224,7 @@ describe("ASRouter", () => {
       assert.calledOnce(channel.sendAsyncMessage);
       assert.deepEqual(channel.sendAsyncMessage.firstCall.args[1], {
         type: "ADMIN_SET_STATE",
-        data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers, userPrefs: ASRouterPreferences.getAllUserPreferences(), targetingParameters: {}}),
+        data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers, userPrefs: ASRouterPreferences.getAllUserPreferences(), targetingParameters: {}, errors: Router.errors}),
       });
     });
     it("should not send a message on a state change asrouter.devtoolsEnabled pref is on", async () => {
@@ -315,7 +316,7 @@ describe("ASRouter", () => {
       ]);
       fetchStub
         .withArgs("http://fake.com/endpoint")
-        .resolves({ok: true, status: 200, json: () => Promise.resolve({messages: NEW_MESSAGES})});
+        .resolves({ok: true, status: 200, json: () => Promise.resolve({messages: NEW_MESSAGES}), headers: FAKE_RESPONSE_HEADERS});
 
       clock.tick(301);
       await Router.loadMessagesFromAllProviders();
@@ -729,7 +730,7 @@ describe("ASRouter", () => {
         assert.calledOnce(msg.target.sendAsyncMessage);
         assert.deepEqual(msg.target.sendAsyncMessage.firstCall.args[1], {
           type: "ADMIN_SET_STATE",
-          data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers, userPrefs: ASRouterPreferences.getAllUserPreferences(), targetingParameters: {}}),
+          data: Object.assign({}, Router.state, {providerPrefs: ASRouterPreferences.providers, userPrefs: ASRouterPreferences.getAllUserPreferences(), targetingParameters: {}, errors: Router.errors}),
         });
       });
     });

--- a/test/unit/asrouter/MessageLoaderUtils.test.js
+++ b/test/unit/asrouter/MessageLoaderUtils.test.js
@@ -135,7 +135,7 @@ describe("MessageLoaderUtils", () => {
         fetchStub.resolves({ok: true, status: 200, json: sandbox.stub().rejects(err), headers: FAKE_RESPONSE_HEADERS});
         await MessageLoaderUtils.loadMessagesForProvider(provider, FAKE_STORAGE);
 
-        assert.calledTwice(MessageLoaderUtils.reportError);
+        assert.calledOnce(MessageLoaderUtils.reportError);
         // Report that json parsing failed
         assert.calledWith(MessageLoaderUtils.reportError, err);
       });

--- a/test/unit/asrouter/MessageLoaderUtils.test.js
+++ b/test/unit/asrouter/MessageLoaderUtils.test.js
@@ -13,12 +13,15 @@ const FAKE_RESPONSE_HEADERS = {get() {}};
 describe("MessageLoaderUtils", () => {
   let fetchStub;
   let clock;
+  let sandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     clock = sinon.useFakeTimers();
     fetchStub = sinon.stub(global, "fetch");
   });
   afterEach(() => {
+    sandbox.restore();
     clock.restore();
     fetchStub.restore();
   });
@@ -124,6 +127,37 @@ describe("MessageLoaderUtils", () => {
         fetchStub.resolves({ok: false, status: 200, json: () => "", headers: FAKE_RESPONSE_HEADERS});
         const result = await MessageLoaderUtils.loadMessagesForProvider(provider, FAKE_STORAGE);
         assert.deepEqual(result.messages, []);
+      });
+
+      it("should report response parsing errors with MessageLoaderUtils.reportError", async () => {
+        const err = {};
+        sandbox.spy(MessageLoaderUtils, "reportError");
+        fetchStub.resolves({ok: true, status: 200, json: sandbox.stub().rejects(err), headers: FAKE_RESPONSE_HEADERS});
+        await MessageLoaderUtils.loadMessagesForProvider(provider, FAKE_STORAGE);
+
+        assert.calledTwice(MessageLoaderUtils.reportError);
+        // Report that json parsing failed
+        assert.calledWith(MessageLoaderUtils.reportError, err);
+      });
+
+      it("should report missing `messages` with MessageLoaderUtils.reportError", async () => {
+        sandbox.spy(MessageLoaderUtils, "reportError");
+        fetchStub.resolves({ok: true, status: 200, json: sandbox.stub().resolves({}), headers: FAKE_RESPONSE_HEADERS});
+        await MessageLoaderUtils.loadMessagesForProvider(provider, FAKE_STORAGE);
+
+        assert.calledOnce(MessageLoaderUtils.reportError);
+        // Report no messages returned
+        assert.calledWith(MessageLoaderUtils.reportError, "No messages returned from https://foo.com.");
+      });
+
+      it("should report bad status responses with MessageLoaderUtils.reportError", async () => {
+        sandbox.spy(MessageLoaderUtils, "reportError");
+        fetchStub.resolves({ok: false, status: 500, json: sandbox.stub().resolves({}), headers: FAKE_RESPONSE_HEADERS});
+        await MessageLoaderUtils.loadMessagesForProvider(provider, FAKE_STORAGE);
+
+        assert.calledOnce(MessageLoaderUtils.reportError);
+        // Report no messages returned
+        assert.calledWith(MessageLoaderUtils.reportError, "Invalid response status 500 from https://foo.com.");
       });
 
       it("should return an empty array if the request rejects", async () => {
@@ -234,18 +268,13 @@ describe("MessageLoaderUtils", () => {
   });
 
   describe("#_loadAddonIconInURLBar", () => {
-    let sandbox;
     let notificationContainerEl;
     let browser;
     let getContainerStub;
     beforeEach(() => {
-      sandbox = sinon.createSandbox();
       notificationContainerEl = {style: {}};
       browser = {ownerDocument: {getElementById() { return {}; }}};
       getContainerStub = sandbox.stub(browser.ownerDocument, "getElementById");
-    });
-    afterEach(() => {
-      sandbox.restore();
     });
     it("should return for empty args", () => {
       MessageLoaderUtils._loadAddonIconInURLBar();
@@ -274,12 +303,10 @@ describe("MessageLoaderUtils", () => {
 
   describe("#installAddonFromURL", () => {
     let globals;
-    let sandbox;
     let getInstallStub;
     let installAddonStub;
     beforeEach(() => {
       globals = new GlobalOverrider();
-      sandbox = sinon.createSandbox();
       getInstallStub = sandbox.stub();
       installAddonStub = sandbox.stub();
       sandbox.stub(MessageLoaderUtils, "_loadAddonIconInURLBar").returns(null);
@@ -289,7 +316,6 @@ describe("MessageLoaderUtils", () => {
       });
     });
     afterEach(() => {
-      sandbox.restore();
       globals.restore();
     });
     it("should call the Addons API when passed a valid URL", async () => {

--- a/test/unit/asrouter/MessageLoaderUtils.test.js
+++ b/test/unit/asrouter/MessageLoaderUtils.test.js
@@ -80,7 +80,7 @@ describe("MessageLoaderUtils", () => {
       });
 
       it("should return messages for a 302 response with json", async () => {
-        fetchStub.resolves({ok: false, status: 302, json: () => Promise.resolve(respJson), headers: FAKE_RESPONSE_HEADERS});
+        fetchStub.resolves({ok: true, status: 302, json: () => Promise.resolve(respJson), headers: FAKE_RESPONSE_HEADERS});
         assertReturnsCorrectMessages(await MessageLoaderUtils.loadMessagesForProvider(provider, FAKE_STORAGE));
       });
 

--- a/test/unit/content-src/components/ASRouterAdmin.test.jsx
+++ b/test/unit/content-src/components/ASRouterAdmin.test.jsx
@@ -67,6 +67,20 @@ describe("ASRouterAdmin", () => {
       wrapper = shallow(<ASRouterAdminInner location={{routes: ["pocket"]}} Sections={[]} />);
       assert.equal(wrapper.find("h2").at(0).text(), "Pocket");
     });
+    it("should render two sorted error messages", () => {
+      wrapper = shallow(<ASRouterAdminInner location={{routes: ["errors"]}} Sections={[]} />);
+      const firstError = {timestamp: Date.now() + 100, error: {message: "first"}};
+      const secondError = {timestamp: Date.now(), error: {message: "second"}};
+      wrapper.setState({errors: [firstError, secondError]});
+
+      // secondError is more recent, it should be first (ascending order)
+      assert.equal(wrapper.find("tr").at(0).find("td")
+        .at(0)
+        .text(), secondError.error.message);
+      assert.equal(wrapper.find("tr").at(1).find("td")
+        .at(0)
+        .text(), firstError.error.message);
+    });
   });
   describe("#render", () => {
     beforeEach(() => {

--- a/test/unit/content-src/components/ASRouterAdmin.test.jsx
+++ b/test/unit/content-src/components/ASRouterAdmin.test.jsx
@@ -25,7 +25,7 @@ describe("ASRouterAdmin", () => {
   }];
   beforeEach(() => {
     globals = new GlobalOverrider();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     sendMessageStub = sandbox.stub();
     addListenerStub = sandbox.stub();
     removeListenerStub = sandbox.stub();

--- a/test/unit/content-src/components/ASRouterAdmin.test.jsx
+++ b/test/unit/content-src/components/ASRouterAdmin.test.jsx
@@ -67,19 +67,16 @@ describe("ASRouterAdmin", () => {
       wrapper = shallow(<ASRouterAdminInner location={{routes: ["pocket"]}} Sections={[]} />);
       assert.equal(wrapper.find("h2").at(0).text(), "Pocket");
     });
-    it("should render two sorted error messages", () => {
+    it.only("should render two error messages", () => {
       wrapper = shallow(<ASRouterAdminInner location={{routes: ["errors"]}} Sections={[]} />);
       const firstError = {timestamp: Date.now() + 100, error: {message: "first"}};
       const secondError = {timestamp: Date.now(), error: {message: "second"}};
-      wrapper.setState({errors: [firstError, secondError]});
+      wrapper.setState({providers: [{id: "foo", errors: [firstError, secondError]}]});
 
-      // secondError is more recent, it should be first (ascending order)
-      assert.equal(wrapper.find("tr").at(0).find("td")
+      assert.equal(wrapper.find("tbody tr").at(0).find("td")
         .at(0)
-        .text(), secondError.error.message);
-      assert.equal(wrapper.find("tr").at(1).find("td")
-        .at(0)
-        .text(), firstError.error.message);
+        .text(), "foo");
+      assert.lengthOf(wrapper.find("tbody tr"), 2);
     });
   });
   describe("#render", () => {

--- a/test/unit/content-src/components/ASRouterAdmin.test.jsx
+++ b/test/unit/content-src/components/ASRouterAdmin.test.jsx
@@ -67,7 +67,7 @@ describe("ASRouterAdmin", () => {
       wrapper = shallow(<ASRouterAdminInner location={{routes: ["pocket"]}} Sections={[]} />);
       assert.equal(wrapper.find("h2").at(0).text(), "Pocket");
     });
-    it.only("should render two error messages", () => {
+    it("should render two error messages", () => {
       wrapper = shallow(<ASRouterAdminInner location={{routes: ["errors"]}} Sections={[]} />);
       const firstError = {timestamp: Date.now() + 100, error: {message: "first"}};
       const secondError = {timestamp: Date.now(), error: {message: "second"}};

--- a/test/unit/content-src/components/ASRouterAdmin.test.jsx
+++ b/test/unit/content-src/components/ASRouterAdmin.test.jsx
@@ -77,6 +77,9 @@ describe("ASRouterAdmin", () => {
         .at(0)
         .text(), "foo");
       assert.lengthOf(wrapper.find("tbody tr"), 2);
+      assert.equal(wrapper.find("tbody tr").at(0).find("td")
+        .at(1)
+        .text(), secondError.error.message);
     });
   });
   describe("#render", () => {


### PR DESCRIPTION
This adds a new section in ASRouterAdmin where you can see all logged errors.

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/810040/54942333-c42ac680-4f26-11e9-9e5a-b9885d453fc6.png">

I've broken down the `_remoteLoader` to report missing messages, response failures or failures to parse json. Also all calls to `Cu.reportError` now go through the same function that captures them to be displayed in the admin panel.
