### PR TITLE
Bug 1541359 - Chore: Increase our frontend code coverage

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -167,8 +167,6 @@ export class _DiscoveryStreamBase extends React.PureComponent {
 
   render() {
     // Select layout render data by adding spocs and position to recommendations
-    console.log(selectLayoutRender);
-    console.log(window.selectLayoutRender);
     const layoutRender = selectLayoutRender(this.props.DiscoveryStream, rickRollCache);
     const styles = [];
     const {spocs, feeds} = this.props.DiscoveryStream;

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -167,6 +167,8 @@ export class _DiscoveryStreamBase extends React.PureComponent {
 
   render() {
     // Select layout render data by adding spocs and position to recommendations
+    console.log(selectLayoutRender);
+    console.log(window.selectLayoutRender);
     const layoutRender = selectLayoutRender(this.props.DiscoveryStream, rickRollCache);
     const styles = [];
     const {spocs, feeds} = this.props.DiscoveryStream;

--- a/content-src/components/TopSites/SearchShortcutsForm.jsx
+++ b/content-src/components/TopSites/SearchShortcutsForm.jsx
@@ -3,7 +3,7 @@ import {FormattedMessage} from "react-intl";
 import React from "react";
 import {TOP_SITES_SOURCE} from "./TopSitesConstants";
 
-class SelectableSearchShortcut extends React.PureComponent {
+export class SelectableSearchShortcut extends React.PureComponent {
   render() {
     const {shortcut, selected} = this.props;
     const imageStyle = {backgroundImage: `url("${shortcut.tippyTopIcon}")`};

--- a/karma.mc.config.js
+++ b/karma.mc.config.js
@@ -81,10 +81,10 @@ module.exports = function(config) {
               branches: 84,
             },
             "content-src/components/DiscoveryStreamComponents/**/*.jsx": {
-              statements: 0,
-              lines: 0,
-              functions: 0,
-              branches: 0,
+              statements: 65.2,
+              lines: 65.2,
+              functions: 50,
+              branches: 50,
             },
             "content-src/asrouter/**/*.jsx": {
               statements: 57,
@@ -92,11 +92,17 @@ module.exports = function(config) {
               functions: 60,
               branches: 50,
             },
-            "content-src/components/**/*.jsx": {
+            "content-src/components/ASRouterAdmin/*.jsx": {
               statements: 0,
               lines: 0,
               functions: 0,
               branches: 0,
+            },
+            "content-src/components/**/*.jsx": {
+              statements: 51.1,
+              lines: 53.6,
+              functions: 31.2,
+              branches: 31.2,
             },
           },
         },

--- a/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
@@ -1,17 +1,14 @@
-import {isAllowedCSS} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
-import {_DiscoveryStreamBase as DiscoveryStreamBase} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
+import {_DiscoveryStreamBase as DiscoveryStreamBase, isAllowedCSS} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
+import {GlobalOverrider, shallowWithIntl} from "test/unit/utils";
+import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
+import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
+import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
 import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
 import {List} from "content-src/components/DiscoveryStreamComponents/List/List";
-import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
-import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
 import {Navigation} from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
-import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
-import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
-import {TopSites} from "content-src/components/DiscoveryStreamComponents/TopSites/TopSites";
-import * as selectors from "content-src/lib/selectLayoutRender";
-import {GlobalOverrider} from "test/unit/utils";
 import React from "react";
-import {shallowWithIntl} from "test/unit/utils";
+import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
+import {TopSites} from "content-src/components/DiscoveryStreamComponents/TopSites/TopSites";
 
 describe("<isAllowedCSS>", () => {
   it("should allow colors", () => {
@@ -51,7 +48,6 @@ describe("<DiscoveryStreamBase>", () => {
   let wrapper;
   let globals;
   let sandbox;
-  let selectLayoutRenderStub;
 
   function mountComponent(props = {}) {
     const defaultProps = {
@@ -59,7 +55,7 @@ describe("<DiscoveryStreamBase>", () => {
       feeds: {loaded: true},
       spocs: {
         loaded: true,
-        data: {spocs: null}
+        data: {spocs: null},
       },
       ...props,
     };
@@ -94,52 +90,60 @@ describe("<DiscoveryStreamBase>", () => {
     assert.ok(wrapper.find(".discovery-stream").exists());
   });
 
-  it("should render a HorizontalRule", () => {
+  it("should render a HorizontalRule component", () => {
     wrapper = mountComponent({layout: [{components: [{type: "HorizontalRule"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), HorizontalRule);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), HorizontalRule);
   });
 
-  it("should render a List", () => {
+  it("should render a List component", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "List"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), List);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), List);
   });
 
-  it("should render a Hero", () => {
+  it("should render a Hero component", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Hero"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), Hero);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), Hero);
   });
 
-  it("should render a CardGrid", () => {
+  it("should render a CardGrid component", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "CardGrid"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), CardGrid);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), CardGrid);
   });
 
-  it("should render a Navigation", () => {
+  it("should render a Navigation component", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Navigation"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), Navigation);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), Navigation);
   });
 
-  it("should render a Message", () => {
+  it("should render a Message component", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Message"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), DSMessage);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), DSMessage);
   });
 
-  it("should render a SectionTitle", () => {
+  it("should render a SectionTitle component", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "SectionTitle"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), SectionTitle);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), SectionTitle);
   });
 
   it("should render TopSites", () => {
     wrapper = mountComponent({layout: [{components: [{properties: {}, type: "TopSites"}]}]});
 
-    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), TopSites);
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), TopSites);
   });
 
   describe("#onStyleMount", () => {
@@ -153,7 +157,7 @@ describe("<DiscoveryStreamBase>", () => {
     afterEach(() => {
       sandbox.restore();
       globals.restore();
-    })
+    });
 
     it("should return if no style", () => {
       assert.isUndefined(wrapper.instance().onStyleMount());
@@ -166,16 +170,16 @@ describe("<DiscoveryStreamBase>", () => {
         [
           null,
           {
-            ".ds-message": "margin-bottom: -20px"
+            ".ds-message": "margin-bottom: -20px",
           },
           null,
-          null
-        ]
+          null,
+        ],
       ]);
-      wrapper.instance().onStyleMount({sheet: sheetStub, dataset: {}}); 
+      wrapper.instance().onStyleMount({sheet: sheetStub, dataset: {}});
 
       assert.calledOnce(sheetStub.insertRule);
       assert.calledWithExactly(sheetStub.insertRule, "DUMMY#CSS.SELECTOR {}");
-    }); 
+    });
   });
 });

--- a/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
@@ -1,4 +1,17 @@
 import {isAllowedCSS} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
+import {_DiscoveryStreamBase as DiscoveryStreamBase} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
+import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
+import {List} from "content-src/components/DiscoveryStreamComponents/List/List";
+import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
+import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
+import {Navigation} from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
+import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
+import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
+import {TopSites} from "content-src/components/DiscoveryStreamComponents/TopSites/TopSites";
+import * as selectors from "content-src/lib/selectLayoutRender";
+import {GlobalOverrider} from "test/unit/utils";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
 
 describe("<isAllowedCSS>", () => {
   it("should allow colors", () => {
@@ -31,5 +44,138 @@ describe("<isAllowedCSS>", () => {
 
   it("should disallow if any invaild", () => {
     assert.isFalse(isAllowedCSS("background-image", `url("chrome://browser/skin/history.svg"), url("ftp://mozilla.org/media/image.png")`));
+  });
+});
+
+describe("<DiscoveryStreamBase>", () => {
+  let wrapper;
+  let globals;
+  let sandbox;
+  let selectLayoutRenderStub;
+
+  function mountComponent(props = {}) {
+    const defaultProps = {
+      layout: [],
+      feeds: {loaded: true},
+      spocs: {
+        loaded: true,
+        data: {spocs: null}
+      },
+      ...props,
+    };
+    return shallowWithIntl(<DiscoveryStreamBase DiscoveryStream={defaultProps} />);
+  }
+
+  beforeEach(() => {
+    globals = new GlobalOverrider();
+    sandbox = sinon.createSandbox();
+    wrapper = mountComponent();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    globals.restore();
+  });
+
+  it("should render null if spocs not loaded", () => {
+    wrapper = mountComponent({spocs: {loaded: false, data: {spocs: null}}});
+
+    assert.equal(wrapper.type(), null);
+  });
+
+  it("should render null if feeds not loaded", () => {
+    wrapper = mountComponent({feeds: {loaded: false}});
+
+    assert.equal(wrapper.type(), null);
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.ok(wrapper.find(".discovery-stream").exists());
+  });
+
+  it("should render a HorizontalRule", () => {
+    wrapper = mountComponent({layout: [{components: [{type: "HorizontalRule"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), HorizontalRule);
+  });
+
+  it("should render a List", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "List"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), List);
+  });
+
+  it("should render a Hero", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Hero"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), Hero);
+  });
+
+  it("should render a CardGrid", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "CardGrid"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), CardGrid);
+  });
+
+  it("should render a Navigation", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Navigation"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), Navigation);
+  });
+
+  it("should render a Message", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Message"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), DSMessage);
+  });
+
+  it("should render a SectionTitle", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "SectionTitle"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), SectionTitle);
+  });
+
+  it("should render TopSites", () => {
+    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "TopSites"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0).type(), TopSites);
+  });
+
+  describe("#onStyleMount", () => {
+    let parseStub;
+
+    beforeEach(() => {
+      parseStub = sandbox.stub();
+      globals.set("JSON", {parse: parseStub});
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      globals.restore();
+    })
+
+    it("should return if no style", () => {
+      assert.isUndefined(wrapper.instance().onStyleMount());
+      assert.notCalled(parseStub);
+    });
+
+    it("should insert rules", () => {
+      const sheetStub = {insertRule: sandbox.stub(), cssRules: [{}]};
+      parseStub.returns([
+        [
+          null,
+          {
+            ".ds-message": "margin-bottom: -20px"
+          },
+          null,
+          null
+        ]
+      ]);
+      wrapper.instance().onStyleMount({sheet: sheetStub, dataset: {}}); 
+
+      assert.calledOnce(sheetStub.insertRule);
+      assert.calledWithExactly(sheetStub.insertRule, "DUMMY#CSS.SELECTOR {}");
+    }); 
   });
 });

