### PR TITLE
(nobug) - Open the bookmark panel when previewing the FxA message

### DIFF
--- a/lib/BookmarkPanelHub.jsm
+++ b/lib/BookmarkPanelHub.jsm
@@ -210,9 +210,16 @@ class _BookmarkPanelHub {
     this._response = null;
   }
 
-  _forceShowMessage(target, message) {
-    const doc = target.browser.ownerGlobal.gBrowser.ownerDocument;
+  async _forceShowMessage(target, message) {
     const win = target.browser.ownerGlobal.window;
+    // Bookmark the page to force the panel to show and
+    // remove the bookmark when the panel is hidden
+    win.StarUI.panel.addEventListener("popupshown", () => {
+      win.StarUI._removeBookmarksOnPopupHidden = true;
+    }, {once: true});
+    await win.PlacesCommandHook.bookmarkPage();
+
+    const doc = target.browser.ownerGlobal.gBrowser.ownerDocument;
     const panelTarget = {
       container: doc.getElementById("editBookmarkPanelRecommendation"),
       infoButton: doc.getElementById("editBookmarkPanelInfoButton"),


### PR DESCRIPTION
This uses internal StarUI properties but I think this is ok since it's for internal use anyway.