### PR TITLE
Bug 1556887 - Convert strings in Top Sites dialog to use fluent (header and body)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
       "files": [
         "content-src/asrouter/templates/OnboardingMessage/**",
         "content-src/asrouter/templates/Trailhead/**",
+        "content-src/components/TopSites/**",
       ],
       "rules": {
         "jsx-a11y/anchor-has-content": 0,

--- a/bin/bug_xxx_newtab.py
+++ b/bin/bug_xxx_newtab.py
@@ -68,20 +68,20 @@ newtab-search-box-search-the-web-input =
     .placeholder = { COPY(from_path, "search_web_placeholder") }
     .title = { COPY(from_path, "search_web_placeholder") }
 
-newtab_topsites_add_header = { COPY(from_path, "topsites_form_add_header") }
-newtab_topsites_edit_header = { COPY(from_path, "topsites_form_edit_header") }
-newtab_topsites_title_label = { COPY(from_path, "topsites_form_title_label") }
-newtab_topsites_title_placeholder =
+newtab-topsites-add-header = { COPY(from_path, "topsites_form_add_header") }
+newtab-topsites-edit-header = { COPY(from_path, "topsites_form_edit_header") }
+newtab-topsites-title-label = { COPY(from_path, "topsites_form_title_label") }
+newtab-topsites-title-input =
     .placeholder = { COPY(from_path, "topsites_form_title_placeholder") }
 
-newtab_topsites_url_label = { COPY(from_path, "topsites_form_url_label") }
-newtab_topsites_url_placeholder =
+newtab-topsites-url-label = { COPY(from_path, "topsites_form_url_label") }
+newtab-topsites-url-input =
     .placeholder = { COPY(from_path, "topsites_form_url_placeholder") }
-newtab_topsites_url_validation = { COPY(from_path, "topsites_form_url_validation") }
+newtab-topsites-url-validation = { COPY(from_path, "topsites_form_url_validation") }
 
-newtab_topsites_image_url_label = { COPY(from_path, "topsites_form_image_url_label") }
-newtab_topsites_use_image_link = { COPY(from_path, "topsites_form_use_image_link") }
-newtab_topsites_image_validation = { COPY(from_path, "topsites_form_image_validation") }
+newtab-topsites-image-url-label = { COPY(from_path, "topsites_form_image_url_label") }
+newtab-topsites-use-image-link = { COPY(from_path, "topsites_form_use_image_link") }
+newtab-topsites-image-validation = { COPY(from_path, "topsites_form_image_validation") }
 
         """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
     )

--- a/bin/bug_xxx_newtab.py
+++ b/bin/bug_xxx_newtab.py
@@ -68,5 +68,20 @@ newtab-search-box-search-the-web-input =
     .placeholder = { COPY(from_path, "search_web_placeholder") }
     .title = { COPY(from_path, "search_web_placeholder") }
 
+newtab_topsites_add_header = { COPY(from_path, "topsites_form_add_header") }
+newtab_topsites_edit_header = { COPY(from_path, "topsites_form_edit_header") }
+newtab_topsites_title_label = { COPY(from_path, "topsites_form_title_label") }
+newtab_topsites_title_placeholder =
+    .placeholder = { COPY(from_path, "topsites_form_title_placeholder") }
+
+newtab_topsites_url_label = { COPY(from_path, "topsites_form_url_label") }
+newtab_topsites_url_placeholder =
+    .placeholder = { COPY(from_path, "topsites_form_url_placeholder") }
+newtab_topsites_url_validation = { COPY(from_path, "topsites_form_url_validation") }
+
+newtab_topsites_image_url_label = { COPY(from_path, "topsites_form_image_url_label") }
+newtab_topsites_use_image_link = { COPY(from_path, "topsites_form_use_image_link") }
+newtab_topsites_image_validation = { COPY(from_path, "topsites_form_image_validation") }
+
         """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
     )

--- a/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -9,6 +9,7 @@
     font-weight: bold;
     margin: 0;
 