--- a/test/unit/content-src/components/DiscoveryStreamComponents/CardGrid.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/CardGrid.test.jsx
@@ -1,6 +1,5 @@
 import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
 import {DSCard} from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
-import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import React from "react";
 import {shallowWithIntl} from "test/unit/utils";
 
@@ -20,7 +19,8 @@ describe("<CardGrid>", () => {
     wrapper.setProps({items: 2, data: {recommendations: [{}, {}]}});
 
     assert.lengthOf(wrapper.find(".ds-card-grid").children(), 2);
-    assert.equal(wrapper.find(".ds-card-grid").children().at(0).type(), DSCard);
+    assert.equal(wrapper.find(".ds-card-grid").children().at(0)
+      .type(), DSCard);
   });
 
   it("should add divisible-by-4 to the grid", () => {

--- a/test/unit/content-src/components/DiscoveryStreamComponents/CardGrid.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/CardGrid.test.jsx
@@ -1,0 +1,37 @@
+import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
+import {DSCard} from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
+
+describe("<CardGrid>", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<CardGrid />);
+  });
+
+  it("should render an empty div", () => {
+    assert.ok(wrapper.exists());
+    assert.lengthOf(wrapper.children(), 0);
+  });
+
+  it("should render DSCards", () => {
+    wrapper.setProps({items: 2, data: {recommendations: [{}, {}]}});
+
+    assert.lengthOf(wrapper.find(".ds-card-grid").children(), 2);
+    assert.equal(wrapper.find(".ds-card-grid").children().at(0).type(), DSCard);
+  });
+
+  it("should add divisible-by-4 to the grid", () => {
+    wrapper.setProps({items: 4, data: {recommendations: [{}, {}]}});
+
+    assert.ok(wrapper.find(".ds-card-grid-divisible-by-4").exists());
+  });
+
+  it("should add divisible-by-3 to the grid", () => {
+    wrapper.setProps({items: 3, data: {recommendations: [{}, {}]}});
+
+    assert.ok(wrapper.find(".ds-card-grid-divisible-by-3").exists());
+  });
+});

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -1,8 +1,8 @@
 import {actionCreators as ac} from "common/Actions.jsm";
 import {DSCard} from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
 import {DSLinkMenu} from "content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu";
