### PR TITLE
Bug 1560235 - Fixing alignment issue and regression.

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -56,6 +56,8 @@ $excerpt-line-height: 20;
 
   .ds-card-link {
     height: 100%;
+    display: flex;
+    flex-direction: column;
 
     &:focus {
       @include ds-fade-in;
@@ -88,10 +90,14 @@ $excerpt-line-height: 20;
     display: flex;
     flex-direction: column;
     padding: 12px 16px;
+    flex-grow: 1;
 
     .info-wrap {
       flex-grow: 1;
-      margin: 0 0 12px;
+    }
+
+    .context {
+      margin: 12px 0 0;
     }
 
     .title {


### PR DESCRIPTION
To test:

1. Set your `browser.newtabpage.activity-stream.discoverystream.config` pref to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":true,"personalized":false,"layout_endpoint":"https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=basic"}`
2. Load a new tab until you see a spoc in the 3rd spot.
3. Inspect the middle stories body text in the firefox inspector. It should look something like `<p class="excerpt clamp"></p>`
4. Remove the `clamp` from the class list.
5. Make the `p` text much longer, until you end up with something like this screenshot: 
![text-align](https://user-images.githubusercontent.com/197334/59868443-e8981280-935e-11e9-8528-7cee6d5d4d6b.png)

ensure the sponsored by text is aligned on the bottom like the screen shot, and that it's aligned with the text in the middle story.
