### PR TITLE
Bug 1542792 - Add telemetry to record undesired events for CFR remote messages

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -874,6 +874,7 @@ This reports when the addon fails to initialize
   "value": -1
 }
 ```
+
 ## Activity Stream Router pings
 
 These pings record the impression and user interactions within Activity Stream Router.
@@ -1007,5 +1008,22 @@ This reports when an error has occurred when parsing/evaluating a JEXL targeting
   "message_id": "some_message_id",
   "event": "TARGETING_EXPRESSION_ERROR",
   "value": ["MALFORMED_EXPRESSION" | "OTHER_ERROR"]
+}
+```
+
+### Remote Settings error pings
+
+This reports a failure in the Remote Settings loader to load messages for Activity Stream Router.
+
+```js
+{
+  "action": "asrouter_undesired_event",
+  "client_id": "n/a",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7,
+  "event": ["ASR_RS_NO_MESSAGES" | "ASR_RS_ERROR"],
+  // The value is set to the ID of the message provider. For example: remote-cfr, remote-onboarding, etc.
+  "value": "REMOTE_PROVIDER_ID"
 }
 ```

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -91,13 +91,13 @@ const MessageLoaderUtils = {
    *
    * @param {obj} provider An AS router provider
    * @param {string} provider.url An endpoint that returns an array of messages as JSON
-   * @param {obj} storage A storage object with get() and set() methods for caching.
+   * @param {obj} options.storage A storage object with get() and set() methods for caching.
    * @returns {Promise} resolves with an array of messages, or an empty array if none could be fetched
    */
-  async _remoteLoader(provider, storage) {
+  async _remoteLoader(provider, options) {
     let remoteMessages = [];
     if (provider.url) {
-      const allCached = await MessageLoaderUtils._remoteLoaderCache(storage);
+      const allCached = await MessageLoaderUtils._remoteLoaderCache(options.storage);
       const cached = allCached[provider.id];
       let etag;
 
@@ -148,7 +148,7 @@ const MessageLoaderUtils = {
               version: STARTPAGE_VERSION,
             };
 
-            storage.set(MessageLoaderUtils.REMOTE_LOADER_CACHE_KEY, {...allCached, [provider.id]: cacheInfo});
+            options.storage.set(MessageLoaderUtils.REMOTE_LOADER_CACHE_KEY, {...allCached, [provider.id]: cacheInfo});
           }
         } else {
           MessageLoaderUtils.reportError(`No messages returned from ${provider.url}.`);
@@ -164,15 +164,21 @@ const MessageLoaderUtils = {
    * _remoteSettingsLoader - Loads messages for a RemoteSettings provider
    *
    * @param {obj} provider An AS router provider
+   * @param {string} provider.id The id of the provider
    * @param {string} provider.bucket The name of the Remote Settings bucket
+   * @param {func} options.dispatchToAS dispatch an action the main AS Store
    * @returns {Promise} resolves with an array of messages, or an empty array if none could be fetched
    */
-  async _remoteSettingsLoader(provider) {
+  async _remoteSettingsLoader(provider, options) {
     let messages = [];
     if (provider.bucket) {
       try {
         messages = await MessageLoaderUtils._getRemoteSettingsMessages(provider.bucket);
+        if (!messages.length) {
+          MessageLoaderUtils._handleRemoteSettingsUndesiredEvent("ASR_RS_NO_MESSAGES", provider.id, options.dispatchToAS);
+        }
       } catch (e) {
+        MessageLoaderUtils._handleRemoteSettingsUndesiredEvent("ASR_RS_ERROR", provider.id, options.dispatchToAS);
         MessageLoaderUtils.reportError(e);
       }
     }
@@ -181,6 +187,16 @@ const MessageLoaderUtils = {
 
   _getRemoteSettingsMessages(bucket) {
     return RemoteSettings(bucket).get();
+  },
+
+  _handleRemoteSettingsUndesiredEvent(event, providerId, dispatchToAS) {
+    if (dispatchToAS) {
+      dispatchToAS(ac.ASRouterUserEvent({
+        action: "asrouter_undesired_event",
+        event,
+        value: providerId,
+      }));
+    }
   },
 
   /**
@@ -219,12 +235,13 @@ const MessageLoaderUtils = {
    *
    * @param {obj} provider An AS Router provider
    * @param {string} provider.type An AS Router provider type (defaults to "local")
-   * @param {obj} storage A storage object with get() and set() methods for caching.
+   * @param {obj} options.storage A storage object with get() and set() methods for caching.
+   * @param {func} options.dispatchToAS dispatch an action the main AS Store
    * @returns {obj} Returns an object with .messages (an array of messages) and .lastUpdated (the time the messages were updated)
    */
-  async loadMessagesForProvider(provider, storage) {
+  async loadMessagesForProvider(provider, options) {
     const loader = this._getMessageLoader(provider);
-    let messages = await loader(provider, storage);
+    let messages = await loader(provider, options);
     // istanbul ignore if
     if (!messages) {
       messages = [];
@@ -443,7 +460,10 @@ class _ASRouter {
       let newState = {messages: [], providers: []};
       for (const provider of this.state.providers) {
         if (needsUpdate.includes(provider)) {
-          let {messages, lastUpdated, errors} = await MessageLoaderUtils.loadMessagesForProvider(provider, this._storage);
+          let {messages, lastUpdated, errors} = await MessageLoaderUtils.loadMessagesForProvider(provider, {
+            storage: this._storage,
+            dispatchToAS: this.dispatchToAS,
+          });
           messages = messages.filter(({content}) => !content || !content.category || ASRouterPreferences.getUserPreference(content.category));
           newState.providers.push({...provider, lastUpdated, errors});
           newState.messages = [...newState.messages, ...messages];


### PR DESCRIPTION
To manually test, you can configure CFR to use a Remote Settings loader and enable A-S telemetry and logging:

```javascript
Services.prefs.setStringPref("browser.newtabpage.activity-stream.asrouter.providers.cfr", JSON.stringify({"id":"cfr-remote","enabled":true,"type":"remote-settings","bucket":"cfr","frequency":{"custom":[{"period":"daily","cap":1}]},"categories":["cfrAddons","cfrFeatures"]}));
Services.prefs.setBoolPref("browser.newtabpage.activity-stream.telemetry", true);
Services.prefs.setBoolPref("browser.ping-centre.log", true);

```

Then restart the browser and look in the browser console for the "activity_stream_undesired_event" ping:

```
TELEMETRY PING: {"locale":"en-US","topic":"activity-stream","client_id":"3afcfb54-1735-0f4e-b77a-459a0cdd4a07","version":"68.0a1","release_channel":"default","addon_version":"20190408161750","user_prefs":255,"value":0,"event":"ASR_RS_NO_MESSAGES","action":"activity_stream_undesired_event","profile_creation_date":17994,"region":"US"}
```

Or I guess if you reorder the pref setting so that the CFR pref is set last, then you'll get the undesired event ping immediately in the console.