### PR TITLE
Bug 1549770 - Addons installed from RTAMO should have rtamo as install telemetry source

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -331,14 +331,15 @@ const MessageLoaderUtils = {
     }
   },
 
-  async installAddonFromURL(browser, url) {
+  async installAddonFromURL(browser, url, telemetrySource = "amo") {
     try {
       MessageLoaderUtils._loadAddonIconInURLBar(browser);
       const aUri = Services.io.newURI(url);
       const systemPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
 
       // AddonManager installation source associated to the addons installed from activitystream's CFR
-      const telemetryInfo = {source: "amo"};
+      // and RTAMO (source is going to be "amo" if not configured explicitly in the message provider).
+      const telemetryInfo = {source: telemetrySource};
       const install = await AddonManager.getInstallForURL(aUri.spec, {telemetryInfo});
       await AddonManager.installAddonFromWebpage("application/x-xpinstall", browser,
         systemPrincipal, install);
@@ -1333,7 +1334,7 @@ class _ASRouter {
         break;
       case ra.INSTALL_ADDON_FROM_URL:
         this._updateOnboardingState();
-        await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url);
+        await MessageLoaderUtils.installAddonFromURL(target.browser, action.data.url, action.data.telemetrySource);
         break;
       case ra.PIN_CURRENT_TAB:
         let tab = target.browser.ownerGlobal.gBrowser.selectedTab;

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -432,7 +432,7 @@ const ONBOARDING_MESSAGES = async () => ([
         label: {string_id: "return-to-amo-extension-button"},
         action: {
           type: "INSTALL_ADDON_FROM_URL",
-          data: {url: null},
+          data: {url: null, telemetrySource: "rtamo"},
         },
       },
       secondary_button: {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1048,13 +1048,14 @@ describe("ASRouter", () => {
     describe("#onMessage: INSTALL_ADDON_FROM_URL", () => {
       it("should call installAddonFromURL with correct arguments", async () => {
         sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);
-        const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com"}});
+        const msg = fakeExecuteUserAction({type: "INSTALL_ADDON_FROM_URL", data: {url: "foo.com", telemetrySource: "foo"}});
 
         await Router.onMessage(msg);
 
         assert.calledOnce(MessageLoaderUtils.installAddonFromURL);
-        assert.calledWithExactly(MessageLoaderUtils.installAddonFromURL, msg.target.browser, "foo.com");
+        assert.calledWithExactly(MessageLoaderUtils.installAddonFromURL, msg.target.browser, "foo.com", "foo");
       });
+
       it("should add/remove observers for `webextension-install-notify`", async () => {
         sandbox.spy(global.Services.obs, "addObserver");
         sandbox.spy(global.Services.obs, "removeObserver");

--- a/test/unit/asrouter/MessageLoaderUtils.test.js
+++ b/test/unit/asrouter/MessageLoaderUtils.test.js
@@ -334,6 +334,19 @@ describe("MessageLoaderUtils", () => {
       // method (See Bug 1496167 for a rationale).
       assert.calledWithExactly(getInstallStub, "foo.com", {telemetryInfo: {source: "amo"}});
     });
+    it("should optionally pass a custom telemetrySource to the Addons API if specified", async () => {
+      getInstallStub.resolves(null);
+      installAddonStub.resolves(null);
+
+      await MessageLoaderUtils.installAddonFromURL({}, "foo.com", "foo");
+
+      assert.calledOnce(getInstallStub);
+      assert.calledOnce(installAddonStub);
+
+      // Verify that a custom installation source can be passed to the getInstallForURL
+      // method (See Bug 1549770 for a rationale).
+      assert.calledWithExactly(getInstallStub, "foo.com", {telemetryInfo: {source: "foo"}});
+    });
     it("should not call the Addons API on invalid URLs", async () => {
       sandbox.stub(global.Services.scriptSecurityManager, "getSystemPrincipal").throws();
 

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -81,6 +81,7 @@ describe("OnboardingMessage", () => {
     assert.propertyVal(translatedMessage.content.text.args, "addon-name", "foo@bar.org");
     assert.propertyVal(translatedMessage.content, "addon_icon", "icon");
     assert.propertyVal(translatedMessage.content.primary_button.action.data, "url", "foo");
+    assert.propertyVal(translatedMessage.content.primary_button.action.data, "telemetrySource", "rtamo");
   });
   it("should skip return_to_amo_overlay if any addon fields are missing", async () => {
     const fakeContent = "foo%bar.org";


### PR DESCRIPTION
This PR contains a small set of proposed changes to ensure that the addons installed from ActivityStream for the RTAMO onboarding are marked with "rtamo" as their install telemetry source (as it has been discussed in [Bug 1549770](https://bugzilla.mozilla.org/show_bug.cgi?id=1549770), which has also attached the new data review request related to this change).