### PR TITLE
Bug 1536285 - Add Highlights as the final discovery stream section

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -4,6 +4,7 @@ import {CollapsibleSection} from "content-src/components/CollapsibleSection/Coll
 import {connect} from "react-redux";
 import {DSMessage} from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
 import {Hero} from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
+import {Highlights} from "content-src/components/DiscoveryStreamComponents/Highlights/Highlights";
 import {HorizontalRule} from "content-src/components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule";
 import {List} from "content-src/components/DiscoveryStreamComponents/List/List";
 import {Navigation} from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
@@ -89,6 +90,8 @@ export class _DiscoveryStreamBase extends React.PureComponent {
 
   renderComponent(component, embedWidth) {
     switch (component.type) {
+      case "Highlights":
+        return (<Highlights />);
       case "TopSites":
         return (<TopSites header={component.header} />);
       case "Message":
@@ -245,6 +248,10 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           title={message.header.title}>
           {this.renderLayout(layoutRender)}
         </CollapsibleSection>}
+        {this.renderLayout([{
+          width: 12,
+          components: [{type: "Highlights"}],
+        }])}
       </React.Fragment>
     );
   }

--- a/content-src/components/DiscoveryStreamComponents/Highlights/Highlights.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Highlights/Highlights.jsx
@@ -1,0 +1,20 @@
+import {connect} from "react-redux";
+import React from "react";
+import {SectionIntl} from "content-src/components/Sections/Sections";
+
+export class _Highlights extends React.PureComponent {
+  render() {
+    const section = this.props.Sections.find(s => s.id === "highlights");
+    if (!section || !section.enabled) {
+      return null;
+    }
+
+    return (
+      <div className="ds-highlights sections-list">
+        <SectionIntl {...section} isFixed={true} />
+      </div>
+    );
+  }
+}
+
+export const Highlights = connect(state => ({Sections: state.Sections}))(_Highlights);

--- a/content-src/components/DiscoveryStreamComponents/Highlights/_Highlights.scss
+++ b/content-src/components/DiscoveryStreamComponents/Highlights/_Highlights.scss
@@ -1,0 +1,34 @@
+.ds-highlights {
+  .section {
+    margin: 0 (-$section-horizontal-padding);
+
+    .section-list {
+      grid-gap: var(--gridRowGap);
+      grid-template-columns: repeat(4, 1fr);
+
+      .card-outer {
+        $line-height: 20px;
+        height: 175px;
+
+        .card-host-name {
+          font-size: 13px;
+          line-height: $line-height;
+          margin-bottom: 2px;
+          padding-bottom: 0;
+          text-transform: unset; // sass-lint:disable-line no-disallowed-properties
+        }
+
+        .card-title {
+          font-size: 14px;
+          font-weight: 600;
+          line-height: $line-height;
+          max-height: $line-height;
+        }
+      }
+    }
+  }
+
+  .hide-for-narrow {
+    display: block;
+  }
+}

