### PR TITLE
Bug 1554734 - Also support context-menu arrow key navigation 

### DIFF
--- a/content-src/components/ContextMenu/ContextMenu.jsx
+++ b/content-src/components/ContextMenu/ContextMenu.jsx
@@ -62,6 +62,17 @@ export class ContextMenuItem extends React.PureComponent {
     this.props.option.onClick();
   }
 
+  // This selects the correct node based on the key pressed
+  focusSibling(target, key) {
+    const parent = target.parentNode;
+    const closestSiblingSelector = (key === "ArrowUp") ? "previousSibling" : "nextSibling";
+    if (parent[closestSiblingSelector].firstElementChild) {
+      parent[closestSiblingSelector].firstElementChild.focus();
+    } else {
+      parent[closestSiblingSelector][closestSiblingSelector].firstElementChild.focus();
+    }
+  }
+
   onKeyDown(event) {
     const {option} = this.props;
     switch (event.key) {
@@ -74,20 +85,9 @@ export class ContextMenuItem extends React.PureComponent {
         }
         break;
       case "ArrowUp":
-        event.preventDefault()
-        if (event.target.parentNode.previousSibling.firstElementChild) {
-          event.target.parentNode.previousSibling.firstElementChild.focus();
-        } else {
-          event.target.parentNode.previousSibling.previousSibling.firstElementChild.focus();
-        }
-        break;
       case "ArrowDown":
-        event.preventDefault()
-        if (event.target.parentNode.nextSibling.firstElementChild) {
-          event.target.parentNode.nextSibling.firstElementChild.focus();
-        } else {
-          event.target.parentNode.nextSibling.nextSibling.firstElementChild.focus();
-        }
+        event.preventDefault();
+        this.focusSibling(event.target, event.key);
         break;
       case "Enter":
         this.props.hideContext();
@@ -100,7 +100,7 @@ export class ContextMenuItem extends React.PureComponent {
     const {option} = this.props;
     return (
       <li role="menuitem" className="context-menu-item" >
-        <button className={option.disabled ? "disabled" : ""} onClick={this.onClick} onKeyDown={this.onKeyDown} tabIndex="0" >
+        <button className={option.disabled ? "disabled" : ""} tabIndex="0" onClick={this.onClick} onKeyDown={this.onKeyDown}>
           {option.icon && <span className={`icon icon-spacer icon-${option.icon}`} />}
           {option.label}
         </button>

--- a/content-src/components/ContextMenu/ContextMenu.jsx
+++ b/content-src/components/ContextMenu/ContextMenu.jsx
@@ -73,6 +73,22 @@ export class ContextMenuItem extends React.PureComponent {
           this.props.hideContext();
         }
         break;
+      case "ArrowUp":
+        event.preventDefault()
+        if (event.target.parentNode.previousSibling.firstElementChild) {
+          event.target.parentNode.previousSibling.firstElementChild.focus();
+        } else {
+          event.target.parentNode.previousSibling.previousSibling.firstElementChild.focus();
+        }
+        break;
+      case "ArrowDown":
+        event.preventDefault()
+        if (event.target.parentNode.nextSibling.firstElementChild) {
+          event.target.parentNode.nextSibling.firstElementChild.focus();
+        } else {
+          event.target.parentNode.nextSibling.nextSibling.firstElementChild.focus();
+        }
+        break;
       case "Enter":
         this.props.hideContext();
         option.onClick();

--- a/content-src/components/ContextMenu/ContextMenu.jsx
+++ b/content-src/components/ContextMenu/ContextMenu.jsx
@@ -66,6 +66,9 @@ export class ContextMenuItem extends React.PureComponent {
   focusSibling(target, key) {
     const parent = target.parentNode;
     const closestSiblingSelector = (key === "ArrowUp") ? "previousSibling" : "nextSibling";
+    if (!parent[closestSiblingSelector]) {
+      return;
+    }
     if (parent[closestSiblingSelector].firstElementChild) {
       parent[closestSiblingSelector].firstElementChild.focus();
     } else {

--- a/test/unit/content-src/components/ContextMenu.test.jsx
+++ b/test/unit/content-src/components/ContextMenu.test.jsx
@@ -52,4 +52,27 @@ describe("<ContextMenu>", () => {
     const wrapper = mount(<ContextMenu {...DEFAULT_PROPS} options={options} />);
     assert.lengthOf(wrapper.find(".context-menu-item button.disabled"), 1);
   });
+  it("should have the context-menu-item class", () => {
+    const options = [{label: "item1", icon: "icon1"}];
+    const wrapper = mount(<ContextMenu {...DEFAULT_PROPS} options={options} />);
+    assert.lengthOf(wrapper.find(".context-menu-item"), 1);
+  });
+  it("should call onClick when onKeyDown is called", () => {
+    const onClick = sinon.spy();
+    const wrapper = mount(<ContextMenu {...DEFAULT_PROPS} options={[{label: "item1", onClick}]} />);
+    wrapper.find(".context-menu-item button").simulate("keydown", {key: "Enter"});
+    assert.calledOnce(onClick);
+  });
+  it("should call focusSibling when onKeyDown is called with ArrowUp", () => {
+    const wrapper = mount(<ContextMenu {...DEFAULT_PROPS} options={[{label: "item1"}]} />);
+    const focusSibling = sinon.stub(wrapper.find(ContextMenuItem).instance(), "focusSibling");
+    wrapper.find(".context-menu-item button").simulate("keydown", {key: "ArrowUp"});
+    assert.calledOnce(focusSibling);
+  });
+  it("should call focusSibling when onKeyDown is called with ArrowDown", () => {
+    const wrapper = mount(<ContextMenu {...DEFAULT_PROPS} options={[{label: "item1"}]} />);
+    const focusSibling = sinon.stub(wrapper.find(ContextMenuItem).instance(), "focusSibling");
+    wrapper.find(".context-menu-item button").simulate("keydown", {key: "ArrowDown"});
+    assert.calledOnce(focusSibling);
+  });
 });


### PR DESCRIPTION
added ArrowUp and ArrowDown listeners to the onKeyDown event on context menus; handled focus with DOM targeting. May try to switch to React refs to make the function a little more resilient.