### PR TITLE
Bug 1533359 - Targeting support for any subdomain

### DIFF
--- a/content-src/asrouter/schemas/message-format.md
+++ b/content-src/asrouter/schemas/message-format.md
@@ -10,6 +10,8 @@ Field name | Type     | Required | Description | Example / Note
 `campaign` | `string` | No | Campaign id that the message belongs to | `RustWebAssembly`
 `targeting` | `string` `JEXL` | No | A [JEXL expression](http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#jexl-basics) with all targeting information needed in order to decide if the message is shown | Not yet implemented, [Examples](#targeting-attributes)
 `trigger` | `string` | No | An event or condition upon which the message will be immediately shown. This can be combined with `targeting`. Messages that define a trigger will not be shown during non-trigger-based passive message rotation.
+`trigger.params` | `[string]` | No | A set of hostnames passed down as parameters to the trigger condition. Used to restrict the number of domains where the trigger/message is valid. | [See example below](#trigger-params)
+`trigger.patterns` | `[string]` | No | A set of patterns that match multiple hostnames passed down as parameters to the trigger condition. Used to restrict the number of domains where the trigger/message is valid. | [See example below](#trigger-patterns)
 `frequency` | `object` | No | A definition for frequency cap information for the message
 `frequency.lifetime` | `integer` | No | The maximum number of lifetime impressions for the message.
 `frequency.custom` | `array` | No | An array of frequency cap definition objects including `period`, a time period in milliseconds, and `cap`, a max number of impressions for that period.
@@ -80,6 +82,20 @@ Links cannot be rendered using regular anchor tags because [Fluent does not allo
 If a tag that is not on the allowed is used, the text content will be extracted and displayed.
 
 Grouping multiple allowed elements is not possible, only the first level will be used: `<u><b>text</b></u>` will be interpreted as `<u>text</u>`.
+
+### Trigger params
+A set of hostnames that need to exactly match the location of the selected tab in order for the trigger to execute.
+```
+["github.com", "wwww.github.com"]
+```
+More examples in the [CFRMessageProvider](https://github.com/mozilla/activity-stream/blob/e76ce12fbaaac1182aa492b84fc038f78c3acc33/lib/CFRMessageProvider.jsm#L40-L47).
+
+### Trigger patterns
+A set of patterns that can match multiple hostnames. When the location of the selected tab matches one of the patterns it can execute a trigger.
+```
+["*://*.github.com"] // can match `github.com` but also match `https://gist.github.com/`
+```
+More [MatchPattern examples](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#Examples).
 
 ### Targeting attributes
 (This section has moved to [targeting-attributes.md](../docs/targeting-attributes.md)).

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -463,7 +463,7 @@ class _ASRouter {
       const unseenListeners = new Set(ASRouterTriggerListeners.keys());
       for (const {trigger} of newState.messages) {
         if (trigger && ASRouterTriggerListeners.has(trigger.id)) {
-          await ASRouterTriggerListeners.get(trigger.id).init(this._triggerHandler, trigger.params);
+          await ASRouterTriggerListeners.get(trigger.id).init(this._triggerHandler, trigger.params, trigger.patterns);
           unseenListeners.delete(trigger.id);
         }
       }

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -337,6 +337,8 @@ this.ASRouterTargeting = {
       return false;
     } else if (!candidateMessageTrigger.params) {
       return true;
+    } else if (candidateMessageTrigger.patterns) {
+      return true;
     }
     return candidateMessageTrigger.params.includes(trigger.param);
   },

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -104,7 +104,7 @@ this.ASRouterTriggerListeners = new Map([
           this._matchPatternSet = new MatchPatternSet([
             ...this._matchPatternSet.patterns,
             ...patterns,
-          ]);
+          ], MATCH_PATTERN_OPTIONS);
         } else {
           this._matchPatternSet = new MatchPatternSet(patterns, MATCH_PATTERN_OPTIONS);
         }

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -239,6 +239,7 @@ this.ASRouterTriggerListeners = new Map([
         this._initialized = false;
         this._triggerHandler = null;
         this._hosts = null;
+        this._matchPatternSet = null;
         this._visits = null;
       }
     },

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -300,7 +300,7 @@ this.ASRouterTriggerListeners = new Map([
       let host;
       try {
         host = aLocationURI ? aLocationURI.host : "";
-      } catch (e) { // about: pages will throw errors
+      } catch (e) { // about: pages throw errors
         return;
       }
       // Some websites trigger redirect events after they finish loading even

--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -141,7 +141,9 @@ this.ASRouterTriggerListeners = new Map([
       try {
         // nsIURI.host can throw for non-nsStandardURL nsIURIs.
         host = gBrowser.currentURI.host;
-      } catch (e) {} // Couldn't parse location URL
+      } catch (e) {
+        return; // Couldn't parse location URL
+      }
 
       if (checkHost(gBrowser.currentURI, {hosts: this._hosts, matchPatternSet: this._matchPatternSet})) {
         this.triggerHandler(gBrowser.selectedBrowser, host);

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -38,12 +38,10 @@ const REDDIT_ENHANCEMENT_PARAMS = {
   min_frecency: 10000,
 };
 const PINNED_TABS_TARGET_SITES = [
-  "docs.google.com", "www.docs.google.com", "calendar.google.com",
-  "messenger.com", "www.messenger.com", "web.whatsapp.com", "mail.google.com",
-  "outlook.live.com", "facebook.com", "www.facebook.com", "twitter.com", "www.twitter.com",
-  "reddit.com", "www.reddit.com", "github.com", "www.github.com", "youtube.com", "www.youtube.com",
-  "feedly.com", "www.feedly.com", "drive.google.com", "amazon.com", "www.amazon.com",
-  "messages.android.com",
+  "docs.google.com", "calendar.google.com",
+  "messenger.com", "web.whatsapp.com", "mail.google.com", "outlook.live.com",
+  "facebook.com", "twitter.com", "twitter.com", "reddit.com", "github.com",
+  "youtube.com", "feedly.com", "drive.google.com", "amazon.com", "messages.android.com",
 ];
 
 const CFR_MESSAGES = [

--- a/lib/CFRMessageProvider.jsm
+++ b/lib/CFRMessageProvider.jsm
@@ -38,10 +38,12 @@ const REDDIT_ENHANCEMENT_PARAMS = {
   min_frecency: 10000,
 };
 const PINNED_TABS_TARGET_SITES = [
-  "docs.google.com", "calendar.google.com",
-  "messenger.com", "web.whatsapp.com", "mail.google.com", "outlook.live.com",
-  "facebook.com", "twitter.com", "twitter.com", "reddit.com", "github.com",
-  "youtube.com", "feedly.com", "drive.google.com", "amazon.com", "messages.android.com",
+  "docs.google.com", "www.docs.google.com", "calendar.google.com",
+  "messenger.com", "www.messenger.com", "web.whatsapp.com", "mail.google.com",
+  "outlook.live.com", "facebook.com", "www.facebook.com", "twitter.com", "www.twitter.com",
+  "reddit.com", "www.reddit.com", "github.com", "www.github.com", "youtube.com", "www.youtube.com",
+  "feedly.com", "www.feedly.com", "drive.google.com", "amazon.com", "www.amazon.com",
+  "messages.android.com",
 ];
 
 const CFR_MESSAGES = [

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -383,4 +383,19 @@ add_task(async function test_matchPattern() {
   await BrowserTestUtils.browserLoaded(browser, false, "http://example.com/");
 
   Assert.equal(count, 1, "Registered pattern matched the current location");
+
+  await BrowserTestUtils.loadURI(browser, "about:config");
+  await BrowserTestUtils.browserLoaded(browser, false, "about:config");
+
+  Assert.equal(count, 1, "Navigated to a new page but not a match");
+
+  await BrowserTestUtils.loadURI(browser, "http://example.com/");
+  await BrowserTestUtils.browserLoaded(browser, false, "http://example.com/");
+
+  Assert.equal(count, 1, "Navigated to a location that matches the pattern but within 15 mins");
+
+  await BrowserTestUtils.loadURI(browser, "http://www.example.com/");
+  await BrowserTestUtils.browserLoaded(browser, false, "http://www.example.com/");
+
+  Assert.equal(count, 2, "www.example.com is a different host that also matches the pattern.");
 });

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -372,3 +372,15 @@ add_task(async function test_onLocationChange_cb() {
 
   Assert.equal(count, 2, "We moved to a new document");
 });
+
+add_task(async function test_matchPattern() {
+  let count = 0;
+  const triggerHandler = () => ++count;
+  ASRouterTriggerListeners.get("frequentVisits").init(triggerHandler, [], ["*://*.example.com/"]);
+
+  const browser = gBrowser.selectedBrowser;
+  await BrowserTestUtils.loadURI(browser, "http://example.com/");
+  await BrowserTestUtils.browserLoaded(browser, false, "http://example.com/");
+
+  Assert.equal(count, 1, "Registered pattern matched the current location");
+});

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -341,9 +341,9 @@ describe("ASRouter", () => {
 
       assert.calledTwice(ASRouterTriggerListeners.get("openURL").init);
       assert.calledWithExactly(ASRouterTriggerListeners.get("openURL").init,
-        Router._triggerHandler, ["www.mozilla.org", "www.mozilla.com"]);
+        Router._triggerHandler, ["www.mozilla.org", "www.mozilla.com"], undefined);
       assert.calledWithExactly(ASRouterTriggerListeners.get("openURL").init,
-        Router._triggerHandler, ["www.example.com"]);
+        Router._triggerHandler, ["www.example.com"], undefined);
     });
     it("should gracefully handle RemoteSettings blowing up", async () => {
       sandbox.stub(MessageLoaderUtils, "_getRemoteSettingsMessages").rejects("fake error");

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -9,7 +9,7 @@ describe("ASRouterTriggerListeners", () => {
   const triggerHandler = () => {};
   const openURLListener = ASRouterTriggerListeners.get("openURL");
   const frequentVisitsListener = ASRouterTriggerListeners.get("frequentVisits");
-  const hosts = ["www.mozilla.com", "www.mozilla.org"];
+  const hosts = ["mozilla.com", "mozilla.org"];
 
   function resetEnumeratorStub(windows) {
     windowEnumeratorStub
@@ -181,7 +181,24 @@ describe("ASRouterTriggerListeners", () => {
         const location = "www.mozilla.org";
         openURLListener.onLocationChange(browser, webProgress, undefined, {host: location});
         assert.calledOnce(newTriggerHandler);
-        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
+      });
+      it("should call triggerHandler for a redirect", async () => {
+        const newTriggerHandler = sinon.stub();
+        await openURLListener.init(newTriggerHandler, hosts);
+
+        const browser = {};
+        const webProgress = {isTopLevel: true};
+        const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
+        const aRequest = {
+          QueryInterface: sandbox.stub().returns({
+            originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+          }),
+        };
+        openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
+        assert.calledOnce(aRequest.QueryInterface);
+        assert.calledOnce(newTriggerHandler);
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
       it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {
         for (let trigger of [openURLListener, frequentVisitsListener]) {

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -195,6 +195,7 @@ describe("ASRouterTriggerListeners", () => {
     describe("#onLocationChange", () => {
       afterEach(() => {
         openURLListener.uninit();
+        frequentVisitsListener.uninit();
       });
 
       it("should call the ._triggerHandler with the right arguments", async () => {

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -183,7 +183,25 @@ describe("ASRouterTriggerListeners", () => {
         assert.calledOnce(newTriggerHandler);
         assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
-      it("should call triggerHandler for a redirect", async () => {
+      it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {
+        for (let trigger of [openURLListener, frequentVisitsListener]) {
+          const newTriggerHandler = sinon.stub();
+          await trigger.init(newTriggerHandler, hosts);
+
+          const browser = {};
+          const webProgress = {isTopLevel: true};
+          const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
+          const aRequest = {
+            QueryInterface: sandbox.stub().returns({
+              originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+            }),
+          };
+          trigger.onLocationChange(browser, webProgress, aRequest, aLocationURI);
+          assert.calledOnce(aRequest.QueryInterface);
+          assert.calledOnce(newTriggerHandler);
+        }
+      });
+      it("should call triggerHandler with the right arguments (redirect)", async () => {
         const newTriggerHandler = sinon.stub();
         await openURLListener.init(newTriggerHandler, hosts);
 
@@ -196,8 +214,6 @@ describe("ASRouterTriggerListeners", () => {
           }),
         };
         openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
-        assert.calledOnce(aRequest.QueryInterface);
-        assert.calledOnce(newTriggerHandler);
         assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
       });
       it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -9,7 +9,7 @@ describe("ASRouterTriggerListeners", () => {
   const triggerHandler = () => {};
   const openURLListener = ASRouterTriggerListeners.get("openURL");
   const frequentVisitsListener = ASRouterTriggerListeners.get("frequentVisits");
-  const hosts = ["mozilla.com", "mozilla.org"];
+  const hosts = ["www.mozilla.com", "www.mozilla.org"];
 
   function resetEnumeratorStub(windows) {
     windowEnumeratorStub
@@ -181,7 +181,7 @@ describe("ASRouterTriggerListeners", () => {
         const location = "www.mozilla.org";
         openURLListener.onLocationChange(browser, webProgress, undefined, {host: location});
         assert.calledOnce(newTriggerHandler);
-        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
       });
       it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {
         for (let trigger of [openURLListener, frequentVisitsListener]) {
@@ -193,7 +193,7 @@ describe("ASRouterTriggerListeners", () => {
           const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
           const aRequest = {
             QueryInterface: sandbox.stub().returns({
-              originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+              originalURI: {spec: "www.mozilla.org", host: "www.mozilla.org"},
             }),
           };
           trigger.onLocationChange(browser, webProgress, aRequest, aLocationURI);
@@ -210,11 +210,11 @@ describe("ASRouterTriggerListeners", () => {
         const aLocationURI = {host: "subdomain.mozilla.org", spec: "subdomain.mozilla.org"};
         const aRequest = {
           QueryInterface: sandbox.stub().returns({
-            originalURI: {spec: "mozilla.org", host: "mozilla.org"},
+            originalURI: {spec: "www.mozilla.org", host: "www.mozilla.org"},
           }),
         };
         openURLListener.onLocationChange(browser, webProgress, aRequest, aLocationURI);
-        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "mozilla.org"});
+        assert.calledWithExactly(newTriggerHandler, browser, {id: "openURL", param: "www.mozilla.org"});
       });
       it("should call triggerHandler for a redirect (openURL + frequentVisits)", async () => {
         for (let trigger of [openURLListener, frequentVisitsListener]) {

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -100,12 +100,12 @@ describe("ASRouterTriggerListeners", () => {
         assert.calledOnce(window.MatchPatternSet);
         assert.calledWithExactly(window.MatchPatternSet, ["pattern"], {ignorePath: true});
       });
-      it("should allow to add multiple patterns", async () => {
+      it("should allow to add multiple patterns and dedupe", async () => {
         await frequentVisitsListener.init(_triggerHandler, hosts, ["pattern"]);
         await frequentVisitsListener.init(_triggerHandler, hosts, ["foo"]);
 
         assert.calledTwice(window.MatchPatternSet);
-        assert.calledWithExactly(window.MatchPatternSet, ["pattern", "foo"], {ignorePath: true});
+        assert.calledWithExactly(window.MatchPatternSet, new Set(["pattern", "foo"]), {ignorePath: true});
       });
     });
   });

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -1,4 +1,5 @@
 import {ASRouterTriggerListeners} from "lib/ASRouterTriggerListeners.jsm";
+import {GlobalOverrider} from "test/unit/utils";
 
 describe("ASRouterTriggerListeners", () => {
   let sandbox;
@@ -82,6 +83,30 @@ describe("ASRouterTriggerListeners", () => {
       frequentVisitsListener.onTabSwitch({target: {ownerGlobal: existingWindow}});
 
       assert.notCalled(stub);
+    });
+    describe("MatchPattern", () => {
+      let globals;
+      beforeEach(() => {
+        globals = new GlobalOverrider();
+        globals.set("MatchPatternSet", sandbox.stub().callsFake(patterns => ({patterns})));
+      });
+      afterEach(() => {
+        globals.restore();
+        frequentVisitsListener.uninit();
+      });
+      it("should create a matchPatternSet", async () => {
+        await frequentVisitsListener.init(_triggerHandler, hosts, ["pattern"]);
+
+        assert.calledOnce(window.MatchPatternSet);
+        assert.calledWithExactly(window.MatchPatternSet, ["pattern"], {ignorePath: true});
+      });
+      it("should allow to add multiple patterns", async () => {
+        await frequentVisitsListener.init(_triggerHandler, hosts, ["pattern"]);
+        await frequentVisitsListener.init(_triggerHandler, hosts, ["foo"]);
+
+        assert.calledTwice(window.MatchPatternSet);
+        assert.calledWithExactly(window.MatchPatternSet, ["pattern", "foo"], {ignorePath: true});
+      });
     });
   });
 


### PR DESCRIPTION
Work on top of #4859, ~~which needs to land first.~~

One issue I ran into here: 
* ASRouterTargeting checks that the selected message has a `trigger param` that matches the `host`
  * https://github.com/mozilla/activity-stream/compare/master...piatra:bug1533359?expand=1#diff-60f0c109d5c368ec6a6b11e2f311b3efR340
* For patterns this check will fail (we would compare `*.foo.com` with `bar.foo.com`) ~~because `MatchPattern` is not available to content~~
* This needs to be fixed when we want to land two different messages that use the same `frequentVisits` trigger
  * - [x] create follow up bug -- https://bugzilla.mozilla.org/show_bug.cgi?id=1540182
