### PR TITLE
(nobug) - Fixing encoding to allow parenthesis in image urls

### DIFF
--- a/lib/TopStoriesFeed.jsm
+++ b/lib/TopStoriesFeed.jsm
@@ -423,7 +423,7 @@ this.TopStoriesFeed = class TopStoriesFeed {
   // fail to render them properly as part of the card template.
   normalizeUrl(url) {
     if (url) {
-      return url.replace(/\(/g, "%28").replace(/\)/g, "%29");
+      return url.replace(/\(/g, "\\(").replace(/\)/g, "\\)");
     }
     return url;
   }


### PR DESCRIPTION
New Thumbor style URLs contain parenthesis (eg `https://img-getpocket.cdn.mozilla.net/450x0/filters:format(jpeg):quality(60):no_upscale():strip_exif()/https%3A%2F%2Fmedia.gq.com%2Fphotos%2F5caf9c876328030f7944ecc1%2F16%3A9%2Fw_1280%2Cc_limit%2Fkeanu-reeves-gq-cover-may-2019-social.jpg`) and were breaking in AS with the existing normalization method.

This was flagged by @mmiermans