### PR TITLE
(nobug) - Remove unused strings and exclude them from export

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -40,7 +40,11 @@ function getStrings(locale, allStrings) {
   const localeFallbacks = [DEFAULT_LOCALE, ...similarLocales, locale];
 
   // Get strings from each locale replacing with those from more desired ones
-  return Object.assign({}, ...localeFallbacks.map(l => allStrings[l]));
+  const desired = Object.assign({}, ...localeFallbacks.map(l => allStrings[l]));
+
+  // Only include strings that are currently used (defined by default locale)
+  return Object.assign({}, ...Object.keys(allStrings[DEFAULT_LOCALE]).map(
+    key => ({[key]: desired[key]})));
 }
 
 /**

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -92,9 +92,7 @@ section_disclaimer_topstories_buttontext=Okay, got it
 prefs_home_header=Firefox Home Content
 prefs_home_description=Choose what content you want on your Firefox Home screen.
 
-prefs_content_discovery_header=Firefox Home
 prefs_content_discovery_description=Content Discovery in Firefox Home allows you to discover high-quality, relevant articles from across the web.
-prefs_content_discovery_button=Turn Off Content Discovery
 
 # LOCALIZATION NOTE (prefs_section_rows_option): This is a semi-colon list of
 # plural forms used in a drop down of multiple row options (1 row, 2 rows).


### PR DESCRIPTION
r? @piatra or @k88hudson We forgot to remove a couple of strings in https://github.com/mozilla/activity-stream/pull/4886#discussion_r274426369 Then I realized the export still contained strings for other locales that we no longer used, so fixed that too. A second `Object.assign({}, ...spread)` to combine arbitrary number of objects! 😉 