### PR TITLE
Bug 1543723 - The import message icon is cut when the screen is horizontally resized to less than half screen

### DIFF
--- a/content-src/components/ManualMigration/_ManualMigration.scss
+++ b/content-src/components/ManualMigration/_ManualMigration.scss
@@ -26,6 +26,7 @@
       align-self: center;
       display: block;
       fill: var(--newtab-icon-secondary-color);
+      flex-shrink: 0;
       margin-inline-end: 6px;
     }
   }


### PR DESCRIPTION
tiny r?

before:
<img width="574" alt="Screen Shot 2019-04-16 at 10 22 31 AM" src="https://user-images.githubusercontent.com/36629/56217742-bc47d900-6031-11e9-9739-bfafb5840088.png">

after:
<img width="561" alt="Screen Shot 2019-04-16 at 10 22 06 AM" src="https://user-images.githubusercontent.com/36629/56217747-beaa3300-6031-11e9-9581-4951825d99f5.png">
