### PR TITLE
Resolving feedback on Fluent comments in PR 5083

### DIFF
--- a/bin/bug_1485002_newtab.py
+++ b/bin/bug_1485002_newtab.py
@@ -73,7 +73,8 @@ newtab-search-box-search-the-web-input =
     .title = { COPY(from_path, "search_web_placeholder") }
     .aria-label = { COPY(from_path, "search_web_placeholder") }
 
-newtab-topsites-add-search-engine-header = { COPY(from_path, "section_menu_action_add_search_engine") }
+newtab-topsites-add-search-engine-header =
+    { COPY(from_path, "section_menu_action_add_search_engine") }
 newtab-topsites-add-topsites-header = { COPY(from_path, "topsites_form_add_header") }
 newtab-topsites-edit-topsites-header = { COPY(from_path, "topsites_form_edit_header") }
 newtab-topsites-title-label = { COPY(from_path, "topsites_form_title_label") }

--- a/bin/bug_1485002_newtab.py
+++ b/bin/bug_1485002_newtab.py
@@ -73,8 +73,9 @@ newtab-search-box-search-the-web-input =
     .title = { COPY(from_path, "search_web_placeholder") }
     .aria-label = { COPY(from_path, "search_web_placeholder") }
 
-newtab-topsites-add-header = { COPY(from_path, "topsites_form_add_header") }
-newtab-topsites-edit-header = { COPY(from_path, "topsites_form_edit_header") }
+newtab-topsites-add-search-engine-header = { COPY(from_path, "section_menu_action_add_search_engine") }
+newtab-topsites-add-topsites-header = { COPY(from_path, "topsites_form_add_header") }
+newtab-topsites-edit-topsites-header = { COPY(from_path, "topsites_form_edit_header") }
 newtab-topsites-title-label = { COPY(from_path, "topsites_form_title_label") }
 newtab-topsites-title-input =
     .placeholder = { COPY(from_path, "topsites_form_title_placeholder") }
@@ -97,7 +98,6 @@ newtab-topsites-add-button = { COPY(from_path, "topsites_form_add_button") }
 newtab-confirm-delete-history-p1 = { COPY(from_path, "confirm_history_delete_p1") }
 newtab-confirm-delete-history-p2 = { COPY(from_path, "confirm_history_delete_notice_p2") }
 
-newtab-topsites-add-search-engine = { COPY(from_path, "section_menu_action_add_search_engine") }
 newtab-menu-section-tooltip =
     .title = { COPY(from_path, "context_menu_title") }
     .aria-label = { COPY(from_path, "context_menu_title") }
@@ -123,14 +123,10 @@ newtab-menu-remove-download = { COPY(from_path, "menu_action_remove_download") }
 newtab-menu-show-file =
     { PLATFORM() ->
       [macos] { COPY(from_path, "menu_action_show_file_mac_os") }
-      [windows] { COPY(from_path, "menu_action_show_file_windows") }
-      [linux] { COPY(from_path, "menu_action_show_file_linux") }
-       *[other] { COPY(from_path, "menu_action_show_file_default") }
+       *[other] { COPY(from_path, "menu_action_show_file_windows") }
     }
 newtab-menu-open-file = { COPY(from_path, "menu_action_open_file") }
 
-newtab-card-tooltip =
-    .title = { COPY(from_path, "context_menu_title") }
 newtab-label-visited = { COPY(from_path, "type_label_visited") }
 newtab-label-bookmarked = { COPY(from_path, "type_label_bookmarked") }
 newtab-label-recommended = { COPY(from_path, "type_label_recommended") }

