### PR TITLE
Bug 1548353 - Timeout DS fetches after 45 seconds.

### DIFF
--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -146,7 +146,8 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       const controller = new AbortController();
       const {signal} = controller;
       const fetchPromise = fetch(endpoint, {credentials: "omit", signal});
-      const timeoutId = setTimeout(controller.abort, FETCH_TIMEOUT);
+      // istanbul ignore next
+      const timeoutId = setTimeout(() => { controller.abort(); }, FETCH_TIMEOUT);
 
       const response = await fetchPromise;
       if (!response.ok) {

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -5,6 +5,7 @@
 
 const {XPCOMUtils} = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const {NewTabUtils} = ChromeUtils.import("resource://gre/modules/NewTabUtils.jsm");
+const {setTimeout, clearTimeout} = ChromeUtils.import("resource://gre/modules/Timer.jsm");
 const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 ChromeUtils.defineModuleGetter(this, "perfService", "resource://activity-stream/common/PerfService.jsm");
@@ -22,6 +23,7 @@ const DEFAULT_RECS_EXPIRE_TIME = 60 * 60 * 1000; // 1 hour
 const MIN_DOMAIN_AFFINITIES_UPDATE_TIME = 12 * 60 * 60 * 1000; // 12 hours
 const MAX_LIFETIME_CAP = 500; // Guard against misconfiguration on the server
 const DEFAULT_MAX_HISTORY_QUERY_RESULTS = 1000;
+const FETCH_TIMEOUT = 45 * 1000;
 const PREF_CONFIG = "discoverystream.config";
 const PREF_ENDPOINTS = "discoverystream.endpoints";
 const PREF_OPT_OUT = "discoverystream.optOut.0";
@@ -141,10 +143,16 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
         throw new Error(`Not one of allowed prefixes (${allowed})`);
       }
 
-      const response = await fetch(endpoint, {credentials: "omit"});
+      const controller = new AbortController();
+      const {signal} = controller;
+      const fetchPromise = fetch(endpoint, {credentials: "omit", signal});
+      const timeoutId = setTimeout(controller.abort, FETCH_TIMEOUT);
+
+      const response = await fetchPromise;
       if (!response.ok) {
         throw new Error(`Unexpected status (${response.status})`);
       }
+      clearTimeout(timeoutId);
       return response.json();
     } catch (error) {
       Cu.reportError(`Failed to fetch ${endpoint}: ${error.message}`);
@@ -228,19 +236,19 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 
   async loadLayout(sendUpdate, isStartup) {
     let layout = {};
-    if (this.config.hardcoded_layout) {
-      layout = {lastUpdate: Date.now(), ...defaultLayoutResp};
-    } else {
+    if (!this.config.hardcoded_layout) {
       layout = await this.fetchLayout(isStartup);
     }
 
-    if (layout && layout.layout) {
-      sendUpdate({
-        type: at.DISCOVERY_STREAM_LAYOUT_UPDATE,
-        data: layout,
-      });
+    if (!layout || !layout.layout) {
+      layout = {lastUpdate: Date.now(), ...defaultLayoutResp};
     }
-    if (layout && layout.spocs && layout.spocs.url) {
+
+    sendUpdate({
+      type: at.DISCOVERY_STREAM_LAYOUT_UPDATE,
+      data: layout,
+    });
+    if (layout.spocs && layout.spocs.url) {
       sendUpdate({
         type: at.DISCOVERY_STREAM_SPOCS_ENDPOINT,
         data: layout.spocs.url,

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -145,7 +145,7 @@ describe("DiscoveryStreamFeed", () => {
 
       await feed.fetchFromEndpoint("https://getpocket.cdn.mozilla.net/dummy?consumer_key=$apiKey");
 
-      assert.calledWith(fetchStub, "https://getpocket.cdn.mozilla.net/dummy?consumer_key=replaced", {credentials: "omit"});
+      assert.calledWith(fetchStub, "https://getpocket.cdn.mozilla.net/dummy?consumer_key=replaced");
     });
   });
 

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -145,7 +145,7 @@ describe("DiscoveryStreamFeed", () => {
 
       await feed.fetchFromEndpoint("https://getpocket.cdn.mozilla.net/dummy?consumer_key=$apiKey");
 
-      assert.calledWith(fetchStub, "https://getpocket.cdn.mozilla.net/dummy?consumer_key=replaced");
+      assert.calledWithMatch(fetchStub, "https://getpocket.cdn.mozilla.net/dummy?consumer_key=replaced", {credentials: "omit"});
     });
   });
 

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -213,6 +213,15 @@ describe("DiscoveryStreamFeed", () => {
       assert.notCalled(feed.fetchLayout);
       assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey");
     });
+    it("should fetch local layout for invalid layout endpoint or when fetch layout fails", async () => {
+      feed.config.hardcoded_layout = false;
+      fetchStub.resolves({ok: false});
+
+      await feed.loadLayout(feed.store.dispatch, true);
+
+      assert.calledOnce(fetchStub);
+      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey");
+    });
   });
 
   describe("#loadLayoutEndPointUsingPref", () => {


### PR DESCRIPTION
To test.

1. You need something to delay a server response longer than 45 seconds, I made this https://github.com/ScottDowne/fetch-delay after another remote service failed me too many times. You can use something else but for the purposes of these test steps I'll be using the above.
2. After cloning fetch delay, run npm install and node start.js
4. Set this pref `browser.newtabpage.activity-stream.discoverystream.endpoints` to `https,http`
3. In the browser, set this pref `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":false,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"http://localhost:3000/?delay=50&url=https%3A%2F%2Fgetpocket.cdn.mozilla.net%2Fv3%2Fnewtab%2Flayout%3Fversion%3D1%26consumer_key%3D40249-e88c401e1b1f2242d9e441c4%26layout_variant%3Dbasic" }`
5. load a new tab, you should just see search for now.
5. After 45 seconds, the fetch should time out, and it'll default to the local hard coded layout. (Has 7 feeds, starting with recommended by pocket, then Health & Fitness 💪, then tech, etc)
6. now set this pref `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":false,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"http://localhost:3000/?delay=10&url=https%3A%2F%2Fgetpocket.cdn.mozilla.net%2Fv3%2Fnewtab%2Flayout%3Fversion%3D1%26consumer_key%3D40249-e88c401e1b1f2242d9e441c4%26layout_variant%3Dbasic" }`
7. After 10 seconds it should succeed (not timeout) and load basic, which only has 1 feed.

I considered a test to test the abort controller, but after a quick start, I stopped because it felt like I was testing abort controller and not DS.

The only real change here other than the timeout, is if it times out, or fails otherwise, we instead load the hardcoded layout.