### PR TITLE
(nobug) - Ensure fetch calls don't include credentials

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,8 @@ module.exports = {
     "json", // require("eslint-plugin-json")
     "promise", // require("eslint-plugin-promise")
     "react", // require("eslint-plugin-react")
-    "react-hooks" // require("react-hooks")
+    "react-hooks", // require("react-hooks")
+    "fetch-options", // require("eslint-plugin-fetch-options")
   ],
   "settings": {
     "react": {
@@ -47,6 +48,8 @@ module.exports = {
   }],
   "rules": {
     "react-hooks/rules-of-hooks": 2,
+
+    "fetch-options/no-fetch-credentials": 2,
 
     "promise/catch-or-return": 2,
     "promise/param-names": 2,

--- a/bin/strings-import.js
+++ b/bin/strings-import.js
@@ -39,7 +39,7 @@ const transvision = {};
 async function cherryPickString(locale) {
   const getTransvision = async string => {
     if (!transvision[string]) {
-      const response = await fetch(`https://transvision.mozfr.org/api/v1/entity/gecko_strings/?id=${string}`);
+      const response = await fetch(`https://transvision.mozfr.org/api/v1/entity/gecko_strings/?id=${string}`); // eslint-disable-line fetch-options/no-fetch-credentials
       transvision[string] = response.ok ? await response.json() : {};
     }
     return transvision[string];
@@ -54,7 +54,7 @@ async function cherryPickString(locale) {
 async function saveProperties(locale) {
   // Only save a file if the repository has the file
   const url = `${L10N_CENTRAL}/${locale}/${PROPERTIES_PATH}`;
-  const response = await fetch(url);
+  const response = await fetch(url); // eslint-disable-line fetch-options/no-fetch-credentials
   if (!response.ok) {
     // Indicate that this locale didn't save
     return locale;

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -49,7 +49,7 @@ export class SubmitFormSnippet extends React.PureComponent {
 
     try {
       const fetchRequest = new Request(url, {body: formData, method: "POST", credentials: "omit"});
-      const response = await fetch(fetchRequest);
+      const response = await fetch(fetchRequest); // eslint-disable-line fetch-options/no-fetch-credentials
       json = await response.json();
     } catch (err) {
       console.log(err); // eslint-disable-line no-console

--- a/lib/PersonalityProvider.jsm
+++ b/lib/PersonalityProvider.jsm
@@ -103,7 +103,7 @@ this.PersonalityProvider = class PersonalityProvider {
     const localFilePath = OS.Path.join(PERSONALITY_PROVIDER_DIR, filename);
     const headers = new Headers();
     headers.set("Accept-Encoding", "gzip");
-    const resp = await fetch(remoteFilePath, {headers});
+    const resp = await fetch(remoteFilePath, {headers, credentials: "omit"});
     if (!resp.ok) {
       Cu.reportError(`Failed to fetch ${remoteFilePath}: ${resp.status}`);
       return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,6 +3025,38 @@
         }
       }
     },
+<<<<<<< HEAD
+=======
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      }
+    },
+    "eslint-plugin-fetch-options": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-fetch-options/-/eslint-plugin-fetch-options-0.0.3.tgz",
+      "integrity": "sha512-F8W+KzKcvxRpVPfGe0MZX75r5ro/K00NLaAPnj0Z+j7LTkLMXbrIYNq69EWOcAh7bPupCqeAnAbtwUFaOihdnA==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      }
+    },
+>>>>>>> 9f95fc31... (nobug) - Ensure fetch calls don't include credentials
     "eslint-plugin-import": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
@@ -9654,6 +9686,12 @@
           "dev": true
         }
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,38 +3025,12 @@
         }
       }
     },
-<<<<<<< HEAD
-=======
-    "eslint-import-resolver-node": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^2.0.0"
-      }
-    },
     "eslint-plugin-fetch-options": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-fetch-options/-/eslint-plugin-fetch-options-0.0.3.tgz",
