### PR TITLE
Bug 1548043 - Changing to personal computer emoji for wider support

### DIFF
--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -1085,7 +1085,7 @@ defaultLayoutResp = {
         {
           "type": "CardGrid",
           "header": {
-            "title": "Tech 🖥",
+            "title": "Tech 💻",
           },
           "feed": {
             "embed_reference": null,


### PR DESCRIPTION
QA:

- Open default layout
- Confirm that you see a non broken emoji after the "Tech" section header:

<img width="889" alt="Screen Shot 2019-05-28 at 11 01 12 AM" src="https://user-images.githubusercontent.com/206379/58500894-00052680-8138-11e9-8dbe-98e1d665ff0e.png">
