### PR TITLE
Bug 1535717 - Update telemetry endpoint for Spocs Fill

### DIFF
--- a/common/Actions.jsm
+++ b/common/Actions.jsm
@@ -296,7 +296,7 @@ function ASRouterUserEvent(data) {
 /**
  * DiscoveryStreamSpocsFill - A telemetry ping indicating a SPOCS Fill event.
  *
- * @param  {object} data Fields to include in the ping (spocs_fills, etc.)
+ * @param  {object} data Fields to include in the ping (spoc_fills, etc.)
  * @param  {int} importContext (For testing) Override the import context for testing.
  * @return {object} An AlsoToMain action
  */

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -844,7 +844,7 @@ this.TelemetryFeed = class TelemetryFeed {
    */
   handleDiscoveryStreamSpocsFill(data) {
     const payload = this.createSpocsFillPing(data);
-    this.sendStructuredIngestionEvent(payload, "spocs-fills", "1");
+    this.sendStructuredIngestionEvent(payload, "spoc-fills", "1");
   }
 
   /**


### PR DESCRIPTION
This is to match the [name change](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/327/files) of the telemetry endpoint for SPOCS Fill.