### PR TITLE
Bug 1535773 - Allow collapsing of top sites and the rest of Discovery Stream content

### DIFF
--- a/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -137,7 +137,7 @@ export class _CollapsibleSection extends React.PureComponent {
   render() {
     const isCollapsible = this.props.collapsed !== undefined;
     const {enableAnimation, isAnimating, maxHeight, menuButtonHover, showContextMenu} = this.state;
-    const {id, eventSource, collapsed, learnMore, title, extraMenuOptions, showPrefName, privacyNoticeURL, dispatch, isFirst, isLast, isWebExtension} = this.props;
+    const {id, eventSource, collapsed, learnMore, title, extraMenuOptions, showPrefName, privacyNoticeURL, dispatch, isFixed, isFirst, isLast, isWebExtension} = this.props;
     const active = menuButtonHover || showContextMenu;
     let bodyStyle;
     if (isAnimating && !collapsed) {
@@ -190,6 +190,7 @@ export class _CollapsibleSection extends React.PureComponent {
                 privacyNoticeURL={privacyNoticeURL}
                 collapsed={collapsed}
                 onUpdate={this.onMenuUpdate}
+                isFixed={isFixed}
                 isFirst={isFirst}
                 isLast={isLast}
                 dispatch={dispatch}

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -223,6 +223,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           dispatch={this.props.dispatch}
           icon={topStories.icon}
           id={topStories.id}
+          isFixed={true}
           learnMore={{
             link: {
               href: message.header.link_url,

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -218,6 +218,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           components: [topSites],
         }])}
         {layoutRender.length > 0 && <CollapsibleSection
+          className="ds-layout"
           collapsed={topStories.pref.collapsed}
           dispatch={this.props.dispatch}
           icon={topStories.icon}

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -1,4 +1,5 @@
 import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
+import {CollapsibleSection} from "content-src/components/CollapsibleSection/CollapsibleSection";
 import {connect} from "react-redux";
 import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
 import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
@@ -168,13 +169,76 @@ export class _DiscoveryStreamBase extends React.PureComponent {
   render() {
     // Select layout render data by adding spocs and position to recommendations
     const layoutRender = selectLayoutRender(this.props.DiscoveryStream, this.props.Prefs.values, rickRollCache);
-    const styles = [];
-    const {spocs, feeds} = this.props.DiscoveryStream;
-
+    const {config, feeds, spocs} = this.props.DiscoveryStream;
     if (!spocs.loaded || !feeds.loaded) {
       return null;
     }
 
+    // Allow rendering without extracting special components
+    if (!config.collapsible) {
+      return this.renderLayout(layoutRender);
+    }
+
+    // Find the first component of a type and remove it from layout
+    const extractComponent = type => {
+      for (const [rowIndex, row] of Object.entries(layoutRender)) {
+        for (const [index, component] of Object.entries(row.components)) {
+          if (component.type === type) {
+            // Remove the row if it was the only component or the single item
+            if (row.components.length === 1) {
+              layoutRender.splice(rowIndex, 1);
+            } else {
+              row.components.splice(index, 1);
+            }
+            return component;
+          }
+        }
+      }
+      return null;
+    };
+
+    // Get "topstories" Section state for default values
+    const topStories = this.props.Sections.find(s => s.id === "topstories");
+
+    // Extract TopSites to render before the rest and Message to use for header
+    const topSites = extractComponent("TopSites");
+    const message = extractComponent("Message") || {
+      header: {
+        link_text: topStories.learnMore.link.id,
+        link_url: topStories.learnMore.link.href,
+        title: topStories.title,
+      },
+    };
+
+    // Render a DS-style TopSites then the rest if any in a collapsible section
+    return (
+      <React.Fragment>
+        {topSites && this.renderLayout([{
+          width: 12,
+          components: [topSites],
+        }])}
+        {layoutRender.length > 0 && <CollapsibleSection
+          collapsed={topStories.pref.collapsed}
+          dispatch={this.props.dispatch}
+          icon={topStories.icon}
+          id={topStories.id}
+          learnMore={{
+            link: {
+              href: message.header.link_url,
+              id: message.header.link_text,
+            },
+          }}
+          privacyNoticeURL={topStories.privacyNoticeURL}
+          showPrefName={topStories.pref.feed}
+          title={message.header.title}>
+          {this.renderLayout(layoutRender)}
+        </CollapsibleSection>}
+      </React.Fragment>
+    );
+  }
+
+  renderLayout(layoutRender) {
+    const styles = [];
     return (
       <div className="discovery-stream ds-layout">
         {layoutRender.map((row, rowIndex) => (
@@ -198,4 +262,5 @@ export class _DiscoveryStreamBase extends React.PureComponent {
 export const DiscoveryStreamBase = connect(state => ({
   DiscoveryStream: state.DiscoveryStream,
   Prefs: state.Prefs,
+  Sections: state.Sections,
 }))(_DiscoveryStreamBase);

--- a/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
+++ b/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
@@ -1,3 +1,5 @@
+$ds-width: 936px;
+
 .discovery-stream.ds-layout {
   $columns: 12;
   --gridColumnGap: 48px;
@@ -6,7 +8,7 @@
   grid-template-columns: repeat($columns, 1fr);
   grid-column-gap: var(--gridColumnGap);
   grid-row-gap: var(--gridRowGap);
-  width: 936px;
+  width: $ds-width;
   margin: 0 auto;
 
   @while $columns > 0 {
@@ -25,6 +27,11 @@
 }
 
 .ds-header {
+  margin: 8px 0;
+}
+
+.ds-header,
+.ds-layout .section-title span {
   @include dark-theme-only {
     color: $grey-30;
   }
@@ -33,9 +40,26 @@
   font-size: 13px;
   font-weight: 600;
   line-height: 20px;
-  margin: 8px 0;
 
   .icon {
     fill: var(--newtab-text-secondary-color);
+  }
+}
+
+.collapsible-section.ds-layout {
+  margin: auto;
+  width: $ds-width + 2 * $section-horizontal-padding;
+
+  .section-top-bar {
+    margin-bottom: 0;
+
+    .learn-more-link a span {
+      color: var(--newtab-link-primary-color);
+      font-weight: normal;
+
+      &:-moz-any(:focus, :hover) {
+        text-decoration: underline;
+      }
+    }
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/TopSites/TopSites.jsx
+++ b/content-src/components/DiscoveryStreamComponents/TopSites/TopSites.jsx
@@ -7,7 +7,9 @@ export class _TopSites extends React.PureComponent {
     const header = this.props.header || {};
     return (
       <div className="ds-top-sites">
-        <OldTopSites title={header.title} />
+        <OldTopSites
+          isFixed={true}
+          title={header.title} />
       </div>
     );
   }

--- a/content-src/components/DiscoveryStreamComponents/TopSites/TopSites.jsx
+++ b/content-src/components/DiscoveryStreamComponents/TopSites/TopSites.jsx
@@ -7,13 +7,7 @@ export class _TopSites extends React.PureComponent {
     const header = this.props.header || {};
     return (
       <div className="ds-top-sites">
-        {header.title ? (
-          <div className="ds-header">
-            <span className="icon icon-small-spacer icon-topsites" />
-            <span className="ds-header-title">{header.title}</span>
-          </div>
-        ) : null}
-        <OldTopSites />
+        <OldTopSites title={header.title} />
       </div>
     );
   }

--- a/content-src/components/DiscoveryStreamComponents/TopSites/_TopSites.scss
+++ b/content-src/components/DiscoveryStreamComponents/TopSites/_TopSites.scss
@@ -4,7 +4,7 @@
   // This is the override layer.
   .top-sites {
     // Slightly different alignment with the other DS components than AS has.
-    padding: 0;
+    margin: 0 (-$section-horizontal-padding);
 
     .top-site-outer {
       padding: 0 12px;

--- a/content-src/components/DiscoveryStreamComponents/TopSites/_TopSites.scss
+++ b/content-src/components/DiscoveryStreamComponents/TopSites/_TopSites.scss
@@ -1,19 +1,10 @@
 // ds topsites wraps the original topsites, with a few css changes.
 .ds-top-sites {
 
-  .ds-header-title {
-    vertical-align: middle;
-  }
-
   // This is the override layer.
   .top-sites {
     // Slightly different alignment with the other DS components than AS has.
     padding: 0;
-
-    // We hide this and don't support it in ds.
-    .section-top-bar {
-      display: none;
-    }
 
     .top-site-outer {
       padding: 0 12px;

--- a/content-src/components/SectionMenu/SectionMenu.jsx
+++ b/content-src/components/SectionMenu/SectionMenu.jsx
@@ -12,6 +12,10 @@ export class _SectionMenu extends React.PureComponent {
     const {props} = this;
 
     const propOptions = props.isWebExtension ? [...WEBEXT_SECTION_MENU_OPTIONS] : [...DEFAULT_SECTION_MENU_OPTIONS];
+    // Remove the move related options if the section is fixed
+    if (props.isFixed) {
+      propOptions.splice(propOptions.indexOf("MoveUp"), 3);
+    }
     // Prepend custom options and a separator
     if (props.extraOptions) {
       propOptions.splice(0, 0, ...props.extraOptions, "Separator");

--- a/content-src/components/TopSites/TopSites.jsx
+++ b/content-src/components/TopSites/TopSites.jsx
@@ -131,6 +131,7 @@ export class _TopSites extends React.PureComponent {
         showPrefName="feeds.topsites"
         eventSource={TOP_SITES_SOURCE}
         collapsed={props.TopSites.pref ? props.TopSites.pref.collapsed : undefined}
+        isFixed={props.isFixed}
         isFirst={props.isFirst}
         isLast={props.isLast}
         dispatch={props.dispatch}>

--- a/content-src/components/TopSites/TopSites.jsx
+++ b/content-src/components/TopSites/TopSites.jsx
@@ -126,7 +126,7 @@ export class _TopSites extends React.PureComponent {
         className="top-sites"
         icon="topsites"
         id="topsites"
-        title={{id: "header_top_sites"}}
+        title={this.props.title || {id: "header_top_sites"}}
         extraMenuOptions={extraMenuOptions}
         showPrefName="feeds.topsites"
         eventSource={TOP_SITES_SOURCE}

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -236,6 +236,7 @@ const PREFS_CONFIG = new Map([
       const isEnabled = IS_NIGHTLY_OR_UNBRANDED_BUILD && locales && locales.includes(locale);
       return JSON.stringify({
         api_key_pref: "extensions.pocket.oAuthConsumerKey",
+        collapsible: true,
         enabled: isEnabled,
         show_spocs: showSpocs({geo}),
         personalized: false,

--- a/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
@@ -1,6 +1,7 @@
 import {_DiscoveryStreamBase as DiscoveryStreamBase, isAllowedCSS} from "content-src/components/DiscoveryStreamBase/DiscoveryStreamBase";
 import {GlobalOverrider, shallowWithIntl} from "test/unit/utils";
 import {CardGrid} from "content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid";
+import {CollapsibleSection} from "content-src/components/CollapsibleSection/CollapsibleSection";
 import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
 import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
 import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
@@ -51,6 +52,7 @@ describe("<DiscoveryStreamBase>", () => {
 
   function mountComponent(props = {}) {
     const defaultProps = {
+      config: {collapsible: true},
       layout: [],
       feeds: {loaded: true},
       spocs: {
@@ -97,9 +99,9 @@ describe("<DiscoveryStreamBase>", () => {
     assert.equal(wrapper.type(), null);
   });
 
-  it("should render", () => {
+  it("should render nothing with no layout", () => {
     assert.ok(wrapper.exists());
-    assert.ok(wrapper.find(".discovery-stream").exists());
+    assert.isEmpty(wrapper.children());
   });
 
   it("should render a HorizontalRule component", () => {
@@ -137,8 +139,28 @@ describe("<DiscoveryStreamBase>", () => {
       .type(), Navigation);
   });
 
+  it("should render nothing if there was only a Message", () => {
+    wrapper = mountComponent({layout: [{components: [{header: {}, properties: {}, type: "Message"}]}]});
+
+    assert.isEmpty(wrapper.children());
+  });
+
+  it("should render a regular Message when not collapsible", () => {
+    wrapper = mountComponent({config: {collapsible: false}, layout: [{components: [{header: {}, properties: {}, type: "Message"}]}]});
+
+    assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
+      .type(), DSMessage);
+  });
+
+  it("should convert first Message component to CollapsibleSection", () => {
+    wrapper = mountComponent({layout: [{components: [{header: {}, properties: {}, type: "Message"}, {type: "HorizontalRule"}]}]});
+
+    assert.equal(wrapper.children().at(0)
+      .type(), CollapsibleSection);
+  });
+
   it("should render a Message component", () => {
-    wrapper = mountComponent({layout: [{components: [{properties: {}, type: "Message"}]}]});
+    wrapper = mountComponent({layout: [{components: [{header: {}, type: "Message"}, {properties: {}, type: "Message"}]}]});
 
     assert.equal(wrapper.find(".ds-column-grid div").children().at(0)
       .type(), DSMessage);


### PR DESCRIPTION
r? @punamdahiya This is on top of #4892 and should probably land after your #4886 to actually get top sites or pocket section to hide. But if it does land ahead of the preferences PR, it will still mostly work.

`basic` with collapsed top sites and showing menu for pocket
![Screen Shot 2019-04-09 at 10 10 11 PM](https://user-images.githubusercontent.com/438537/55853156-b4a9a100-5b14-11e9-9f43-dafd3dfc8f5c.png)

`66-release-2-above-2-below-1` with top sites menu open
![Screen Shot 2019-04-09 at 10 14 48 PM](https://user-images.githubusercontent.com/438537/55853263-1ec24600-5b15-11e9-94c5-a1ef17b6357a.png)


---

Original:

@punamdahiya @k88hudson Looks like this approach of extracting the first `TopSites` and first `Message` works for various layout json. Still need to fix up styling and the section menu options.

66-release-2-above-2-below-1 (individual topsite row followed by individual message row)
<img width="1055" alt="66-release-2-above-2-below-1" src="https://user-images.githubusercontent.com/438537/55763940-1d622200-5a1e-11e9-83a4-a62d21c03652.png">

dev-test-all (custom Message title, many "row"s with components scattered)
<img width="1054" alt="dev-test-all" src="https://user-images.githubusercontent.com/438537/55763945-27842080-5a1e-11e9-965c-2c576bb88849.png">

basic (single 12-width "row" with many components)
<img width="1044" alt="basic" src="https://user-images.githubusercontent.com/438537/55763952-2b17a780-5a1e-11e9-973e-5f5871622562.png">

66-beta-2-complex (individual topsite row followed by individual message row)
<img width="1044" alt="66-beta-2-complex" src="https://user-images.githubusercontent.com/438537/55763943-2226d600-5a1e-11e9-8d69-15e180590271.png">