### PR TITLE
Bug 1561414 - Fixing unintended changes to About:Prefs that uses same strings in newtab pocket section

### DIFF
--- a/lib/SectionsManager.jsm
+++ b/lib/SectionsManager.jsm
@@ -19,7 +19,7 @@ const BUILT_IN_SECTIONS = {
   "feeds.section.topstories": options => ({
     id: "topstories",
     pref: {
-      titleString: {id: "newtab-section-header-pocket", values: {provider: options.provider_name}},
+      titleString: {id: "header_recommended_by", values: {provider: options.provider_name}},
       descString: {id: "prefs_topstories_description2"},
       nestedPrefs: options.show_spocs ? [{
         name: "showSponsored",
@@ -35,6 +35,7 @@ const BUILT_IN_SECTIONS = {
       link: {
         href: "https://getpocket.com/firefox/new_tab_learn_more",
         message: {id: "newtab-pocket-how-it-works"},
+        id: "pocket_how_it_works",
       },
     },
     privacyNoticeURL: "https://www.mozilla.org/privacy/firefox/#suggest-relevant-content",

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -1,3 +1,7 @@
+# LOCALIZATION NOTE(header_recommended_by): This is followed by the name
+# of the corresponding content provider.
+header_recommended_by=Recommended by {provider}
+
 # LOCALIZATION NOTE (prefs_*, settings_*): These are shown in about:preferences
 # for a "Firefox Home" section. "Firefox" should be treated as a brand and kept
 # in English, while "Home" should be localized matching the about:preferences
@@ -30,6 +34,8 @@ settings_pane_highlights_options_bookmarks=Bookmarks
 # something that expresses the idea of "a small message, shortened from
 # something else, and non-essential but also not entirely trivial and useless."
 settings_pane_snippets_header=Snippets
+
+pocket_how_it_works=How it works
 
 # LOCALIZATION NOTE (firstrun_*). These strings are displayed only once, on the
 # firstrun of the browser, they give an introduction to Firefox and Sync.


### PR DESCRIPTION
@Mardak . Following #5127 (checkout last commit until it gets merged). 

Fortunately, the "header_recommended_by" was originally used in two different places, one for about prefs and one for newtab pocket section. But, "pocket_how_it_works" was shared from one source. Made changes ontop of #5127 to keep newtab fluent changes.