### PR TITLE
Bug 1535448 - Handle focus state while navigating with keyboard

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
+++ b/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
@@ -15,6 +15,10 @@ $col4-header-font-size: 14;
     border-radius: 4px;
   }
 
+  .ds-card-link:focus {
+    @include ds-fade-in;
+  }
+
   &.ds-card-grid-border {
     .ds-card:not(.placeholder) {
       @include dark-theme-only {

--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -58,6 +58,10 @@ $excerpt-line-height: 20;
   }
 
   .ds-card-link {
+    &:focus {
+      @include ds-fade-in;
+    }
+
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -58,14 +58,14 @@ $excerpt-line-height: 20;
   }
 
   .ds-card-link {
-    &:focus {
-      @include ds-fade-in;
-    }
-
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     height: 100%;
+
+    &:focus {
+      @include ds-fade-in;
+    }
   }
 
   .meta {

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -61,6 +61,10 @@ $card-header-in-hero-line-height: 20;
       color: $grey-30;
     }
 
+    &:focus {
+      @include ds-fade-in;
+    }
+
     color: $grey-50;
     display: block;
     margin: 12px 0 16px;

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -61,15 +61,15 @@ $card-header-in-hero-line-height: 20;
       color: $grey-30;
     }
 
-    &:focus {
-      @include ds-fade-in;
-    }
-
     color: $grey-50;
     display: block;
     margin: 12px 0 16px;
     padding-top: 16px;
     height: 100%;
+
+    &:focus {
+      @include ds-fade-in;
+    }
 
     @at-root .ds-hero-no-border .ds-hero-item .wrapper {
       border-top: 0;

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -86,6 +86,10 @@ $item-line-height: 20;
   }
 }
 
+.ds-list-item-link:focus {
+  @include ds-fade-in;
+}
+
 .ds-list-numbers {
   $counter-whitespace: ($item-line-height - $item-font-size) * 1px;
   $counter-size: 32px;

--- a/content-src/components/DiscoveryStreamComponents/TopSites/_TopSites.scss
+++ b/content-src/components/DiscoveryStreamComponents/TopSites/_TopSites.scss
@@ -8,6 +8,10 @@
 
     .top-site-outer {
       padding: 0 12px;
+
+      .top-site-inner > a:-moz-any(.active, :focus) .tile {
+        @include ds-fade-in;
+      }
     }
 
     .top-sites-list {

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -41,3 +41,9 @@
 
   border-bottom: 1px solid $grey-30;
 }
+
+@mixin ds-fade-in {
+  box-shadow: 0 0 0 1px #0a84ff inset, 0 0 0 1px #0a84ff, 0 0 0 5px rgba(10, 132, 255, 0.3);
+  transition: box-shadow 150ms;
+  border-radius: 4px;
+}

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -46,4 +46,5 @@
   box-shadow: 0 0 0 1px #0a84ff inset, 0 0 0 1px #0a84ff, 0 0 0 5px rgba(10, 132, 255, 0.3);
   transition: box-shadow 150ms;
   border-radius: 4px;
+  outline: none;
 }

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -43,7 +43,7 @@
 }
 
 @mixin ds-fade-in {
-  box-shadow: 0 0 0 1px #0a84ff inset, 0 0 0 1px #0a84ff, 0 0 0 5px rgba(10, 132, 255, 0.3);
+  box-shadow: 0 0 0 1px $blue-50 inset, 0 0 0 1px $blue-50, 0 0 0 5px $blue-50-30;
   transition: box-shadow 150ms;
   border-radius: 4px;
   outline: none;

--- a/content-src/styles/_variables.scss
+++ b/content-src/styles/_variables.scss
@@ -45,6 +45,8 @@ $grey-90-70: rgba($grey-90, 0.7);
 $grey-90-80: rgba($grey-90, 0.8);
 $grey-90-90: rgba($grey-90, 0.9);
 
+$blue-50-30: rgba($blue-50, 0.3);
+
 $black: #000;
 $black-5: rgba($black, 0.05);
 $black-10: rgba($black, 0.1);


### PR DESCRIPTION
Testing:

- Set `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=dev-test-all"}`
- Tab through all items and confirm focus states match [spec](https://www.figma.com/file/0xZkmT86rSXbGRB4eIvrn0ts/New-Tab-Spec-for-Fx-v68?node-id=383%3A1)