-import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import React from "react";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import {shallowWithIntl} from "test/unit/utils";
 
 describe("<DSCard>", () => {
@@ -51,12 +51,12 @@ describe("<DSCard>", () => {
       assert.calledWith(dispatch, ac.UserEvent({
         event: "CLICK",
         source: "FOO",
-        action_position: 1
+        action_position: 1,
       }));
       assert.calledWith(dispatch, ac.ImpressionStats({
         click: 0,
         source: "FOO",
-        tiles: [{id: "fooidx", pos: 1}]
+        tiles: [{id: "fooidx", pos: 1}],
       }));
     });
   });

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -1,0 +1,67 @@
+import {actionCreators as ac} from "common/Actions.jsm";
+import {DSCard} from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
+import {DSLinkMenu} from "content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
+
+describe("<DSCard>", () => {
+  let wrapper;
+  let sandbox;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<DSCard />);
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.ok(wrapper.find(".ds-card"));
+  });
+
+  it("should render a SafeAnchor", () => {
+    wrapper.setProps({url: "https://foo.com"});
+
+    assert.equal(wrapper.children().at(0).type(), SafeAnchor);
+    assert.propertyVal(wrapper.children().at(0).props(), "url", "https://foo.com");
+  });
+
+  it("should pass onLinkClick prop", () => {
+    assert.propertyVal(wrapper.children().at(0).props(), "onLinkClick", wrapper.instance().onLinkClick);
+  });
+
+  describe("onLinkClick", () => {
+    let dispatch;
+
+    beforeEach(() => {
+      dispatch = sandbox.stub();
+      wrapper = shallowWithIntl(<DSCard dispatch={dispatch} />);
+    });
+
+    it("should call dispatch with the correct events", () => {
+      wrapper.setProps({id: "fooidx", pos: 1, type: "foo"});
+
+      wrapper.instance().onLinkClick();
+
+      assert.calledTwice(dispatch);
+      assert.calledWith(dispatch, ac.UserEvent({
+        event: "CLICK",
+        source: "FOO",
+        action_position: 1
+      }));
+      assert.calledWith(dispatch, ac.ImpressionStats({
+        click: 0,
+        source: "FOO",
+        tiles: [{id: "fooidx", pos: 1}]
+      }));
+    });
+  });
+
+  it("should render DSLinkMenu", () => {
+    assert.equal(wrapper.children().at(1).type(), DSLinkMenu);
+  });
+});

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSMessage.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSMessage.test.jsx
@@ -1,0 +1,38 @@
+import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
+
+describe("<DSMessage>", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<DSMessage />);
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.ok(wrapper.find(".ds-message").exists());
+  });
+
+  it("should render an icon", () => {
+    wrapper.setProps({icon: "foo"});
+
+    assert.ok(wrapper.find(".glyph").exists());
+    assert.propertyVal(wrapper.find(".glyph").props().style, "backgroundImage", `url(foo)`);
+  });
+
+  it("should render a title", () => {
+    wrapper.setProps({title: "foo"});
+
+    assert.ok(wrapper.find(".title-text").exists());
+    assert.equal(wrapper.find(".title-text").text(), "foo");
+  });
+
+  it("should render a SafeAnchor", () => {
+    wrapper.setProps({link_text: "foo", link_url: "https://foo.com"});
+
+    assert.equal(wrapper.find(".title").children().at(0).type(), SafeAnchor);
+  });
+});
+

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSMessage.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSMessage.test.jsx
@@ -1,6 +1,6 @@
 import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
