### PR TITLE
Bug 1558903 - Passing proper shims for specific events.

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -26,7 +26,7 @@ export class DSCard extends React.PureComponent {
         tiles: [{
           id: this.props.id,
           pos: this.props.pos,
-          ...(this.props.shim ? {shim: this.props.shim} : {}),
+          ...(this.props.shim && this.props.shim.click ? {shim: this.props.shim.click} : {}),
         }],
       }));
     }
@@ -58,7 +58,7 @@ export class DSCard extends React.PureComponent {
             rows={[{
               id: this.props.id,
               pos: this.props.pos,
-              ...(this.props.shim ? {shim: this.props.shim} : {}),
+              ...(this.props.shim && this.props.shim.impression ? {shim: this.props.shim.impression} : {}),
             }]}
             dispatch={this.props.dispatch}
             source={this.props.type} />

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -28,7 +28,7 @@ export class Hero extends React.PureComponent {
         tiles: [{
           id: this.heroRec.id,
           pos: this.heroRec.pos,
-          ...(this.heroRec.shim ? {shim: this.heroRec.shim} : {}),
+          ...(this.heroRec.shim && this.heroRec.shim.click ? {shim: this.heroRec.shim.click} : {}),
         }],
       }));
     }
@@ -96,7 +96,7 @@ export class Hero extends React.PureComponent {
               rows={[{
                 id: heroRec.id,
                 pos: heroRec.pos,
-                ...(heroRec.shim ? {shim: heroRec.shim} : {}),
+                ...(heroRec.shim && heroRec.shim.impression ? {shim: heroRec.shim.impression} : {}),
               }]}
               dispatch={this.props.dispatch}
               source={this.props.type} />

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -32,7 +32,7 @@ export class ListItem extends React.PureComponent {
         tiles: [{
           id: this.props.id,
           pos: this.props.pos,
-          ...(this.props.shim ? {shim: this.props.shim} : {}),
+          ...(this.props.shim && this.props.shim.click ? {shim: this.props.shim.click} : {}),
         }],
       }));
     }
@@ -67,7 +67,7 @@ export class ListItem extends React.PureComponent {
             rows={[{
               id: this.props.id,
               pos: this.props.pos,
-              ...(this.props.shim ? {shim: this.props.shim} : {}),
+              ...(this.props.shim && this.props.shim.impression ? {shim: this.props.shim.impression} : {}),
             }]}
             dispatch={this.props.dispatch}
             source={this.props.type} />


### PR DESCRIPTION
1. Clone this repo locally https://github.com/ScottDowne/test-data
2. Run npm install
3. Run node start.js

1. Set this pref `browser.newtabpage.activity-stream.discoverystream.endpoints` to "https,http"
2. Set this pref `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://gist.githubusercontent.com/ScottDowne/1a08ca9f15ceb4ea0aafb9532e5d1381/raw/eef821bf4f40594d3c12ea684df3bdef8508a84e/adzerk-layout-2"}`
3. Ensure you can see telemetry events
4. Open a new tab, you should see a layout of weird cards, heros, and lists.
5. You should see 6 spocs total.
6. Open your browser toolbox (tools -> web developer -> browser toolbox)
7. Ensure click and view ping events have the shim prop being passes in for spocs, and not for regular cards. The shim prop might look close to this:

```
"shim": "spoc shim 6 click"
```
The numbers in there might change depending on which spoc you clicked on.