### PR TITLE
Bug 1543108 - Land a new provider for CFR FxA messages

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -225,6 +225,16 @@ const PREFS_CONFIG = new Map([
       exclude: [],
     }),
   }],
+  ["asrouter.providers.fxa", {
+    title: "Configuration for CFR FxA Messages provider",
+    value: JSON.stringify({
+      id: "cfr-fxa",
+      enabled: true,
+      type: "remote-settings",
+      bucket: "cfr-fxa",
+      frequency: {custom: [{period: "daily", cap: 1}]},
+    }),
+  }],
   // See browser/app/profile/firefox.js for other ASR preferences. They must be defined there to enable roll-outs.
   ["discoverystream.config", {
     title: "Configuration for the new pocket new tab",

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -225,7 +225,7 @@ const PREFS_CONFIG = new Map([
       exclude: [],
     }),
   }],
-  ["asrouter.providers.fxa", {
+  ["asrouter.providers.cfr-fxa", {
     title: "Configuration for CFR FxA Messages provider",
     value: JSON.stringify({
       id: "cfr-fxa",

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -229,7 +229,7 @@ const PREFS_CONFIG = new Map([
     title: "Configuration for CFR FxA Messages provider",
     value: JSON.stringify({
       id: "cfr-fxa",
-      enabled: true,
+      enabled: false,
       type: "remote-settings",
       bucket: "cfr-fxa",
       frequency: {custom: [{period: "daily", cap: 1}]},

--- a/test/browser/browser_asrouter_cfr.js
+++ b/test/browser/browser_asrouter_cfr.js
@@ -399,3 +399,14 @@ add_task(async function test_matchPattern() {
 
   Assert.equal(count, 2, "www.example.com is a different host that also matches the pattern.");
 });
+
+add_task(async function test_providerNames() {
+  const providersBranch = "browser.newtabpage.activity-stream.asrouter.providers.";
+  const cfrProviderPrefs = Services.prefs.getChildList(providersBranch);
+  for (const prefName of cfrProviderPrefs) {
+    const prefValue = JSON.parse(Services.prefs.getStringPref(prefName));
+    if (prefValue.id) { // Snippets are disabled in tests and value is set to []
+      Assert.equal(prefValue.id, prefName.slice(providersBranch.length), "Provider id and pref name do not match");
+    }
+  }
+});


### PR DESCRIPTION
I want to land this dummy provider to unblock landing code, later we can move the preference to `firefox.js`.
I added a mochitest to verify that provider id and pref id match. I didn't realize this is required. It's because we use the `provider.id` [to update the correct pref](https://github.com/mozilla/activity-stream/blob/8b20ec0902e5109303c2fe30a32fda7cf33d74e8/lib/ASRouterPreferences.jsm#L98).

Along with this I also created a script to automate publishing messages to kinto.

```javascript
// Make sure you are using the dev server
Services.prefs.setStringPref("services.settings.server", "https://kinto.dev.mozaws.net/v1");
Services.prefs.setBoolPref("services.settings.verify_signature", false);
```

## Publishing a message
It reads a message from a file from disk (`message.json`) and publishes it to kinto.
1. Create a message.json similar to the template below (notice the top level `data` prop)
2. Copy publishMessage.sh in the same directory
3. `bash ./publishMessage.sh` (after it runs it gives you a link to the bucket).
### message.json
```json
{
  "data": {
    "id": "fxa-bookmark-sync-2",
    "title": "cfr-doorhanger-bookmark-fxa-header",
    "content": "cfr-doorhanger-bookmark-fxa-body",
    "link": {
      "text": "cfr-doorhanger-bookmark-fxa-link-text",
      "url": "https://mozilla.com"
    }
  }
}
```
### publishMessage.sh
```bash
SERVER=https://kinto.dev.mozaws.net/v1
BASIC_AUTH=devuser:devpass
CID=cfr-fxa

echo "\nCreate user"

curl -X PUT ${SERVER}/accounts/devuser \
     -d '{"data": {"password": "devpass"}}' \
     -H 'Content-Type:application/json'

echo "\nCreate collection"

curl -X PUT ${SERVER}/buckets/main/collections/${CID} \
     -H 'Content-Type:application/json' \
     -u ${BASIC_AUTH}

echo "\nPublish a message"

curl -X POST ${SERVER}/buckets/main/collections/${CID}/records \
     -d $(cat message.json | tr -d " \t\n\r") \
     -H 'Content-Type:application/json' \
     -u ${BASIC_AUTH}

echo "\nMessage available at https://kinto.dev.mozaws.net/v1//buckets/main/collections/$CID/records"
```
## Result
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/810040/55878334-bfebe380-5b8b-11e9-95ca-2de42d731964.png">
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/810040/55878346-c4180100-5b8b-11e9-8774-626302d4b8fd.png">