-      "integrity": "sha512-F8W+KzKcvxRpVPfGe0MZX75r5ro/K00NLaAPnj0Z+j7LTkLMXbrIYNq69EWOcAh7bPupCqeAnAbtwUFaOihdnA==",
-      "dev": true,
-      "requires": {
-        "requireindex": "~1.1.0"
-      }
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-fetch-options/-/eslint-plugin-fetch-options-0.0.4.tgz",
+      "integrity": "sha512-Cre2qoYkn0OUdavSFb2duRk1sMChwlger01FvRoG5zO9BRgaMSH3kK3eURSlrOGiKbq7oNwl6Ha39eLeXSZ3Sg==",
+      "dev": true
     },
->>>>>>> 9f95fc31... (nobug) - Ensure fetch calls don't include credentials
     "eslint-plugin-import": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
@@ -9686,12 +9660,6 @@
           "dev": true
         }
       }
-    },
-    "requireindex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
-      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.10.0",
     "eslint": "5.15.1",
-    "eslint-plugin-fetch-options": "0.0.3",
+    "eslint-plugin-fetch-options": "0.0.4",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-json": "1.4.0",
     "eslint-plugin-mozilla": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.10.0",
     "eslint": "5.15.1",
+    "eslint-plugin-fetch-options": "0.0.3",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-json": "1.4.0",
     "eslint-plugin-mozilla": "1.1.1",

--- a/ping-centre/PingCentre.jsm
+++ b/ping-centre/PingCentre.jsm
@@ -177,7 +177,11 @@ class PingCentre {
       }
     }
 
-    return fetch(this._pingEndpoint, {method: "POST", body: JSON.stringify(payload)}).then(response => {
+    return fetch(this._pingEndpoint, {
+      method: "POST",
+      body: JSON.stringify(payload),
+      credentials: "omit",
+    }).then(response => {
       if (!response.ok) {
         Cu.reportError(`Ping failure with HTTP response code: ${response.status}`);
       }
@@ -203,7 +207,11 @@ class PingCentre {
 
     const payload = await this._createPing(data, options);
 
-    return fetch(endpoint, {method: "POST", body: JSON.stringify(payload)}).then(response => {
+    return fetch(endpoint, {
+      method: "POST",
+      body: JSON.stringify(payload),
+      credentials: "omit",
+    }).then(response => {
       if (!response.ok) {
         Cu.reportError(`Structured Ingestion ping failure with HTTP response code: ${response.status}`);
       }

--- a/test/browser/browser_activity_stream_strings.js
+++ b/test/browser/browser_activity_stream_strings.js
@@ -9,7 +9,7 @@ const LOCALE_PATH = "resource://activity-stream/prerendered/";
  */
 add_task(async function test_activity_stream_fetch_strings() {
   const file = `${LOCALE_PATH}${aboutNewTabService.activityStreamLocale}/activity-stream-strings.js`;
-  const strings = JSON.parse((await (await fetch(file)).text()).match(/{[^]*}/)[0]);
+  const strings = JSON.parse((await (await fetch(file)).text()).match(/{[^]*}/)[0]); // eslint-disable-line fetch-options/no-fetch-credentials
   const ids = Object.keys(strings);
 
   info(`Got string ids: ${ids}`);

--- a/test/unit/ping-centre/PingCentre.test.js
+++ b/test/unit/ping-centre/PingCentre.test.js
@@ -374,7 +374,7 @@ describe("PingCentre", () => {
 
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, fakeEndpointUrl,
-        {method: "POST", body: JSON.stringify(EXPECTED_RESULT)});
+        {method: "POST", body: JSON.stringify(EXPECTED_RESULT), credentials: "omit"});
     });
 
     it("should log HTTP failures using Cu.reportError", async () => {
@@ -468,7 +468,7 @@ describe("PingCentre", () => {
 
       assert.calledOnce(fetchStub);
       assert.calledWithExactly(fetchStub, fakeEndpointUrl,
-        {method: "POST", body: JSON.stringify(EXPECTED_RESULT)});
+        {method: "POST", body: JSON.stringify(EXPECTED_RESULT), credentials: "omit"});
     });
 
     it("should log HTTP failures using Cu.reportError", async () => {


### PR DESCRIPTION
There were 2 occurrences in `PingCentre` and 1 in `PersonalityProvider` that were an actual issue because that code runs in the main process. The content process occurrence is a false positive (the request object includes `credentials: omit`) and the others are just built time usages.
I've looked into `no-restricted-syntax` but it seems to completely forbid usage of certain features regardless of how they are used/their options.