+    &.grey-title,
     span {
       color: var(--newtab-section-header-text-color);
       display: inline-block;

--- a/content-src/components/TopSites/TopSiteForm.jsx
+++ b/content-src/components/TopSites/TopSiteForm.jsx
@@ -164,13 +164,12 @@ export class TopSiteForm extends React.PureComponent {
       customScreenshotUrl && this.props.previewUrl === this.cleanUrl(customScreenshotUrl);
 
     if (!this.state.showCustomScreenshotForm) {
-      return (<A11yLinkButton onClick={this.onEnableScreenshotUrlForm} className="enable-custom-image-input">
-                <FormattedMessage id="topsites_form_use_image_link" />
-              </A11yLinkButton>);
+      return (<A11yLinkButton onClick={this.onEnableScreenshotUrlForm} className="enable-custom-image-input"
+          data-l10n-id="newtab_topsites_use_image_link" />);
     }
     return (<div className="custom-image-input-container">
       <TopSiteFormInput
-        errorMessageId={requestFailed ? "topsites_form_image_validation" : "topsites_form_url_validation"}
+        errorMessageId={requestFailed ? "newtab_topsites_image_validation" : "newtab_topsites_url_validation"}
         loading={isLoading}
         onChange={this.onCustomScreenshotUrlChange}
         onClear={this.onClearScreenshotInput}
@@ -178,9 +177,8 @@ export class TopSiteForm extends React.PureComponent {
         typeUrl={true}
         value={customScreenshotUrl}
         validationError={validationError}
-        titleId="topsites_form_image_url_label"
-        placeholderId="topsites_form_url_placeholder"
-        intl={this.props.intl} />
+        titleId="newtab_topsites_image_url_label"
+        placeholderId="newtab_topsites_url_placeholder" />
     </div>);
   }
 
@@ -205,25 +203,23 @@ export class TopSiteForm extends React.PureComponent {
       <form className="topsite-form" onSubmit={onSubmit}>
         <div className="form-input-container">
           <h3 className="section-title">
-            <FormattedMessage id={showAsAdd ? "topsites_form_add_header" : "topsites_form_edit_header"} />
+            <span data-l10n-id={showAsAdd ? "newtab_topsites_add_header" : "newtab_topsites_edit_header"} />
           </h3>
           <div className="fields-and-preview">
             <div className="form-wrapper">
               <TopSiteFormInput onChange={this.onLabelChange}
                 value={this.state.label}
-                titleId="topsites_form_title_label"
-                placeholderId="topsites_form_title_placeholder"
-                intl={this.props.intl} />
+                titleId="newtab_topsites_title_label"
+                placeholderId="newtab_topsites_title_placeholder" />
               <TopSiteFormInput onChange={this.onUrlChange}
                 shouldFocus={this.state.validationError && !this.validateUrl(this.state.url)}
                 value={this.state.url}
                 onClear={this.onClearUrlClick}
                 validationError={this.state.validationError && !this.validateUrl(this.state.url)}
-                titleId="topsites_form_url_label"
+                titleId="newtab_topsites_url_label"
                 typeUrl={true}
-                placeholderId="topsites_form_url_placeholder"
-                errorMessageId="topsites_form_url_validation"
-                intl={this.props.intl} />
+                placeholderId="newtab_topsites_url_placeholder"
+                errorMessageId="newtab_topsites_url_validation" />
               {this._renderCustomScreenshotInput()}
             </div>
             <TopSiteLink link={previewLink}

--- a/content-src/components/TopSites/TopSiteForm.jsx
+++ b/content-src/components/TopSites/TopSiteForm.jsx
@@ -202,9 +202,7 @@ export class TopSiteForm extends React.PureComponent {
     return (
       <form className="topsite-form" onSubmit={onSubmit}>
         <div className="form-input-container">
-          <h3 className="section-title">
-            <span data-l10n-id={showAsAdd ? "newtab-topsites-add-header" : "newtab-topsites-edit-header"} />
-          </h3>
+          <h3 className="section-title grey-title" data-l10n-id={showAsAdd ? "newtab-topsites-add-header" : "newtab-topsites-edit-header"} />
           <div className="fields-and-preview">
             <div className="form-wrapper">
               <TopSiteFormInput onChange={this.onLabelChange}

--- a/content-src/components/TopSites/TopSiteForm.jsx
+++ b/content-src/components/TopSites/TopSiteForm.jsx
@@ -165,11 +165,11 @@ export class TopSiteForm extends React.PureComponent {
 
     if (!this.state.showCustomScreenshotForm) {
       return (<A11yLinkButton onClick={this.onEnableScreenshotUrlForm} className="enable-custom-image-input"
-          data-l10n-id="newtab_topsites_use_image_link" />);
+          data-l10n-id="newtab-topsites-use-image-link" />);
     }
     return (<div className="custom-image-input-container">
       <TopSiteFormInput
-        errorMessageId={requestFailed ? "newtab_topsites_image_validation" : "newtab_topsites_url_validation"}
+        errorMessageId={requestFailed ? "newtab-topsites-image-validation" : "newtab-topsites-url-validation"}
         loading={isLoading}
         onChange={this.onCustomScreenshotUrlChange}
         onClear={this.onClearScreenshotInput}
@@ -177,8 +177,8 @@ export class TopSiteForm extends React.PureComponent {
         typeUrl={true}
         value={customScreenshotUrl}
         validationError={validationError}
-        titleId="newtab_topsites_image_url_label"
-        placeholderId="newtab_topsites_url_placeholder" />
+        titleId="newtab-topsites-image-url-label"
+        placeholderId="newtab-topsites-url-input" />
     </div>);
   }
 
@@ -203,23 +203,23 @@ export class TopSiteForm extends React.PureComponent {
       <form className="topsite-form" onSubmit={onSubmit}>
         <div className="form-input-container">
           <h3 className="section-title">
-            <span data-l10n-id={showAsAdd ? "newtab_topsites_add_header" : "newtab_topsites_edit_header"} />
+            <span data-l10n-id={showAsAdd ? "newtab-topsites-add-header" : "newtab-topsites-edit-header"} />
           </h3>
           <div className="fields-and-preview">
             <div className="form-wrapper">
               <TopSiteFormInput onChange={this.onLabelChange}
                 value={this.state.label}
-                titleId="newtab_topsites_title_label"
-                placeholderId="newtab_topsites_title_placeholder" />
+                titleId="newtab-topsites-title-label"
+                placeholderId="newtab-topsites-title-input" />
               <TopSiteFormInput onChange={this.onUrlChange}
                 shouldFocus={this.state.validationError && !this.validateUrl(this.state.url)}
                 value={this.state.url}
                 onClear={this.onClearUrlClick}
                 validationError={this.state.validationError && !this.validateUrl(this.state.url)}
-                titleId="newtab_topsites_url_label"
+                titleId="newtab-topsites-url-label"
                 typeUrl={true}
-                placeholderId="newtab_topsites_url_placeholder"
-                errorMessageId="newtab_topsites_url_validation" />
+                placeholderId="newtab-topsites-url-input"
+                errorMessageId="newtab-topsites-url-validation" />
               {this._renderCustomScreenshotInput()}
             </div>
             <TopSiteLink link={previewLink}

--- a/content-src/components/TopSites/TopSiteFormInput.jsx
+++ b/content-src/components/TopSites/TopSiteFormInput.jsx
@@ -1,4 +1,3 @@
-import {FormattedMessage} from "react-intl";
 import React from "react";
 
 export class TopSiteFormInput extends React.PureComponent {
@@ -60,13 +59,14 @@ export class TopSiteFormInput extends React.PureComponent {
     const {typeUrl} = this.props;
     const {validationError} = this.state;
 
-    return (<label><FormattedMessage id={this.props.titleId} />
+    return (<label>
+      <span data-l10n-id={this.props.titleId} />
       <div className={`field ${typeUrl ? "url" : ""}${validationError ? " invalid" : ""}`}>
         <input type="text"
           value={this.props.value}
           ref={this.onMount}
           onChange={this.onChange}
-          placeholder={this.props.intl.formatMessage({id: this.props.placeholderId})}
+          data-l10n-id={this.props.placeholderId}
           // Set focus on error if the url field is valid or when the input is first rendered and is empty
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={this.props.shouldFocus}
@@ -74,7 +74,7 @@ export class TopSiteFormInput extends React.PureComponent {
         {this.renderLoadingOrCloseButton()}
         {validationError &&
           <aside className="error-tooltip">
-            <FormattedMessage id={this.props.errorMessageId} />
+            <span data-l10n-id={this.props.errorMessageId} />
           </aside>}
       </div>
     </label>);

--- a/content-src/components/TopSites/TopSiteFormInput.jsx
+++ b/content-src/components/TopSites/TopSiteFormInput.jsx
@@ -73,9 +73,8 @@ export class TopSiteFormInput extends React.PureComponent {
           disabled={this.props.loading} />
         {this.renderLoadingOrCloseButton()}
         {validationError &&
-          <aside className="error-tooltip">
-            <span data-l10n-id={this.props.errorMessageId} />
-          </aside>}
+          <aside className="error-tooltip" data-l10n-id={this.props.errorMessageId} />
+          }
       </div>
     </label>);
   }

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -107,22 +107,11 @@ settings_pane_snippets_header=Snippets
 edit_topsites_button_text=Edit
 edit_topsites_edit_button=Edit this site
 
-# LOCALIZATION NOTE (topsites_form_*): This is shown in the New/Edit Topsite modal.
-topsites_form_add_header=New Top Site
-topsites_form_edit_header=Edit Top Site
-topsites_form_title_label=Title
-topsites_form_title_placeholder=Enter a title
-topsites_form_url_label=URL
-topsites_form_image_url_label=Custom Image URL
-topsites_form_url_placeholder=Type or paste a URL
-topsites_form_use_image_link=Use a custom image…
 # LOCALIZATION NOTE (topsites_form_*_button): These are verbs/actions.
 topsites_form_preview_button=Preview
 topsites_form_add_button=Add
 topsites_form_save_button=Save
 topsites_form_cancel_button=Cancel
-topsites_form_url_validation=Valid URL required
-topsites_form_image_validation=Image failed to load. Try a different URL.
 
 # LOCALIZATION NOTE (pocket_read_more): This is shown at the bottom of the
 # trending stories section and precedes a list of links to popular topics.

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -22,17 +22,17 @@ newtab-search-box-search-the-web-input =
 
 ## Top Sites form dialog
 
-newtab_topsites_add_header = New Top Site
-newtab_topsites_edit_header = Edit Top Site
-newtab_topsites_title_label = Title
-newtab_topsites_title_placeholder =
+newtab-topsites-add-header = New Top Site
+newtab-topsites-edit-header = Edit Top Site
+newtab-topsites-title-label = Title
+newtab-topsites-title-input =
     .placeholder = Enter a title
 
-newtab_topsites_url_label = URL
-newtab_topsites_url_placeholder =
+newtab-topsites-url-label = URL
+newtab-topsites-url-input =
     .placeholder = Type or paste a URL
-newtab_topsites_url_validation = Valid URL required
+newtab-topsites-url-validation = Valid URL required
 
-newtab_topsites_image_url_label = Custom Image URL
-newtab_topsites_use_image_link = Use a custom image…
-newtab_topsites_image_validation = Image failed to load. Try a different URL.
+newtab-topsites-image-url-label = Custom Image URL
+newtab-topsites-use-image-link = Use a custom image…
+newtab-topsites-image-validation = Image failed to load. Try a different URL.

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -19,3 +19,20 @@ newtab-search-box-search-the-web-text = Search the Web
 newtab-search-box-search-the-web-input =
     .placeholder = Search the Web
     .title = Search the Web
+
+## Top Sites form dialog
+
+newtab_topsites_add_header = New Top Site
+newtab_topsites_edit_header = Edit Top Site
+newtab_topsites_title_label = Title
+newtab_topsites_title_placeholder =
+    .placeholder = Enter a title
+
+newtab_topsites_url_label = URL
+newtab_topsites_url_placeholder =
+    .placeholder = Type or paste a URL
+newtab_topsites_url_validation = Valid URL required
+
+newtab_topsites_image_url_label = Custom Image URL
+newtab_topsites_use_image_link = Use a custom image…
+newtab_topsites_image_validation = Image failed to load. Try a different URL.

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -4,7 +4,6 @@ import {MIN_CORNER_FAVICON_SIZE, MIN_RICH_FAVICON_SIZE} from "content-src/compon
 import {TOP_SITES_DEFAULT_ROWS, TOP_SITES_MAX_SITES_PER_ROW} from "common/Reducers.jsm";
 import {TopSite, TopSiteLink, _TopSiteList as TopSiteList, TopSitePlaceholder} from "content-src/components/TopSites/TopSite";
 import {A11yLinkButton} from "content-src/components/A11yLinkButton/A11yLinkButton";
-import {FormattedMessage} from "react-intl";
 import {LinkMenu} from "content-src/components/LinkMenu/LinkMenu";
 import React from "react";
 import {SectionMenu} from "content-src/components/SectionMenu/SectionMenu";
@@ -807,9 +806,6 @@ describe("<TopSiteForm>", () => {
     it("should render the component", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
     });
-    it("should have the correct header", () => {
-      assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_add_header").length, 1);
-    });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_save_button").length, 0);
       assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_add_button").length, 1);
@@ -879,9 +875,6 @@ describe("<TopSiteForm>", () => {
 
     it("should render the component", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
-    });
-    it("should have the correct header", () => {
-      assert.equal(wrapper.findWhere(n => n.props().id === "topsites_form_edit_header").length, 1);
     });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.props().id === "topsites_form_add_button").length, 0);
@@ -1201,12 +1194,6 @@ describe("#TopSiteFormInput", () => {
         value="foo" />);
     });
 
-    it("should render the provided title", () => {
-      const title = wrapper.find(FormattedMessage);
-
-      assert.propertyVal(title.props(), "id", "topsites_form_title_label");
-    });
-
     it("should render the provided value", () => {
       const input = wrapper.find("input");
 
@@ -1247,10 +1234,6 @@ describe("#TopSiteFormInput", () => {
         validationError={true}
         errorMessageId="topsites_form_url_validation"
         value="foo" />);
-    });
-
-    it("should render the error message", () => {
-      assert.equal(wrapper.findWhere(n => n.props().id === "topsites_form_url_validation").length, 1);
     });
 
     it("should reset the error state on value change", () => {

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -806,6 +806,9 @@ describe("<TopSiteForm>", () => {
     it("should render the component", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
     });
+    it("should have the correct header", () => {
+      assert.equal(wrapper.findWhere(n => n.length && n.prop("data-l10n-id") === "newtab_topsites_add_header").length, 1);
+    });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_save_button").length, 0);
       assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_add_button").length, 1);
@@ -875,6 +878,9 @@ describe("<TopSiteForm>", () => {
 
     it("should render the component", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
+    });
+    it("should have the correct header", () => {
+      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab_topsites_edit_header").length, 1);
     });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.props().id === "topsites_form_add_button").length, 0);
@@ -1187,11 +1193,16 @@ describe("#TopSiteFormInput", () => {
     beforeEach(() => {
       onChangeStub = sinon.stub();
 
-      wrapper = mountWithIntl(<TopSiteFormInput titleId="topsites_form_title_label"
-        placeholderId="topsites_form_title_placeholder"
-        errorMessageId="topsites_form_url_validation"
+      wrapper = mountWithIntl(<TopSiteFormInput titleId="newtab_topsites_title_label"
+        placeholderId="newtab_topsites_title_placeholder"
+        errorMessageId="newtab_topsites_url_validation"
         onChange={onChangeStub}
         value="foo" />);
+    });
+
+    it("should render the provided title", () => {
+      const title = wrapper.find("span");
+      assert.propertyVal(title.props(), "data-l10n-id", "newtab_topsites_title_label");
     });
 
     it("should render the provided value", () => {
@@ -1228,12 +1239,16 @@ describe("#TopSiteFormInput", () => {
     beforeEach(() => {
       onChangeStub = sinon.stub();
 
-      wrapper = mountWithIntl(<TopSiteFormInput titleId="topsites_form_title_label"
-        placeholderId="topsites_form_title_placeholder"
+      wrapper = mountWithIntl(<TopSiteFormInput titleId="newtab_topsites_title_label"
+        placeholderId="newtab_topsites_title_placeholder"
         onChange={onChangeStub}
         validationError={true}
-        errorMessageId="topsites_form_url_validation"
+        errorMessageId="newtab_topsites_url_validation"
         value="foo" />);
+    });
+
+    it("should render the error message", () => {
+      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab_topsites_url_validation").length, 1);
     });
 
     it("should reset the error state on value change", () => {

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -807,7 +807,7 @@ describe("<TopSiteForm>", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
     });
     it("should have the correct header", () => {
-      assert.equal(wrapper.findWhere(n => n.length && n.prop("data-l10n-id") === "newtab_topsites_add_header").length, 1);
+      assert.equal(wrapper.findWhere(n => n.length && n.prop("data-l10n-id") === "newtab-topsites-add-header").length, 1);
     });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.length && n.props().id === "topsites_form_save_button").length, 0);
@@ -880,7 +880,7 @@ describe("<TopSiteForm>", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
     });
     it("should have the correct header", () => {
-      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab_topsites_edit_header").length, 1);
+      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab-topsites-edit-header").length, 1);
     });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.props().id === "topsites_form_add_button").length, 0);
@@ -1193,16 +1193,16 @@ describe("#TopSiteFormInput", () => {
     beforeEach(() => {
       onChangeStub = sinon.stub();
 
-      wrapper = mountWithIntl(<TopSiteFormInput titleId="newtab_topsites_title_label"
-        placeholderId="newtab_topsites_title_placeholder"
-        errorMessageId="newtab_topsites_url_validation"
+      wrapper = mountWithIntl(<TopSiteFormInput titleId="newtab-topsites-title-label"
+        placeholderId="newtab-topsites-title-input"
+        errorMessageId="newtab-topsites-url-validation"
         onChange={onChangeStub}
         value="foo" />);
     });
 
     it("should render the provided title", () => {
       const title = wrapper.find("span");
-      assert.propertyVal(title.props(), "data-l10n-id", "newtab_topsites_title_label");
+      assert.propertyVal(title.props(), "data-l10n-id", "newtab-topsites-title-label");
     });
 
     it("should render the provided value", () => {
@@ -1239,16 +1239,16 @@ describe("#TopSiteFormInput", () => {
     beforeEach(() => {
       onChangeStub = sinon.stub();
 
-      wrapper = mountWithIntl(<TopSiteFormInput titleId="newtab_topsites_title_label"
-        placeholderId="newtab_topsites_title_placeholder"
+      wrapper = mountWithIntl(<TopSiteFormInput titleId="newtab-topsites-title-label"
+        placeholderId="newtab-topsites-title-input"
         onChange={onChangeStub}
         validationError={true}
-        errorMessageId="newtab_topsites_url_validation"
+        errorMessageId="newtab-topsites-url-validation"
         value="foo" />);
     });
 
     it("should render the error message", () => {
-      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab_topsites_url_validation").length, 1);
+      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab-topsites-url-validation").length, 1);
     });
 
     it("should reset the error state on value change", () => {


### PR DESCRIPTION
Made changes in the TopSites dialog to move to Fluent. Did not touch footer components because they get reused in another component.