### PR TITLE
Port 1518545 - Remove the superfluous 'engine-current' Search Service observer topic in favour of 'engine-default'. r=daleharvey

### DIFF
--- a/lib/TopSitesFeed.jsm
+++ b/lib/TopSitesFeed.jsm
@@ -87,7 +87,7 @@ this.TopSitesFeed = class TopSitesFeed {
   observe(subj, topic, data) {
     // We should update the current top sites if the search engine has been changed since
     // the search engine that gets filtered out of top sites has changed.
-    if (topic === "browser-search-engine-modified" && data === "engine-current" && this.store.getState().Prefs.values[NO_DEFAULT_SEARCH_TILE_EXP_PREF]) {
+    if (topic === "browser-search-engine-modified" && data === "engine-default" && this.store.getState().Prefs.values[NO_DEFAULT_SEARCH_TILE_EXP_PREF]) {
       delete this._currentSearchHostname;
       this._currentSearchHostname = getShortURLForCurrentSearch();
       this.refresh({broadcast: true});

--- a/test/unit/lib/TopSitesFeed.test.js
+++ b/test/unit/lib/TopSitesFeed.test.js
@@ -1164,7 +1164,7 @@ describe("Top Sites Feed", () => {
     it("should call refresh and set ._currentSearchHostname to the new engine hostname when the the default search engine has been set", () => {
       sinon.stub(feed, "refresh");
       sandbox.stub(global.Services.search, "defaultEngine").value({identifier: "ddg", searchForm: "duckduckgo.com"});
-      feed.observe(null, "browser-search-engine-modified", "engine-current");
+      feed.observe(null, "browser-search-engine-modified", "engine-default");
       assert.equal(feed._currentSearchHostname, "duckduckgo");
       assert.calledOnce(feed.refresh);
     });


### PR DESCRIPTION
r?@rlr https://hg.mozilla.org/mozilla-central/rev/aa8babb8b1ee
