### PR TITLE
Bug 1500061 - Switch to regular script tags, tighten CSP

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -93,7 +93,7 @@ function templateHTML(options, html) {
 <html lang="${options.locale}" dir="${options.direction}">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' resource: chrome:; connect-src https:; img-src https: data: blob:; style-src 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; object-src 'none'; script-src resource: chrome:; connect-src https:; img-src https: data: blob:; style-src 'unsafe-inline';">
     <title>${options.strings.newtab_page_title}</title>
     <link rel="icon" type="image/png" href="chrome://branding/content/icon32.png"/>
     <link rel="stylesheet" href="chrome://browser/content/contentSearchUI.css" />

--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -85,18 +85,10 @@ function templateHTML(options, html) {
   if (isPrerendered) {
     scripts.unshift(`${options.baseUrl}prerendered/static/activity-stream-initial-state.js`);
   }
-  const scriptTag = `
-    <script>
-// Don't directly load the following scripts as part of html to let the page
-// finish loading to render the content sooner.
-for (const src of ${JSON.stringify(scripts, null, 2)}) {
-  // These dynamically inserted scripts by default are async, but we need them
-  // to load in the desired order (i.e., bundle last).
-  const script = document.body.appendChild(document.createElement("script"));
-  script.async = false;
-  script.src = src;
-}
-    </script>`;
+
+  // Add spacing and script tags
+  const scriptRender = `\n${scripts.map(script => `    <script src="${script}"></script>`).join("\n")}`;
+
   return `<!doctype html>
 <html lang="${options.locale}" dir="${options.direction}">
   <head>
@@ -109,7 +101,7 @@ for (const src of ${JSON.stringify(scripts, null, 2)}) {
   </head>
   <body class="activity-stream">
     <div id="root">${isPrerendered ? html : "<!-- Regular React Rendering -->"}</div>
-    <div id="footer-snippets-container" />${options.noscripts ? "" : scriptTag}
+    <div id="footer-snippets-container" />${options.noscripts ? "" : scriptRender}
   </body>
 </html>
 `;


### PR DESCRIPTION
Finally figured this out while I was looking into pre-rendering stuff.

Test failures before were happening because our script injection was happening from an inline script that we render for the non-noscript version (which is currently on in release and asan builds but not nightly)

To manually test all variants, check:
* prerendered (turn ds off)
* noscripts on (default on nightly)
* noscripts off: set `browser.tabs.remote.separatePrivilegedContentProcess` to `false`
* `browser.newtabpage.activity-stream.debug` on

I'm a bit worried this could result in a perf hit since loading an external resource is likely to be a bit slower than inline, what do you think?

Tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=60d5046b3ccc0d8ea5a245ce8c82de691a45f582