### PR TITLE
(nobug) - Turn on CFR FxA remote provider

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -215,7 +215,7 @@ const PREFS_CONFIG = new Map([
     title: "Configuration for CFR FxA Messages provider",
     value: JSON.stringify({
       id: "cfr-fxa",
-      enabled: false,
+      enabled: true,
       type: "remote-settings",
       bucket: "cfr-fxa",
       frequency: {custom: [{period: "daily", cap: 1}]},


### PR DESCRIPTION
Let's turn this on since no messages are published yet.