### PR TITLE
Bug 1546898 - Bookmark Panel QA test provider

### DIFF
--- a/common/Reducers.jsm
+++ b/common/Reducers.jsm
@@ -16,10 +16,7 @@ const INITIAL_STATE = {
     // Have we received real data from the app yet?
     initialized: false,
   },
-  ASRouter: {
-    initialized: false,
-    allowLegacySnippets: null,
-  },
+  ASRouter: {initialized: false},
   Snippets: {initialized: false},
   TopSites: {
     // Have we received real data from history yet?
@@ -91,8 +88,6 @@ function ASRouter(prevState = INITIAL_STATE.ASRouter, action) {
   switch (action.type) {
     case at.AS_ROUTER_INITIALIZED:
       return {...action.data, initialized: true};
-    case at.AS_ROUTER_PREF_CHANGED:
-      return {...prevState, ...action.data};
     default:
       return prevState;
   }

--- a/content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json
+++ b/content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json
@@ -61,39 +61,26 @@
         }
       ]
     },
-    "link": {
+    "cta": {
       "description": "Link shown at the bottom of the message, call to action",
-      "properties": {
-        "text": {
-          "description": "Message shown as part of anchor tag",
-          "oneOf": [
-            {
-              "allOf": [
-                {"$ref": "#/definitions/richText"},
-                {"description": "Message to be shown"}
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "string_id": {
-                  "type": "string",
-                  "description": "Fluent id of localized string"
-                }
-              },
-              "required": ["string_id"]
-            }
-          ] 
-        },
-        "url": {
-          "description": "Value for href attribute of the anchor",
+      "oneOf": [
+        {
           "allOf": [
-            {"$ref": "#/definitions/link_url"},
-            {"description": "Link that opens in a new tab"}
+            {"$ref": "#/definitions/richText"},
+            {"description": "Message to be shown"}
           ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "string_id": {
+              "type": "string",
+              "description": "Fluent id of localized string"
+            }
+          },
+          "required": ["string_id"]
         }
-      },
-      "required": ["text", "url"]
+      ]
     },
     "info_icon": {
       "type": "object",
@@ -148,8 +135,29 @@
         }
       },
       "required": ["tooltiptext"]
+    },
+    "color": {
+      "description": "Message text color",
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Valid CSS color"}
+      ]
+    },
+    "background_color_1": {
+      "description": "Configurable background color through CSS gradient",
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Valid CSS color"}
+      ]
+    },
+    "background_color_2": {
+      "description": "Configurable background color through CSS gradient",
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Valid CSS color"}
+      ]
     }
   },
   "additionalProperties": false,
-  "required": ["title", "text", "link", "info_icon"]
+  "required": ["title", "text", "cta", "info_icon"]
 }

--- a/content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json
+++ b/content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json
@@ -121,6 +121,33 @@
         }
       },
       "required": ["tooltiptext"]
+    },
+    "close_button": {
+      "type": "object",
+      "description": "The small dissmiss icon displayed in the top right corner of the message. Not configurable, only the tooltip text." ,
+      "properties": {
+        "tooltiptext": {
+          "oneOf": [
+            {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Message to be shown"}
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string",
+                  "description": "Fluent id of localized string"
+                }
+              },
+              "required": ["string_id"]
+            }
+          ]
+        }
+      },
+      "required": ["tooltiptext"]
     }
   },
   "additionalProperties": false,

