### PR TITLE
(nobug) - Switch existing onboarding to use fluent-dom

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -1,6 +1,12 @@
 import {ModalOverlay} from "../../components/ModalOverlay/ModalOverlay";
 import React from "react";
 
+const FLUENT_FILES = [
+  "branding/brand.ftl",
+  "browser/branding/sync-brand.ftl",
+  "browser/newtab/onboarding.ftl",
+];
+
 export class OnboardingCard extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -26,14 +32,14 @@ export class OnboardingCard extends React.PureComponent {
         <div className={`onboardingMessageImage ${content.icon}`} />
         <div className="onboardingContent">
           <span>
-            <h3 data-l10n-id={content.title}>{content.title}</h3>
-            <p data-l10n-id={content.text}>{content.text}</p>
+            <h3 data-l10n-id={content.title.string_id} />
+            <p data-l10n-id={content.text.string_id} />
           </span>
           <span>
-            <button data-l10n-id={content.primary_button.label}
+            <button data-l10n-id={content.primary_button.label.string_id}
               tabIndex="1"
               className="button onboardingButton"
-              onClick={this.onClick}>{content.primary_button.label}</button>
+              onClick={this.onClick} />
           </span>
         </div>
       </div>
@@ -42,6 +48,14 @@ export class OnboardingCard extends React.PureComponent {
 }
 
 export class OnboardingMessage extends React.PureComponent {
+  componentWillMount() {
+    FLUENT_FILES.forEach(file => {
+      const link = document.head.appendChild(document.createElement("link"));
+      link.href = file;
+      link.rel = "localization";
+    });
+  }
+
   render() {
     const {props} = this;
     const {button_label, header} = props.extraTemplateStrings;

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -227,17 +227,6 @@ const OnboardingMessageProvider = {
         }
       }
 
-      if (msg.template === "onboarding") {
-        const [primary_button_string, title_string, text_string] = await L10N.formatMessages([
-          {id: msg.content.primary_button.label.string_id},
-          {id: msg.content.title.string_id},
-          {id: msg.content.text.string_id, args: msg.content.text.args},
-        ]);
-        translatedMessage.content.primary_button.label = primary_button_string.value;
-        translatedMessage.content.title = title_string.value;
-        translatedMessage.content.text = text_string.value;
-      }
-
       // Translate any secondary buttons separately
       if (msg.content.secondary_button) {
         const [secondary_button_string] = await L10N.formatMessages([{id: msg.content.secondary_button.label.string_id}]);


### PR DESCRIPTION
r?@k88hudson This removes the `L10N.formatMessages` step for onboarding and duplicates the fluent loading for `OnboardingMessage`. Looking at the PR now, I suppose I could have left the messages untouched and grabbed string_id in the OnboardingMessage.jsx instead… Also, see related #4950.