### PR TITLE
Bug 1530740 - Add loaded content ping for Discovery Stream

### DIFF
--- a/common/Actions.jsm
+++ b/common/Actions.jsm
@@ -46,6 +46,7 @@ for (const type of [
   "DISCOVERY_STREAM_IMPRESSION_STATS",
   "DISCOVERY_STREAM_LAYOUT_RESET",
   "DISCOVERY_STREAM_LAYOUT_UPDATE",
+  "DISCOVERY_STREAM_LOADED_CONTENT",
   "DISCOVERY_STREAM_OPT_OUT",
   "DISCOVERY_STREAM_SPOCS_ENDPOINT",
   "DISCOVERY_STREAM_SPOCS_UPDATE",
@@ -351,6 +352,21 @@ function DiscoveryStreamImpressionStats(data, importContext = globalImportContex
   return importContext === UI_CODE ? AlsoToMain(action) : action;
 }
 
+/**
+ * DiscoveryStreamLoadedContent - A telemetry ping indicating a content gets loaded in Discovery Stream.
+ *
+ * @param  {object} data Fields to include in the ping
+ * @param  {int} importContext (For testing) Override the import context for testing.
+ * #return {object} An action. For UI code, a AlsoToMain action.
+ */
+function DiscoveryStreamLoadedContent(data, importContext = globalImportContext) {
+  const action = {
+    type: actionTypes.DISCOVERY_STREAM_LOADED_CONTENT,
+    data,
+  };
+  return importContext === UI_CODE ? AlsoToMain(action) : action;
+}
+
 function SetPref(name, value, importContext = globalImportContext) {
   const action = {type: actionTypes.SET_PREF, data: {name, value}};
   return importContext === UI_CODE ? AlsoToMain(action) : action;
@@ -382,6 +398,7 @@ this.actionCreators = {
   SetPref,
   WebExtEvent,
   DiscoveryStreamImpressionStats,
+  DiscoveryStreamLoadedContent,
 };
 
 // These are helpers to test for certain kinds of actions

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -759,6 +759,30 @@ These report any failures during domain affinity v2 calculations, and where it f
 }
 ```
 
+### Discovery Stream loaded content
+
+This reports all the loaded content (a list of `id`s and positions) when the user opens a newtab page and the page becomes visible. Note that this ping is a superset of the Discovery Stream impression ping, as impression pings are also subject to the individual visibility.
+
+```js
+{
+  "action": "activity_stream_impression_stats",
+
+  // Both "client_id" and "session_id" are set to "n/a" in this ping.
+  "client_id": "n/a",
+  "session_id": "n/a",
+  "impression_id": "{005deed0-e3e4-4c02-a041-17405fd703f6}",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "source": ["HERO" | "CARDGRID" | "LIST"],
+  "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
+  "user_prefs": 7,
+
+  // Indicating this is a `loaded content` ping (as opposed to impression) as well as the size of `tiles`
+  "loaded": 3,
+  "tiles": [{"id": 10000, "pos": 0}, {"id": 10001, "pos": 1}, {"id": 10002, "pos": 2}]
+}
+```
+
 ### Discovery Stream performance pings
 
 #### Request time of layout feed in ms

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -341,6 +341,7 @@ this.TelemetryFeed = class TelemetryFeed {
       return;
     }
 
+    this.sendDiscoveryStreamLoadedContent(portID, session);
     this.sendDiscoveryStreamImpressions(portID, session);
 
     if (session.perf.visibility_event_rcvd_ts) {
@@ -371,6 +372,34 @@ this.TelemetryFeed = class TelemetryFeed {
 
     Object.keys(impressionSets).forEach(source => {
       const payload = this.createImpressionStats(port, {source, tiles: impressionSets[source]});
+      this.sendEvent(payload);
+      this.sendStructuredIngestionEvent(payload, "impression-stats", "1");
+    });
+  }
+
+  /**
+   * Send loaded content pings for Discovery Stream for a given session.
+   *
+   * @note the loaded content reports are stored in session.loadedContentSets for different
+   * sources, and will be sent separately accordingly.
+   *
+   * @param {String} port  The session port with which this is associated
+   * @param {Object} session  The session object
+   */
+  sendDiscoveryStreamLoadedContent(port, session) {
+    const {loadedContentSets} = session;
+
+    if (!loadedContentSets) {
+      return;
+    }
+
+    Object.keys(loadedContentSets).forEach(source => {
+      const tiles = loadedContentSets[source];
+      const payload = this.createImpressionStats(port, {
+        source,
+        tiles,
+        loaded: tiles.length,
+      });
       this.sendEvent(payload);
       this.sendStructuredIngestionEvent(payload, "impression-stats", "1");
     });
@@ -701,6 +730,9 @@ this.TelemetryFeed = class TelemetryFeed {
       case at.DISCOVERY_STREAM_IMPRESSION_STATS:
         this.handleDiscoveryStreamImpressionStats(au.getPortIdOfSender(action), action.data);
         break;
+      case at.DISCOVERY_STREAM_LOADED_CONTENT:
+        this.handleDiscoveryStreamLoadedContent(au.getPortIdOfSender(action), action.data);
+        break;
       case at.TELEMETRY_UNDESIRED_EVENT:
         this.handleUndesiredEvent(action);
         break;
@@ -740,10 +772,37 @@ this.TelemetryFeed = class TelemetryFeed {
 
     const impressionSets = session.impressionSets || {};
     const impressions = impressionSets[data.source] || [];
-    // The payload might contain other properties, we only need `id` here.
+    // The payload might contain other properties, we need `id` and `pos` here.
     data.tiles.forEach(tile => impressions.push({id: tile.id, pos: tile.pos}));
     impressionSets[data.source] = impressions;
     session.impressionSets = impressionSets;
+  }
+
+  /**
+   * Handle loaded content actions from Discovery Stream. The data will be
+   * stored into the session.loadedContentSets object for the given port, so that
+   * it is sent to the server when the session ends.
+   *
+   * @note session.loadedContentSets will be keyed on `source` of the `data`,
+   * all the data will be appended to an array for the same source.
+   *
+   * @param {String} port  The session port with which this is associated
+   * @param {Object} data  The loaded content structured as {source: "SOURCE", tiles: [{id: 123}]}
+   *
+   */
+  handleDiscoveryStreamLoadedContent(port, data) {
+    let session = this.sessions.get(port);
+
+    if (!session) {
+      throw new Error("Session does not exist.");
+    }
+
+    const loadedContentSets = session.loadedContentSets || {};
+    const loadedContents = loadedContentSets[data.source] || [];
+    // The payload might contain other properties, we need `id` and `pos` here.
+    data.tiles.forEach(tile => loadedContents.push({id: tile.id, pos: tile.pos}));
+    loadedContentSets[data.source] = loadedContents;
+    session.loadedContentSets = loadedContentSets;
   }
 
   /**


### PR DESCRIPTION
This adds a new ping for content loaded event in Discovery Stream. Similar to impression pings, it relies on the page visibility, but not the individual visibility.

NB:
* This needs a data review
* Requires a schema change in both old&new data pipeline. 