### PR TITLE
Bug 1544867 - Make AS devtools collapsible

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -713,7 +713,7 @@ export class ASRouterAdminInner extends React.PureComponent {
   }
 
   render() {
-    return (<div className="asrouter-admin">
+    return (<div className={`asrouter-admin ${this.props.collapsed ? "collapsed" : "expanded"}`}>
       <aside className="sidebar">
         <ul>
           <li><a href="#devtools">General</a></li>
@@ -740,5 +740,54 @@ export class ASRouterAdminInner extends React.PureComponent {
   }
 }
 
-export const _ASRouterAdmin = props => (<SimpleHashRouter><ASRouterAdminInner {...props} /></SimpleHashRouter>);
+export class CollapseToggle extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onCollapseToggle = this.onCollapseToggle.bind(this);
+    this.state = {collapsed: false};
+  }
+
+  get renderAdmin() {
+    const {props} = this;
+    return props.location.hash && (props.location.hash.startsWith("#asrouter") || props.location.hash.startsWith("#devtools"));
+  }
+
+  onCollapseToggle(e) {
+    e.preventDefault();
+    this.setState(state => ({collapsed: !state.collapsed}));
+  }
+
+  setBodyClass() {
+    if (this.renderAdmin && !this.state.collapsed) {
+      global.document.body.classList.add("no-scroll");
+    } else {
+      global.document.body.classList.remove("no-scroll");
+    }
+  }
+
+  componentDidMount() {
+    this.setBodyClass();
+  }
+
+  componentDidUpdate() {
+    this.setBodyClass();
+  }
+
+  componentWillUnmount() {
+    global.document.body.classList.remove("no-scroll");
+  }
+
+  render() {
+    const {props} = this;
+    const {renderAdmin} = this;
+    const action = (this.state.collapsed || !renderAdmin) ? "Expand" : "Collapse";
+    return (<React.Fragment>
+      <a href="#devtools" className="asrouter-toggle" onClick={this.renderAdmin ? this.onCollapseToggle : null}>{action} Devtools</a>
+      {renderAdmin ? <ASRouterAdminInner {...props} collapsed={this.state.collapsed} /> : null}
+    </React.Fragment>);
+  }
+}
+
+const _ASRouterAdmin = props => <SimpleHashRouter><CollapseToggle {...props} /></SimpleHashRouter>;
+
 export const ASRouterAdmin = connect(state => ({Sections: state.Sections, DiscoveryStream: state.DiscoveryStream, Prefs: state.Prefs}))(_ASRouterAdmin);

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -1,13 +1,36 @@
 
