### PR TITLE
Bug 1545455 - Bottom corners of images in bordered cards should be rounded

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
+++ b/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
@@ -34,7 +34,7 @@ $col4-header-font-size: 14;
         outline: none;
       }
 
-      .img-wrapper .img {
+      .img-wrapper .img img {
         border-radius: 4px 4px 0 0;
       }
     }


### PR DESCRIPTION
Repro:

1. Load up `dev-test-all` layout.
2. Verify that bottom left and bottom right corners of images in bordered cards are not rounded.
