### PR TITLE
Bug 1531734 - Remove pref migration code in FFx69

### DIFF
--- a/lib/ASRouterPreferences.jsm
+++ b/lib/ASRouterPreferences.jsm
@@ -17,11 +17,6 @@ const DEFAULT_STATE = {
   _devtoolsPref: DEVTOOLS_PREF,
 };
 
-const MIGRATE_PREFS = [
-  // Old pref, New pref
-  ["browser.newtabpage.activity-stream.asrouter.userprefs.cfr", "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons"],
-];
-
 const USER_PREFERENCES = {
   snippets: "browser.newtabpage.activity-stream.feeds.snippets",
   cfrAddons: "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons",
@@ -64,24 +59,6 @@ class _ASRouterPreferences {
       }
       return filtered;
     }, []);
-  }
-
-  // XXX Bug 1531734
-  // Required for 67 when the pref change will happen
-  _migratePrefs() {
-    for (let [oldPref, newPref] of MIGRATE_PREFS) {
-      if (!Services.prefs.prefHasUserValue(oldPref)) {
-        continue;
-      }
-      if (Services.prefs.prefHasUserValue(newPref)) {
-        Services.prefs.clearUserPref(oldPref);
-        continue;
-      }
-      // If the pref was user modified we assume it was set to false
-      const oldValue = Services.prefs.getBoolPref(oldPref, false);
-      Services.prefs.clearUserPref(oldPref);
-      Services.prefs.setBoolPref(newPref, oldValue);
-    }
   }
 
   get providers() {
@@ -168,7 +145,6 @@ class _ASRouterPreferences {
     if (this._initialized) {
       return;
     }
-    this._migratePrefs();
     Services.prefs.addObserver(this._providerPrefBranch, this);
     Services.prefs.addObserver(this._devtoolsPref, this);
     for (const id of Object.keys(USER_PREFERENCES)) {

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -368,7 +368,6 @@ this.ActivityStream = class ActivityStream {
 
   init() {
     try {
-      this._migratePrefs();
       this._updateDynamicPrefs();
       this._defaultPrefs.init();
 
@@ -420,29 +419,6 @@ this.ActivityStream = class ActivityStream {
     // Give the callback the current value then clear the pref
     cbIfNotDefault(Services.prefs[prefGetter](oldPrefName));
     Services.prefs.clearUserPref(oldPrefName);
-  }
-
-  _migratePrefs() {
-    // Do a one time migration of Tiles about:newtab prefs that have been modified
-    this._migratePref("browser.newtabpage.rows", rows => {
-      // Just disable top sites if rows are not desired
-      if (rows <= 0) {
-        Services.prefs.setBoolPref("browser.newtabpage.activity-stream.feeds.topsites", false);
-      } else {
-        Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesRows", rows);
-      }
-    });
-
-    this._migratePref("browser.newtabpage.activity-stream.showTopSites", value => {
-      if (value === false) {
-        Services.prefs.setBoolPref("browser.newtabpage.activity-stream.feeds.topsites", false);
-      }
-    });
-
-    // Old activity stream topSitesCount pref showed 6 per row
-    this._migratePref("browser.newtabpage.activity-stream.topSitesCount", count => {
-      Services.prefs.setIntPref("browser.newtabpage.activity-stream.topSitesRows", Math.ceil(count / 6));
-    });
   }
 
   uninit() {

--- a/lib/PrefsFeed.jsm
+++ b/lib/PrefsFeed.jsm
@@ -14,17 +14,6 @@ ChromeUtils.defineModuleGetter(this, "PrivateBrowsingUtils",
 ChromeUtils.defineModuleGetter(this, "AppConstants",
   "resource://gre/modules/AppConstants.jsm");
 
-// List of prefs that require migration to indexedDB.
-// Object key is the name of the pref in indexedDB, each will contain a
-// map (key: name of preference to migrate, value: name of component).
-const PREF_MIGRATION = {
-  collapsed: new Map([
-    ["collapseTopSites", "topsites"],
-    ["section.highlights.collapsed", "highlights"],
-    ["section.topstories.collapsed", "topstories"],
-  ]),
-};
-
 this.PrefsFeed = class PrefsFeed {
   constructor(prefMap) {
     this._prefMap = prefMap;
@@ -52,20 +41,6 @@ this.PrefsFeed = class PrefsFeed {
     }
 
     this._checkPrerender(name);
-  }
-
-  _migratePrefs() {
-    for (const indexedDBPref of Object.keys(PREF_MIGRATION)) {
-      for (const migratePref of PREF_MIGRATION[indexedDBPref].keys()) {
-        // Check if pref exists (if the user changed the default)
-        if (this._prefs.get(migratePref, null) === true) {
-          const data = {id: PREF_MIGRATION[indexedDBPref].get(migratePref), value: {}};
-          data.value[indexedDBPref] = true;
-          this.store.dispatch(ac.OnlyToMain({type: at.UPDATE_SECTION_PREFS, data}));
-          this._prefs.reset(migratePref);
-        }
-      }
-    }
   }
 
   init() {
@@ -104,7 +79,6 @@ this.PrefsFeed = class PrefsFeed {
     // Set the initial state of all prefs in redux
     this.store.dispatch(ac.BroadcastToContent({type: at.PREFS_INITIAL_VALUES, data: values}));
 
-    this._migratePrefs();
     this._setPrerenderPref();
   }
 

--- a/test/unit/asrouter/ASRouterPreferences.test.js
+++ b/test/unit/asrouter/ASRouterPreferences.test.js
@@ -289,40 +289,4 @@ describe("ASRouterPreferences", () => {
       assert.notCalled(callback);
     });
   });
-  describe("_migratePrefs", () => {
-    beforeEach(() => {
-      sandbox.stub(global.Services.prefs, "setBoolPref");
-      sandbox.stub(global.Services.prefs, "clearUserPref");
-    });
-    it("should not do anything if userpref was not modified", () => {
-      ASRouterPreferences.init();
-
-      assert.notCalled(global.Services.prefs.getBoolPref);
-      assert.notCalled(global.Services.prefs.setBoolPref);
-    });
-    it("should not do migration if newPref was modified", () => {
-      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
-
-      ASRouterPreferences.init();
-
-      assert.notCalled(global.Services.prefs.getBoolPref);
-      assert.notCalled(global.Services.prefs.setBoolPref);
-      assert.calledOnce(global.Services.prefs.clearUserPref);
-      assert.calledWith(global.Services.prefs.clearUserPref, "browser.newtabpage.activity-stream.asrouter.userprefs.cfr");
-    });
-    it("should migrate userprefs.cfr", () => {
-      const hasUserValueStub = sandbox.stub(global.Services.prefs, "prefHasUserValue");
-      hasUserValueStub.onCall(0).returns(true);
-      hasUserValueStub.returns(false);
-
-      ASRouterPreferences.init();
-
-      assert.calledOnce(global.Services.prefs.getBoolPref);
-      assert.calledWith(global.Services.prefs.getBoolPref, "browser.newtabpage.activity-stream.asrouter.userprefs.cfr");
-      assert.calledOnce(global.Services.prefs.setBoolPref);
-      assert.calledWith(global.Services.prefs.setBoolPref, CFR_USER_PREF_ADDONS, false);
-      assert.calledOnce(global.Services.prefs.clearUserPref);
-      assert.calledWith(global.Services.prefs.clearUserPref, "browser.newtabpage.activity-stream.asrouter.userprefs.cfr");
-    });
-  });
 });

--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -68,11 +68,6 @@ describe("ActivityStream", () => {
       const [, , action] = as.store.init.firstCall.args;
       assert.equal(action.type, "UNINIT");
     });
-    it("should call _migratePrefs on init", () => {
-      sandbox.stub(as, "_migratePrefs");
-      as.init();
-      assert.calledOnce(as._migratePrefs);
-    });
   });
   describe("#uninit", () => {
     beforeEach(() => {
@@ -145,55 +140,7 @@ describe("ActivityStream", () => {
       assert.instanceOf(feed, Fake);
     });
   });
-  describe("_migratePrefs and _migratePref", () => {
-    it("should migrate the correct prefs", () => {
-      sandbox.stub(as, "_migratePref");
-      as._migratePrefs();
-      // pref names we want to migrate
-      assert.calledWith(as._migratePref.firstCall, "browser.newtabpage.rows");
-      assert.calledWith(as._migratePref.secondCall, "browser.newtabpage.activity-stream.showTopSites");
-      assert.calledWith(as._migratePref.thirdCall, "browser.newtabpage.activity-stream.topSitesCount");
-    });
-    it("should properly set the new value for browser.newtabpage.rows migration", () => {
-      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
-      sandbox.stub(global.Services.prefs, "getPrefType").returns("integer");
-      sandbox.stub(global.Services.prefs, "getIntPref").returns(10);
-      sandbox.stub(global.Services.prefs, "setIntPref");
-      as._migratePrefs();
-      // Set new pref with value of old pref 'browser.newtabpage.rows'
-      assert.calledWith(global.Services.prefs.setIntPref, "browser.newtabpage.activity-stream.topSitesRows", 10);
-
-      global.Services.prefs.getIntPref.returns(0);
-      sandbox.stub(global.Services.prefs, "setBoolPref");
-      as._migratePrefs();
-      // Turn off top sites feed if 'browser.newtabpage.rows' was <= 0
-      assert.calledWith(global.Services.prefs.setBoolPref, "browser.newtabpage.activity-stream.feeds.topsites", false);
-    });
-    it("should properly set the new value for browser.newtabpage.activity-stream.showTopSites migration", () => {
-      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
-      sandbox.stub(global.Services.prefs, "getPrefType").returns("boolean");
-      sandbox.stub(global.Services.prefs, "getBoolPref").returns(true);
-      sandbox.stub(global.Services.prefs, "setBoolPref");
-      as._migratePrefs();
-      // If top sites should be shown, do nothing during migration
-      assert.notCalled(global.Services.prefs.setBoolPref);
-
-      global.Services.prefs.getBoolPref.returns(false);
-      as._migratePrefs();
-      // If top sites has been turned off, turn the top sites feed off too
-      assert.calledWith(global.Services.prefs.setBoolPref, "browser.newtabpage.activity-stream.feeds.topsites", false);
-    });
-    it("should properly set the new value for browser.newtabpage.activity-stream.topSitesCount migration", () => {
-      const count = 40;
-      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
-      sandbox.stub(global.Services.prefs, "getPrefType").returns("integer");
-      sandbox.stub(global.Services.prefs, "getIntPref").returns(count);
-      sandbox.stub(global.Services.prefs, "setIntPref");
-      const expectedCount = Math.ceil(count / 6);
-      as._migratePrefs();
-      // If topSitesCount has been modified, calculate how many rows of top sites to show
-      assert.calledWith(global.Services.prefs.setIntPref, "browser.newtabpage.activity-stream.topSitesRows", expectedCount);
-    });
+  describe("_migratePref", () => {
     it("should migrate a pref if the user has set a custom value", () => {
       sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
       sandbox.stub(global.Services.prefs, "getPrefType").returns("integer");

--- a/test/unit/lib/PrefsFeed.test.js
+++ b/test/unit/lib/PrefsFeed.test.js
@@ -195,32 +195,4 @@ describe("PrefsFeed", () => {
       assert.calledWith(feed._prefs.set, PRERENDER_PREF_NAME, false);
     });
   });
-  describe("migration code", () => {
-    it("should migrate prefs on init", async () => {
-      sandbox.stub(feed, "_migratePrefs");
-
-      await feed.init();
-
-      assert.calledOnce(feed._migratePrefs);
-    });
-    it("should migrate user set values", () => {
-      FAKE_PREFS.set("collapseTopSites", true);
-
-      feed._migratePrefs();
-
-      assert.calledOnce(feed.store.dispatch);
-      assert.calledWithExactly(feed.store.dispatch, ac.OnlyToMain({
-        type: at.UPDATE_SECTION_PREFS,
-        data: {id: "topsites", value: {collapsed: true}},
-      }));
-    });
-    it("should reset any migrated prefs", () => {
-      FAKE_PREFS.set("collapseTopSites", true);
-
-      feed._migratePrefs();
-
-      assert.calledOnce(feed._prefs.reset);
-      assert.calledWithExactly(feed._prefs.reset, "collapseTopSites");
-    });
-  });
 });


### PR DESCRIPTION
I've additionally remove 
* `browser.newtabpage.rows` pref migration (this landed in Firefox 63) https://bugzilla.mozilla.org/show_bug.cgi?id=1474411
* `collapsed*` pref migration (This landed in Firefox 61) https://bugzilla.mozilla.org/show_bug.cgi?id=1445157

I can revert them if it still makes sense to keep them around.