### PR TITLE
Bug 1549846 - Set normandy-targetable string pref for interrupt survey

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -39,6 +39,7 @@ ChromeUtils.defineModuleGetter(this, "Sampling",
 const TRAILHEAD_CONFIG = {
   OVERRIDE_PREF: "trailhead.firstrun.branches",
   DID_SEE_ABOUT_WELCOME_PREF: "trailhead.firstrun.didSeeAboutWelcome",
+  INTERRUPTS_EXPERIMENT_PREF: "trailhead.firstrun.interruptsExperiment",
   BRANCHES: {
     interrupts: [
       ["control"],
@@ -728,6 +729,13 @@ class _ASRouter {
         experiment === "interrupts" ? interrupt : triplet,
         {type: "as-firstrun"}
       );
+
+      // On the first time setting the interrupts experiment, expose the branch
+      // for normandy to target for survey study.
+      if (experiment === "interrupts" &&
+          !Services.prefs.prefHasUserValue(TRAILHEAD_CONFIG.INTERRUPTS_EXPERIMENT_PREF)) {
+        Services.prefs.setStringPref(TRAILHEAD_CONFIG.INTERRUPTS_EXPERIMENT_PREF, interrupt);
+      }
     }
   }
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1530,12 +1530,14 @@ describe("ASRouter", () => {
 
     describe(".setupTrailhead", () => {
       let getBoolPrefStub;
+      let setStringPrefStub;
 
       beforeEach(() => {
         getBoolPrefStub = sandbox.stub(global.Services.prefs, "getBoolPref").withArgs(TRAILHEAD_CONFIG.DID_SEE_ABOUT_WELCOME_PREF).returns(true);
+        setStringPrefStub = sandbox.stub(global.Services.prefs, "setStringPref");
       });
 
-      const configWithExperiment = {experiment: "interrupt", interrupt: "join", triplet: "privacy"};
+      const configWithExperiment = {experiment: "interrupts", interrupt: "join", triplet: "privacy"};
       const configWithoutExperiment = {experiment: "", interrupt: "control", triplet: ""};
 
       it("should generates an experiment/branch configuration and update Router.state", async () => {
@@ -1572,6 +1574,7 @@ describe("ASRouter", () => {
         await Router.setupTrailhead();
 
         assert.calledOnce(global.TelemetryEnvironment.setExperimentActive);
+        assert.calledWith(setStringPrefStub, TRAILHEAD_CONFIG.INTERRUPTS_EXPERIMENT_PREF, "join");
       });
       it("should not set an active experiment if no experiment is defined", async () => {
         sandbox.stub(Router, "_generateTrailheadBranches").resolves(configWithoutExperiment);
@@ -1580,6 +1583,7 @@ describe("ASRouter", () => {
         await Router.setupTrailhead();
 
         assert.notCalled(global.TelemetryEnvironment.setExperimentActive);
+        assert.notCalled(setStringPrefStub);
       });
     });
 


### PR DESCRIPTION
r?@rlr Seems simple enough ? cc @mythmon

Here's some screenshots using user_id from https://bugzilla.mozilla.org/show_bug.cgi?id=1547062#c8

`user_id="1"  {"experiment":"interrupts","interrupt":"nofirstrun"}`
![Screen Shot 2019-05-07 at 2 39 53 PM](https://user-images.githubusercontent.com/438537/57335811-a8dfd900-70d8-11e9-8567-03afd6fdedb0.png)

`user_id="12" {"experiment":"interrupts","interrupt":"cards","triplet":"supercharge"}`
![Screen Shot 2019-05-07 at 2 41 04 PM](https://user-images.githubusercontent.com/438537/57335833-bb5a1280-70d8-11e9-8699-542912f46e5e.png)
