### PR TITLE
Trailhead basic flow with single message, no bundles

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -11,6 +11,7 @@ import ReactDOM from "react-dom";
 import {ReturnToAMO} from "./templates/ReturnToAMO/ReturnToAMO";
 import {SnippetsTemplates} from "./templates/template-manifest";
 import {StartupOverlay} from "./templates/StartupOverlay/StartupOverlay";
+import {Trailhead} from "./templates/Trailhead/Trailhead";
 
 const INCOMING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const OUTGOING_MESSAGE_NAME = "ASRouter:child-to-parent";
@@ -221,7 +222,8 @@ export class ASRouterUISurface extends React.PureComponent {
   renderSnippets() {
     if (this.state.bundle.template === "onboarding" ||
         this.state.message.template === "fxa_overlay" ||
-        this.state.message.template === "return_to_amo_overlay") {
+        this.state.message.template === "return_to_amo_overlay" ||
+        this.state.message.template === "trailhead") {
       return null;
     }
     const SnippetComponent = SnippetsTemplates[this.state.message.template];
@@ -288,6 +290,18 @@ export class ASRouterUISurface extends React.PureComponent {
     return null;
   }
 
+  renderTrailhead() {
+    const {message} = this.state;
+    if (message.template === "trailhead") {
+      return (<Trailhead
+        message={message}
+        onAction={ASRouterUtils.executeAction}
+        onDoneButton={this.dismissBundle(this.state.bundle.bundle)}
+        sendUserActionTelemetry={this.sendUserActionTelemetry} />);
+    }
+    return null;
+  }
+
   renderPreviewBanner() {
     if (this.state.message.provider !== "preview") {
       return null;
@@ -314,6 +328,7 @@ export class ASRouterUISurface extends React.PureComponent {
       ReactDOM.createPortal(
         <>
           {this.renderPreviewBanner()}
+          {this.renderTrailhead()}
           {this.renderFirstRunOverlay()}
           {this.renderOnboarding()}
           {this.renderSnippets()}

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -28,6 +28,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [sync](#sync)
 * [topFrecentSites](#topfrecentsites)
 * [totalBookmarksCount](#totalbookmarkscount)
+* [trailheadCohort](#trailheadcohort)
 * [usesFirefoxSync](#usesfirefoxsync)
 * [xpinstallEnabled](#xpinstallEnabled)
 * [hasPinnedTabs](#haspinnedtabs)
@@ -423,6 +424,11 @@ Total number of bookmarks.
 ```ts
 declare const totalBookmarksCount: number;
 ```
+
+### `trailheadCohort`
+
+(67+ only) Experiment cohort for special trailhead project
+
 
 ### `usesFirefoxSync`
 

--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -1,7 +1,7 @@
 import {ModalOverlay} from "../../components/ModalOverlay/ModalOverlay";
 import React from "react";
 
-class OnboardingCard extends React.PureComponent {
+export class OnboardingCard extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onClick = this.onClick.bind(this);

--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -25,8 +25,8 @@ export class OnboardingCard extends React.PureComponent {
         <div className={`onboardingMessageImage ${content.icon}`} />
         <div className="onboardingContent">
           <span>
-            <h3> {content.title} </h3>
-            <p> {content.text} </p>
+            <h3> {content.title}</h3>
+            <p> {content.text}</p>
           </span>
           <span>
             <button tabIndex="1" className="button onboardingButton" onClick={this.onClick}> {content.primary_button.label} </button>

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -4,18 +4,17 @@ import React from "react";
 export class Trailhead extends React.PureComponent {
   render() {
     const {props} = this;
+    const {content} = props.message;
+
     return (<div className="overlay-wrapper show trailhead">
       <div className="trailheadInner">
         <div className="trailheadContent">
-          <h1>This is not the real design. <br /> It is just a functional prototype.</h1>
-          <p>This is just demonstrating a single-stage flow instead of the regular one.</p>
+          <h3>{content.title}</h3>
+          <p>{content.subtitle}</p>
         </div>
         <div className="trailheadCards">
-          <div className="trailheadContent">
-            <h2>More than just a browser</h2>
-          </div>
           <div className="onboardingMessageContainer">
-          {props.message.content.cards.map(card => (
+          {content.cards.map(card => (
             <OnboardingCard key={card.id}
               sendUserActionTelemetry={props.sendUserActionTelemetry}
               onAction={props.onAction}
@@ -23,6 +22,10 @@ export class Trailhead extends React.PureComponent {
               {...card} />
           ))}
           </div>
+        </div>
+        <div className="trailheadContent">
+          <h2>{content.ctaHeader}</h2>
+          <p>{content.ctaText}</p>
         </div>
       </div>
 

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -1,0 +1,31 @@
+import {OnboardingCard} from "../OnboardingMessage/OnboardingMessage";
+import React from "react";
+
+export class Trailhead extends React.PureComponent {
+  render() {
+    const {props} = this;
+    return (<div className="overlay-wrapper show trailhead">
+      <div className="trailheadInner">
+        <div className="trailheadContent">
+          <h1>This is not the real design. <br /> It is just a functional prototype.</h1>
+          <p>This is just demonstrating a single-stage flow instead of the regular one.</p>
+        </div>
+        <div className="trailheadCards">
+          <div className="trailheadContent">
+            <h2>More than just a browser</h2>
+          </div>
+          <div className="onboardingMessageContainer">
+          {props.message.content.cards.map(card => (
+            <OnboardingCard key={card.id}
+              sendUserActionTelemetry={props.sendUserActionTelemetry}
+              onAction={props.onAction}
+              UISurface="TRAILHEAD"
+              {...card} />
+          ))}
+          </div>
+        </div>
+      </div>
+
+    </div>);
+  }
+}

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -172,6 +172,9 @@ function sortMessagesByTargeting(messages) {
 }
 
 const TargetingGetters = {
+  get trailheadCohort() {
+    return Services.prefs.getIntPref("trailhead.firstrun.cohort", 0);
+  },
   get locale() {
     return Services.locale.appLocaleAsLangTag;
   },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -167,8 +167,11 @@ const ONBOARDING_MESSAGES = async () => ([
     targeting: "localeLanguageCode == 'en' && trailheadCohort > 0",
     trigger: {id: "firstRun"},
     content: {
-      title: "Hello world",
-      cards: ["foo", "bar", "baz"].map(getPlaceholderTrailheadCard),
+      title: "This is not a real thing",
+      subtitle: "It is just a test",
+      ctaHeader: "Join Firefox",
+      ctaText: "Because we're awesome obviously",
+      cards: ["Hello", "World", "Foo"].map(getPlaceholderTrailheadCard),
     },
   },
   {

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -46,6 +46,25 @@ const L10N = new Localization([
   "browser/newtab/onboarding.ftl",
 ]);
 
+function getPlaceholderTrailheadCard(title) {
+  return {
+    id: "ONBOARDING_2",
+    template: "onboarding",
+    content: {
+      title,
+      text: "Hello world blah",
+      icon: "screenshots",
+      primary_button: {
+        label: "Try now",
+        action: {
+          type: "OPEN_URL",
+          data: {args: "https://screenshots.firefox.com/#tour", where: "tabshifted"},
+        },
+      },
+    },
+  };
+}
+
 const ONBOARDING_MESSAGES = async () => ([
   {
     id: "ONBOARDING_1",
@@ -143,6 +162,16 @@ const ONBOARDING_MESSAGES = async () => ([
     trigger: {id: "showOnboarding"},
   },
   {
+    id: "TRAILHEAD",
+    template: "trailhead",
+    targeting: "localeLanguageCode == 'en' && trailheadCohort > 0",
+    trigger: {id: "firstRun"},
+    content: {
+      title: "Hello world",
+      cards: ["foo", "bar", "baz"].map(getPlaceholderTrailheadCard),
+    },
+  },
+  {
     id: "FXA_1",
     template: "fxa_overlay",
     trigger: {id: "firstRun"},
@@ -219,14 +248,16 @@ const OnboardingMessageProvider = {
         }
       }
 
-      const [primary_button_string, title_string, text_string] = await L10N.formatMessages([
-        {id: msg.content.primary_button.label.string_id},
-        {id: msg.content.title.string_id},
-        {id: msg.content.text.string_id, args: msg.content.text.args},
-      ]);
-      translatedMessage.content.primary_button.label = primary_button_string.value;
-      translatedMessage.content.title = title_string.value;
-      translatedMessage.content.text = text_string.value;
+      if (msg.template === "onboarding") {
+        const [primary_button_string, title_string, text_string] = await L10N.formatMessages([
+          {id: msg.content.primary_button.label.string_id},
+          {id: msg.content.title.string_id},
+          {id: msg.content.text.string_id, args: msg.content.text.args},
+        ]);
+        translatedMessage.content.primary_button.label = primary_button_string.value;
+        translatedMessage.content.title = title_string.value;
+        translatedMessage.content.text = text_string.value;
+      }
 
       // Translate any secondary buttons separately
       if (msg.content.secondary_button) {

--- a/test/unit/asrouter/ASRouterTargeting.test.js
+++ b/test/unit/asrouter/ASRouterTargeting.test.js
@@ -57,9 +57,10 @@ describe("#CachedTargetingGetter", () => {
     const context = {attributionData: {campaign: "non-fx-button", source: "addons.mozilla.org"}};
     await ASRouterTargeting.findMatchingMessage({messages, trigger: {id: "firstRun"}, context});
 
-    assert.calledTwice(stub);
-    assert.equal(stub.firstCall.args[0].id, "RETURN_TO_AMO_1");
-    assert.equal(stub.secondCall.args[0].id, "FXA_1");
+    assert.calledThrice(stub);
+    const calls = stub.getCalls().map(call => call.args[0]);
+    const lastCall = calls[calls.length - 1];
+    assert.equal(lastCall.id, "FXA_1");
   });
   it("should return FxA message (is fallback)", async () => {
     const messages = (await OnboardingMessageProvider.getUntranslatedMessages())

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -3,7 +3,10 @@ import {OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME} from "content
 import {FAKE_LOCAL_MESSAGES} from "./constants";
 import {GlobalOverrider} from "test/unit/utils";
 import {mount} from "enzyme";
+import {OnboardingMessageProvider} from "lib/OnboardingMessageProvider.jsm";
 import React from "react";
+import {Trailhead} from "../../../content-src/asrouter/templates/Trailhead/Trailhead";
+
 let [FAKE_MESSAGE] = FAKE_LOCAL_MESSAGES;
 const FAKE_NEWSLETTER_SNIPPET = FAKE_LOCAL_MESSAGES.find(msg => msg.id === "newsletter");
 const FAKE_FXA_SNIPPET = FAKE_LOCAL_MESSAGES.find(msg => msg.id === "fxa");
@@ -159,6 +162,14 @@ describe("ASRouterUISurface", () => {
 
       wrapper.find(".blockButton").simulate("click");
       assert.notCalled(ASRouterUtils.sendTelemetry);
+    });
+  });
+
+  describe("trailhead", () => {
+    it("should render trailhead if a trailhead message is received", async () => {
+      const message = (await OnboardingMessageProvider.getUntranslatedMessages()).find(msg => msg.template === "trailhead");
+      wrapper.setState({message});
+      assert.lengthOf(wrapper.find(Trailhead), 1);
     });
   });
 

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -47,7 +47,7 @@ describe("OnboardingMessage", () => {
   it("should validate all messages from OnboardingMessageProvider", async () => {
     const messages = await OnboardingMessageProvider.getUntranslatedMessages();
     // FXA_1 doesn't have content - so filter it out
-    messages.filter(msg => msg.content).forEach(msg => assert.jsonSchema(msg.content, schema));
+    messages.filter(msg => msg.template in ["onboarding", "return_to_amo_overlay"]).forEach(msg => assert.jsonSchema(msg.content, schema));
   });
   it("should decode the content field (double decoding)", async () => {
     const fakeContent = "foo%2540bar.org";


### PR DESCRIPTION
I this option, instead of using `bundled` I added `cards` as a subproperty of of a new `TRAILHEAD` message 

we could modify getBundled... to actually add them in 