+.asrouter-toggle {
+  background: $yellow-50;
+  color: $black;
+  position: fixed;
+  top: 0;
+  left: 43px;
+  padding: 5px 10px;
+  border-radius: 0 0 3px 3px;
+  border: 1px solid $black-10;
+  border-top: 0;
+  z-index: 3000;
+}
+
 .asrouter-admin {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: var(--newtab-background-color);
+  height: 100%;
+  overflow-y: scroll;
   $border-color: var(--newtab-border-secondary-color);
   $monospace: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
   $sidebar-width: 240px;
   margin: 0 auto;
   font-size: 14px;
   padding-left: $sidebar-width;
-  display: flex;
   color: var(--newtab-text-primary-color);
+
+  &.collapsed {
+    display: none;
+  }
 
   .sidebar {
     inset-inline-start: 0;
@@ -150,9 +173,8 @@
   .helpLink {
     padding: 10px;
     display: flex;
-    background: $yellow-50;
+    background: $black-10;
     border-radius: 3px;
-    color: $grey-90;
 
     a {
       text-decoration: underline;

--- a/content-src/components/ASRouterAdmin/SimpleHashRouter.jsx
+++ b/content-src/components/ASRouterAdmin/SimpleHashRouter.jsx
@@ -20,7 +20,7 @@ export class SimpleHashRouter extends React.PureComponent {
   }
 
   render() {
-    const [, ...routes] = this.state.hash.replace("#asrouter", "").split("-");
+    const [, ...routes] = this.state.hash.split("-");
     return React.cloneElement(this.props.children, {
       location: {
         hash: this.state.hash,

--- a/content-src/components/Base/Base.jsx
+++ b/content-src/components/Base/Base.jsx
@@ -12,8 +12,6 @@ import React from "react";
 import {Search} from "content-src/components/Search/Search";
 import {Sections} from "content-src/components/Sections/Sections";
 
-let didLogDevtoolsHelpText = false;
-
 const PrefsButton = injectIntl(props => (
   <div className="prefs-button">
     <button className="icon icon-settings" onClick={props.onClick} title={props.intl.formatMessage({id: "settings_pane_button_label"})} />
@@ -83,30 +81,20 @@ export class _Base extends React.PureComponent {
     const {props} = this;
     const {App, locale, strings} = props;
     const {initialized} = App;
-
-    const prefs = props.Prefs.values;
-    if (prefs["asrouter.devtoolsEnabled"]) {
-      if (window.location.hash.startsWith("#asrouter") ||
-          window.location.hash.startsWith("#devtools")) {
-        return (<div>
-          <ASRouterAdmin />
-          <ASRouterUISurface dispatch={this.props.dispatch} />
-        </div>);
-      } else if (!didLogDevtoolsHelpText) {
-        console.log("Activity Stream devtools enabled. To access visit %cabout:newtab#devtools", "font-weight: bold"); // eslint-disable-line no-console
-        didLogDevtoolsHelpText = true;
-      }
-    }
+    const isDevtoolsEnabled = props.Prefs.values["asrouter.devtoolsEnabled"];
 
     if (!props.isPrerendered && !initialized) {
       return null;
     }
 
     return (<IntlProvider locale={locale} messages={strings}>
-        <ErrorBoundary className="base-content-fallback">
+      <ErrorBoundary className="base-content-fallback">
+        <React.Fragment>
           <BaseContent {...this.props} />
-        </ErrorBoundary>
-      </IntlProvider>);
+          {isDevtoolsEnabled ? <ASRouterAdmin /> : null}
+        </React.Fragment>
+      </ErrorBoundary>
+    </IntlProvider>);
   }
 }
 

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -20,6 +20,10 @@ body {
   overflow-y: scroll;
 }
 
+.no-scroll {
+  overflow: hidden;
+}
+
 h1,
 h2 {
   font-weight: normal;

--- a/test/unit/content-src/components/ASRouterAdmin.test.jsx
+++ b/test/unit/content-src/components/ASRouterAdmin.test.jsx
@@ -1,4 +1,4 @@
-import {ASRouterAdminInner, DiscoveryStreamAdmin, ToggleSpocButton} from "content-src/components/ASRouterAdmin/ASRouterAdmin";
+import {ASRouterAdminInner, CollapseToggle, DiscoveryStreamAdmin, ToggleSpocButton} from "content-src/components/ASRouterAdmin/ASRouterAdmin";
 import {GlobalOverrider} from "test/unit/utils";
 import React from "react";
 import {shallow} from "enzyme";
@@ -34,7 +34,7 @@ describe("ASRouterAdmin", () => {
     globals.set("RPMAddMessageListener", addListenerStub);
     globals.set("RPMRemoveMessageListener", removeListenerStub);
 
-    wrapper = shallow(<ASRouterAdminInner location={{routes: [""]}} />);
+    wrapper = shallow(<ASRouterAdminInner collapsed={false} location={{routes: [""]}} />);
   });
   afterEach(() => {
     sandbox.restore();
@@ -54,6 +54,15 @@ describe("ASRouterAdmin", () => {
   it("should remove listener on unmount", () => {
     wrapper.unmount();
     assert.calledOnce(removeListenerStub);
+  });
+  it("should set a .collapsed class on the outer div if props.collapsed is true", () => {
+    wrapper.setProps({collapsed: true});
+    assert.isTrue(wrapper.find(".asrouter-admin").hasClass("collapsed"));
+  });
+  it("should set a .expanded class on the outer div if props.collapsed is false", () => {
+    wrapper.setProps({collapsed: false});
+    assert.isTrue(wrapper.find(".asrouter-admin").hasClass("expanded"));
+    assert.isFalse(wrapper.find(".asrouter-admin").hasClass("collapsed"));
   });
   describe("#getSection", () => {
     it("should render a message provider section by default", () => {
@@ -217,6 +226,36 @@ describe("ASRouterAdmin", () => {
       wrapper.find("button").simulate("click");
 
       assert.equal(result, "spoc");
+    });
+  });
+});
+
+describe("CollapseToggle", () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<CollapseToggle location={{routes: [""]}} />);
+  });
+
+  describe("rendering inner content", () => {
+    it("should not render ASRouterAdminInner for about:newtab (no hash)", () => {
+      wrapper.setProps({location: {hash: "", routes: [""]}});
+      assert.lengthOf(wrapper.find(ASRouterAdminInner), 0);
+    });
+
+    it("should render ASRouterAdminInner for about:newtab#asrouter and subroutes", () => {
+      wrapper.setProps({location: {hash: "#asrouter", routes: [""]}});
+      assert.lengthOf(wrapper.find(ASRouterAdminInner), 1);
+
+      wrapper.setProps({location: {hash: "#asrouter-foo", routes: [""]}});
+      assert.lengthOf(wrapper.find(ASRouterAdminInner), 1);
+    });
+
+    it("should render ASRouterAdminInner for about:newtab#devtools and subroutes", () => {
+      wrapper.setProps({location: {hash: "#devtools", routes: [""]}});
+      assert.lengthOf(wrapper.find(ASRouterAdminInner), 1);
+
+      wrapper.setProps({location: {hash: "#devtools-foo", routes: [""]}});
+      assert.lengthOf(wrapper.find(ASRouterAdminInner), 1);
     });
   });
 });

--- a/test/unit/content-src/components/Base.test.jsx
+++ b/test/unit/content-src/components/Base.test.jsx
@@ -1,4 +1,5 @@
 import {_Base as Base, BaseContent} from "content-src/components/Base/Base";
+import {ASRouterAdmin} from "content-src/components/ASRouterAdmin/ASRouterAdmin";
 import {ErrorBoundary} from "content-src/components/ErrorBoundary/ErrorBoundary";
 import React from "react";
 import {Search} from "content-src/components/Search/Search";
@@ -23,6 +24,16 @@ describe("<Base>", () => {
 
     assert.equal(
       wrapper.find(ErrorBoundary).first().prop("className"), "base-content-fallback");
+  });
+
+  it("should render an ASRouterAdmin if the devtools pref is true", () => {
+    const wrapper = shallow(<Base {...DEFAULT_PROPS} Prefs={{values: {"asrouter.devtoolsEnabled": true}}} />);
+    assert.lengthOf(wrapper.find(ASRouterAdmin), 1);
+  });
+
+  it("should not render an ASRouterAdmin if the devtools pref is false", () => {
+    const wrapper = shallow(<Base {...DEFAULT_PROPS} Prefs={{values: {"asrouter.devtoolsEnabled": false}}} />);
+    assert.lengthOf(wrapper.find(ASRouterAdmin), 0);
   });
 });
 


### PR DESCRIPTION
This is needed so we can test the below-search-bar snippet.

This change ensures that a button shows up on ALL newtab pages when the `browser.newtabpage.activity-stream.asrouter.devtoolsEnabled` pref is on, but that the devtools are only actually loaded when it's clicked / when the URL has `#devtools` or `#asrouter in it`.

It also allows collapsing/hiding of the devtools.

QA steps:

- set your `browser.newtabpage.activity-stream.asrouter.providers.snippets` pref to `{"id":"snippets","enabled":true,"type":"remote","url":"https://snippets.cdn.mozilla.net/%STARTPAGE_VERSION%/%NAME%/%VERSION%/%APPBUILDID%/%BUILD_TARGET%/%LOCALE%/release/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/","updateCycleInMs":14400000}`
- set your devtools pref to `false`. Ensure you see snippets but you don't see a yellow button on `about:newtab`
- set your devtools pref to `true`. Ensure you see a button on `about:newtab` in the top left corner: 
![image](https://user-images.githubusercontent.com/1455535/56230095-8d3d6180-6049-11e9-86c4-7e53671c692b.png)
- click the button. Ensure you now see devtools, and scrolling/positioning works ok.
- click the button again. ensure you no longer see devtools, and scrolling/positioning is ok on regular newtab
- turn your devtools pref off
- ensure everything looks normal on about:newtab with no button
