### PR TITLE
Bug 1550438 - Return-to-AMO strings need to be formatted

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -485,6 +485,16 @@ const OnboardingMessageProvider = {
         } catch (e) {
           continue;
         }
+
+        // We know we want to show this message, so translate message strings
+        const [primary_button_string, title_string, text_string] = await L10N.formatMessages([
+          {id: msg.content.primary_button.label.string_id},
+          {id: msg.content.title.string_id},
+          {id: msg.content.text.string_id, args: msg.content.text.args},
+        ]);
+        translatedMessage.content.primary_button.label = primary_button_string.value;
+        translatedMessage.content.title = title_string.value;
+        translatedMessage.content.text = text_string.value;
       }
 
       // Translate any secondary buttons separately


### PR DESCRIPTION
r?@piatra Restores the code that was moved into incorrect `template === "onboarding"` condition.

Reuses the existing ` if (msg.template === "return_to_amo_overlay") {`

before:
![Screen Shot 2019-05-09 at 3 07 14 AM](https://user-images.githubusercontent.com/438537/57446603-ed1ec680-7209-11e9-9f35-f7f1df92f6a8.png)

after:
![Screen Shot 2019-05-09 at 3 06 45 AM](https://user-images.githubusercontent.com/438537/57446607-f019b700-7209-11e9-8e9c-1a539f386009.png)
