### PR TITLE
Bug 1550119 - Pass Adzerk shim to spoc click and view pings.

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid.jsx
+++ b/content-src/components/DiscoveryStreamComponents/CardGrid/CardGrid.jsx
@@ -22,6 +22,7 @@ export class CardGrid extends React.PureComponent {
           excerpt={rec.excerpt}
           url={rec.url}
           id={rec.id}
+          shim={rec.shim}
           type={this.props.type}
           context={rec.context}
           dispatch={this.props.dispatch}

--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -24,7 +24,11 @@ export class DSCard extends React.PureComponent {
       this.props.dispatch(ac.ImpressionStats({
         source: this.props.type.toUpperCase(),
         click: 0,
-        tiles: [{id: this.props.id, pos: this.props.pos}],
+        tiles: [{
+          id: this.props.id,
+          pos: this.props.pos,
+          ...(this.props.shim ? {shim: this.props.shim} : {}),
+        }],
       }));
     }
   }
@@ -54,7 +58,11 @@ export class DSCard extends React.PureComponent {
           </div>
           <ImpressionStats
             campaignId={this.props.campaignId}
-            rows={[{id: this.props.id, pos: this.props.pos}]}
+            rows={[{
+              id: this.props.id,
+              pos: this.props.pos,
+              ...(this.props.shim ? {shim: this.props.shim} : {}),
+            }]}
             dispatch={this.props.dispatch}
             source={this.props.type} />
         </SafeAnchor>

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -26,7 +26,11 @@ export class Hero extends React.PureComponent {
       this.props.dispatch(ac.ImpressionStats({
         source: this.props.type.toUpperCase(),
         click: 0,
-        tiles: [{id: this.heroRec.id, pos: this.heroRec.pos}],
+        tiles: [{
+          id: this.heroRec.id,
+          pos: this.heroRec.pos,
+          ...(this.heroRec.shim ? {shim: this.heroRec.shim} : {}),
+        }],
       }));
     }
   }
@@ -42,20 +46,21 @@ export class Hero extends React.PureComponent {
         <PlaceholderDSCard key={`dscard-${index}`} />
       ) : (
         <DSCard
-        campaignId={rec.campaign_id}
-        key={`dscard-${index}`}
-        image_src={rec.image_src}
-        raw_image_src={rec.raw_image_src}
-        title={rec.title}
-        url={rec.url}
-        id={rec.id}
-        pos={rec.pos}
-        type={this.props.type}
-        dispatch={this.props.dispatch}
-        context={rec.context}
-        source={rec.domain}
-        pocket_id={rec.pocket_id}
-        bookmarkGuid={rec.bookmarkGuid} />
+          campaignId={rec.campaign_id}
+          key={`dscard-${index}`}
+          image_src={rec.image_src}
+          raw_image_src={rec.raw_image_src}
+          title={rec.title}
+          url={rec.url}
+          id={rec.id}
+          shim={rec.shim}
+          pos={rec.pos}
+          type={this.props.type}
+          dispatch={this.props.dispatch}
+          context={rec.context}
+          source={rec.domain}
+          pocket_id={rec.pocket_id}
+          bookmarkGuid={rec.bookmarkGuid} />
       ));
     }
 
@@ -91,7 +96,11 @@ export class Hero extends React.PureComponent {
             </div>
             <ImpressionStats
               campaignId={heroRec.campaignId}
-              rows={[{id: heroRec.id, pos: heroRec.pos}]}
+              rows={[{
+                id: heroRec.id,
+                pos: heroRec.pos,
+                ...(heroRec.shim ? {shim: heroRec.shim} : {}),
+              }]}
               dispatch={this.props.dispatch}
               source={this.props.type} />
           </SafeAnchor>

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -30,7 +30,11 @@ export class ListItem extends React.PureComponent {
       this.props.dispatch(ac.ImpressionStats({
         source: this.props.type.toUpperCase(),
         click: 0,
-        tiles: [{id: this.props.id, pos: this.props.pos}],
+        tiles: [{
+          id: this.props.id,
+          pos: this.props.pos,
+          ...(this.props.shim ? {shim: this.props.shim} : {}),
+        }],
       }));
     }
   }
