### PR TITLE
Port 1549906 - Use brandings.ftl to allow OnboardingMessageProvider.jsm to use new strings

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -42,6 +42,7 @@ async function getAddonInfo() {
 
 const L10N = new Localization([
   "branding/brand.ftl",
+  "browser/branding/brandings.ftl",
   "browser/branding/sync-brand.ftl",
   "browser/newtab/onboarding.ftl",
 ]);


### PR DESCRIPTION
This isn't needed for current export and it actually makes us do an additional change in the next export reverting  https://hg.mozilla.org/mozilla-central/rev/c688fc5b2c0b

We'll want this as part of the uplift to avoid needing the all_files_referenced change as part of the uplift.