### PR TITLE
Bug 1550566 - Retrieve `deviceID` parameter from FxA metrics endpoint and append as additional query parameter for FxA flows

### DIFF
--- a/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
@@ -18,6 +18,7 @@ export class _StartupOverlay extends React.PureComponent {
     this.state = {
       emailInput: "",
       overlayRemoved: false,
+      deviceId: "",
       flowId: "",
       flowBeginTime: 0,
     };
@@ -31,8 +32,8 @@ export class _StartupOverlay extends React.PureComponent {
         const fxaParams = "entrypoint=activity-stream-firstrun&form_type=email";
         const response = await fetch(`${this.props.fxa_endpoint}/metrics-flow?${fxaParams}&${this.utmParams}`, {credentials: "omit"});
         if (response.status === 200) {
-          const {flowId, flowBeginTime} = await response.json();
-          this.setState({flowId, flowBeginTime});
+          const {deviceId, flowId, flowBeginTime} = await response.json();
+          this.setState({deviceId, flowId, flowBeginTime});
         } else {
           this.props.dispatch(ac.OnlyToMain({type: at.TELEMETRY_UNDESIRED_EVENT, data: {event: "FXA_METRICS_FETCH_ERROR", value: response.status}}));
         }
@@ -132,6 +133,7 @@ export class _StartupOverlay extends React.PureComponent {
                 <input name="utm_campaign" type="hidden" value="firstrun" />
                 <input name="utm_medium" type="hidden" value="referral" />
                 <input name="utm_term" type="hidden" value="trailhead-control" />
+                <input name="device_id" type="hidden" value={this.state.deviceId} />
                 <input name="flow_id" type="hidden" value={this.state.flowId} />
                 <input name="flow_begin_time" type="hidden" value={this.state.flowBeginTime} />
                 <span className="error">{this.props.intl.formatMessage({id: "firstrun_invalid_input"})}</span>

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -38,10 +38,12 @@ export class _Trailhead extends React.PureComponent {
       isModalOpen: true,
       showCardPanel: true,
       showCards: false,
+      // The params below are for FxA metrics
+      deviceId: "",
       flowId: "",
       flowBeginTime: 0,
     };
-    this.didFetch = false;
+    this.fxaMetricsInitialized = false;
   }
 
   get dialog() {
@@ -55,15 +57,15 @@ export class _Trailhead extends React.PureComponent {
       link.rel = "localization";
     });
 
-    if (this.props.fxaEndpoint && !this.didFetch) {
+    if (this.props.fxaEndpoint && !this.fxaMetricsInitialized) {
       try {
-        this.didFetch = true;
+        this.fxaMetricsInitialized = true;
         const url = new URL(`${this.props.fxaEndpoint}/metrics-flow?entrypoint=activity-stream-firstrun&form_type=email`);
         this.addUtmParams(url);
         const response = await fetch(url, {credentials: "omit"});
         if (response.status === 200) {
-          const {flowId, flowBeginTime} = await response.json();
-          this.setState({flowId, flowBeginTime});
+          const {deviceId, flowId, flowBeginTime} = await response.json();
+          this.setState({deviceId, flowId, flowBeginTime});
         } else {
           this.props.dispatch(ac.OnlyToMain({type: at.TELEMETRY_UNDESIRED_EVENT, data: {event: "FXA_METRICS_FETCH_ERROR", value: response.status}}));
         }
@@ -194,6 +196,7 @@ export class _Trailhead extends React.PureComponent {
       this.addUtmParams(url, true);
 
       if (action.addFlowParams) {
+        url.searchParams.append("device_id", this.state.deviceId);
         url.searchParams.append("flow_id", this.state.flowId);
         url.searchParams.append("flow_begin_time", this.state.flowBeginTime);
       }
@@ -243,6 +246,7 @@ export class _Trailhead extends React.PureComponent {
             <input name="utm_source" type="hidden" value="activity-stream" />
             <input name="utm_campaign" type="hidden" value="firstrun" />
             <input name="utm_term" type="hidden" value={utm_term} />
+            <input name="device_id" type="hidden" value={this.state.deviceId} />
             <input name="flow_id" type="hidden" value={this.state.flowId} />
             <input name="flow_begin_time" type="hidden" value={this.state.flowBeginTime} />
             <input name="style" type="hidden" value="trailhead" />

--- a/test/unit/asrouter/templates/Trailhead.test.jsx
+++ b/test/unit/asrouter/templates/Trailhead.test.jsx
@@ -93,13 +93,14 @@ describe("<Trailhead>", () => {
       data: {args: "https://example.com/path?foo=bar"},
     };
     wrapper.setState({
+      deviceId: "abc",
       flowId: "123",
       flowBeginTime: 456,
     });
     wrapper.instance().onCardAction(action);
     assert.calledOnce(onAction);
     const url = onAction.firstCall.args[0].data.args;
-    assert.equal(url, "https://example.com/path?foo=bar&utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card&flow_id=123&flow_begin_time=456");
+    assert.equal(url, "https://example.com/path?foo=bar&utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card&device_id=abc&flow_id=123&flow_begin_time=456");
   });
 
   it("should keep focus in dialog when blurring start button", () => {


### PR DESCRIPTION
new form:
<img width="904" alt="Screen Shot 2019-05-10 at 7 41 40 AM" src="https://user-images.githubusercontent.com/36629/57525090-c3dc6400-72f7-11e9-86dd-1275005d98be.png">

old form:
<img width="876" alt="Screen Shot 2019-05-10 at 7 43 27 AM" src="https://user-images.githubusercontent.com/36629/57525092-c6d75480-72f7-11e9-8f1f-7090c3764848.png">
