### PR TITLE
Bug 1417163 - Show ellipsis at end of long title and description texts with line-clamp

### DIFF
--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -10,7 +10,10 @@
 
 // Note: lineHeight and fontSize should be unitless but can be derived from pixel values
 @mixin limit-visibile-lines($line-count, $line-height, $font-size) {
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
   font-size: $font-size * 1px;
+  -webkit-line-clamp: $line-count;
   line-height: $line-height * 1px;
   max-height: 1em * $line-count * $line-height / $font-size;
   overflow: hidden;


### PR DESCRIPTION
r?@gvn or @punamdahiya This adds the ellipsis while not touching the existing behavior. Seems like there's potential for cleanup but maybe do that later? Notably split apart the dual aspect of this mixin in setting font size as well as limiting lines.

before:
![Screen Shot 2019-05-09 at 10 06 22 AM](https://user-images.githubusercontent.com/438537/57473309-65a27900-7244-11e9-9226-1c9754a57412.png)

after:
![Screen Shot 2019-05-09 at 10 05 56 AM](https://user-images.githubusercontent.com/438537/57473317-69360000-7244-11e9-9535-37641a3c8d2a.png)
