### PR TITLE
Bug 1550217 - Pref on Trailhead with desired experimentation for 67.0.5

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -58,9 +58,9 @@ const TRAILHEAD_CONFIG = {
   },
   LOCALES: ["en-US", "en-GB", "en-CA", "de", "de-DE", "fr", "fr-FR"],
   EXPERIMENT_RATIOS: [
-    ["", 1],
+    ["", 0],
     ["interrupts", 1],
-    ["triplets", 1],
+    ["triplets", 3],
   ],
 };
 


### PR DESCRIPTION
r?@rlr or @k88hudson Based on the information from

https://bugzilla.mozilla.org/show_bug.cgi?id=1548072#c5
"interrupts": `we decided to enrol 25% of new profiles for 4 weeks`

https://bugzilla.mozilla.org/show_bug.cgi?id=1549895#c1
"triplets": `the 75% of new clients who aren't enrolled in bug 1548072`

I did ni?felix just to double check but will probably be out until Tuesday.