### PR TITLE
Bug 1552937 - Preserve hover state on cards when hovering over context menu

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -38,7 +38,7 @@ $excerpt-line-height: 20;
     }
   }
 
-  &:hover .ds-card-link {
+  &:not(.placeholder):hover .ds-card-link {
     @include ds-fade-in($grey-30);
 
     @include dark-theme-only {

--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -38,6 +38,22 @@ $excerpt-line-height: 20;
     }
   }
 
+  &:hover .ds-card-link {
+    @include ds-fade-in($grey-30);
+
+    @include dark-theme-only {
+      @include ds-fade-in($grey-60);
+    }
+
+    header {
+      @include dark-theme-only {
+        color: $blue-40;
+      }
+
+      color: $blue-60;
+    }
+  }
+
   .ds-card-link {
     height: 100%;
 
@@ -47,18 +63,7 @@ $excerpt-line-height: 20;
       @include dark-theme-only {
         @include ds-fade-in($blue-40-40);
       }
-    }
 
-    &:hover {
-      @include ds-fade-in($grey-30);
-
-      @include dark-theme-only {
-        @include ds-fade-in($grey-60);
-      }
-    }
-
-    &:focus,
-    &:hover {
       header {
         @include dark-theme-only {
           color: $blue-40;


### PR DESCRIPTION
Testing: Confirm that hovering over context menu preserves the hover state on the rest of the card.