--- a/content-src/components/TopSites/SearchShortcutsForm.jsx
+++ b/content-src/components/TopSites/SearchShortcutsForm.jsx
@@ -119,7 +119,7 @@ export class SearchShortcutsForm extends React.PureComponent {
     return (
       <form className="topsite-form">
         <div className="search-shortcuts-container">
-          <h3 className="section-title grey-title" data-l10n-id="newtab-topsites-add-search-engine" />
+          <h3 className="section-title grey-title" data-l10n-id="newtab-topsites-add-search-engine-header" />
           <div>
             {this.state.shortcuts.map(shortcut => <SelectableSearchShortcut key={shortcut.keyword} shortcut={shortcut} selected={shortcut.isSelected} onChange={this.handleChange} />)}
           </div>

--- a/content-src/components/TopSites/TopSiteForm.jsx
+++ b/content-src/components/TopSites/TopSiteForm.jsx
@@ -201,7 +201,7 @@ export class TopSiteForm extends React.PureComponent {
     return (
       <form className="topsite-form" onSubmit={onSubmit}>
         <div className="form-input-container">
-          <h3 className="section-title grey-title" data-l10n-id={showAsAdd ? "newtab-topsites-add-header" : "newtab-topsites-edit-header"} />
+          <h3 className="section-title grey-title" data-l10n-id={showAsAdd ? "newtab-topsites-add-topsites-header" : "newtab-topsites-edit-topsites-header"} />
           <div className="fields-and-preview">
             <div className="form-wrapper">
               <TopSiteFormInput onChange={this.onLabelChange}

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -139,7 +139,7 @@ newtab-section-header-highlights = Highlights
 #  $provider (String): Name of the corresponding content provider.
 newtab-section-header-pocket = Recommended by { $provider }
 
-## Empty Section States: These show when there are no more items in a section. Ex. When there are no more Pocket story recomendations, in the space where there would have been stories, this is shown instead.
+## Empty Section States: These show when there are no more items in a section. Ex. When there are no more Pocket story recommendations, in the space where there would have been stories, this is shown instead.
 
 newtab-empty-section-highlights = Start browsing, and we’ll show some of the great articles, videos, and other pages you’ve recently visited or bookmarked here.
 

--- a/locales-src/newtab.ftl
+++ b/locales-src/newtab.ftl
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-### Firefox Home / New Tab strings for about:home / about:newtab / about:welcome
+### Firefox Home / New Tab strings for about:home / about:newtab.
 
 newtab-page-title = New Tab
 newtab-settings-button =
     .title = Customize your New Tab page
 
-## Search box component
+## Search box component.
 
 # "Search" is a verb/action
 newtab-search-box-search-button =
@@ -21,10 +21,11 @@ newtab-search-box-search-the-web-input =
     .title = Search the Web
     .aria-label = Search the Web
 
-## Top Sites - General form dialog
+## Top Sites - General form dialog.
 
-newtab-topsites-add-header = New Top Site
-newtab-topsites-edit-header = Edit Top Site
+newtab-topsites-add-search-engine-header = Add Search Engine
+newtab-topsites-add-topsites-header = New Top Site
+newtab-topsites-edit-topsites-header = Edit Top Site
 newtab-topsites-title-label = Title
 newtab-topsites-title-input =
     .placeholder = Enter a title
@@ -38,22 +39,22 @@ newtab-topsites-image-url-label = Custom Image URL
 newtab-topsites-use-image-link = Use a custom image…
 newtab-topsites-image-validation = Image failed to load. Try a different URL.
 
-## Top Sites - General form dialog buttons. These are verbs/actions
+## Top Sites - General form dialog buttons. These are verbs/actions.
+
 newtab-topsites-cancel-button = Cancel
 newtab-topsites-delete-history-button = Delete from History
 newtab-topsites-save-button = Save
 newtab-topsites-preview-button = Preview
 newtab-topsites-add-button = Add
 
-## Top Sites - Delete history confirmation dialog. newtab-confirm-delete-history-p1 appears in the same dialog
-## as newtab-confirm-delete-history-p2.
+## Top Sites - Delete history confirmation dialog. 
+
 newtab-confirm-delete-history-p1 = Are you sure you want to delete every instance of this page from your history?
-# Note: "This action" refers to deleting a page from history.
+# "This action" refers to deleting a page from history.
 newtab-confirm-delete-history-p2 = This action cannot be undone.
 
-newtab-topsites-add-search-engine = Add Search Engine
-
 ## Context Menu - Action Tooltips.
+
 # General tool tip for context menus.
 newtab-menu-section-tooltip =
     .title = Open menu
@@ -61,7 +62,7 @@ newtab-menu-section-tooltip =
 
 # This tooltip is for the context menu of Pocket cards or Topsites
 # Variables:
-#  $title (String): Title is the label or hostname of the site. This is for screen readers when the context menu button is focused/active.
+#  $title (String): The label or hostname of the site. This is for screen readers when the context menu button is focused/active.
 newtab-menu-content-tooltip =
     .title = Open menu
     .aria-label = Open context menu for { $title }
@@ -71,6 +72,7 @@ newtab-menu-topsites-placeholder-tooltip =
     .aria-label = Edit this site
 
 ## Context Menu: These strings are displayed in a context menu and are meant as a call to action for a given page.
+
 newtab-menu-edit-topsites = Edit
 newtab-menu-open-new-window = Open in a New Window
 newtab-menu-open-new-private-window = Open in a New Private Window
@@ -82,13 +84,14 @@ newtab-menu-save-to-pocket = Save to { -pocket-brand-name }
 newtab-menu-delete-pocket = Delete from { -pocket-brand-name }
 newtab-menu-archive-pocket = Archive in { -pocket-brand-name }
 
-# Note: Bookmark is a noun in this case, "Remove bookmark".
+# Bookmark is a noun in this case, "Remove bookmark".
 newtab-menu-remove-bookmark = Remove Bookmark
-# Note: Bookmark is a verb here.
+# Bookmark is a verb here.
 newtab-menu-bookmark = Bookmark
 
-## Context Menu - Downloaded Menu: In (newtab-menu-copy-download-link, newtab-menu-go-to-download-page), 
-## "Download" in these cases is not a verb, it is a noun. As in, "Copy the link that belongs to this downloaded item".
+## Context Menu - Downloaded Menu. "Download" in these cases is not a verb, 
+## it is a noun. As in, "Copy the link that belongs to this downloaded item".
+
 newtab-menu-copy-download-link = Copy Download Link
 newtab-menu-go-to-download-page = Go to Download Page
 newtab-menu-remove-download = Remove from History
@@ -96,22 +99,18 @@ newtab-menu-remove-download = Remove from History
 ## Context Menu - Download Menu: These are platform specific strings found in the context menu of an item that has
 ## been downloaded. The intention behind "this action" is that it will show where the downloaded file exists on the file
 ## system for each operating system.
+
 newtab-menu-show-file =
     { PLATFORM() ->
         [macos] Show in Finder
-        [windows] Open Containing Folder
-        [linux] Open Containing Folder
-       *[other] Show File
+       *[other] Open Containing Folder
     }
 newtab-menu-open-file = Open File
 
-## Card Tooltip: Action tooltip to open a context menu
-newtab-card-tooltip =
-    .title = Open menu
-
 ## Card Labels: These labels are associated to pages to give
 ## context on how the element is related to the user, e.g. type indicates that
-## the page is bookmarked, or is currently open on another device
+## the page is bookmarked, or is currently open on another device.
+
 newtab-label-visited = Visited
 newtab-label-bookmarked = Bookmarked
 newtab-label-recommended = Trending
@@ -120,6 +119,7 @@ newtab-label-download = Downloaded
 
 ## Section Menu: These strings are displayed in the section context menu and are 
 ## meant as a call to action for the given section.
+
 newtab-section-menu-remove-section = Remove Section
 newtab-section-menu-collapse-section = Collapse Section
 newtab-section-menu-expand-section = Expand Section
@@ -131,22 +131,26 @@ newtab-section-menu-move-up = Move Up
 newtab-section-menu-move-down = Move Down
 newtab-section-menu-privacy-notice = Privacy Notice
 
-## Section Headers
+## Section Headers.
+
 newtab-section-header-topsites = Top Sites
 newtab-section-header-highlights = Highlights
 # Variables:
-#  $provider (String): This is followed by the name of the corresponding content provider.
+#  $provider (String): Name of the corresponding content provider.
 newtab-section-header-pocket = Recommended by { $provider }
 
-## Empty Section States: These show when there are no more items in a section. Ex. When there are no more Pocket story reccomendations, in the space where there would have been stories, this is shown instead.
+## Empty Section States: These show when there are no more items in a section. Ex. When there are no more Pocket story recomendations, in the space where there would have been stories, this is shown instead.
+
 newtab-empty-section-highlights = Start browsing, and we’ll show some of the great articles, videos, and other pages you’ve recently visited or bookmarked here.
+
 # Ex. When there are no more Pocket story recommendations, in the space where there would have been stories, this is shown instead.
 # Variables:
 #  $provider (String): Name of the content provider for this section, e.g "Pocket".
 newtab-empty-section-topstories = You’ve caught up. Check back later for more top stories from { $provider }. Can’t wait? Select a popular topic to find more great stories from around the web.
 
-## Pocket Content Section
-# Note: This is shown at the bottom of the trending stories section and precedes a list of links to popular topics.
+## Pocket Content Section.
+
+# This is shown at the bottom of the trending stories section and precedes a list of links to popular topics.
 newtab-pocket-read-more = Popular Topics:
 newtab-pocket-more-recommendations = More Recommendations
 newtab-pocket-how-it-works = How it works
@@ -154,6 +158,7 @@ newtab-pocket-cta-button = Get { -pocket-brand-name }
 newtab-pocket-cta-text = Save the stories you love in { -pocket-brand-name }, and fuel your mind with fascinating reads.
 
 ## Error Fallback Content.
-## This message and suggested action link are shown in each section of UI that fails to render
+## This message and suggested action link are shown in each section of UI that fails to render.
+
 newtab-error-fallback-info = Oops, something went wrong loading this content.
 newtab-error-fallback-refresh-link = Refresh page to try again.

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -807,7 +807,7 @@ describe("<TopSiteForm>", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
     });
     it("should have the correct header", () => {
-      assert.equal(wrapper.findWhere(n => n.length && n.prop("data-l10n-id") === "newtab-topsites-add-header").length, 1);
+      assert.equal(wrapper.findWhere(n => n.length && n.prop("data-l10n-id") === "newtab-topsites-add-topsites-header").length, 1);
     });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.length && n.prop("data-l10n-id") === "newtab-topsites-save-button").length, 0);
@@ -880,7 +880,7 @@ describe("<TopSiteForm>", () => {
       assert.ok(wrapper.find(TopSiteForm).exists());
     });
     it("should have the correct header", () => {
-      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab-topsites-edit-header").length, 1);
+      assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab-topsites-edit-topsites-header").length, 1);
     });
     it("should have the correct button text", () => {
       assert.equal(wrapper.findWhere(n => n.prop("data-l10n-id") === "newtab-topsites-add-button").length, 0);


### PR DESCRIPTION
Resolving Fluent comment feedback in #5083. 
- ##'s have a new line after them.
- ##'s end in a "." so that there is a separator when concatenated with single-hash comments.
-  Changed Open File location label to only handle "macos" (show in finder) and "other" (Open Containing Folder).
- Migrated and renamed some strings.