### PR TITLE
(nobug) - Have ratioSample resolve 0 instead of return 0

### DIFF
--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -286,7 +286,7 @@ const TEST_GLOBAL = {
   },
   Sampling: {
     ratioSample(seed, ratios) {
-      return 0;
+      return Promise.resolve(0);
     },
   },
 };


### PR DESCRIPTION
Ran into this test failure when rebasing onto beta. Looks like some dependency was stricter back then even though `await 0` is valid.
```
You may only yield a function, promise, generator, array, or object, but the following was passed: "0"
```