### PR TITLE
Bug 1551711 - Added alt-text prop to all snippet schemas that include an icon.

### DIFF
--- a/content-src/asrouter/templates/EOYSnippet/EOYSnippet.schema.json
+++ b/content-src/asrouter/templates/EOYSnippet/EOYSnippet.schema.json
@@ -80,6 +80,11 @@
       "type": "string",
       "description": "Snippet icon. Dark theme variant. 64x64px. SVG or PNG preferred."
     },
+    "icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
+    },
     "title": {
       "allOf": [
         {"$ref": "#/definitions/plainText"},

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
@@ -4,7 +4,7 @@ import {safeURI} from "../../template-utils";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
 const DEFAULT_ICON_PATH = "chrome://branding/content/icon64.png";
-// Alt text placeholder in case the prop from the server isn't available; See bug 1551711
+// Alt text placeholder in case the prop from the server isn't available
 const ICON_ALT_TEXT = "";
 
 export class SimpleBelowSearchSnippet extends React.PureComponent {

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
@@ -4,7 +4,7 @@ import {safeURI} from "../../template-utils";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
 const DEFAULT_ICON_PATH = "chrome://branding/content/icon64.png";
-// Alt text if available; in the future this should come from the server. See bug 1551711
+// Alt text placeholder in case the prop from the server isn't available; See bug 1551711
 const ICON_ALT_TEXT = "";
 
 export class SimpleBelowSearchSnippet extends React.PureComponent {
@@ -26,8 +26,8 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
     }
 
     return (<SnippetBase {...props} className={className} textStyle={this.props.textStyle}>
-      <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-light-theme" alt={ICON_ALT_TEXT} />
-      <img src={safeURI(props.content.icon_dark_theme || props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-dark-theme" alt={ICON_ALT_TEXT} />
+      <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-light-theme" alt={props.content.icon_alt_text || ICON_ALT_TEXT} />
+      <img src={safeURI(props.content.icon_dark_theme || props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-dark-theme" alt={props.content.icon_alt_text || ICON_ALT_TEXT} />
       <div>
         <p className="body">{this.renderText()}</p>
         {this.props.extraContent}

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
@@ -31,7 +31,7 @@
     },
     "icon_alt_text": {
       "type": "string",
-      "description": "Alt text for accessibility",
+      "description": "Alt text describing icon for screen readers",
       "default": ""
     },
     "block_button_text": {

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
@@ -29,6 +29,11 @@
       "type": "string",
       "description": "Snippet icon. Dark theme variant. 64x64px. SVG or PNG preferred."
     },
+    "icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
+    },
     "block_button_text": {
       "type": "string",
       "description": "Tooltip text used for dismiss button.",

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -6,7 +6,7 @@ import {safeURI} from "../../template-utils";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
 const DEFAULT_ICON_PATH = "chrome://branding/content/icon64.png";
-// Alt text if available; in the future this should come from the server. See bug 1551711
+// Alt text placeholder in case the prop from the server isn't available; See bug 1551711
 const ICON_ALT_TEXT = "";
 
 export class SimpleSnippet extends React.PureComponent {
@@ -131,8 +131,8 @@ export class SimpleSnippet extends React.PureComponent {
     return (<SnippetBase {...props} className={className} textStyle={this.props.textStyle}>
       {sectionHeader}
       <ConditionalWrapper condition={sectionHeader} wrap={this.wrapSnippetContent}>
-        <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-light-theme" alt={ICON_ALT_TEXT} />
-        <img src={safeURI(props.content.icon_dark_theme || props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-dark-theme" alt={ICON_ALT_TEXT} />
+        <img src={safeURI(props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-light-theme" alt={props.content.icon_alt_text || ICON_ALT_TEXT} />
+        <img src={safeURI(props.content.icon_dark_theme || props.content.icon) || DEFAULT_ICON_PATH} className="icon icon-dark-theme" alt={props.content.icon_alt_text || ICON_ALT_TEXT} />
         <div>
           {this.renderTitle()} <p className="body">{this.renderText()}</p>
           {this.props.extraContent}

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -6,7 +6,7 @@ import {safeURI} from "../../template-utils";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
 const DEFAULT_ICON_PATH = "chrome://branding/content/icon64.png";
-// Alt text placeholder in case the prop from the server isn't available; See bug 1551711
+// Alt text placeholder in case the prop from the server isn't available
 const ICON_ALT_TEXT = "";
 
 export class SimpleSnippet extends React.PureComponent {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -41,7 +41,7 @@
     },
     "icon_alt_text": {
       "type": "string",
-      "description": "Alt text for accessibility",
+      "description": "Alt text describing icon for screen readers",
       "default": ""
     },
     "title_icon": {
@@ -54,7 +54,7 @@
     },
     "title_icon_alt_text": {
       "type": "string",
-      "description": "Alt text for accessibility",
+      "description": "Alt text describing title icon for screen readers",
       "default": ""
     },
     "button_action": {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -39,6 +39,11 @@
       "type": "string",
       "description": "Snippet icon, dark theme variant. 64x64px. SVG or PNG preferred."
     },
+    "icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
+    },
     "title_icon": {
       "type": "string",
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
@@ -46,6 +51,11 @@
     "title_icon_dark_theme": {
       "type": "string",
       "description": "Small icon that shows up before the title / text. Dark theme variant. 16x16px. SVG or PNG preferred. Grayscale."
+    },
+    "title_icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
     },
     "button_action": {
       "type": "string",

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -5,7 +5,7 @@ import {safeURI} from "../../template-utils";
 import {SimpleSnippet} from "../SimpleSnippet/SimpleSnippet";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
-// Alt text placeholder in case the prop from the server isn't available; See bug 1551711
+// Alt text placeholder in case the prop from the server isn't available
 const ICON_ALT_TEXT = "";
 
 export class SubmitFormSnippet extends React.PureComponent {

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.jsx
@@ -5,7 +5,7 @@ import {safeURI} from "../../template-utils";
 import {SimpleSnippet} from "../SimpleSnippet/SimpleSnippet";
 import {SnippetBase} from "../../components/SnippetBase/SnippetBase";
 
-// Alt text if available; in the future this should come from the server. See bug 1551711
+// Alt text placeholder in case the prop from the server isn't available; See bug 1551711
 const ICON_ALT_TEXT = "";
 
 export class SubmitFormSnippet extends React.PureComponent {
@@ -168,8 +168,8 @@ export class SubmitFormSnippet extends React.PureComponent {
     return (<SnippetBase {...this.props} className={containerClass} footerDismiss={true}>
         {content.scene2_icon ?
           <div className="scene2Icon">
-            <img src={safeURI(content.scene2_icon)} className="icon-light-theme" alt={ICON_ALT_TEXT} />
-            <img src={safeURI(content.scene2_icon_dark_theme || content.scene2_icon)} className="icon-dark-theme" alt={ICON_ALT_TEXT} />
+            <img src={safeURI(content.scene2_icon)} className="icon-light-theme" alt={content.scene2_icon_alt_text || ICON_ALT_TEXT} />
+            <img src={safeURI(content.scene2_icon_dark_theme || content.scene2_icon)} className="icon-dark-theme" alt={content.scene2_icon_alt_text || ICON_ALT_TEXT} />
           </div> : null}
         <div className="message">
           <p>

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
@@ -61,7 +61,7 @@
     },
     "scene1_icon_alt_text": {
       "type": "string",
-      "description": "Alt text for accessibility",
+      "description": "Alt text describing scene1 icon for screen readers",
       "default": ""
     },
     "scene1_title_icon": {
@@ -74,7 +74,7 @@
     },
     "scene1_title_icon_alt_text": {
       "type": "string",
-      "description": "Alt text for accessibility",
+      "description": "Alt text describing scene1 title icon for screen readers",
       "default": ""
     },
     "form_action": {
@@ -127,7 +127,7 @@
     },
     "scene2_icon_alt_text": {
       "type": "string",
-      "description": "Alt text for accessibility",
+      "description": "Alt text describing scene2 icon for screen readers",
       "default": ""
     },
     "scene2_newsletter": {

--- a/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
+++ b/content-src/asrouter/templates/SubmitFormSnippet/SubmitFormSnippet.schema.json
@@ -59,6 +59,11 @@
       "type": "string",
       "description": "Snippet icon. Dark theme variant. 64x64px. SVG or PNG preferred."
     },
+    "scene1_icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
+    },
     "scene1_title_icon": {
       "type": "string",
       "description": "Small icon that shows up before the title / text. 16x16px. SVG or PNG preferred. Grayscale."
@@ -66,6 +71,11 @@
     "scene1_title_icon_dark_theme": {
       "type": "string",
       "description": "Small icon that shows up before the title / text. Dark theme variant. 16x16px. SVG or PNG preferred. Grayscale."
+    },
+    "scene1_title_icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
     },
     "form_action": {
       "type": "string",
@@ -114,6 +124,11 @@
     "scene2_icon_dark_theme": {
       "type": "string",
       "description": "(send to device) Image to display above the form. Dark theme variant. 98x98px. SVG or PNG preferred."
+    },
+    "scene2_icon_alt_text": {
+      "type": "string",
+      "description": "Alt text for accessibility",
+      "default": ""
     },
     "scene2_newsletter": {
       "type": "string",


### PR DESCRIPTION
 Fallback is an empty string.