### PR TITLE
(nobug) Make button for collapsing devtools less prominent

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -805,11 +805,15 @@ export class CollapseToggle extends React.PureComponent {
   render() {
     const {props} = this;
     const {renderAdmin} = this;
-    const action = (this.state.collapsed || !renderAdmin) ? "Expand" : "Collapse";
+    const isCollapsed = this.state.collapsed || !renderAdmin;
+    const label = `${isCollapsed ? "Expand" : "Collapse"} devtools`;
     return (<React.Fragment>
       <a href="#devtools"
-        className={`asrouter-toggle asrouter-${action.toLowerCase()}`}
-        onClick={this.renderAdmin ? this.onCollapseToggle : null}>{action} Devtools</a>
+        title={label}
+        className={`asrouter-toggle ${isCollapsed ? "collapsed" : "expanded"}`}
+        onClick={this.renderAdmin ? this.onCollapseToggle : null}>
+        <span className="sr-only">{label}</span><span className="icon icon-devtools" />
+      </a>
       {renderAdmin ? <ASRouterAdminInner {...props} collapsed={this.state.collapsed} /> : null}
     </React.Fragment>);
   }

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.scss
@@ -1,21 +1,24 @@
 
 .asrouter-toggle {
-  background: $yellow-50;
-  color: $black;
   position: fixed;
-  top: 0;
-  left: 43px;
-  opacity: 0;
-  padding: 5px 10px;
-  transition: opacity 1s $photon-easing 333ms;
-  border-radius: 0 0 3px 3px;
-  border: 1px solid $black-10;
-  border-top: 0;
+  top: 15px;
+  right: 48px;
+  border: 0;
+  background: none;
   z-index: 3000;
+  border-radius: 2px;
 
-  &:hover,
-  &.asrouter-collapse {
-    opacity: 1;
+  .icon-devtools {
+    background-image: url('chrome://browser/skin/developer.svg');
+    padding: 15px;
+  }
+
+  &:hover {
+    background: var(--newtab-element-hover-color);
+  }
+
+  &.expanded {
+    background: $black-20;
   }
 }
 


### PR DESCRIPTION
At aaron's request, slight design change for the devtools button.

![image](https://user-images.githubusercontent.com/1455535/56613580-ee82a900-65e4-11e9-95f4-5f74eee14b9a.png)
