### PR TITLE
Bug 1550053 - Fix busted topsites and topstores configs enable/disable

### DIFF
--- a/content-src/lib/selectLayoutRender.js
+++ b/content-src/lib/selectLayoutRender.js
@@ -99,13 +99,13 @@ export const selectLayoutRender = (state, prefs, rickRollCache) => {
 
   const renderLayout = () => {
     const renderedLayoutArray = [];
-    for (const row of layout.filter(r => r.components.length)) {
+    for (const row of layout.filter(r => r.components.filter(c => !filterArray.includes(c.type)).length)) {
       let components = [];
       renderedLayoutArray.push({
         ...row,
         components,
       });
-      for (const component of row.components.filter(c => !filterArray.includes(c.type))) {
+      for (const component of row.components) {
         if (component.feed) {
           const spocsConfig = component.spocs;
           // Are we still waiting on a feed/spocs, render what we have, and bail out early.

--- a/test/unit/content-src/lib/selectLayoutRender.test.js
+++ b/test/unit/content-src/lib/selectLayoutRender.test.js
@@ -353,4 +353,23 @@ describe("selectLayoutRender", () => {
 
     assert.deepEqual(layoutRender[0].components[2].data.recommendations[0], {name: "rec", pos: 0});
   });
+  it("should not render a row if no components exist after filter in that row", () => {
+    const fakeLayout = [{
+      width: 3,
+      components: [
+        {type: "TopSites"},
+      ],
+    }, {
+      width: 3,
+      components: [
+        {type: "Message"},
+      ],
+    }];
+    store.dispatch({type: at.DISCOVERY_STREAM_LAYOUT_UPDATE, data: {layout: fakeLayout}});
+
+    const {layoutRender} = selectLayoutRender(store.getState().DiscoveryStream, {"feeds.topsites": true}, []);
+
+    assert.equal(layoutRender[0].components[0].type, "TopSites");
+    assert.equal(layoutRender[1], undefined);
+  });
 });


### PR DESCRIPTION
To test:

Turn off either topsites, or topstores, by clicking the gear in the topright of about:home

It should disable either of those, but display the other one, and not look broken.

If you see "Oops, something went wrong loading this content.
Refresh page to try again." or a topstories message title with no topstories, it's broken.