### PR TITLE
Bug 1558550 - Convert strings in newtab content for topstories, highl…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,8 @@ module.exports = {
         "content-src/asrouter/templates/OnboardingMessage/**",
         "content-src/asrouter/templates/Trailhead/**",
         "content-src/components/TopSites/**",
+        "content-src/components/MoreRecommendations/MoreRecommendations.jsx",
+        "content-src/components/CollapsibleSection/CollapsibleSection.jsx"
       ],
       "rules": {
         "jsx-a11y/anchor-has-content": 0,

--- a/bin/bug_xxx_newtab.py
+++ b/bin/bug_xxx_newtab.py
@@ -149,6 +149,7 @@ newtab-empty-section-highlights = { COPY(from_path, "highlights_empty_state") }
 
 newtab-pocket-read-more = { COPY(from_path, "pocket_read_more") }
 newtab-pocket-more-recommendations = { COPY(from_path, "pocket_more_reccommendations") }
+newtab-pocket-how-it-works = { COPY(from_path, "pocket_how_it_works") }
 
 newtab-error-fallback-info = { COPY(from_path, "error_fallback_default_info") }
 newtab-error-fallback-refresh-link =
@@ -240,16 +241,6 @@ newtab-error-fallback-refresh-link =
                     "topstories_empty_state",
                     {
                         "{provider}": VARIABLE_REFERENCE("provider")
-                    },
-                )
-            ),
-            FTL.Message(
-                id=FTL.Identifier("newtab-pocket-how-it-works"),
-                value=REPLACE(
-                    "browser/chrome/browser/activity-stream/newtab.properties",
-                    "pocket_how_it_works",
-                    {
-                        "How it works": FTL.TextElement('<a data-l10n-name="learn-more">How it works</a>')
                     },
                 )
             ),

--- a/bin/bug_xxx_newtab.py
+++ b/bin/bug_xxx_newtab.py
@@ -143,7 +143,16 @@ newtab-section-menu-add-search-engine =
 newtab-section-menu-move-up = { COPY(from_path, "section_menu_action_move_up") }
 newtab-section-menu-move-down = { COPY(from_path, "section_menu_action_move_down") }
 newtab-section-menu-privacy-notice = { COPY(from_path, "section_menu_action_privacy_notice") }
+newtab-section-header-topsites = { COPY(from_path, "header_top_sites") }
+newtab-section-header-highlights = { COPY(from_path, "header_highlights") }
 newtab-empty-section-highlights = { COPY(from_path, "highlights_empty_state") }
+
+newtab-pocket-read-more = { COPY(from_path, "pocket_read_more") }
+newtab-pocket-more-recommendations = { COPY(from_path, "pocket_more_reccommendations") }
+newtab-pocket-how-it-works = { COPY(from_path, "pocket_how_it_works") }
+
+newtab-error-fallback-info = { COPY(from_path, "error_fallback_default_info") }
+newtab-error-fallback-refresh-link = { COPY(from_path, "error_fallback_default_refresh_suggestion") }
 
         """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
     )
@@ -215,12 +224,42 @@ newtab-empty-section-highlights = { COPY(from_path, "highlights_empty_state") }
                 )
             ),
             FTL.Message(
+                id=FTL.Identifier("newtab-section-header-pocket"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "header_recommended_by",
+                    {
+                        "{provider}": VARIABLE_REFERENCE("provider")
+                    },
+                )
+            ),
+            FTL.Message(
                 id=FTL.Identifier("newtab-empty-section-topstories"),
                 value=REPLACE(
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "topstories_empty_state",
                     {
                         "{provider}": VARIABLE_REFERENCE("provider")
+                    },
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newtab-pocket-cta-button"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "pocket_cta_button",
+                    {
+                        "Pocket": TERM_REFERENCE("pocket-brand-name")
+                    },
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newtab-pocket-cta-text"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "pocket_cta_text",
+                    {
+                        "Pocket": TERM_REFERENCE("pocket-brand-name")
                     },
                 )
             ),

--- a/bin/bug_xxx_newtab.py
+++ b/bin/bug_xxx_newtab.py
@@ -149,10 +149,10 @@ newtab-empty-section-highlights = { COPY(from_path, "highlights_empty_state") }
 
 newtab-pocket-read-more = { COPY(from_path, "pocket_read_more") }
 newtab-pocket-more-recommendations = { COPY(from_path, "pocket_more_reccommendations") }
-newtab-pocket-how-it-works = { COPY(from_path, "pocket_how_it_works") }
 
 newtab-error-fallback-info = { COPY(from_path, "error_fallback_default_info") }
-newtab-error-fallback-refresh-link = { COPY(from_path, "error_fallback_default_refresh_suggestion") }
+newtab-error-fallback-refresh-link =
+    { COPY(from_path, "error_fallback_default_refresh_suggestion") }
 
         """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
     )
