### PR TITLE
(nobug) - Add basic discovery stream rendering mochitest

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -221,6 +221,7 @@ const PREFS_CONFIG = new Map([
   ["discoverystream.config", {
     title: "Configuration for the new pocket new tab",
     getValue: ({geo, locale}) => {
+      // XXX hardcoded_layout only works for en-*, so fix before adding locales
       const locales = ({
         "US": ["en-CA", "en-GB", "en-US", "en-ZA"],
         "CA": ["en-CA", "en-GB", "en-US", "en-ZA"],

--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -15,6 +15,7 @@ prefs =
 [browser_asrouter_snippets.js]
 [browser_asrouter_targeting.js]
 [browser_asrouter_trigger_listeners.js]
+[browser_discovery_render.js]
 [browser_discovery_styles.js]
 [browser_enabled_newtabpage.js]
 [browser_highlights_section.js]

--- a/test/browser/browser_discovery_render.js
+++ b/test/browser/browser_discovery_render.js
@@ -1,0 +1,20 @@
+"use strict";
+
+async function before({pushPrefs}) {
+  await pushPrefs(["browser.newtabpage.activity-stream.discoverystream.config", JSON.stringify({
+    collapsible: true,
+    enabled: true,
+    hardcoded_layout: true,
+  })]);
+}
+
+test_newtab({
+  before,
+  test: async function test_render_hardcoded() {
+    const topSites = await ContentTaskUtils.waitForCondition(() => content.document.querySelector(".ds-top-sites"));
+    ok(topSites, "Got the discovery stream top sites section");
+
+    const learnMore = content.document.querySelector(".ds-layout a[href$=new_tab_learn_more]");
+    is(learnMore.textContent, "How it works", "Got the rendered Message with link text and url within discovery stream");
+  },
+});


### PR DESCRIPTION
r?@ScottDowne Adds a test similar to browser_as_render and browser_discovery_styles. To be clear, this doesn't fail without your expired fix #4930 because there's no network connections allowed, so spocs never get updated anyway. This is just basic rendering test with an extra reload thrown in for fun.

Also adds a developer XXX comment/warning re: hardcoded_layout.