### PR TITLE
Bug 1548268 - Improve accessibility of trailhead flow

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -100,9 +100,9 @@ function templateHTML(options, html) {
     <link rel="stylesheet" href="${options.baseUrl}css/activity-stream.css" />
   </head>
   <body class="activity-stream">
-    <div id="header-asrouter-container"></div>
+    <div id="header-asrouter-container" role="presentation"></div>
     <div id="root">${isPrerendered ? html : "<!-- Regular React Rendering -->"}</div>
-    <div id="footer-asrouter-container"></div>${options.noscripts ? "" : scriptRender}
+    <div id="footer-asrouter-container" role="presentation"></div>${options.noscripts ? "" : scriptRender}
   </body>
 </html>
 `;

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -296,6 +296,7 @@ export class ASRouterUISurface extends React.PureComponent {
     const {message} = this.state;
     if (message.template === "trailhead") {
       return (<Trailhead
+        document={this.props.document}
         message={message}
         onAction={ASRouterUtils.executeAction}
         onDoneButton={this.dismissBundle(this.state.bundle.bundle)}

--- a/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
+++ b/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
@@ -26,7 +26,10 @@ export class ModalOverlayWrapper extends React.PureComponent {
     const {props} = this;
     return (<React.Fragment>
       <div className="modalOverlayOuter active" onClick={props.onClose} role="presentation" />
-      <div className={`modalOverlayInner active ${props.innerClassName || ""}`}>
+      <div className={`modalOverlayInner active ${props.innerClassName || ""}`}
+        aria-labelledby={props.headerId}
+        id={props.id}
+        role="dialog">
         {props.children}
       </div>
     </React.Fragment>);

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -51,6 +51,7 @@ describe("ASRouterUISurface", () => {
     sandbox = sinon.createSandbox();
     headerPortal = document.createElement("div");
     footerPortal = document.createElement("div");
+    sandbox.stub(footerPortal, "querySelector").returns(footerPortal);
     fakeDocument = {
       location: {href: ""},
       _listeners: new Set(),
@@ -70,6 +71,9 @@ describe("ASRouterUISurface", () => {
       },
       removeEventListener(event, listener) {
         this._listeners.delete(listener);
+      },
+      get body() {
+        return document.createElement("body");
       },
       getElementById(id) {
         return id === "header-asrouter-container" ? headerPortal : footerPortal;


### PR DESCRIPTION
r?@rlr Needed to do some document passing to get testing happy. You can test accessibility from devtools to see what a screenreader would "see" so changes here make the stuff behind modal "hidden" and correctly identifies the modal as a "dialog" with header. PR also makes tabbing cycle through just the dialog instead of to cards/topsites/etc behind. I'll rebase on your changes in #4985 as there'll be test merge conflicts.

before (shows cards, search, etc):
![Screen Shot 2019-05-07 at 2 44 22 AM](https://user-images.githubusercontent.com/438537/57290528-73a0a000-7072-11e9-8ae9-301c405a93f1.png)

after (dialog only):
![Screen Shot 2019-05-07 at 2 45 37 AM](https://user-images.githubusercontent.com/438537/57290535-78fdea80-7072-11e9-83fe-a3065319b363.png)