@@ -240,6 +240,16 @@ newtab-error-fallback-refresh-link = { COPY(from_path, "error_fallback_default_r
                     "topstories_empty_state",
                     {
                         "{provider}": VARIABLE_REFERENCE("provider")
+                    },
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newtab-pocket-how-it-works"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "pocket_how_it_works",
+                    {
+                        "How it works": FTL.TextElement('<a data-l10n-name="learn-more">How it works</a>')
                     },
                 )
             ),

--- a/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -178,10 +178,8 @@ export class CollapsibleSection extends React.PureComponent {
               </span>
               <span className="learn-more-link-wrapper">
                 {learnMore &&
-                  <span className="learn-more-link">
-                    <a href={learnMore.link.href}>
-                      <span data-l10n-id={learnMore.link.id} />
-                    </a>
+                  <span className="learn-more-link" data-l10n-id={learnMore.link.id}>
+                    <a data-l10n-name="learn-more" href={learnMore.link.href} />
                   </span>
                 }
               </span>

--- a/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -1,4 +1,3 @@
-import {FormattedMessage, injectIntl} from "react-intl";
 import {actionCreators as ac} from "common/Actions.jsm";
 import {ErrorBoundary} from "content-src/components/ErrorBoundary/ErrorBoundary";
 import React from "react";
@@ -9,10 +8,18 @@ const VISIBLE = "visible";
 const VISIBILITY_CHANGE_EVENT = "visibilitychange";
 
 function getFormattedMessage(message) {
-  return typeof message === "string" ? <span>{message}</span> : <FormattedMessage {...message} />;
+  return typeof message === "string" ? (
+    <span>{message}</span>
+  ) : (
+    <span
+      data-l10n-id={message.id}
+      data-l10n-args={
+        !message.values ? "{}" : `{ "provider": "${message.values.provider}" }`
+      } />
+  );
 }
 
-export class _CollapsibleSection extends React.PureComponent {
+export class CollapsibleSection extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onBodyMount = this.onBodyMount.bind(this);
@@ -173,7 +180,7 @@ export class _CollapsibleSection extends React.PureComponent {
                 {learnMore &&
                   <span className="learn-more-link">
                     <a href={learnMore.link.href}>
-                      <FormattedMessage id={learnMore.link.id} />
+                      <span data-l10n-id={learnMore.link.id} />
                     </a>
                   </span>
                 }
@@ -218,7 +225,7 @@ export class _CollapsibleSection extends React.PureComponent {
   }
 }
 
-_CollapsibleSection.defaultProps = {
+CollapsibleSection.defaultProps = {
   document: global.document || {
     addEventListener: () => {},
     removeEventListener: () => {},
@@ -226,5 +233,3 @@ _CollapsibleSection.defaultProps = {
   },
   Prefs: {values: {}},
 };
-
-export const CollapsibleSection = injectIntl(_CollapsibleSection);

--- a/content-src/components/CollapsibleSection/CollapsibleSection.jsx
+++ b/content-src/components/CollapsibleSection/CollapsibleSection.jsx
@@ -178,8 +178,8 @@ export class CollapsibleSection extends React.PureComponent {
               </span>
               <span className="learn-more-link-wrapper">
                 {learnMore &&
-                  <span className="learn-more-link" data-l10n-id={learnMore.link.id}>
-                    <a data-l10n-name="learn-more" href={learnMore.link.href} />
+                  <span className="learn-more-link">
+                    <a href={learnMore.link.href} data-l10n-id={learnMore.link.id}>{learnMore.link.text}</a>
                   </span>
                 }
               </span>

--- a/content-src/components/CollapsibleSection/_CollapsibleSection.scss
+++ b/content-src/components/CollapsibleSection/_CollapsibleSection.scss
@@ -104,7 +104,7 @@
     font-size: 11px;
     margin-inline-start: 12px;
 
-    a span {
+    a {
       color: var(--newtab-link-secondary-color);
     }
   }

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -189,8 +189,6 @@ export class _DiscoveryStreamBase extends React.PureComponent {
     }
 
     // Find the first component of a type and remove it from layout
-    // Note: Do not use the return component for additional FluentDOM use. Otherwise,
-    // the fluent IDs will be stripped and replaced with copy/replace strings.
     const extractComponent = type => {
       for (const [rowIndex, row] of Object.entries(layoutRender)) {
         for (const [index, component] of Object.entries(row.components)) {
@@ -219,7 +217,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
     const topSites = extractComponent("TopSites");
     const message = extractComponent("Message") || {
       header: {
-        link_text: topStories.learnMore.link.id,
+        link_id: topStories.learnMore.link.id,
         link_url: topStories.learnMore.link.href,
         title: topStories.title,
       },
@@ -241,8 +239,9 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           isFixed={true}
           learnMore={{
             link: {
-              href: topStories.learnMore.link.href,
-              id: topStories.learnMore.link.id,
+              href: message.header.link_url,
+              text: message.header.link_text,
+              id: message.header.link_id
             },
           }}
           privacyNoticeURL={topStories.privacyNoticeURL}

--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -189,6 +189,8 @@ export class _DiscoveryStreamBase extends React.PureComponent {
     }
 
     // Find the first component of a type and remove it from layout
+    // Note: Do not use the return component for additional FluentDOM use. Otherwise,
+    // the fluent IDs will be stripped and replaced with copy/replace strings.
     const extractComponent = type => {
       for (const [rowIndex, row] of Object.entries(layoutRender)) {
         for (const [index, component] of Object.entries(row.components)) {
@@ -239,8 +241,8 @@ export class _DiscoveryStreamBase extends React.PureComponent {
           isFixed={true}
           learnMore={{
             link: {
-              href: message.header.link_url,
-              id: message.header.link_text,
+              href: topStories.learnMore.link.href,
+              id: topStories.learnMore.link.id,
             },
           }}
           privacyNoticeURL={topStories.privacyNoticeURL}

--- a/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
+++ b/content-src/components/DiscoveryStreamBase/_DiscoveryStreamBase.scss
@@ -53,7 +53,7 @@ $ds-width: 936px;
   .section-top-bar {
     margin-bottom: 0;
 
-    .learn-more-link a span {
+    .learn-more-link a {
       color: var(--newtab-link-primary-color);
       font-weight: normal;
 

--- a/content-src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/content-src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,5 +1,4 @@
 import {A11yLinkButton} from "content-src/components/A11yLinkButton/A11yLinkButton";
-import {FormattedMessage} from "react-intl";
 import React from "react";
 
 export class ErrorBoundaryFallback extends React.PureComponent {
@@ -29,17 +28,9 @@ export class ErrorBoundaryFallback extends React.PureComponent {
     // "A11yLinkButton" to force normal link styling stuff (eg cursor on hover)
     return (
       <div className={className}>
-        <div>
-          <FormattedMessage
-            defaultMessage="Oops, something went wrong loading this content."
-            id="error_fallback_default_info" />
-        </div>
+        <div data-l10n-id="newtab-error-fallback-info" />
         <span>
-          <A11yLinkButton className="reload-button" onClick={this.onClick}>
-            <FormattedMessage
-              defaultMessage="Refresh page to try again."
-              id="error_fallback_default_refresh_suggestion" />
-          </A11yLinkButton>
+          <A11yLinkButton className="reload-button" onClick={this.onClick} data-l10n-id="newtab-error-fallback-refresh-link" />
         </span>
       </div>
     );

--- a/content-src/components/MoreRecommendations/MoreRecommendations.jsx
+++ b/content-src/components/MoreRecommendations/MoreRecommendations.jsx
@@ -1,4 +1,3 @@
-import {FormattedMessage} from "react-intl";
 import React from "react";
 
 export class MoreRecommendations extends React.PureComponent {
@@ -7,7 +6,7 @@ export class MoreRecommendations extends React.PureComponent {
     if (read_more_endpoint) {
       return (
         <a className="more-recommendations" href={read_more_endpoint}>
-          <FormattedMessage id="pocket_more_reccommendations" />
+          <span data-l10n-id="newtab-pocket-more-recommendations" />
         </a>
       );
     }

--- a/content-src/components/MoreRecommendations/MoreRecommendations.jsx
+++ b/content-src/components/MoreRecommendations/MoreRecommendations.jsx
@@ -5,9 +5,7 @@ export class MoreRecommendations extends React.PureComponent {
     const {read_more_endpoint} = this.props;
     if (read_more_endpoint) {
       return (
-        <a className="more-recommendations" href={read_more_endpoint}>
-          <span data-l10n-id="newtab-pocket-more-recommendations" />
-        </a>
+        <a className="more-recommendations" href={read_more_endpoint} data-l10n-id="newtab-pocket-more-recommendations" />
       );
     }
     return null;

--- a/content-src/components/PocketLoggedInCta/PocketLoggedInCta.jsx
+++ b/content-src/components/PocketLoggedInCta/PocketLoggedInCta.jsx
@@ -1,5 +1,4 @@
 import {connect} from "react-redux";
-import {FormattedMessage} from "react-intl";
 import React from "react";
 
 export class _PocketLoggedInCta extends React.PureComponent {
@@ -8,12 +7,12 @@ export class _PocketLoggedInCta extends React.PureComponent {
     return (
       <span className="pocket-logged-in-cta">
         <a className="pocket-cta-button" href={pocketCta.ctaUrl ? pocketCta.ctaUrl : "https://getpocket.com/"}>
-         {pocketCta.ctaButton ? pocketCta.ctaButton : <FormattedMessage id="pocket_cta_button" />}
+         {pocketCta.ctaButton ? pocketCta.ctaButton : <span data-l10n-id="newtab-pocket-cta-button" />}
         </a>
 
         <a href={pocketCta.ctaUrl ? pocketCta.ctaUrl : "https://getpocket.com/"}>
           <span className="cta-text">
-           {pocketCta.ctaText ? pocketCta.ctaText : <FormattedMessage id="pocket_cta_text" />}
+           {pocketCta.ctaText ? pocketCta.ctaText : <span data-l10n-id="newtab-pocket-cta-text" />}
           </span>
         </a>
       </span>

--- a/content-src/components/TopSites/TopSites.jsx
+++ b/content-src/components/TopSites/TopSites.jsx
@@ -3,7 +3,6 @@ import {MIN_CORNER_FAVICON_SIZE, MIN_RICH_FAVICON_SIZE, TOP_SITES_SOURCE} from "
 import {CollapsibleSection} from "content-src/components/CollapsibleSection/CollapsibleSection";
 import {ComponentPerfTimer} from "content-src/components/ComponentPerfTimer/ComponentPerfTimer";
 import {connect} from "react-redux";
-import {injectIntl} from "react-intl";
 import {ModalOverlayWrapper} from "../../asrouter/components/ModalOverlay/ModalOverlay";
 import React from "react";
 import {SearchShortcutsForm} from "./SearchShortcutsForm";
@@ -127,7 +126,7 @@ export class _TopSites extends React.PureComponent {
         className="top-sites"
         icon="topsites"
         id="topsites"
-        title={this.props.title || {id: "header_top_sites"}}
+        title={this.props.title || {id: "newtab-section-header-topsites"}}
         extraMenuOptions={extraMenuOptions}
         showPrefName="feeds.topsites"
         eventSource={TOP_SITES_SOURCE}
@@ -170,4 +169,4 @@ export const TopSites = connect(state => ({
   TopSites: state.TopSites,
   Prefs: state.Prefs,
   TopSitesRows: state.Prefs.values.topSitesRows,
-}))(injectIntl(_TopSites));
+}))(_TopSites);

--- a/content-src/components/Topics/Topics.jsx
+++ b/content-src/components/Topics/Topics.jsx
@@ -1,4 +1,3 @@
-import {FormattedMessage} from "react-intl";
 import React from "react";
 
 export class Topic extends React.PureComponent {
@@ -13,7 +12,7 @@ export class Topics extends React.PureComponent {
     const {topics} = this.props;
     return (
       <span className="topics">
-        <span><FormattedMessage id="pocket_read_more" /></span>
+        <span data-l10n-id="newtab-pocket-read-more" />
         <ul>{topics && topics.map(t => <Topic key={t.name} url={t.url} name={t.name} />)}</ul>
       </span>
     );

--- a/lib/SectionsManager.jsm
+++ b/lib/SectionsManager.jsm
@@ -19,7 +19,7 @@ const BUILT_IN_SECTIONS = {
   "feeds.section.topstories": options => ({
     id: "topstories",
     pref: {
-      titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
+      titleString: {id: "newtab-section-header-pocket", values: {provider: options.provider_name}},
       descString: {id: "prefs_topstories_description2"},
       nestedPrefs: options.show_spocs ? [{
         name: "showSponsored",
@@ -30,11 +30,11 @@ const BUILT_IN_SECTIONS = {
     shouldHidePref: options.hidden,
     eventSource: "TOP_STORIES",
     icon: options.provider_icon,
-    title: {id: "header_recommended_by", values: {provider: options.provider_name}},
+    title: {id: "newtab-section-header-pocket", values: {provider: options.provider_name}},
     learnMore: {
       link: {
         href: "https://getpocket.com/firefox/new_tab_learn_more",
-        id: "pocket_how_it_works",
+        id: "newtab-pocket-how-it-works",
       },
     },
     privacyNoticeURL: "https://www.mozilla.org/privacy/firefox/#suggest-relevant-content",
@@ -71,7 +71,7 @@ const BUILT_IN_SECTIONS = {
     shouldHidePref:  false,
     eventSource: "HIGHLIGHTS",
     icon: "highlights",
-    title: {id: "header_highlights"},
+    title: {id: "newtab-section-header-highlights"},
     compactCards: true,
     rowsPref: "section.highlights.rows",
     maxRows: 4,

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -1,18 +1,3 @@
-header_top_sites=Top Sites
-header_highlights=Highlights
-# LOCALIZATION NOTE(header_recommended_by): This is followed by the name
-# of the corresponding content provider.
-header_recommended_by=Recommended by {provider}
-
-# LOCALIZATION NOTE (section_disclaimer_topstories): This is shown below
-# the topstories section title to provide additional information about
-# how the stories are selected.
-section_disclaimer_topstories=The most interesting stories on the web, selected based on what you read. From Pocket, now part of Mozilla.
-section_disclaimer_topstories_linktext=Learn how it works.
-# LOCALIZATION NOTE (section_disclaimer_topstories_buttontext): The text of
-# the button used to acknowledge, and hide this disclaimer in the future.
-section_disclaimer_topstories_buttontext=Okay, got it
-
 # LOCALIZATION NOTE (prefs_*, settings_*): These are shown in about:preferences
 # for a "Firefox Home" section. "Firefox" should be treated as a brand and kept
 # in English, while "Home" should be localized matching the about:preferences
@@ -45,22 +30,6 @@ settings_pane_highlights_options_bookmarks=Bookmarks
 # something that expresses the idea of "a small message, shortened from
 # something else, and non-essential but also not entirely trivial and useless."
 settings_pane_snippets_header=Snippets
-
-# LOCALIZATION NOTE (pocket_read_more): This is shown at the bottom of the
-# trending stories section and precedes a list of links to popular topics.
-pocket_read_more=Popular Topics:
-# LOCALIZATION NOTE (pocket_read_even_more): This is shown as a link at the
-# end of the list of popular topic links.
-pocket_read_even_more=View More Stories
-pocket_more_reccommendations=More Recommendations
-pocket_how_it_works=How it works
-pocket_cta_button=Get Pocket
-pocket_cta_text=Save the stories you love in Pocket, and fuel your mind with fascinating reads.
-
-# LOCALIZATION NOTE (error_fallback_default_*): This message and suggested
-# action link are shown in each section of UI that fails to render
-error_fallback_default_info=Oops, something went wrong loading this content.
-error_fallback_default_refresh_suggestion=Refresh page to try again.
 
 # LOCALIZATION NOTE (firstrun_*). These strings are displayed only once, on the
 # firstrun of the browser, they give an introduction to Firefox and Sync.

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -131,9 +131,29 @@ newtab-section-menu-move-up = Move Up
 newtab-section-menu-move-down = Move Down
 newtab-section-menu-privacy-notice = Privacy Notice
 
-## Empty Section States: These show when there are no more items in a section.
+## Section Headers
+newtab-section-header-topsites = Top Sites
+newtab-section-header-highlights = Highlights
+# Variables:
+#  $provider (String): This is followed by the name of the corresponding content provider.
+newtab-section-header-pocket = Recommended by { $provider }
+
+## Empty Section States: These show when there are no more items in a section. Ex. When there are no more Pocket story reccomendations, in the space where there would have been stories, this is shown instead.
 newtab-empty-section-highlights = Start browsing, and we’ll show some of the great articles, videos, and other pages you’ve recently visited or bookmarked here.
 # Ex. When there are no more Pocket story recommendations, in the space where there would have been stories, this is shown instead.
 # Variables:
 #  $provider (String): Name of the content provider for this section, e.g "Pocket".
 newtab-empty-section-topstories = You’ve caught up. Check back later for more top stories from { $provider }. Can’t wait? Select a popular topic to find more great stories from around the web.
+
+## Pocket Content Section
+# Note: This is shown at the bottom of the trending stories section and precedes a list of links to popular topics.
+newtab-pocket-read-more = Popular Topics:
+newtab-pocket-more-recommendations = More Recommendations
+newtab-pocket-how-it-works = How it works
+newtab-pocket-cta-button = Get { -pocket-brand-name }
+newtab-pocket-cta-text = Save the stories you love in { -pocket-brand-name }, and fuel your mind with fascinating reads.
+
+## Error Fallback Content.
+## This message and suggested action link are shown in each section of UI that fails to render
+newtab-error-fallback-info = Oops, something went wrong loading this content.
+newtab-error-fallback-refresh-link = Refresh page to try again.

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -149,7 +149,7 @@ newtab-empty-section-topstories = You’ve caught up. Check back later for more 
 # Note: This is shown at the bottom of the trending stories section and precedes a list of links to popular topics.
 newtab-pocket-read-more = Popular Topics:
 newtab-pocket-more-recommendations = More Recommendations
-newtab-pocket-how-it-works = How it works
+newtab-pocket-how-it-works = <a data-l10n-name="learn-more">How it works</a>
 newtab-pocket-cta-button = Get { -pocket-brand-name }
 newtab-pocket-cta-text = Save the stories you love in { -pocket-brand-name }, and fuel your mind with fascinating reads.
 

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -149,7 +149,7 @@ newtab-empty-section-topstories = You’ve caught up. Check back later for more 
 # Note: This is shown at the bottom of the trending stories section and precedes a list of links to popular topics.
 newtab-pocket-read-more = Popular Topics:
 newtab-pocket-more-recommendations = More Recommendations
-newtab-pocket-how-it-works = <a data-l10n-name="learn-more">How it works</a>
+newtab-pocket-how-it-works = How it works
 newtab-pocket-cta-button = Get { -pocket-brand-name }
 newtab-pocket-cta-text = Save the stories you love in { -pocket-brand-name }, and fuel your mind with fascinating reads.
 

--- a/test/unit/content-src/components/CollapsibleSection.test.jsx
+++ b/test/unit/content-src/components/CollapsibleSection.test.jsx
@@ -1,7 +1,7 @@
 import {actionTypes as at} from "common/Actions.jsm";
-import {_CollapsibleSection as CollapsibleSection} from "content-src/components/CollapsibleSection/CollapsibleSection";
+import {CollapsibleSection} from "content-src/components/CollapsibleSection/CollapsibleSection";
 import {ErrorBoundary} from "content-src/components/ErrorBoundary/ErrorBoundary";
-import {mountWithIntl} from "test/unit/utils";
+import {mount} from "enzyme";
 import React from "react";
 
 const DEFAULT_PROPS = {
@@ -9,7 +9,6 @@ const DEFAULT_PROPS = {
   className: "cool-section",
   title: "Cool Section",
   prefName: "collapseSection",
-  disclaimer: {text: {id: "section_disclaimer_topstories_linktext"}, link: {id: "menu_action_remove_bookmark"}, button: {id: "search_button"}},
   collapsed: false,
   document: {
     addEventListener: () => {},
@@ -24,7 +23,7 @@ describe("CollapsibleSection", () => {
 
   function setup(props = {}) {
     const customProps = Object.assign({}, DEFAULT_PROPS, props);
-    wrapper = mountWithIntl(<CollapsibleSection {...customProps}>foo</CollapsibleSection>);
+    wrapper = mount(<CollapsibleSection {...customProps}>foo</CollapsibleSection>);
   }
 
   beforeEach(() => setup());

--- a/test/unit/content-src/components/ErrorBoundary.test.jsx
+++ b/test/unit/content-src/components/ErrorBoundary.test.jsx
@@ -1,5 +1,5 @@
+import {A11yLinkButton} from "content-src/components/A11yLinkButton/A11yLinkButton";
 import {ErrorBoundary, ErrorBoundaryFallback} from "content-src/components/ErrorBoundary/ErrorBoundary";
-import {FormattedMessage} from "react-intl";
 import React from "react";
 import {shallow} from "enzyme";
 
@@ -81,23 +81,22 @@ describe("ErrorBoundaryFallback", () => {
     assert.lengthOf(wrapper.find("A11yLinkButton.reload-button"), 1);
   });
 
-  it("should render error_fallback_default_refresh_suggestion FormattedMessage",
+  it("should render newtab-error-fallback-refresh-link node",
     () => {
       const wrapper = shallow(<ErrorBoundaryFallback />);
 
       const msgWrapper =
-        wrapper.find('[id="error_fallback_default_refresh_suggestion"]');
+        wrapper.find('[data-l10n-id="newtab-error-fallback-refresh-link"]');
       assert.lengthOf(msgWrapper, 1);
-      assert.isTrue(msgWrapper.is(FormattedMessage));
+      assert.isTrue(msgWrapper.is(A11yLinkButton));
     });
 
-  it("should render error_fallback_default_info FormattedMessage",
+  it("should render newtab-error-fallback-info node",
     () => {
       const wrapper = shallow(<ErrorBoundaryFallback />);
 
       const msgWrapper =
-        wrapper.find('[id="error_fallback_default_info"]');
+        wrapper.find('[data-l10n-id="newtab-error-fallback-info"]');
       assert.lengthOf(msgWrapper, 1);
-      assert.isTrue(msgWrapper.is(FormattedMessage));
     });
 });

--- a/test/unit/content-src/components/PocketLoggedInCta.test.jsx
+++ b/test/unit/content-src/components/PocketLoggedInCta.test.jsx
@@ -1,14 +1,13 @@
 import {combineReducers, createStore} from "redux";
 import {INITIAL_STATE, reducers} from "common/Reducers.jsm";
-import {mountWithIntl, shallowWithIntl} from "test/unit/utils";
+import {mount, shallow} from "enzyme";
 import {PocketLoggedInCta, _PocketLoggedInCta as PocketLoggedInCtaRaw} from "content-src/components/PocketLoggedInCta/PocketLoggedInCta";
-import {FormattedMessage} from "react-intl";
 import {Provider} from "react-redux";
 import React from "react";
 
 function mountSectionWithProps(props) {
   const store = createStore(combineReducers(reducers), INITIAL_STATE);
-  return mountWithIntl(<Provider store={store}><PocketLoggedInCta {...props} /></Provider>);
+  return mount(<Provider store={store}><PocketLoggedInCta {...props} /></Provider>);
 }
 
 describe("<PocketLoggedInCta>", () => {
@@ -16,21 +15,21 @@ describe("<PocketLoggedInCta>", () => {
     const wrapper = mountSectionWithProps({});
     assert.ok(wrapper.exists());
   });
-  it("should render FormattedMessages when rendered without props", () => {
+  it("should render Fluent spans when rendered without props", () => {
     const wrapper = mountSectionWithProps({});
 
-    const message = wrapper.find(FormattedMessage);
+    const message = wrapper.find("span[data-l10n-id]");
     assert.lengthOf(message, 2);
   });
-  it("should not render FormattedMessages when rendered with props", () => {
-    const wrapper = shallowWithIntl(<PocketLoggedInCtaRaw Pocket={{
+  it("should not render Fluent spans when rendered with props", () => {
+    const wrapper = shallow(<PocketLoggedInCtaRaw Pocket={{
       pocketCta: {
         ctaButton: "button",
         ctaText: "text",
       },
     }} />);
 
-    const message = wrapper.find(FormattedMessage);
+    const message = wrapper.find("span[data-l10n-id]");
     assert.lengthOf(message, 0);
   });
 });


### PR DESCRIPTION
Fluent migrations
- Header Labels (“Top Sites”, “Highlights”, “Recommended by Pocket”)
- Pocket header and footer strings
- Error strings that appear when the tab fails to load or when a section fails to load (https://imgur.com/a/edjJCgy)

- Removed dead Strings
    - section_disclaimer_topstories, section_disclaimer_topstories_linktext, section_disclaimer_topstories_buttontext
    - pocket_read_even_more