### PR TITLE
Bug 1549716 - The email input field border wrongly remains red after clearing an invalid email

### DIFF
--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -183,18 +183,28 @@
 
     button,
     input {
-      border: 0;
       width: 100%;
     }
 
     input {
       background-color: $white;
+      border: solid 1px transparent;
+      box-shadow: none;
       color: $grey-70;
       font-size: 15px;
+
+      &.invalid {
+        border-color: $red-60;
+      }
+
+      &.invalid:focus {
+        box-shadow: 0 0 0 3px $email-input-invalid;
+      }
     }
 
     button {
       background-color: $blue-60;
+      border: 0;
       cursor: pointer;
       display: block;
       font-size: 15px;

--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -188,10 +188,20 @@
 
     input {
       background-color: $white;
-      border: solid 1px transparent;
+      border: 1px solid $grey-50;
       box-shadow: none;
       color: $grey-70;
       font-size: 15px;
+      transition: border-color 150ms, box-shadow 150ms;
+
+      &:hover {
+        border-color: $grey-90;
+      }
+
+      &:focus {
+        border-color: $blue-50;
+        box-shadow: 0 0 0 3px $email-input-focus;
+      }
 
       &.invalid {
         border-color: $red-60;


### PR DESCRIPTION
I just realized we dont have any `:focus` styles on the email field. I'm checking with Aaron to see if he wants to add that.