### PR TITLE
Bug 1559689 - Allow history highlights that happen to be bookmarked to appear in normal history order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Firefox Home (New Tab)
 
 [![Task Status](https://github.taskcluster.net/v1/repository/mozilla/activity-stream/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla/activity-stream/master/latest)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Firefox Home (New Tab)
 
 [![Task Status](https://github.taskcluster.net/v1/repository/mozilla/activity-stream/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla/activity-stream/master/latest)

--- a/lib/HighlightsFeed.jsm
+++ b/lib/HighlightsFeed.jsm
@@ -103,9 +103,7 @@ this.HighlightsFeed = class HighlightsFeed {
   _orderHighlights(pages) {
     const splitHighlights = {chronologicalCandidates: [], visited: []};
     for (let page of pages) {
-      // If we have a page that is both a history item and a bookmark, treat it
-      // as a bookmark
-      if (page.type === "history" && !page.bookmarkGuid) {
+      if (page.type === "history") {
         splitHighlights.visited.push(page);
       } else {
         splitHighlights.chronologicalCandidates.push(page);

--- a/test/unit/lib/HighlightsFeed.test.js
+++ b/test/unit/lib/HighlightsFeed.test.js
@@ -223,23 +223,22 @@ describe("Highlights Feed", () => {
     });
     it("should chronologically order highlight data types", async () => {
       links = [
-        {url: "https://site0.com", type: "bookmark", bookmarkGuid: "1234", date_added: Date.now() - 80}, // 4th newest
-        {url: "https://site1.com", type: "history", bookmarkGuid: "1234", date_added: Date.now() - 60}, // 3rd newest
+        {url: "https://site0.com", type: "bookmark", bookmarkGuid: "1234", date_added: Date.now() - 80}, // 3rd newest
+        {url: "https://site1.com", type: "history", bookmarkGuid: "1234", date_added: Date.now() - 60}, // append at the end
         {url: "https://site2.com", type: "history", date_added: Date.now() - 160}, // append at the end
         {url: "https://site3.com", type: "history", date_added: Date.now() - 60}, // append at the end
         {url: "https://site4.com", type: "pocket", date_added: Date.now()}, // newest highlight
-        {url: "https://site5.com", type: "pocket", date_added: Date.now() - 100}, // 5th newest
+        {url: "https://site5.com", type: "pocket", date_added: Date.now() - 100}, // 4th newest
         {url: "https://site6.com", type: "bookmark", bookmarkGuid: "1234", date_added: Date.now() - 40}, // 2nd newest
       ];
+      const expectedChronological = [4, 6, 0, 5];
+      const expectedHistory = [1, 2, 3];
 
       let highlights = await fetchHighlights();
-      assert.equal(highlights[0].url, links[4].url);
-      assert.equal(highlights[1].url, links[6].url);
-      assert.equal(highlights[2].url, links[1].url);
-      assert.equal(highlights[3].url, links[0].url);
-      assert.equal(highlights[4].url, links[5].url);
-      assert.equal(highlights[5].url, links[2].url);
-      assert.equal(highlights[6].url, links[3].url);
+
+      [...expectedChronological, ...expectedHistory].forEach((link, index) => {
+        assert.propertyVal(highlights[index], "url", links[link].url, `highlight[${index}] should be link[${link}]`);
+      });
     });
     it("should fetch Highlights if TopSites are not enabled", async () => {
       sandbox.spy(feed.linksCache, "request");


### PR DESCRIPTION
r?@gvn or @ScottDowne Just removes the old special behavior of always putting bookmarks first even when it's just a history page that happens to be bookmarked. (Still keeps the special behavior of putting recent bookmark/pocket/download first before history.)