@@ -62,7 +66,11 @@ export class ListItem extends React.PureComponent {
           <DSImage extraClassNames="ds-list-image" source={this.props.image_src} rawSource={this.props.raw_image_src} />
           <ImpressionStats
             campaignId={this.props.campaignId}
-            rows={[{id: this.props.id, pos: this.props.pos}]}
+            rows={[{
+              id: this.props.id,
+              pos: this.props.pos,
+              ...(this.props.shim ? {shim: this.props.shim} : {}),
+            }]}
             dispatch={this.props.dispatch}
             source={this.props.type} />
         </SafeAnchor>
@@ -98,20 +106,21 @@ export function _List(props) {
         <PlaceholderListItem key={`ds-list-item-${index}`} />
       ) : (
         <ListItem key={`ds-list-item-${index}`}
-        dispatch={props.dispatch}
-        campaignId={rec.campaign_id}
-        domain={rec.domain}
-        excerpt={rec.excerpt}
-        id={rec.id}
-        image_src={rec.image_src}
-        raw_image_src={rec.raw_image_src}
-        pos={rec.pos}
-        title={rec.title}
-        context={rec.context}
-        type={props.type}
-        url={rec.url}
-        pocket_id={rec.pocket_id}
-        bookmarkGuid={rec.bookmarkGuid} />
+          dispatch={props.dispatch}
+          campaignId={rec.campaign_id}
+          domain={rec.domain}
+          excerpt={rec.excerpt}
+          id={rec.id}
+          shim={rec.shim}
+          image_src={rec.image_src}
+          raw_image_src={rec.raw_image_src}
+          pos={rec.pos}
+          title={rec.title}
+          context={rec.context}
+          type={props.type}
+          url={rec.url}
+          pocket_id={rec.pocket_id}
+          bookmarkGuid={rec.bookmarkGuid} />
       ));
     }
 