-import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import React from "react";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import {shallowWithIntl} from "test/unit/utils";
 
 describe("<DSMessage>", () => {
@@ -32,7 +32,7 @@ describe("<DSMessage>", () => {
   it("should render a SafeAnchor", () => {
     wrapper.setProps({link_text: "foo", link_url: "https://foo.com"});
 
-    assert.equal(wrapper.find(".title").children().at(0).type(), SafeAnchor);
+    assert.equal(wrapper.find(".title").children().at(0)
+      .type(), SafeAnchor);
   });
 });
-

--- a/test/unit/content-src/components/DiscoveryStreamComponents/HorizontalRule.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/HorizontalRule.test.jsx
@@ -1,0 +1,16 @@
+import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
+
+describe("<HorizontalRule>", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<HorizontalRule />);
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.ok(wrapper.find(".ds-hr").exists());
+  });
+});

--- a/test/unit/content-src/components/DiscoveryStreamComponents/Navigation.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/Navigation.test.jsx
@@ -1,6 +1,6 @@
 import {Navigation, Topic} from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
-import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import React from "react";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
 import {shallowWithIntl} from "test/unit/utils";
 
 describe("<Navigation>", () => {
@@ -21,10 +21,12 @@ describe("<Navigation>", () => {
   });
 
   it("should render 2 Topics", () => {
-    wrapper.setProps({links: [
-      {url: "https://foo.com", name: "foo"},
-      {url: "https://bar.com", name: "bar"},
-    ]});
+    wrapper.setProps({
+      links: [
+        {url: "https://foo.com", name: "foo"},
+        {url: "https://bar.com", name: "bar"},
+      ],
+    });
 
     assert.lengthOf(wrapper.find("ul").children(), 2);
   });
@@ -36,7 +38,7 @@ describe("<Topic>", () => {
   beforeEach(() => {
     wrapper = shallowWithIntl(<Topic url="https://foo.com" name="foo" />);
   });
-  
+
   it("should render", () => {
     assert.ok(wrapper.exists());
     assert.equal(wrapper.type(), "li");

--- a/test/unit/content-src/components/DiscoveryStreamComponents/Navigation.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/Navigation.test.jsx
@@ -1,0 +1,45 @@
+import {Navigation, Topic} from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
+import {SafeAnchor} from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
+
+describe("<Navigation>", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<Navigation header={{}} />);
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+  });
+
+  it("should render a title", () => {
+    wrapper.setProps({header: {title: "Foo"}});
+
+    assert.equal(wrapper.find(".ds-header").text(), "Foo");
+  });
+
+  it("should render 2 Topics", () => {
+    wrapper.setProps({links: [
+      {url: "https://foo.com", name: "foo"},
+      {url: "https://bar.com", name: "bar"},
+    ]});
+
+    assert.lengthOf(wrapper.find("ul").children(), 2);
+  });
+});
+
+describe("<Topic>", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<Topic url="https://foo.com" name="foo" />);
+  });
+  
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.equal(wrapper.type(), "li");
+    assert.equal(wrapper.children().at(0).type(), SafeAnchor);
+  });
+});