--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -505,7 +505,7 @@ export class ASRouterAdminInner extends React.PureComponent {
 
     return (<table>{this.renderTableHead()}<tbody>
       {providersConfig.map((provider, i) => {
-        const isTestProvider = provider.id === "snippets_local_testing";
+        const isTestProvider = provider.id.includes("_local_testing");
         const info = providerInfo.find(p => p.id === provider.id) || {};
         const isUserEnabled = provider.id in userPrefInfo ? userPrefInfo[provider.id] : true;
         const isSystemEnabled = (isTestProvider || provider.enabled);

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -361,7 +361,6 @@ class _ASRouter {
   async onPrefChange() {
     this._updateMessageProviders();
     await this.loadMessagesFromAllProviders();
-    this.dispatchToAS(ac.BroadcastToContent({type: at.AS_ROUTER_PREF_CHANGED, data: ASRouterPreferences.specialConditions}));
   }
 
   // Replace all frequency time period aliases with their millisecond values

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -13,11 +13,12 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   AppConstants: "resource://gre/modules/AppConstants.jsm",
   OS: "resource://gre/modules/osfile.jsm",
   BookmarkPanelHub: "resource://activity-stream/lib/BookmarkPanelHub.jsm",
+  SnippetsTestMessageProvider: "resource://activity-stream/lib/SnippetsTestMessageProvider.jsm",
+  PanelTestProvider: "resource://activity-stream/lib/PanelTestProvider.jsm",
 });
 const {ASRouterActions: ra, actionTypes: at, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm");
 const {CFRMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/CFRMessageProvider.jsm");
 const {OnboardingMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/OnboardingMessageProvider.jsm");
-const {SnippetsTestMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/SnippetsTestMessageProvider.jsm");
 const {RemoteSettings} = ChromeUtils.import("resource://services-settings/remote-settings.js");
 const {CFRPageActions} = ChromeUtils.import("resource://activity-stream/lib/CFRPageActions.jsm");
 
@@ -44,7 +45,7 @@ const SNIPPETS_ENDPOINT_WHITELIST = "browser.newtab.activity-stream.asrouter.whi
 // Max possible impressions cap for any message
 const MAX_MESSAGE_LIFETIME_CAP = 100;
 
-const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider, CFRMessageProvider, SnippetsTestMessageProvider};
+const LOCAL_MESSAGE_PROVIDERS = {OnboardingMessageProvider, CFRMessageProvider};
 const STARTPAGE_VERSION = "6";
 
 const MessageLoaderUtils = {
@@ -523,6 +524,15 @@ class _ASRouter {
     ASRouterPreferences.init();
     ASRouterPreferences.addListener(this.onPrefChange);
     BookmarkPanelHub.init(this.handleMessageRequest, this.addImpression);
+
+    // If we're in ASR debug mode add the local test providers
+    if (ASRouterPreferences.devtoolsEnabled) {
+      this._localProviders = {
+        ...this._localProviders,
+        SnippetsTestMessageProvider,
+        PanelTestProvider,
+      };
+    }
 
     const messageBlockList = await this._storage.get("messageBlockList") || [];
     const providerBlockList = await this._storage.get("providerBlockList") || [];

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -825,7 +825,7 @@ class _ASRouter {
         target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {type: "CLEAR_ALL"});
       } catch (e) {}
 
-      // For bundled messages, look for the rest of the bundle or else send CLEAR_ALL
+    // For bundled messages, look for the rest of the bundle or else send CLEAR_ALL
     } else if (message.bundled) {
       const bundledMessages = await this._getBundledMessages(message, target, trigger, force);
       const action = bundledMessages ? {type: "SET_BUNDLED_MESSAGES", data: bundledMessages} : {type: "CLEAR_ALL"};
@@ -833,7 +833,7 @@ class _ASRouter {
         target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, action);
       } catch (e) {}
 
-      // For nested bundled messages, look for the desired bundle
+    // For nested bundled messages, look for the desired bundle
     } else if (message.includeBundle) {
       const bundledMessages = await this._getBundledMessages(message, target, message.includeBundle.trigger, force);
       try {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -15,6 +15,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   BookmarkPanelHub: "resource://activity-stream/lib/BookmarkPanelHub.jsm",
   SnippetsTestMessageProvider: "resource://activity-stream/lib/SnippetsTestMessageProvider.jsm",
   PanelTestProvider: "resource://activity-stream/lib/PanelTestProvider.jsm",
+  BookmarkPanelHub: "resource://activity-stream/lib/BookmarkPanelHub.jsm",
 });
 const {ASRouterActions: ra, actionTypes: at, actionCreators: ac} = ChromeUtils.import("resource://activity-stream/common/Actions.jsm");
 const {CFRMessageProvider} = ChromeUtils.import("resource://activity-stream/lib/CFRMessageProvider.jsm");

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -359,6 +359,7 @@ class _ASRouter {
 
   // Update message providers and fetch new messages on pref change
   async onPrefChange() {
+    this._loadLocalProviders();
     this._updateMessageProviders();
     await this.loadMessagesFromAllProviders();
   }
@@ -524,14 +525,7 @@ class _ASRouter {
     ASRouterPreferences.addListener(this.onPrefChange);
     BookmarkPanelHub.init(this.handleMessageRequest, this.addImpression);
 
-    // If we're in ASR debug mode add the local test providers
-    if (ASRouterPreferences.devtoolsEnabled) {
-      this._localProviders = {
-        ...this._localProviders,
-        SnippetsTestMessageProvider,
-        PanelTestProvider,
-      };
-    }
+    this._loadLocalProviders();
 
     const messageBlockList = await this._storage.get("messageBlockList") || [];
     const providerBlockList = await this._storage.get("providerBlockList") || [];
@@ -587,6 +581,17 @@ class _ASRouter {
   _onStateChanged(state) {
     if (ASRouterPreferences.devtoolsEnabled) {
       this._updateAdminState();
+    }
+  }
+
+  _loadLocalProviders() {
+    // If we're in ASR debug mode add the local test providers
+    if (ASRouterPreferences.devtoolsEnabled) {
+      this._localProviders = {
+        ...this._localProviders,
+        SnippetsTestMessageProvider,
+        PanelTestProvider,
+      };
     }
   }
 

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -27,12 +27,17 @@ const USER_PREFERENCES = {
   cfrFeatures: "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features",
 };
 
-const TEST_PROVIDER = {
+const TEST_PROVIDERS = [{
   id: "snippets_local_testing",
   type: "local",
   localProvider: "SnippetsTestMessageProvider",
   enabled: true,
-};
+}, {
+  id: "panel_local_testing",
+  type: "local",
+  localProvider: "PanelTestProvider",
+  enabled: true,
+}];
 
 class _ASRouterPreferences {
   constructor() {
@@ -79,7 +84,7 @@ class _ASRouterPreferences {
       const config = this._getProviderConfig();
       const providers = config.map(provider => Object.freeze(provider));
       if (this.devtoolsEnabled) {
-        providers.unshift(TEST_PROVIDER);
+        providers.unshift(...TEST_PROVIDERS);
       }
       this._providers = Object.freeze(providers);
     }
@@ -192,6 +197,6 @@ class _ASRouterPreferences {
 this._ASRouterPreferences = _ASRouterPreferences;
 
 this.ASRouterPreferences = new _ASRouterPreferences();
-this.TEST_PROVIDER = TEST_PROVIDER;
+this.TEST_PROVIDERS = TEST_PROVIDERS;
 
-const EXPORTED_SYMBOLS = ["_ASRouterPreferences", "ASRouterPreferences", "TEST_PROVIDER"];
+const EXPORTED_SYMBOLS = ["_ASRouterPreferences", "ASRouterPreferences", "TEST_PROVIDERS"];

--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -119,16 +119,6 @@ class _ASRouterPreferences {
     return this._devtoolsEnabled;
   }
 
-  get specialConditions() {
-    let allowLegacySnippets = true;
-    for (const provider of this.providers) {
-      if (provider.id === "snippets" && provider.enabled) {
-        allowLegacySnippets = false;
-      }
-    }
-    return {allowLegacySnippets};
-  }
-
   observe(aSubject, aTopic, aPrefName) {
     if (aPrefName && aPrefName.startsWith(this._providerPrefBranch)) {
       this._providers = null;

--- a/lib/BookmarkPanelHub.jsm
+++ b/lib/BookmarkPanelHub.jsm
@@ -97,6 +97,7 @@ class _BookmarkPanelHub {
       this.toggleRecommendation(false);
       return;
     }
+
     const createElement = elem => target.document.createElementNS("http://www.w3.org/1999/xhtml", elem);
 
     if (!target.container.querySelector("#cfrMessageContainer")) {

--- a/lib/BookmarkPanelHub.jsm
+++ b/lib/BookmarkPanelHub.jsm
@@ -22,6 +22,7 @@ class _BookmarkPanelHub {
 
     this.messageRequest = this.messageRequest.bind(this);
     this.toggleRecommendation = this.toggleRecommendation.bind(this);
+    this.collapseMessage = this.collapseMessage.bind(this);
   }
 
   /**
@@ -56,8 +57,9 @@ class _BookmarkPanelHub {
    * @returns {obj|null} response object or null if no messages matched
    */
   async messageRequest(target, win) {
-    if (this._response && this._response.url === target.url) {
-      return this.onResponse(this._response, target, win);
+    if (this._response && this._response.url === target.url && this._response.content) {
+      this.showMessage(this._response.content, target, win);
+      return true;
     }
 
     const response = await this._handleMessageRequest(this._trigger);
@@ -72,6 +74,7 @@ class _BookmarkPanelHub {
   onResponse(response, target, win) {
     this._response = {
       ...response,
+      collapsed: false,
       target,
       win,
       url: target.url,
@@ -90,6 +93,10 @@ class _BookmarkPanelHub {
   }
 
   showMessage(message, target, win) {
+    if (this._response.collapsed) {
+      this.toggleRecommendation(false);
+      return;
+    }
     const createElement = elem => target.document.createElementNS("http://www.w3.org/1999/xhtml", elem);
 
     if (!target.container.querySelector("#cfrMessageContainer")) {
@@ -110,7 +117,10 @@ class _BookmarkPanelHub {
       close.setAttribute("id", "cfrClose");
       close.setAttribute("aria-label", "close");
       this._l10n.setAttributes(close, message.close_button.tooltiptext);
-      close.addEventListener("click", target.close);
+      close.addEventListener("click", e => {
+        this.collapseMessage();
+        target.close(e);
+      });
       const title = createElement("h1");
       title.setAttribute("id", "editBookmarkPanelRecommendationTitle");
       this._l10n.setAttributes(title, message.title);
@@ -133,12 +143,24 @@ class _BookmarkPanelHub {
 
   toggleRecommendation(visible) {
     const {target} = this._response;
-    target.infoButton.checked = visible !== undefined ? !!visible : !target.infoButton.checked;
+    if (visible === undefined) {
+      // When called from the info button of the bookmark panel
+      target.infoButton.checked = !target.infoButton.checked;
+    } else {
+      target.infoButton.checked = visible;
+    }
     if (target.infoButton.checked) {
+      // If it was ever collapsed we need to cancel the state
+      this._response.collapsed = false;
       target.recommendationContainer.removeAttribute("disabled");
     } else {
       target.recommendationContainer.setAttribute("disabled", "disabled");
     }
+  }
+
+  collapseMessage() {
+    this._response.collapsed = true;
+    this.toggleRecommendation(false);
   }
 
   hideMessage(target) {
@@ -147,11 +169,12 @@ class _BookmarkPanelHub {
       container.remove();
     }
     this.toggleRecommendation(false);
+    this._response = null;
   }
 
   _forceShowMessage(message) {
+    this.toggleRecommendation(true);
     this.showMessage(message.content, this._response.target, this._response.win);
-    this._response.target.infoButton.disabled = false;
   }
 
   sendImpression() {

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -5,15 +5,16 @@
 
 const MESSAGES = () => ([
   {
-    "id": "SIMPLE_TEST_1",
-    "template": "simple_snippet",
-    "campaign": "test_campaign_blocking",
+    "id": "SIMPLE_FXA_BOOKMARK_TEST_1",
     "content": {
-      "title": "Firefox Account!",
-      "text": "<syncLink>Sync it, link it, take it with you</syncLink>. All this and more with a Firefox Account.",
-      "links": {"syncLink": {"url": "https://www.mozilla.org/en-US/firefox/accounts"}},
-      "block_button_text": "Block",
+      "title": "cfr-doorhanger-bookmark-fxa-header",
+      "text": "cfr-doorhanger-bookmark-fxa-body",
+      "link": {
+        "text": "cfr-doorhanger-bookmark-fxa-link-text",
+        "url": "https://mozilla.com",
+      },
     },
+    "trigger": {"id": "bookmark-panel"},
   },
 ]);
 

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const MESSAGES = () => ([
+  {
+    "id": "SIMPLE_TEST_1",
+    "template": "simple_snippet",
+    "campaign": "test_campaign_blocking",
+    "content": {
+      "title": "Firefox Account!",
+      "text": "<syncLink>Sync it, link it, take it with you</syncLink>. All this and more with a Firefox Account.",
+      "links": {"syncLink": {"url": "https://www.mozilla.org/en-US/firefox/accounts"}},
+      "block_button_text": "Block",
+    },
+  },
+]);
+
+const PanelTestProvider = {
+  getMessages() {
+    return MESSAGES()
+      // Ensures we never actually show test except when triggered by debug tools
+      // TODO where is this coming from
+      .map(message => ({...message, targeting: `providerCohorts.panel_local_testing == "SHOW_TEST"`}));
+  },
+};
+this.PanelTestProvider = PanelTestProvider;
+
+const EXPORTED_SYMBOLS = ["PanelTestProvider"];

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -6,13 +6,14 @@
 const MESSAGES = () => ([
   {
     "id": "SIMPLE_FXA_BOOKMARK_TEST_1",
+    "template": "fxa_bookmark_panel",
     "content": {
       "title": "cfr-doorhanger-bookmark-fxa-header",
       "text": "cfr-doorhanger-bookmark-fxa-body",
-      "link": {
-        "text": "cfr-doorhanger-bookmark-fxa-link-text",
-        "url": "https://mozilla.com",
-      },
+      "cta": "cfr-doorhanger-bookmark-fxa-link-text",
+      "color": "white",
+      "background_color_1": "#7d31ae",
+      "background_color_2": "#5033be",
       "info_icon": {
         "tooltiptext": "cfr-doorhanger-bookmark-fxa-info-icon-tooltip",
       },

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -28,8 +28,7 @@ const MESSAGES = () => ([
 const PanelTestProvider = {
   getMessages() {
     return MESSAGES()
-      // Ensures we never actually show test except when triggered by debug tools
-      .map(message => ({...message, targeting: `providerCohorts.panel_local_testing == "SHOW_TEST"`}));
+      .map(message => ({...message, targeting: `true`}));
   },
 };
 this.PanelTestProvider = PanelTestProvider;

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -13,6 +13,12 @@ const MESSAGES = () => ([
         "text": "cfr-doorhanger-bookmark-fxa-link-text",
         "url": "https://mozilla.com",
       },
+      "info_icon": {
+        "tooltiptext": "cfr-doorhanger-bookmark-fxa-info-icon-tooltip",
+      },
+      "close_button": {
+        "tooltiptext": "cfr-doorhanger-bookmark-fxa-close-btn-tooltip",
+      },
     },
     "trigger": {"id": "bookmark-panel"},
   },
@@ -22,7 +28,6 @@ const PanelTestProvider = {
   getMessages() {
     return MESSAGES()
       // Ensures we never actually show test except when triggered by debug tools
-      // TODO where is this coming from
       .map(message => ({...message, targeting: `providerCohorts.panel_local_testing == "SHOW_TEST"`}));
   },
 };

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -943,7 +943,7 @@ describe("ASRouter", () => {
       });
 
       it("should call BookmarkPanelHub._forceShowMessage the provider is cfr-fxa", async () => {
-        const testMessage = {id: "foo", template: "cfr_doorhanger", provider: "cfr-fxa"};
+        const testMessage = {id: "foo", template: "fxa_bookmark_panel"};
         await Router.setState({messages: [testMessage]});
         const msg = fakeAsyncMessage({type: "OVERRIDE_MESSAGE", data: {id: testMessage.id}});
         await Router.onMessage(msg);

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -1,4 +1,4 @@
-import {_ASRouterPreferences, ASRouterPreferences as ASRouterPreferencesSingleton, TEST_PROVIDER} from "lib/ASRouterPreferences.jsm";
+import {_ASRouterPreferences, ASRouterPreferences as ASRouterPreferencesSingleton, TEST_PROVIDERS} from "lib/ASRouterPreferences.jsm";
 const FAKE_PROVIDERS = [{id: "foo"}, {id: "bar"}];
 
 const PROVIDER_PREF_BRANCH = "browser.newtabpage.activity-stream.asrouter.providers.";
@@ -130,11 +130,11 @@ describe("ASRouterPreferences", () => {
 
       assert.deepEqual(ASRouterPreferences.providers, [{id: "bar"}]);
     });
-    it("should include TEST_PROVIDER if devtools is turned on", () => {
+    it("should include TEST_PROVIDERS if devtools is turned on", () => {
       boolPrefStub.withArgs(DEVTOOLS_PREF).returns(true);
       ASRouterPreferences.init();
 
-      assert.deepEqual(ASRouterPreferences.providers, [TEST_PROVIDER, ...FAKE_PROVIDERS]);
+      assert.deepEqual(ASRouterPreferences.providers, [...TEST_PROVIDERS, ...FAKE_PROVIDERS]);
     });
   });
   describe(".devtoolsEnabled", () => {
@@ -277,7 +277,7 @@ describe("ASRouterPreferences", () => {
       // Cache should be invalidated so we access the new value of the pref now
       // Note that providers needs to be invalidated because devtools adds test content to it.
       assert.isTrue(ASRouterPreferences.devtoolsEnabled);
-      assert.deepEqual(ASRouterPreferences.providers, [TEST_PROVIDER]);
+      assert.deepEqual(ASRouterPreferences.providers, TEST_PROVIDERS);
     });
     it("should call listeners added with .addListener", () => {
       const callback1 = sinon.stub();

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -161,25 +161,6 @@ describe("ASRouterPreferences", () => {
       assert.calledTwice(boolPrefStub);
     });
   });
-  describe(".specialConditions", () => {
-    it("should return .allowLegacySnippets=true if snippets is not present or disabled", () => {
-      ASRouterPreferences.init();
-      let testProviders = [];
-      sandbox.stub(ASRouterPreferences, "providers").get(() => testProviders);
-
-      testProviders = [{id: "foo"}];
-      assert.isTrue(ASRouterPreferences.specialConditions.allowLegacySnippets);
-
-      testProviders = [{id: "snippets", enabled: false}];
-      assert.isTrue(ASRouterPreferences.specialConditions.allowLegacySnippets);
-    });
-    it("should return .allowLegacySnippets=false if snippets is enabled", () => {
-      ASRouterPreferences.init();
-      sandbox.stub(ASRouterPreferences, "providers").get(() => [{id: "snippets", enabled: true}]);
-
-      assert.isFalse(ASRouterPreferences.specialConditions.allowLegacySnippets);
-    });
-  });
   describe("#getUserPreference(providerId)", () => {
     it("should return the user preference for snippets", () => {
       boolPrefStub.withArgs(SNIPPETS_USER_PREF).returns(true);

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -1,8 +1,12 @@
 import {PanelTestProvider} from "lib/PanelTestProvider.jsm";
+import schema from "content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json";
 const messages = PanelTestProvider.getMessages();
 
 describe("PanelTestProvider", () => {
   it("should have a message", () => {
     assert.lengthOf(messages, 1);
+  });
+  it("should be a validat message", () => {
+    assert.jsonSchema(messages[0].content, schema);
   });
 });

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -1,0 +1,8 @@
+import {PanelTestProvider} from "lib/PanelTestProvider.jsm";
+const messages = PanelTestProvider.getMessages();
+
+describe("PanelTestProvider", () => {
+  it("should have a message", () => {
+    assert.lengthOf(messages, 1);
+  });
+});

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -6,7 +6,7 @@ describe("PanelTestProvider", () => {
   it("should have a message", () => {
     assert.lengthOf(messages, 1);
   });
-  it("should be a validat message", () => {
+  it("should be a valid message", () => {
     assert.jsonSchema(messages[0].content, schema);
   });
 });

--- a/test/unit/asrouter/schemas/panel/cfr-fxa-bookmark.schema.test.js
+++ b/test/unit/asrouter/schemas/panel/cfr-fxa-bookmark.schema.test.js
@@ -3,10 +3,7 @@ import schema from "content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.j
 const DEFAULT_CONTENT = {
   "title": "Sync your bookmarks everywhere",
   "text": "Great find! Now don't be left without this bookmark.",
-  "link": {
-    "text": "Sync bookmarks now",
-    "url": "https://mozilla.com",
-  },
+  "cta": "Sync bookmarks now",
   "info_icon": {
     "tooltiptext": "Learn more",
   },
@@ -15,10 +12,7 @@ const DEFAULT_CONTENT = {
 const L10N_CONTENT = {
   "title": {string_id: "cfr-bookmark-title"},
   "text": {string_id: "cfr-bookmark-body"},
-  "link": {
-    "text": {string_id: "cfr-bookmark-link-text"},
-    "url": "https://mozilla.com",
-  },
+  "cta": {string_id: "cfr-bookmark-link-text"},
   "info_icon": {
     "tooltiptext": {string_id: "cfr-bookmark-tooltip-text"},
   },

--- a/test/unit/common/Reducers.test.js
+++ b/test/unit/common/Reducers.test.js
@@ -1056,15 +1056,6 @@ describe("Reducers", () => {
       assert.propertyVal(nextState, "hide", false);
     });
   });
-  describe("ASRouter", () => {
-    it("should listen for pref changes on AS_ROUTER_PREF_CHANGED", async () => {
-      const action = {data: {foo: "bar"}, type: at.AS_ROUTER_PREF_CHANGED};
-
-      const result = ASRouter({}, action);
-
-      assert.propertyVal(result, "foo", "bar");
-    });
-  });
   it("should set initialized to true on AS_ROUTER_INITIALIZED", () => {
     const nextState = ASRouter(undefined, {type: "AS_ROUTER_INITIALIZED"});
     assert.propertyVal(nextState, "initialized", true);


### PR DESCRIPTION
I've changed the local providers to be lazily loaded with `defineLazyGlobalGetters`. And they are added only if `devtoolsEnabled`.
I assumed we'll be adding more and each will have their own file.
I also found some more code related to snippets that should have been removed. `allowLegacySnippets` in the `Reducer` state and in `ASRouterPreferences`.