--- a/content-src/components/DiscoveryStreamImpressionStats/ImpressionStats.jsx
+++ b/content-src/components/DiscoveryStreamImpressionStats/ImpressionStats.jsx
@@ -54,7 +54,11 @@ export class ImpressionStats extends React.PureComponent {
     if (this._needsImpressionStats(cards)) {
       props.dispatch(ac.DiscoveryStreamImpressionStats({
         source: props.source.toUpperCase(),
-        tiles: cards.map(link => ({id: link.id, pos: link.pos})),
+        tiles: cards.map(link => ({
+          id: link.id,
+          pos: link.pos,
+          ...(link.shim ? {shim: link.shim} : {}),
+        })),
       }));
       this.impressionCardGuids = cards.map(link => link.id);
     }

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -154,7 +154,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "user_prefs": 7,
 
   // "pos" is the 0-based index to record the tile's position in the Pocket section.
-  // "shim" is a base64 encoded shim attached to spocs, unique to the impression from Adzerk.
+  // "shim" is a base64 encoded shim attached to spocs, unique to the impression from the Ad server.
   "tiles": [{"id": 10000, "pos": 0, "shim": "enuYa1j73z3RzxgTexHNxYPC/b,9JT6w5KB0CRKYEU+"}],
 
   // A 0-based index to record which tile in the "tiles" list that the user just interacted with.
@@ -250,7 +250,7 @@ and losing focus. | :one:
 | `topsites_pinned` | [Optional] Number of topsites that are pinned. | :one:
 | `topsites_search_shortcuts` | [Optional] Number of search shortcut topsites. | :one:
 | `visibility_event_rcvd_ts` | [Optional][Server Counter][Server Alert for too many omissions] DOMHighResTimeStamp of when the page itself receives an event that document.visibilityState == visible. | :one:
-| `tiles` | [Required] A list of tile objects for the Pocket articles. Each tile object mush have a ID, optionally a "pos" property to indicate the tile position, and optionally a "shim" property unique to the impression from Adzerk | :one:
+| `tiles` | [Required] A list of tile objects for the Pocket articles. Each tile object mush have a ID, optionally a "pos" property to indicate the tile position, and optionally a "shim" property unique to the impression from the Ad server | :one:
 | `click` | [Optional] An integer to record the 0-based index when user clicks on a Pocket tile. | :one:
 | `block` | [Optional] An integer to record the 0-based index when user blocks a Pocket tile. | :one:
 | `pocket` | [Optional] An integer to record the 0-based index when user saves a Pocket tile to Pocket. | :one:

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -154,7 +154,8 @@ Schema definitions/validations that can be used for tests can be found in `syste
   "user_prefs": 7,
 
   // "pos" is the 0-based index to record the tile's position in the Pocket section.
-  "tiles": [{"id": 10000, "pos": 0}],
+  // "shim" is a base64 encoded shim attached to spocs, unique to the impression from Adzerk.
+  "tiles": [{"id": 10000, "pos": 0, "shim": "enuYa1j73z3RzxgTexHNxYPC/b,9JT6w5KB0CRKYEU+"}],
 
   // A 0-based index to record which tile in the "tiles" list that the user just interacted with.
   "click|block|pocket": 0
@@ -249,7 +250,7 @@ and losing focus. | :one:
 | `topsites_pinned` | [Optional] Number of topsites that are pinned. | :one:
 | `topsites_search_shortcuts` | [Optional] Number of search shortcut topsites. | :one:
 | `visibility_event_rcvd_ts` | [Optional][Server Counter][Server Alert for too many omissions] DOMHighResTimeStamp of when the page itself receives an event that document.visibilityState == visible. | :one:
-| `tiles` | [Required] A list of tile objects for the Pocket articles. Each tile object mush have a ID, and optionally a "pos" property to indicate the tile position | :one:
+| `tiles` | [Required] A list of tile objects for the Pocket articles. Each tile object mush have a ID, optionally a "pos" property to indicate the tile position, and optionally a "shim" property unique to the impression from Adzerk | :one:
 | `click` | [Optional] An integer to record the 0-based index when user clicks on a Pocket tile. | :one:
 | `block` | [Optional] An integer to record the 0-based index when user blocks a Pocket tile. | :one:
 | `pocket` | [Optional] An integer to record the 0-based index when user saves a Pocket tile to Pocket. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -587,7 +587,8 @@ This reports the user's interaction with those Pocket tiles.
   "user_prefs": 7,
 
   // "pos" is the 0-based index to record the tile's position in the Pocket section.
-  "tiles": [{"id": 10000, "pos": 0}],
+  // "shim" is a base64 encoded shim attached to spocs, unique to the impression from Adzerk.
+  "tiles": [{"id": 10000, "pos": 0, "shim": "enuYa1j73z3RzxgTexHNxYPC/b,9JT6w5KB0CRKYEU+"}],
 
   // A 0-based index to record which tile in the "tiles" list that the user just interacted with.
   "click|block|pocket": 0

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -587,7 +587,7 @@ This reports the user's interaction with those Pocket tiles.
   "user_prefs": 7,
 
   // "pos" is the 0-based index to record the tile's position in the Pocket section.
-  // "shim" is a base64 encoded shim attached to spocs, unique to the impression from Adzerk.
+  // "shim" is a base64 encoded shim attached to spocs, unique to the impression from the Ad server.
   "tiles": [{"id": 10000, "pos": 0, "shim": "enuYa1j73z3RzxgTexHNxYPC/b,9JT6w5KB0CRKYEU+"}],
 
   // A 0-based index to record which tile in the "tiles" list that the user just interacted with.

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -802,7 +802,7 @@ this.TelemetryFeed = class TelemetryFeed {
 
     const impressionSets = session.impressionSets || {};
     const impressions = impressionSets[data.source] || [];
-    // The payload might contain other properties, we need `id` and `pos` here.
+    // The payload might contain other properties, we need `id`, `pos` and potentially `shim` here.
     data.tiles.forEach(tile => impressions.push({
       id: tile.id,
       pos: tile.pos,

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -803,7 +803,11 @@ this.TelemetryFeed = class TelemetryFeed {
     const impressionSets = session.impressionSets || {};
     const impressions = impressionSets[data.source] || [];
     // The payload might contain other properties, we need `id` and `pos` here.
-    data.tiles.forEach(tile => impressions.push({id: tile.id, pos: tile.pos}));
+    data.tiles.forEach(tile => impressions.push({
+      id: tile.id,
+      pos: tile.pos,
+      ...(tile.shim ? {shim: tile.shim} : {}),
+    }));
     impressionSets[data.source] = impressions;
     session.impressionSets = impressionSets;
   }

--- a/test/unit/lib/TelemetryFeed.test.js
+++ b/test/unit/lib/TelemetryFeed.test.js
@@ -639,6 +639,14 @@ describe("TelemetryFeed", () => {
       assert.propertyVal(ping, "pocket", 0);
       assert.propertyVal(ping, "tiles", tiles);
     });
+    it("should pass shim if it is available to impression ping", async () => {
+      const tiles = [{id: 10001, pos: 2, shim: 1234}];
+      const action = ac.ImpressionStats({source: "POCKET", tiles, pocket: 0});
+      const ping = await instance.createImpressionStats(au.getPortIdOfSender(action), action.data);
+
+      assert.propertyVal(ping, "pocket", 0);
+      assert.propertyVal(ping, "tiles", tiles);
+    });
   });
   describe("#createSpocsFillPing", () => {
     it("should create a valid SPOCS Fill ping", async () => {

--- a/test/unit/lib/TelemetryFeed.test.js
+++ b/test/unit/lib/TelemetryFeed.test.js
@@ -641,11 +641,11 @@ describe("TelemetryFeed", () => {
     });
     it("should pass shim if it is available to impression ping", async () => {
       const tiles = [{id: 10001, pos: 2, shim: 1234}];
-      const action = ac.ImpressionStats({source: "POCKET", tiles, pocket: 0});
+      const action = ac.ImpressionStats({source: "POCKET", tiles});
       const ping = await instance.createImpressionStats(au.getPortIdOfSender(action), action.data);
 
-      assert.propertyVal(ping, "pocket", 0);
       assert.propertyVal(ping, "tiles", tiles);
+      assert.propertyVal(ping.tiles[0], "shim", tiles[0].shim);
     });
   });
   describe("#createSpocsFillPing", () => {


### PR DESCRIPTION
To test:

1. Set this pref `browser.newtabpage.activity-stream.discoverystream.endpoints` to "https,http"
2. Set this pref `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://gist.githubusercontent.com/ScottDowne/b85c57830405db12a18222ca62b4a3f6/raw/8febea501f10ad43aa2ca9f90b531bdd40136127/adzerk-layout"}`
3. Ensure you can see telemetry events
4. Open a new tab, you should see a layout of weird cards, heros, and lists.
5. You should see 6 spocs total.
6. Open your jsdebugger
7. Ensure click and view ping events have the shim prop being passes in for spocs, and not for regular cards.