### PR TITLE
Bug 1550115 - Include impression id to spoc request.

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -237,6 +237,7 @@ const PREFS_CONFIG = new Map([
         show_spocs: showSpocs({geo}),
         hardcoded_layout: true,
         personalized: false,
+        adserver: false,
         // This is currently an exmple layout used for dev purposes.
         layout_endpoint: "https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=basic",
       });

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -237,7 +237,6 @@ const PREFS_CONFIG = new Map([
         show_spocs: showSpocs({geo}),
         hardcoded_layout: true,
         personalized: false,
-        adserver: false,
         // This is currently an exmple layout used for dev purposes.
         layout_endpoint: "https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=basic",
       });

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -406,11 +406,15 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
         const headers = new Headers();
         headers.append("content-type", "application/json");
 
+        const apiKeyPref = this._prefCache.config.api_key_pref;
+        const apiKey = Services.prefs.getCharPref(apiKeyPref, "");
+
         const spocsResponse = await this.fetchFromEndpoint(endpoint, {
           method: "POST",
           headers,
           body: JSON.stringify({
             pocket_id: this._impressionId,
+            consumer_key: apiKey,
           }),
         });
 
@@ -1041,7 +1045,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 
 defaultLayoutResp = {
   "spocs": {
-    "url": "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey",
+    "url": "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs",
     "spocs_per_domain": 1,
   },
   "layout": [

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -398,7 +398,6 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
         const rawEndpoint = this.store.getState().DiscoveryStream.spocs.spocs_endpoint;
         const start = perfService.absNow();
         const endpoint = rawEndpoint.replace("$impressionId", this._impressionId);
-        console.log(endpoint);
         const spocsResponse = await this.fetchFromEndpoint(endpoint);
         if (spocsResponse) {
           this.spocsRequestTime = Math.round(perfService.absNow() - start);

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -132,7 +132,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     this._prefCache = {};
   }
 
-  async fetchFromEndpoint(rawEndpoint) {
+  async fetchFromEndpoint(rawEndpoint, init = {}) {
     if (!rawEndpoint) {
       Cu.reportError("Tried to fetch endpoint but none was configured.");
       return null;
@@ -155,7 +155,11 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 
       const controller = new AbortController();
       const {signal} = controller;
-      const fetchPromise = fetch(endpoint, {credentials: "omit", signal});
+      const fetchPromise = fetch(endpoint, {
+        ...init,
+        credentials: "omit",
+        signal,
+      });
       // istanbul ignore next
       const timeoutId = setTimeout(() => { controller.abort(); }, FETCH_TIMEOUT);
 
@@ -398,7 +402,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
         const rawEndpoint = this.store.getState().DiscoveryStream.spocs.spocs_endpoint;
         const start = perfService.absNow();
         const endpoint = rawEndpoint.replace("$impressionId", this._impressionId);
-        const spocsResponse = await this.fetchFromEndpoint(endpoint);
+        const spocsResponse = await this.fetchFromEndpoint(endpoint, {method: "POST"});
         if (spocsResponse) {
           this.spocsRequestTime = Math.round(perfService.absNow() - start);
           spocs = {

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -399,10 +399,20 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     if (this.showSpocs) {
       spocs = cachedData.spocs;
       if (this.isExpired({cachedData, key: "spocs", isStartup})) {
-        const rawEndpoint = this.store.getState().DiscoveryStream.spocs.spocs_endpoint;
+        const endpoint = this.store.getState().DiscoveryStream.spocs.spocs_endpoint;
         const start = perfService.absNow();
-        const endpoint = rawEndpoint.replace("$impressionId", this._impressionId);
-        const spocsResponse = await this.fetchFromEndpoint(endpoint, {method: "POST"});
+
+        const headers = new Headers();
+        headers.append("content-type", "application/json");
+
+        const spocsResponse = await this.fetchFromEndpoint(endpoint, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            impression_id: this._impressionId,
+          }),
+        });
+
         if (spocsResponse) {
           this.spocsRequestTime = Math.round(perfService.absNow() - start);
           spocs = {
@@ -1030,7 +1040,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 
 defaultLayoutResp = {
   "spocs": {
-    "url": "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey&impression_id=$impressionId",
+    "url": "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey",
     "spocs_per_domain": 1,
   },
   "layout": [

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -132,7 +132,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     this._prefCache = {};
   }
 
-  async fetchFromEndpoint(rawEndpoint, init = {}) {
+  async fetchFromEndpoint(rawEndpoint, options = {}) {
     if (!rawEndpoint) {
       Cu.reportError("Tried to fetch endpoint but none was configured.");
       return null;
@@ -155,8 +155,11 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 
       const controller = new AbortController();
       const {signal} = controller;
+
       const fetchPromise = fetch(endpoint, {
-        ...init,
+        method: options.method || "GET",
+        body: options.body,
+        headers: options.headers,
         credentials: "omit",
         signal,
       });

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -157,9 +157,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       const {signal} = controller;
 
       const fetchPromise = fetch(endpoint, {
-        method: options.method || "GET",
-        body: options.body,
-        headers: options.headers,
+        ...options,
         credentials: "omit",
         signal,
       });

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -53,7 +53,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     let impressionId = Services.prefs.getCharPref(PREF_IMPRESSION_ID, "");
     if (!impressionId) {
       impressionId = String(gUUIDGenerator.generateUUID());
-      Services.prefs.getCharPref(PREF_IMPRESSION_ID, impressionId);
+      Services.prefs.setCharPref(PREF_IMPRESSION_ID, impressionId);
     }
     return impressionId;
   }

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -410,7 +410,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
           method: "POST",
           headers,
           body: JSON.stringify({
-            impression_id: this._impressionId,
+            pocket_id: this._impressionId,
           }),
         });
 

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -12,6 +12,8 @@ const REC_IMPRESSION_TRACKING_PREF = "discoverystream.rec.impressions";
 const THIRTY_MINUTES = 30 * 60 * 1000;
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000; // 1 week
 
+const FAKE_UUID = "{foo-123-foo}";
+
 describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
   let DiscoveryStreamFeed;
   let feed;
@@ -63,6 +65,9 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
       "lib/UserDomainAffinityProvider.jsm": {UserDomainAffinityProvider: FakeUserDomainAffinityProvider},
     }));
 
+    globals = new GlobalOverrider();
+    globals.set("gUUIDGenerator", {generateUUID: () => FAKE_UUID});
+
     // Feed
     feed = new DiscoveryStreamFeed();
     feed.store = createStore(combineReducers(reducers), {
@@ -79,6 +84,7 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
 
     globals = new GlobalOverrider();
     globals.set("setTimeout", callback => { callback(); });
+
     fakeNewTabUtils = {
       blockedLinks: {
         links: [],

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -83,7 +83,6 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
 
     sandbox.stub(feed, "_maybeUpdateCachedData").resolves();
 
-    globals = new GlobalOverrider();
     globals.set("setTimeout", callback => { callback(); });
 
     fakeNewTabUtils = {

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -155,6 +155,40 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
 
       assert.calledWithMatch(fetchStub, "https://getpocket.cdn.mozilla.net/dummy?consumer_key=replaced", {credentials: "omit"});
     });
+    it("should allow POST and with other options", async () => {
+      await feed.fetchFromEndpoint("https://getpocket.cdn.mozilla.net/dummy", {
+        method: "POST",
+        body: "{}"
+      });
+
+      assert.calledWithMatch(fetchStub, "https://getpocket.cdn.mozilla.net/dummy", {
+        credentials: "omit",
+        method: "POST",
+        body: "{}",
+      });
+    });
+  });
+
+  describe("#getOrCreateImpressionId", () => {
+    it.only("should create impression id in constructor", async () => {
+      assert.equal(feed._impressionId, FAKE_UUID);
+    });
+    it.only("should create impression id if none exists", async () => {
+      sandbox.stub(global.Services.prefs, "setCharPref").returns();
+
+      const result = feed.getOrCreateImpressionId();
+
+      assert.equal(result, FAKE_UUID);
+      assert.calledOnce(global.Services.prefs.setCharPref);
+    });
+    it.only("should use impression id if exists", async () => {
+      sandbox.stub(global.Services.prefs, "getCharPref").returns("from get");
+
+      const result = feed.getOrCreateImpressionId();
+
+      assert.equal(result, "from get");
+      assert.calledOnce(global.Services.prefs.getCharPref);
+    });
   });
 
   describe("#loadLayout", () => {

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -63,6 +63,7 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
       DiscoveryStreamFeed,
     } = injector({
       "lib/UserDomainAffinityProvider.jsm": {UserDomainAffinityProvider: FakeUserDomainAffinityProvider},
+      "lib/TelemetryFeed.jsm": {PREF_IMPRESSION_ID: "fake-pref-impression-id"},
     }));
 
     globals = new GlobalOverrider();

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -158,7 +158,7 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
     it("should allow POST and with other options", async () => {
       await feed.fetchFromEndpoint("https://getpocket.cdn.mozilla.net/dummy", {
         method: "POST",
-        body: "{}"
+        body: "{}",
       });
 
       assert.calledWithMatch(fetchStub, "https://getpocket.cdn.mozilla.net/dummy", {
@@ -170,10 +170,10 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
   });
 
   describe("#getOrCreateImpressionId", () => {
-    it.only("should create impression id in constructor", async () => {
+    it("should create impression id in constructor", async () => {
       assert.equal(feed._impressionId, FAKE_UUID);
     });
-    it.only("should create impression id if none exists", async () => {
+    it("should create impression id if none exists", async () => {
       sandbox.stub(global.Services.prefs, "setCharPref").returns();
 
       const result = feed.getOrCreateImpressionId();
@@ -181,7 +181,7 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
       assert.equal(result, FAKE_UUID);
       assert.calledOnce(global.Services.prefs.setCharPref);
     });
-    it.only("should use impression id if exists", async () => {
+    it("should use impression id if exists", async () => {
       sandbox.stub(global.Services.prefs, "getCharPref").returns("from get");
 
       const result = feed.getOrCreateImpressionId();
@@ -253,7 +253,7 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
       await feed.loadLayout(feed.store.dispatch);
 
       assert.notCalled(feed.fetchLayout);
-      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey");
+      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs");
     });
     it("should fetch local layout for invalid layout endpoint or when fetch layout fails", async () => {
       feed.config.hardcoded_layout = false;
@@ -262,7 +262,7 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
       await feed.loadLayout(feed.store.dispatch, true);
 
       assert.calledOnce(fetchStub);
-      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs?consumer_key=$apiKey");
+      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs");
     });
   });
 
@@ -488,6 +488,11 @@ describe("DiscoveryStreamFeed", () => { // eslint-disable-line max-statements
 
   describe("#loadSpocs", () => {
     beforeEach(() => {
+      feed._prefCache = {
+        config: {
+          api_key_pref: "",
+        },
+      };
       Object.defineProperty(feed, "showSpocs", {get: () => true});
     });
     it("should not fetch or update cache if no spocs endpoint is defined", async () => {

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -187,6 +187,7 @@ const TEST_GLOBAL = {
       getBoolPref() {},
       getCharPref() {},
       setBoolPref() {},
+      setCharPref() {},
       setIntPref() {},
       getBranch() {},
       PREF_BOOL: "boolean",


### PR DESCRIPTION
At the moment testing this is just a matter of turning on spocs and making sure they still render.

Testing that the actual pocket id works when passed in is hard given the server still hasn't be made to handle this. This part can have a larger round of QA as different pieces for this integration fall into place. That said, if you have reason to suspect I am not properly passing in the pocket id, you should def call it out.

Part of what we're doing with this is passing in the client id to pocket's spoc endpoint. (@ncloudioj do you know what kind of specialized reviews I may need for that?)

We needed to update this fetch to be post, and not get, because of the new id.

And on a personal level, I wanted to include in this is not need to rely on a pref. So, these changes should be backwards compatible. If the spoc url is setup to be adzerk, it should make use of the pocket id, if not, it should just be ignored and the old experience is business as usual.

Thoughts?

To test:

1. Set `browser.newtabpage.activity-stream.discoverystream.config` to default
2. In browser console, open up the network tab and probably clear it.
3. in about:config, change `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":true,"personalized":false,"layout_endpoint":"https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=basic"}`
4. In the network tab, you should now see a POST to unique-spocs and also check that requests params tab for something along these lines: `{"pocket_id":"{123-123-123-123-123}","consumer_key":"123345678"}`