### PR TITLE
Bug 1551832 - Onboarding button label not wrapping

### DIFF
--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -371,9 +371,10 @@
     color: var(--newtab-text-conditional-color);
     background: var(--trailhead-card-button-background-color);
     border: 0;
-    height: 30px;
+    margin: 30px;
     min-width: 70%;
-    padding: 0 14px;
+    padding: 6px 14px;
+    white-space: pre-wrap;
 
     &:focus,
     &:hover {
@@ -391,7 +392,6 @@
   }
 
   .onboardingButtonContainer {
-    height: 60px;
     position: absolute;
     bottom: 0;
     left: 0;

--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -371,7 +371,7 @@
     color: var(--newtab-text-conditional-color);
     background: var(--trailhead-card-button-background-color);
     border: 0;
-    margin: 30px;
+    margin: 14px;
     min-width: 70%;
     padding: 6px 14px;
     white-space: pre-wrap;
@@ -393,7 +393,7 @@
 
   .onboardingButtonContainer {
     position: absolute;
-    bottom: 0;
+    bottom: 16px;
     left: 0;
     width: 100%;
     text-align: center;


### PR DESCRIPTION
r?@rlr or @k88hudson I tried to maintain the existing single-line button positioning/sizing/spacing. You can test this by changing onboarding.ftl:
```
onboarding-send-tabs-button =
  Commencer à utiliser
  « Envoyer l’onglet »
```
Before:
![Screen Shot 2019-05-15 at 9 49 59 AM](https://user-images.githubusercontent.com/438537/57794864-78f88d00-76f9-11e9-8721-2fe27efd865e.png)


After:
![Screen Shot 2019-05-15 at 9 53 29 AM](https://user-images.githubusercontent.com/438537/57794858-75fd9c80-76f9-11e9-9d39-f922e4d72c80.png)