--- a/content-src/components/Sections/Sections.jsx
+++ b/content-src/components/Sections/Sections.jsx
@@ -226,6 +226,7 @@ export class Section extends React.PureComponent {
         showPrefName={(pref && pref.feed) || id}
         privacyNoticeURL={privacyNoticeURL}
         Prefs={this.props.Prefs}
+        isFixed={this.props.isFixed}
         isFirst={isFirst}
         isLast={isLast}
         learnMore={learnMore}

--- a/content-src/styles/_activity-stream.scss
+++ b/content-src/styles/_activity-stream.scss
@@ -161,6 +161,7 @@ input {
 // Discovery Stream Components
 @import '../components/DiscoveryStreamComponents/CardGrid/CardGrid';
 @import '../components/DiscoveryStreamComponents/Hero/Hero';
+@import '../components/DiscoveryStreamComponents/Highlights/Highlights';
 @import '../components/DiscoveryStreamComponents/HorizontalRule/HorizontalRule';
 @import '../components/DiscoveryStreamComponents/List/List';
 @import '../components/DiscoveryStreamComponents/Navigation/Navigation';

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -100,10 +100,6 @@ this.AboutPreferences = class AboutPreferences {
     // Deep copy object to not modify original Sections state in store
     let sectionsCopy = JSON.parse(JSON.stringify(sections));
     sectionsCopy.forEach(obj => {
-      if (obj.id === "highlights") {
-        obj.shouldHidePref = true;
-      }
-
       if (obj.id === "topstories") {
         obj.rowsPref = "";
       }

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -145,7 +145,7 @@ const PREFS_CONFIG = new Map([
   }],
   ["section.highlights.rows", {
     title: "Number of rows of Highlights to display",
-    value: 2,
+    value: 1,
   }],
   ["section.topstories.rows", {
     title: "Number of rows of Top Stories to display",

--- a/test/browser/browser_highlights_section.js
+++ b/test/browser/browser_highlights_section.js
@@ -31,7 +31,7 @@ test_highlights(
     is(found, 2, "there should be 2 highlights cards");
 
     found = content.document.querySelectorAll(".section-list .placeholder").length;
-    is(found, 6, "there should be 2 rows * 4 - 2 = 6 highlights placeholder");
+    is(found, 2, "there should be 1 row * 4 - 2 = 2 highlights placeholder");
 
     found = content.document.querySelectorAll(".card-context-icon.icon-bookmark-added").length;
     is(found, 2, "there should be 2 bookmark icons");

--- a/test/unit/content-src/components/DiscoveryStreamComponents/Highlights.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/Highlights.test.jsx
@@ -1,0 +1,33 @@
+import {combineReducers, createStore} from "redux";
+import {INITIAL_STATE, reducers} from "common/Reducers.jsm";
+import {Highlights} from "content-src/components/DiscoveryStreamComponents/Highlights/Highlights";
+import {mountWithIntl} from "test/unit/utils";
+import {Provider} from "react-redux";
+import React from "react";
+
+describe("Discovery Stream <Highlights>", () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it("should render nothing with no highlights data", () => {
+    const store = createStore(combineReducers(reducers), {...INITIAL_STATE});
+
+    wrapper = mountWithIntl(<Provider store={store}><Highlights /></Provider>);
+
+    assert.ok(wrapper.isEmptyRender());
+  });
+
+  it("should render highlights", () => {
+    const store = createStore(combineReducers(reducers), {
+      ...INITIAL_STATE,
+      Sections: [{id: "highlights", enabled: true}],
+    });
+
+    wrapper = mountWithIntl(<Provider store={store}><Highlights /></Provider>);
+
+    assert.lengthOf(wrapper.find(".ds-highlights"), 1);
+  });
+});

--- a/test/unit/lib/AboutPreferences.test.js
+++ b/test/unit/lib/AboutPreferences.test.js
@@ -83,22 +83,6 @@ describe("AboutPreferences Feed", () => {
       assert.deepEqual(stub.firstCall.args[1], instance._strings);
       assert.include(stub.firstCall.args[2], Sections[0]);
     });
-    it("Hide highlights in sections if discovery stream is enabled", async () => {
-      const stub = sandbox.stub(instance, "renderPreferences");
-      instance._strings = {};
-      const titleString = "title";
-
-      Sections.push({pref: {titleString}, id: "highlights"});
-      DiscoveryStream = {config: {enabled: true}};
-
-      await instance.observe(window, PREFERENCES_LOADED_EVENT);
-
-      assert.calledOnce(stub);
-      assert.equal(stub.firstCall.args[2][0].id, "search");
-      assert.equal(stub.firstCall.args[2][1].id, "topsites");
-      assert.equal(stub.firstCall.args[2][2].id, "highlights");
-      assert.isTrue(stub.firstCall.args[2][2].shouldHidePref);
-    });
     it("Hide topstories rows select in sections if discovery stream is enabled", async () => {
       const stub = sandbox.stub(instance, "renderPreferences");
       instance._strings = {};


### PR DESCRIPTION
r?@ScottDowne Wraps similar to what we did for TopSites and adjusting the styling to fit with discoverystream cards:

![Screen Shot 2019-06-14 at 5 32 50 PM](https://user-images.githubusercontent.com/438537/59544878-434aed80-8ecb-11e9-80e4-0ee29349242d.png)

![Screen Shot 2019-06-14 at 2 29 28 PM](https://user-images.githubusercontent.com/438537/59539123-f6f2b400-8eb0-11e9-964e-740db9784dcd.png)