--- a/test/unit/content-src/components/DiscoveryStreamComponents/SafeAnchor.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/SafeAnchor.test.jsx
@@ -38,7 +38,7 @@ describe("Discovery Stream <SafeAnchor>", () => {
   it("should dispatch an event on click", () => {
     const dispatchStub = sandbox.stub();
     const fakeEvent = {preventDefault: sandbox.stub(), currentTarget: {}};
-    const wrapper = shallow(<SafeAnchor dispatch={dispatchStub}/>);
+    const wrapper = shallow(<SafeAnchor dispatch={dispatchStub} />);
 
     wrapper.find("a").simulate("click", fakeEvent);
 
@@ -47,7 +47,7 @@ describe("Discovery Stream <SafeAnchor>", () => {
   });
   it("should call onLinkClick if provided", () => {
     const onLinkClickStub = sandbox.stub();
-    const wrapper = shallow(<SafeAnchor onLinkClick={onLinkClickStub}/>);
+    const wrapper = shallow(<SafeAnchor onLinkClick={onLinkClickStub} />);
 
     wrapper.find("a").simulate("click");
 

--- a/test/unit/content-src/components/DiscoveryStreamComponents/SafeAnchor.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/SafeAnchor.test.jsx
@@ -4,11 +4,14 @@ import {shallow} from "enzyme";
 
 describe("Discovery Stream <SafeAnchor>", () => {
   let warnStub;
+  let sandbox;
   beforeEach(() => {
     warnStub = sinon.stub(console, "warn");
+    sandbox = sinon.createSandbox();
   });
   afterEach(() => {
     warnStub.restore();
+    sandbox.restore();
   });
   it("should render with anchor", () => {
     const wrapper = shallow(<SafeAnchor />);
@@ -31,5 +34,23 @@ describe("Discovery Stream <SafeAnchor>", () => {
     const wrapper = shallow(<SafeAnchor url="" />);
     assert.equal(wrapper.find("a").prop("href"), "");
     assert.notCalled(warnStub);
+  });
+  it("should dispatch an event on click", () => {
+    const dispatchStub = sandbox.stub();
+    const fakeEvent = {preventDefault: sandbox.stub(), currentTarget: {}};
+    const wrapper = shallow(<SafeAnchor dispatch={dispatchStub}/>);
+
+    wrapper.find("a").simulate("click", fakeEvent);
+
+    assert.calledOnce(dispatchStub);
+    assert.calledOnce(fakeEvent.preventDefault);
+  });
+  it("should call onLinkClick if provided", () => {
+    const onLinkClickStub = sandbox.stub();
+    const wrapper = shallow(<SafeAnchor onLinkClick={onLinkClickStub}/>);
+
+    wrapper.find("a").simulate("click");
+
+    assert.calledOnce(onLinkClickStub);
   });
 });

--- a/test/unit/content-src/components/DiscoveryStreamComponents/SectionTitle.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/SectionTitle.test.jsx
@@ -1,5 +1,5 @@
-import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
 import React from "react";
+import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
 import {shallowWithIntl} from "test/unit/utils";
 
 describe("<SectionTitle>", () => {

--- a/test/unit/content-src/components/DiscoveryStreamComponents/SectionTitle.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/SectionTitle.test.jsx
@@ -1,0 +1,22 @@
+import {SectionTitle} from "content-src/components/DiscoveryStreamComponents/SectionTitle/SectionTitle";
+import React from "react";
+import {shallowWithIntl} from "test/unit/utils";
+
+describe("<SectionTitle>", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowWithIntl(<SectionTitle header={{}} />);
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.ok(wrapper.find(".ds-section-title").exists());
+  });
+
+  it("should render a subtitle", () => {
+    wrapper.setProps({header: {title: "Foo", subtitle: "Bar"}});
+
+    assert.equal(wrapper.find(".subtitle").text(), "Bar");
+  });
+});

--- a/test/unit/content-src/components/TopSites/SearchShortcutsForm.test.jsx
+++ b/test/unit/content-src/components/TopSites/SearchShortcutsForm.test.jsx
@@ -1,0 +1,45 @@
+import {SearchShortcutsForm, SelectableSearchShortcut} from "content-src/components/TopSites/SearchShortcutsForm";
+import React from "react";
+import {shallow} from "enzyme";
+
+describe("<SearchShortcutsForm>", () => {
+  let wrapper;
+  let sandbox;
+  let dispatchStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    dispatchStub = sandbox.stub();
+    const defaultProps = {rows: [], searchShortcuts: []};
+    wrapper = shallow(<SearchShortcutsForm TopSites={defaultProps} dispatch={dispatchStub} />);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper.exists());
+    assert.ok(wrapper.find(".topsite-form").exists());
+  });
+
+  it("should render SelectableSearchShortcut components", () => {
+    wrapper.setState({shortcuts: [{}, {}]});
+
+    assert.lengthOf(wrapper.find(".search-shortcuts-container div").children(), 2);
+    assert.equal(wrapper.find(".search-shortcuts-container div").children().at(0).type(), SelectableSearchShortcut);
+  });
+
+  it("should render SelectableSearchShortcut components", () => {
+    const onCloseStub = sandbox.stub();
+    const fakeEvent = {preventDefault: sandbox.stub()};
+    wrapper.setState({shortcuts: [{}, {}]});
+    wrapper.setProps({onClose: onCloseStub});
+
+    wrapper.find(".done").simulate("click", fakeEvent);
+
+    assert.calledOnce(dispatchStub);
+    assert.calledOnce(fakeEvent.preventDefault);
+    assert.calledOnce(onCloseStub);
+  });
+});

--- a/test/unit/content-src/components/TopSites/SearchShortcutsForm.test.jsx
+++ b/test/unit/content-src/components/TopSites/SearchShortcutsForm.test.jsx
@@ -27,7 +27,8 @@ describe("<SearchShortcutsForm>", () => {
     wrapper.setState({shortcuts: [{}, {}]});
 
     assert.lengthOf(wrapper.find(".search-shortcuts-container div").children(), 2);
-    assert.equal(wrapper.find(".search-shortcuts-container div").children().at(0).type(), SelectableSearchShortcut);
+    assert.equal(wrapper.find(".search-shortcuts-container div").children().at(0)
+      .type(), SelectableSearchShortcut);
   });
 
   it("should render SelectableSearchShortcut components", () => {


### PR DESCRIPTION
After: 
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/810040/55557702-f7651680-56d9-11e9-987c-e68a726128b3.png">
Added unit tests to bump our coverage to where the report is mostly green/gray making it easier to spot issues when trying to land new code.
ASRouterAdmin has a threshold set to 0 so adding new code there won't require any tests (that's the only one showing up in red).