### PR TITLE
Bug 1546683 - Use fluent to localize trailhead first run

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -25,11 +25,14 @@ export class OnboardingCard extends React.PureComponent {
         <div className={`onboardingMessageImage ${content.icon}`} />
         <div className="onboardingContent">
           <span>
-            <h3> {content.title}</h3>
-            <p> {content.text}</p>
+            <h3 data-l10n-id={content.title}>{content.title}</h3>
+            <p data-l10n-id={content.text}>{content.text}</p>
           </span>
           <span>
-            <button tabIndex="1" className="button onboardingButton" onClick={this.onClick}> {content.primary_button.label} </button>
+            <button data-l10n-id={content.primary_button.label}
+              tabIndex="1"
+              className="button onboardingButton"
+              onClick={this.onClick}>{content.primary_button.label}</button>
           </span>
         </div>
       </div>

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -1,7 +1,25 @@
 import {OnboardingCard} from "../OnboardingMessage/OnboardingMessage";
 import React from "react";
 
+const FLUENT_FILES = [
+  "branding/brand.ftl",
+  "browser/branding/sync-brand.ftl",
+  // These are finalized strings exposed to localizers
+  "browser/newtab/onboarding.ftl",
+  // These are WIP/in-development strings that only get used if the string
+  // doesn't already exist in onboarding.ftl above
+  "trailhead.ftl",
+];
+
 export class Trailhead extends React.PureComponent {
+  componentWillMount() {
+    FLUENT_FILES.forEach(file => {
+      const link = document.head.appendChild(document.createElement("link"));
+      link.href = file;
+      link.rel = "localization";
+    });
+  }
+
   render() {
     const {props} = this;
     const {content} = props.message;
@@ -9,8 +27,8 @@ export class Trailhead extends React.PureComponent {
     return (<div className="overlay-wrapper show trailhead">
       <div className="trailheadInner">
         <div className="trailheadContent">
-          <h3>{content.title}</h3>
-          <p>{content.subtitle}</p>
+          <h3 data-l10n-id="onboarding-welcome-header" />
+          <p data-l10n-id="onboarding-welcome-body" />
         </div>
         <div className="trailheadCards">
           <div className="onboardingMessageContainer">
@@ -24,9 +42,17 @@ export class Trailhead extends React.PureComponent {
           </div>
         </div>
         <div className="trailheadContent">
-          <h2>{content.ctaHeader}</h2>
-          <p>{content.ctaText}</p>
+          <h2 data-l10n-id="onboarding-membership-form-header" />
+          <input type="email" data-l10n-id="onboarding-membership-form-email" />
+          <p data-l10n-id="onboarding-membership-form-legal-links">
+            <a data-l10n-name="terms"
+              href="https://accounts.firefox.com/legal/terms" />
+            <a data-l10n-name="privacy"
+              href="https://accounts.firefox.com/legal/privacy" />
+          </p>
+          <button data-l10n-id="onboarding-membership-form-continue" />
         </div>
+        <button data-l10n-id="onboarding-start-browsing-button-label" />
       </div>
 
     </div>);

--- a/data/trailhead.ftl
+++ b/data/trailhead.ftl
@@ -1,0 +1,66 @@
+onboarding-welcome-body = You’ve got the browser. Let’s explore the rest of Firefox.
+
+onboarding-membership-form-header = Set Up Your Firefox Membership
+onboarding-membership-form-email =
+    .placeholder = Your email …
+onboarding-membership-form-legal-links = By proceeding, you agree to the <a data-l10n-name="terms">Terms of Service</a> and <a data-l10n-name="privacy">Privacy Notice</a>.
+onboarding-membership-form-continue = Continue
+
+
+## These are individual items shown with an image, title and description.
+
+onboarding-subhead-productive-title = Be productive
+onboarding-subhead-productive-text = Get your everyday done with the browser, features, and apps.
+
+onboarding-subhead-smarter-title = Be a smarter browser
+onboarding-subhead-smarter-text = Get doable advice from world-class experts.
+
+onboarding-subhead-privacy-title = Keep your privacy
+onboarding-subhead-privacy-text = Everything we make honors our Personal Data Pledge to you. We always ask, take less, and keep it safe.
+
+
+## These are individual cards shown with an image, title, description and button with some action.
+
+onboarding-card-tracking-protection-title = Control How You’re Tracked
+onboarding-card-tracking-protection-text = Don’t like when ads follow you around? Firefox helps you control how advertisers track your activity online.
+onboarding-card-tracking-protection-button = Learn More
+
+onboarding-card-data-sync-title = Take Your Settings With You
+onboarding-card-data-sync-text = Sync your bookmarks and passwords everywhere you use Firefox.
+onboarding-card-data-sync-button = Turn on Sync
+
+onboarding-card-firefox-monitor-title = Watch Your Identity
+onboarding-card-firefox-monitor-text = Firefox Monitor keeps track of whether your personal information has been in a publicly reported online data breach.
+onboarding-card-firefox-monitor-button = Sign up for Alerts
+
+onboarding-card-private-browsing-title = Browse Privately
+onboarding-card-private-browsing-text = Private Browsing clears your search and browsing history to keep it secret from anyone who uses your computer.
+onboarding-card-private-browsing-button = Open a Private Window
+
+onboarding-card-firefox-send-title = Keep Your Shared Files Private
+onboarding-card-firefox-send-text = Firefox Send protects the files you share with end-to-end encryption and a link that automatically expires.
+onboarding-card-firefox-send-button = Try Firefox Send
+
+onboarding-card-mobile-phone-title = Get Firefox on Your Phone
+onboarding-card-mobile-phone-text = Download the browser for iOS or Android and sync your data across devices.
+onboarding-card-mobile-phone-button = Download Mobile Browser
+
+onboarding-card-personal-data-title = Privacy is Your Right
+onboarding-card-personal-data-text = Firefox will promise to take less and help keep you safe when it comes to your data. It’s not just a pledge, it’s in our DNA.
+onboarding-card-personal-data-button = Read the Personal Data Pledge
+
+onboarding-card-send-tabs-title = Instantly Send Yourself Tabs
+onboarding-card-send-tabs-text = Send Tabs instantly shares pages between your devices without having to copy, paste, or leave the browser.
+onboarding-card-send-tabs-button = Start Using Send Tabs
+
+onboarding-card-pocket-anywhere-title = Read and Listen Anywhere
+onboarding-card-pocket-anywhere-text = Pocket saves your favorite stories so you can read, listen, and watch during your downtime, even if you’re offline.
+onboarding-card-pocket-anywhere-button = Try Pocket
+
+onboarding-card-lockwise-passwords-title =  Take Your Passwords Everywhere
+onboarding-card-lockwise-passwords-text = Firefox Lockwise creates a single, secure place to store passwords that autofill everywhere you use Firefox.
+onboarding-card-lockwise-passwords-button = Get Firefox Lockwise
+
+onboarding-card-facebook-container-title = Set Boundaries With Facebook
+onboarding-card-facebook-container-text = Facebook Container keeps your Facebook identity separate from everything else, making it harder to track you across the web.
+onboarding-card-facebook-container-button = Add the Extension

--- a/jar.mn
+++ b/jar.mn
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+[localization] en-US.jar:
+  trailhead.ftl (./data/trailhead.ftl)
+
 browser.jar:
 % resource activity-stream %res/activity-stream/ contentaccessible=yes
   res/activity-stream/lib/ (./lib/*)

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -46,16 +46,16 @@ const L10N = new Localization([
   "browser/newtab/onboarding.ftl",
 ]);
 
-function getPlaceholderTrailheadCard(title) {
+function getPlaceholderTrailheadCard(id) {
   return {
     id: "ONBOARDING_2",
     template: "onboarding",
     content: {
-      title,
-      text: "Hello world blah",
+      title: `onboarding-card-${id}-title`,
+      text: `onboarding-card-${id}-text`,
       icon: "screenshots",
       primary_button: {
-        label: "Try now",
+        label: `onboarding-card-${id}-button`,
         action: {
           type: "OPEN_URL",
           data: {args: "https://screenshots.firefox.com/#tour", where: "tabshifted"},
@@ -167,11 +167,7 @@ const ONBOARDING_MESSAGES = async () => ([
     targeting: "localeLanguageCode == 'en' && trailheadCohort > 0",
     trigger: {id: "firstRun"},
     content: {
-      title: "This is not a real thing",
-      subtitle: "It is just a test",
-      ctaHeader: "Join Firefox",
-      ctaText: "Because we're awesome obviously",
-      cards: ["Hello", "World", "Foo"].map(getPlaceholderTrailheadCard),
+      cards: ["tracking-protection", "data-sync", "firefox-monitor"].map(getPlaceholderTrailheadCard),
     },
   },
   {


### PR DESCRIPTION
r?@k88hudson or @rlr Dynamically adds `<link rel=localization>` to activate fluent-dom. Existing onboarding happens to not do anything with the data-l10n-id as nothing is watching for those attributes. Do we need/want to remove the links on unmount? I suppose dismissing with Start Browsing could just hide the modal. Although I suppose we don't want to unnecessarily keep re-adding the links?
![Screen Shot 2019-04-26 at 2 27 47 PM](https://user-images.githubusercontent.com/438537/56837569-c5a22400-682f-11e9-86fc-c6fccc6cc95f.png)

FYI, the strings appear at `resource:///localization/en-US/trailhead.ftl` (note extra /)
