### PR TITLE
Bug 1556895 - Convert first run strings in about:welcome and startup overlay to use fluent

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
       "files": [
         "content-src/asrouter/templates/OnboardingMessage/**",
         "content-src/asrouter/templates/Trailhead/**",
+        "content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx",
         "content-src/components/TopSites/**",
         "content-src/components/MoreRecommendations/MoreRecommendations.jsx",
         "content-src/components/CollapsibleSection/CollapsibleSection.jsx"

--- a/bin/bug_1556895_newtab.py
+++ b/bin/bug_1556895_newtab.py
@@ -44,8 +44,6 @@ NB: migrate-l10n will make local commits to gecko-strings
 The diff should result in no differences if the migration recipe matches the
 fluent file.
 """
-SOURCE_FILE = 'locales-src/onboarding.ftl'
-
 
 def migrate(ctx):
     """Bug 1556895 - Migrate newtab.properties to onboarding.ftl, part {index}"""
@@ -56,13 +54,14 @@ def migrate(ctx):
         transforms_from("""
 
 onboarding-sync-welcome-content = { COPY(from_path, "firstrun_content") }
+onboarding-sync-welcome-learn-more-link = { COPY(from_path, "firstrun_learn_more_link") }
 onboarding-sync-form-invalid-input = { COPY(from_path, "firstrun_invalid_input") }
 onboarding-sync-form-header = { COPY(from_path, "firstrun_form_header") }
 onboarding-sync-form-input =
     .placeholder = { COPY(from_path, "firstrun_email_input_placeholder") }
 onboarding-sync-form-continue-button = { COPY(from_path, "firstrun_continue_to_login") }
 onboarding-sync-form-skip-login-button = { COPY(from_path, "firstrun_skip_login") }
-onboarding-menu-dismiss =
+onboarding-cards-dismiss =
     .title = { COPY(from_path, "menu_action_dismiss") }
     .aria-label = { COPY(from_path, "menu_action_dismiss") }
 
@@ -78,16 +77,6 @@ onboarding-menu-dismiss =
                 value=REPLACE(
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "firstrun_title",
-                    {
-                        "Firefox": TERM_REFERENCE("brand-product-name")
-                    },
-                )
-            ),
-            FTL.Message(
-                id=FTL.Identifier("onboarding-sync-welcome-learn-more-link"),
-                value=REPLACE(
-                    "browser/chrome/browser/activity-stream/newtab.properties",
-                    "firstrun_learn_more_link",
                     {
                         "Firefox": TERM_REFERENCE("brand-product-name")
                     },

--- a/bin/bug_1556895_newtab.py
+++ b/bin/bug_1556895_newtab.py
@@ -45,6 +45,7 @@ The diff should result in no differences if the migration recipe matches the
 fluent file.
 """
 
+
 def migrate(ctx):
     """Bug 1556895 - Migrate newtab.properties to onboarding.ftl, part {index}"""
 

--- a/bin/bug_1556895_newtab.py
+++ b/bin/bug_1556895_newtab.py
@@ -55,14 +55,16 @@ def migrate(ctx):
         SOURCE_FILE,
         transforms_from("""
 
-onboarding-control-form-privacy-notice = { COPY(from_path, "firstrun_privacy_notice") }
-onboarding-control-welcome-content = { COPY(from_path, "firstrun_content") }
-onboarding-control-form-invalid-input = { COPY(from_path, "firstrun_invalid_input") }
-onboarding-control-form-header = { COPY(from_path, "firstrun_form_header") }
-onboarding-control-form-input =
+onboarding-sync-welcome-content = { COPY(from_path, "firstrun_content") }
+onboarding-sync-form-invalid-input = { COPY(from_path, "firstrun_invalid_input") }
+onboarding-sync-form-header = { COPY(from_path, "firstrun_form_header") }
+onboarding-sync-form-input =
     .placeholder = { COPY(from_path, "firstrun_email_input_placeholder") }
-onboarding-control-form-continue-button = { COPY(from_path, "firstrun_continue_to_login") }
-onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_login") }
+onboarding-sync-form-continue-button = { COPY(from_path, "firstrun_continue_to_login") }
+onboarding-sync-form-skip-login-button = { COPY(from_path, "firstrun_skip_login") }
+onboarding-menu-dismiss =
+    .title = { COPY(from_path, "menu_action_dismiss") }
+    .aria-label = { COPY(from_path, "menu_action_dismiss") }
 
         """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
     )
@@ -72,7 +74,7 @@ onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_log
         SOURCE_FILE,
         [
             FTL.Message(
-                id=FTL.Identifier("onboarding-control-welcome-header"),
+                id=FTL.Identifier("onboarding-sync-welcome-header"),
                 value=REPLACE(
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "firstrun_title",
@@ -82,7 +84,7 @@ onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_log
                 )
             ),
             FTL.Message(
-                id=FTL.Identifier("onboarding-control-welcome-learn-more-link"),
+                id=FTL.Identifier("onboarding-sync-welcome-learn-more-link"),
                 value=REPLACE(
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "firstrun_learn_more_link",
@@ -92,7 +94,7 @@ onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_log
                 )
             ),
             FTL.Message(
-                id=FTL.Identifier("onboarding-control-legal-notice"),
+                id=FTL.Identifier("onboarding-sync-legal-notice"),
                 value=REPLACE(
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "firstrun_extra_legal_links",
@@ -117,7 +119,7 @@ onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_log
                 )
             ),
             FTL.Message(
-                id=FTL.Identifier("onboarding-control-form-sub-header"),
+                id=FTL.Identifier("onboarding-sync-form-sub-header"),
                 value=REPLACE(
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "firstrun_form_sub_header",

--- a/bin/bug_1556895_newtab.py
+++ b/bin/bug_1556895_newtab.py
@@ -43,9 +43,6 @@ NB: migrate-l10n will make local commits to gecko-strings
 
 The diff should result in no differences if the migration recipe matches the
 fluent file.
-
-
-NB: Move the following line out of this comment to test from activity-stream
 """
 SOURCE_FILE = 'locales-src/onboarding.ftl'
 
@@ -69,7 +66,7 @@ onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_log
 
         """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
     )
-    
+
     ctx.add_transforms(
         TARGET_FILE,
         SOURCE_FILE,
@@ -125,7 +122,7 @@ onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_log
                     "browser/chrome/browser/activity-stream/newtab.properties",
                     "firstrun_form_sub_header",
                     {
-                        "Firefox": TERM_REFERENCE("brand-product-name")
+                        "Firefox Sync": TERM_REFERENCE("sync-brand-name")
                     },
                 )
             ),

--- a/bin/bug_1556895_newtab.py
+++ b/bin/bug_1556895_newtab.py
@@ -1,0 +1,133 @@
+# coding=utf8
+
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import TERM_REFERENCE
+from fluent.migrate import COPY, REPLACE, CONCAT
+
+TARGET_FILE = 'browser/browser/newtab/onboarding.ftl'
+SOURCE_FILE = TARGET_FILE
+
+"""
+For now while we're testing, use a recipe with slightly different paths for
+testing from activity-stream instead of the usual steps:
+https://firefox-source-docs.mozilla.org/intl/l10n/l10n/fluent_migrations.html#how-to-test-migration-recipes
+
+
+One-time setup starting from activity-stream directory:
+
+```
+cd ..
+git clone hg::https://hg.mozilla.org/l10n/fluent-migration
+cd fluent-migration
+pip install -e .
+
+cd ..
+hg clone https://hg.mozilla.org/l10n/gecko-strings
+```
+NB: gecko-strings needs to be cloned with mercurial not git-cinnabar
+
+
+Testing from activity-stream directory:
+
+```
+PYTHONPATH=./bin migrate-l10n bug_1556895_newtab --lang en-US --reference-dir . \
+  --localization-dir ../gecko-strings
+diff -B -w locales-src/onboarding.ftl ../gecko-strings/browser/browser/newtab/onboarding.ftl
+```
+NB: migrate-l10n will make local commits to gecko-strings
+
+The diff should result in no differences if the migration recipe matches the
+fluent file.
+
+
+NB: Move the following line out of this comment to test from activity-stream
+"""
+SOURCE_FILE = 'locales-src/onboarding.ftl'
+
+
+def migrate(ctx):
+    """Bug 1556895 - Migrate newtab.properties to onboarding.ftl, part {index}"""
+
+    ctx.add_transforms(
+        TARGET_FILE,
+        SOURCE_FILE,
+        transforms_from("""
+
+onboarding-control-form-privacy-notice = { COPY(from_path, "firstrun_privacy_notice") }
+onboarding-control-welcome-content = { COPY(from_path, "firstrun_content") }
+onboarding-control-form-invalid-input = { COPY(from_path, "firstrun_invalid_input") }
+onboarding-control-form-header = { COPY(from_path, "firstrun_form_header") }
+onboarding-control-form-input =
+    .placeholder = { COPY(from_path, "firstrun_email_input_placeholder") }
+onboarding-control-form-continue-button = { COPY(from_path, "firstrun_continue_to_login") }
+onboarding-control-form-skip-login-button = { COPY(from_path, "firstrun_skip_login") }
+
+        """, from_path='browser/chrome/browser/activity-stream/newtab.properties')
+    )
+    
+    ctx.add_transforms(
+        TARGET_FILE,
+        SOURCE_FILE,
+        [
+            FTL.Message(
+                id=FTL.Identifier("onboarding-control-welcome-header"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "firstrun_title",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-product-name")
+                    },
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("onboarding-control-welcome-learn-more-link"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "firstrun_learn_more_link",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-product-name")
+                    },
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("onboarding-control-legal-notice"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "firstrun_extra_legal_links",
+                    {
+                        "{terms}": CONCAT(
+                            FTL.TextElement('<a data-l10n-name="terms">'),
+                            COPY(
+                                "browser/chrome/browser/activity-stream/newtab.properties",
+                                "firstrun_terms_of_service"
+                            ),
+                            FTL.TextElement("</a>")
+                        ),
+                        "{privacy}": CONCAT(
+                            FTL.TextElement('<a data-l10n-name="privacy">'),
+                            COPY(
+                                "browser/chrome/browser/activity-stream/newtab.properties",
+                                "firstrun_privacy_notice"
+                            ),
+                            FTL.TextElement("</a>")
+                        )
+                    },
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("onboarding-control-form-sub-header"),
+                value=REPLACE(
+                    "browser/chrome/browser/activity-stream/newtab.properties",
+                    "firstrun_form_sub_header",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-product-name")
+                    },
+                )
+            ),
+        ]
+    )

--- a/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
@@ -4,6 +4,7 @@ import React from "react";
 
 const FLUENT_FILES = [
   "branding/brand.ftl",
+  "browser/branding/sync-brand.ftl",
   "browser/newtab/onboarding.ftl",
 ];
 
@@ -130,14 +131,14 @@ export class _StartupOverlay extends React.PureComponent {
         <div className="firstrun-scene">
           <div className="fxaccounts-container">
             <div className="firstrun-left-divider">
-              <h1 className="firstrun-title" data-l10n-id="onboarding-control-welcome-header" />
-              <p className="firstrun-content" data-l10n-id="onboarding-control-welcome-content" />
-              <a className="firstrun-link" href={`https://www.mozilla.org/firefox/features/sync/?${this.utmParams}`} target="_blank" rel="noopener noreferrer" data-l10n-id="onboarding-control-welcome-learn-more-link" />
+              <h1 className="firstrun-title" data-l10n-id="onboarding-sync-welcome-header" />
+              <p className="firstrun-content" data-l10n-id="onboarding-sync-welcome-content" />
+              <a className="firstrun-link" href={`https://www.mozilla.org/firefox/features/sync/?${this.utmParams}`} target="_blank" rel="noopener noreferrer" data-l10n-id="onboarding-sync-welcome-learn-more-link" />
             </div>
             <div className="firstrun-sign-in">
               <p className="form-header">
-                <span data-l10n-id="onboarding-control-form-header"/>
-                <span className="sub-header" data-l10n-id="onboarding-control-form-sub-header" />
+                <span data-l10n-id="onboarding-sync-form-header"/>
+                <span className="sub-header" data-l10n-id="onboarding-sync-form-sub-header" />
               </p>
               <form method="get" action={this.props.fxa_endpoint} target="_blank" rel="noopener noreferrer" onSubmit={this.onSubmit}>
                 <input name="service" type="hidden" value="sync" />
@@ -151,19 +152,19 @@ export class _StartupOverlay extends React.PureComponent {
                 <input name="device_id" type="hidden" value={this.state.deviceId} />
                 <input name="flow_id" type="hidden" value={this.state.flowId} />
                 <input name="flow_begin_time" type="hidden" value={this.state.flowBeginTime} />
-                <span className="error" data-l10n-id="onboarding-control-form-invalid-input" />
-                <input className="email-input" name="email" type="email" required="true" onInvalid={this.onInputInvalid} onChange={this.onInputChange} data-l10n-id="onboarding-control-form-input" />
+                <span className="error" data-l10n-id="onboarding-sync-form-invalid-input" />
+                <input className="email-input" name="email" type="email" required="true" onInvalid={this.onInputInvalid} onChange={this.onInputChange} data-l10n-id="onboarding-sync-form-input" />
                 <div className="extra-links">
-                <p data-l10n-id="onboarding-control-legal-notice">
+                <p data-l10n-id="onboarding-sync-legal-notice">
                   <a data-l10n-name="terms" target="_blank" rel="noopener noreferrer"
                     href={`${this.props.fxa_endpoint}/legal/terms?${this.utmParams}`} />
                   <a data-l10n-name="privacy" target="_blank" rel="noopener noreferrer"
                     href={`${this.props.fxa_endpoint}/legal/privacy?${this.utmParams}`} />
                 </p>
                 </div>
-                <button className="continue-button" type="submit" data-l10n-id="onboarding-control-form-continue-button" />
+                <button className="continue-button" type="submit" data-l10n-id="onboarding-sync-form-continue-button" />
               </form>
-              <button className="skip-button" disabled={!!this.state.emailInput} onClick={this.clickSkip} data-l10n-id="onboarding-control-form-skip-login-button" />
+              <button className="skip-button" disabled={!!this.state.emailInput} onClick={this.clickSkip} data-l10n-id="onboarding-sync-form-skip-login-button" />
             </div>
           </div>
         </div>

--- a/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
@@ -1,7 +1,11 @@
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
-import {FormattedMessage, injectIntl} from "react-intl";
 import {connect} from "react-redux";
 import React from "react";
+
+const FLUENT_FILES = [
+  "branding/brand.ftl",
+  "browser/newtab/onboarding.ftl",
+];
 
 export class _StartupOverlay extends React.PureComponent {
   constructor(props) {
@@ -41,6 +45,16 @@ export class _StartupOverlay extends React.PureComponent {
         this.props.dispatch(ac.OnlyToMain({type: at.TELEMETRY_UNDESIRED_EVENT, data: {event: "FXA_METRICS_ERROR"}}));
       }
     }
+  }
+
+  async componentWillMount() {
+    FLUENT_FILES.forEach(file => {
+      const link = document.head.appendChild(document.createElement("link"));
+      link.href = file;
+      link.rel = "localization";
+    });
+
+    await this.componentWillUpdate(this.props);
   }
 
   componentDidMount() {
@@ -109,21 +123,22 @@ export class _StartupOverlay extends React.PureComponent {
       return null;
     }
 
-    let termsLink = (<a href={`${this.props.fxa_endpoint}/legal/terms?${this.utmParams}`} target="_blank" rel="noopener noreferrer"><FormattedMessage id="firstrun_terms_of_service" /></a>);
-    let privacyLink = (<a href={`${this.props.fxa_endpoint}/legal/privacy?${this.utmParams}`} target="_blank" rel="noopener noreferrer"><FormattedMessage id="firstrun_privacy_notice" /></a>);
-
+ 
     return (
       <div className={`overlay-wrapper ${this.state.show ? "show" : ""}`}>
         <div className="background" />
         <div className="firstrun-scene">
           <div className="fxaccounts-container">
             <div className="firstrun-left-divider">
-              <h1 className="firstrun-title"><FormattedMessage id="firstrun_title" /></h1>
-              <p className="firstrun-content"><FormattedMessage id="firstrun_content" /></p>
-              <a className="firstrun-link" href={`https://www.mozilla.org/firefox/features/sync/?${this.utmParams}`} target="_blank" rel="noopener noreferrer"><FormattedMessage id="firstrun_learn_more_link" /></a>
+              <h1 className="firstrun-title" data-l10n-id="onboarding-control-welcome-header" />
+              <p className="firstrun-content" data-l10n-id="onboarding-control-welcome-content" />
+              <a className="firstrun-link" href={`https://www.mozilla.org/firefox/features/sync/?${this.utmParams}`} target="_blank" rel="noopener noreferrer" data-l10n-id="onboarding-control-welcome-learn-more-link" />
             </div>
             <div className="firstrun-sign-in">
-              <p className="form-header"><FormattedMessage id="firstrun_form_header" /><span className="sub-header"><FormattedMessage id="firstrun_form_sub_header" /></span></p>
+              <p className="form-header">
+                <span data-l10n-id="onboarding-control-form-header"/>
+                <span className="sub-header" data-l10n-id="onboarding-control-form-sub-header" />
+              </p>
               <form method="get" action={this.props.fxa_endpoint} target="_blank" rel="noopener noreferrer" onSubmit={this.onSubmit}>
                 <input name="service" type="hidden" value="sync" />
                 <input name="action" type="hidden" value="email" />
@@ -136,19 +151,19 @@ export class _StartupOverlay extends React.PureComponent {
                 <input name="device_id" type="hidden" value={this.state.deviceId} />
                 <input name="flow_id" type="hidden" value={this.state.flowId} />
                 <input name="flow_begin_time" type="hidden" value={this.state.flowBeginTime} />
-                <span className="error">{this.props.intl.formatMessage({id: "firstrun_invalid_input"})}</span>
-                <input className="email-input" name="email" type="email" required="true" onInvalid={this.onInputInvalid} placeholder={this.props.intl.formatMessage({id: "firstrun_email_input_placeholder"})} onChange={this.onInputChange} />
+                <span className="error" data-l10n-id="onboarding-control-form-invalid-input" />
+                <input className="email-input" name="email" type="email" required="true" onInvalid={this.onInputInvalid} onChange={this.onInputChange} data-l10n-id="onboarding-control-form-input" />
                 <div className="extra-links">
-                  <FormattedMessage
-                    id="firstrun_extra_legal_links"
-                    values={{
-                      terms: termsLink,
-                      privacy: privacyLink,
-                    }} />
+                <p data-l10n-id="onboarding-control-legal-notice">
+                  <a data-l10n-name="terms" target="_blank" rel="noopener noreferrer"
+                    href={`${this.props.fxa_endpoint}/legal/terms?${this.utmParams}`} />
+                  <a data-l10n-name="privacy" target="_blank" rel="noopener noreferrer"
+                    href={`${this.props.fxa_endpoint}/legal/privacy?${this.utmParams}`} />
+                </p>
                 </div>
-                <button className="continue-button" type="submit"><FormattedMessage id="firstrun_continue_to_login" /></button>
+                <button className="continue-button" type="submit" data-l10n-id="onboarding-control-form-continue-button" />
               </form>
-              <button className="skip-button" disabled={!!this.state.emailInput} onClick={this.clickSkip}><FormattedMessage id="firstrun_skip_login" /></button>
+              <button className="skip-button" disabled={!!this.state.emailInput} onClick={this.clickSkip} data-l10n-id="onboarding-control-form-skip-login-button" />
             </div>
           </div>
         </div>
@@ -158,4 +173,4 @@ export class _StartupOverlay extends React.PureComponent {
 }
 
 const getState = state => ({fxa_endpoint: state.Prefs.values.fxa_endpoint});
-export const StartupOverlay = connect(getState)(injectIntl(_StartupOverlay));
+export const StartupOverlay = connect(getState)(_StartupOverlay);

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -182,13 +182,6 @@ export class _Trailhead extends React.PureComponent {
     this.setState({showCards: true});
   }
 
-  getStringValue(str) {
-    if (str.property_id) {
-      str.value = this.props.intl.formatMessage({id: str.property_id});
-    }
-    return str.value;
-  }
-
   /**
    * Takes in a url as a string or URL object and returns a URL object with the
    * utm_* parameters added to it. If a URL object is passed in, the paraemeters
@@ -233,30 +226,29 @@ export class _Trailhead extends React.PureComponent {
       "trailhead",
       content && content.className,
     ].filter(v => v).join(" ");
+
     return (<>
     {this.state.isModalOpen && content ? <ModalOverlayWrapper innerClassName={innerClassName} onClose={this.closeModal} id="trailheadDialog" headerId="trailheadHeader">
       <div className="trailheadInner">
         <div className="trailheadContent">
           <h1 data-l10n-id={content.title.string_id}
-            id="trailheadHeader">{this.getStringValue(content.title)}</h1>
+            id="trailheadHeader" />
           {content.subtitle &&
-            <p data-l10n-id={content.subtitle.string_id}>{this.getStringValue(content.subtitle)}</p>
+            <p data-l10n-id={content.subtitle.string_id} />
           }
           <ul className="trailheadBenefits">
             {content.benefits.map(item => (
               <li key={item.id} className={item.id}>
-                <h3 data-l10n-id={item.title.string_id}>{this.getStringValue(item.title)}</h3>
-                <p data-l10n-id={item.text.string_id}>{this.getStringValue(item.text)}</p>
+                <h3 data-l10n-id={item.title.string_id} />
+                <p data-l10n-id={item.text.string_id} />
               </li>
             ))}
           </ul>
-          <a className="trailheadLearn" data-l10n-id={content.learn.text.string_id} href={this.addUtmParams(content.learn.url)} target="_blank" rel="noopener noreferrer">
-            {this.getStringValue(content.learn.text)}
-          </a>
+          <a className="trailheadLearn" data-l10n-id={content.learn.text.string_id} href={this.addUtmParams(content.learn.url)} target="_blank" rel="noopener noreferrer" />
         </div>
         <div role="group" aria-labelledby="joinFormHeader" aria-describedby="joinFormBody" className="trailheadForm">
-          <h3 id="joinFormHeader" data-l10n-id={content.form.title.string_id}>{this.getStringValue(content.form.title)}</h3>
-          <p id="joinFormBody" data-l10n-id={content.form.text.string_id}>{this.getStringValue(content.form.text)}</p>
+          <h3 id="joinFormHeader" data-l10n-id={content.form.title.string_id} />
+          <p id="joinFormBody" data-l10n-id={content.form.text.string_id} />
           <form method="get" action={this.props.fxaEndpoint} target="_blank" rel="noopener noreferrer" onSubmit={this.onSubmit}>
             <input name="service" type="hidden" value="sync" />
             <input name="action" type="hidden" value="email" />
@@ -272,7 +264,6 @@ export class _Trailhead extends React.PureComponent {
             <p data-l10n-id="onboarding-join-form-email-error" className="error" />
             <input
               data-l10n-id={content.form.email.string_id}
-              placeholder={this.getStringValue(content.form.email)}
               name="email"
               type="email"
               onInvalid={this.onInputInvalid}
@@ -283,9 +274,7 @@ export class _Trailhead extends React.PureComponent {
               <a data-l10n-name="privacy" target="_blank" rel="noopener noreferrer"
                 href={this.addUtmParams("https://accounts.firefox.com/legal/privacy")} />
             </p>
-            <button data-l10n-id={content.form.button.string_id} type="submit">
-              {this.getStringValue(content.form.button)}
-            </button>
+            <button data-l10n-id={content.form.button.string_id} type="submit" />
           </form>
         </div>
       </div>
@@ -293,7 +282,7 @@ export class _Trailhead extends React.PureComponent {
       <button className="trailheadStart"
         data-l10n-id={content.skipButton.string_id}
         onBlur={this.onStartBlur}
-        onClick={this.closeModal}>{this.getStringValue(content.skipButton)}</button>
+        onClick={this.closeModal} />
     </ModalOverlayWrapper> : null}
     {(cards && cards.length) ? <div className={`trailheadCards ${this.state.showCardPanel ? "expanded" : "collapsed"}`}>
       <div className="trailheadCardsInner"

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -300,7 +300,7 @@ export class Trailhead extends React.PureComponent {
         {this.state.showCardPanel &&
           <button
             className="icon icon-dismiss" onClick={this.hideCardPanel}
-            data-l10n-id="onboarding-menu-dismiss" />
+            data-l10n-id="onboarding-cards-dismiss" />
         }
       </div>
     </div> : null}

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -1,5 +1,4 @@
 import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
-import {injectIntl} from "react-intl";
 import {ModalOverlayWrapper} from "../../components/ModalOverlay/ModalOverlay";
 import {OnboardingCard} from "../OnboardingMessage/OnboardingMessage";
 import React from "react";
@@ -22,7 +21,7 @@ const FOCUSABLE_SELECTOR = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(", ");
 
-export class _Trailhead extends React.PureComponent {
+export class Trailhead extends React.PureComponent {
   constructor(props) {
     super(props);
     this.closeModal = this.closeModal.bind(this);
@@ -301,13 +300,10 @@ export class _Trailhead extends React.PureComponent {
         {this.state.showCardPanel &&
           <button
             className="icon icon-dismiss" onClick={this.hideCardPanel}
-            title={props.intl.formatMessage({id: "menu_action_dismiss"})}
-            aria-label={props.intl.formatMessage({id: "menu_action_dismiss"})} />
+            data-l10n-id="onboarding-menu-dismiss" />
         }
       </div>
     </div> : null}
     </>);
   }
 }
-
-export const Trailhead = injectIntl(_Trailhead);

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -183,20 +183,20 @@ const ONBOARDING_MESSAGES = async () => ([
     utm_term: "trailhead-sync",
     content: {
       className: "syncCohort",
-      title: {string_id: "onboarding-control-welcome-header"},
-      subtitle: {string_id: "onboarding-control-welcome-content"},
+      title: {string_id: "onboarding-sync-welcome-header"},
+      subtitle: {string_id: "onboarding-sync-welcome-content"},
       benefits: [],
       learn: {
-        text: {string_id: "onboarding-control-welcome-learn-more-link"},
+        text: {string_id: "onboarding-sync-welcome-learn-more-link"},
         url: "https://www.mozilla.org/firefox/accounts/",
       },
       form: {
-        title: {string_id: "onboarding-control-form-header"},
-        text: {string_id: "onboarding-control-form-sub-header"},
-        email: {string_id: "onboarding-control-form-input"},
-        button: {string_id: "onboarding-control-form-continue-button"},
+        title: {string_id: "onboarding-sync-form-header"},
+        text: {string_id: "onboarding-sync-form-sub-header"},
+        email: {string_id: "onboarding-sync-form-input"},
+        button: {string_id: "onboarding-sync-form-continue-button"},
       },
-      skipButton: {string_id: "onboarding-control-form-skip-login-button"},
+      skipButton: {string_id: "onboarding-sync-form-skip-login-button"},
     },
   },
   {

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -183,20 +183,20 @@ const ONBOARDING_MESSAGES = async () => ([
     utm_term: "trailhead-sync",
     content: {
       className: "syncCohort",
-      title: {property_id: "firstrun_title"},
-      subtitle: {property_id: "firstrun_content"},
+      title: {string_id: "onboarding-control-welcome-header"},
+      subtitle: {string_id: "onboarding-control-welcome-content"},
       benefits: [],
       learn: {
-        text: {property_id: "firstrun_learn_more_link"},
+        text: {string_id: "onboarding-control-welcome-learn-more-link"},
         url: "https://www.mozilla.org/firefox/accounts/",
       },
       form: {
-        title: {property_id: "firstrun_form_header"},
-        text: {property_id: "firstrun_form_sub_header"},
-        email: {property_id: "firstrun_email_input_placeholder"},
-        button: {property_id: "firstrun_continue_to_login"},
+        title: {string_id: "onboarding-control-form-header"},
+        text: {string_id: "onboarding-control-form-sub-header"},
+        email: {string_id: "onboarding-control-form-input"},
+        button: {string_id: "onboarding-control-form-continue-button"},
       },
-      skipButton: {property_id: "firstrun_skip_login"},
+      skipButton: {string_id: "onboarding-control-form-skip-login-button"},
     },
   },
   {

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -50,13 +50,6 @@ firstrun_form_header=Enter your email
 firstrun_form_sub_header=to continue to Firefox Sync
 
 firstrun_email_input_placeholder=Email
-firstrun_invalid_input=Valid email required
-
-# LOCALIZATION NOTE (firstrun_extra_legal_links): {terms} is equal to firstrun_terms_of_service, and
-# {privacy} is equal to firstrun_privacy_notice. {terms} and {privacy} are clickable links.
-firstrun_extra_legal_links=By proceeding, you agree to the {terms} and {privacy}.
-firstrun_terms_of_service=Terms of Service
-firstrun_privacy_notice=Privacy Notice
 
 firstrun_continue_to_login=Continue
 firstrun_skip_login=Skip this step

--- a/locales-src/en-US/strings.properties
+++ b/locales-src/en-US/strings.properties
@@ -36,20 +36,3 @@ settings_pane_highlights_options_bookmarks=Bookmarks
 settings_pane_snippets_header=Snippets
 
 pocket_how_it_works=How it works
-
-# LOCALIZATION NOTE (firstrun_*). These strings are displayed only once, on the
-# firstrun of the browser, they give an introduction to Firefox and Sync.
-firstrun_title=Take Firefox with You
-firstrun_content=Get your bookmarks, history, passwords and other settings on all your devices.
-firstrun_learn_more_link=Learn more about Firefox Accounts
-
-# LOCALIZATION NOTE (firstrun_form_header and firstrun_form_sub_header):
-# firstrun_form_sub_header is a continuation of firstrun_form_header, they are one sentence.
-# firstrun_form_header is displayed more boldly as the call to action.
-firstrun_form_header=Enter your email
-firstrun_form_sub_header=to continue to Firefox Sync
-
-firstrun_email_input_placeholder=Email
-
-firstrun_continue_to_login=Continue
-firstrun_skip_login=Skip this step

--- a/locales-src/onboarding.ftl
+++ b/locales-src/onboarding.ftl
@@ -29,29 +29,28 @@ onboarding-join-form-legal = By proceeding, you agree to the <a data-l10n-name="
 onboarding-join-form-continue = Continue
 
 onboarding-start-browsing-button-label = Start Browsing
+onboarding-menu-dismiss =
+    .title = Dismiss
+    .aria-label = Dismiss
 
-## Welcome modal dialog strings for pre-trailhead about welcome.
+## Firefox Sync modal dialog strings.
 
-onboarding-control-welcome-header = Take { -brand-product-name } with You
-onboarding-control-welcome-content = Get your bookmarks, history, passwords and other settings on all your devices.
-onboarding-control-welcome-learn-more-link = Learn more about { -brand-product-name } Accounts
+onboarding-sync-welcome-header = Take { -brand-product-name } with You
+onboarding-sync-welcome-content = Get your bookmarks, history, passwords and other settings on all your devices.
+onboarding-sync-welcome-learn-more-link = Learn more about { -brand-product-name } Accounts
+onboarding-sync-form-invalid-input = Valid email required
+onboarding-sync-legal-notice = By proceeding, you agree to the <a data-l10n-name="terms">Terms of Service</a> and <a data-l10n-name="privacy">Privacy Notice</a>.
 
-onboarding-control-form-privacy-notice = Privacy Notice
-
-onboarding-control-form-invalid-input = Valid email required
-onboarding-control-legal-notice = By proceeding, you agree to the <a data-l10n-name="terms">Terms of Service</a> and <a data-l10n-name="privacy">Privacy Notice</a>.
-
-onboarding-control-form-input =
+onboarding-sync-form-input =
     .placeholder = Email
 
-onboarding-control-form-continue-button = Continue
-onboarding-control-form-skip-login-button = Skip this step
+onboarding-sync-form-continue-button = Continue
+onboarding-sync-form-skip-login-button = Skip this step
 
-## Welcome modal dialog strings for pre-trailhead about welcome. This is part of the line
-## "Enter your email to continue to Firefox Sync"
+## This is part of the line "Enter your email to continue to Firefox Sync"
 
-onboarding-control-form-header = Enter your email
-onboarding-control-form-sub-header = to continue to { -sync-brand-name }
+onboarding-sync-form-header = Enter your email
+onboarding-sync-form-sub-header = to continue to { -sync-brand-name }
 
 
 ## These are individual benefit messages shown with an image, title and

--- a/locales-src/onboarding.ftl
+++ b/locales-src/onboarding.ftl
@@ -30,6 +30,29 @@ onboarding-join-form-continue = Continue
 
 onboarding-start-browsing-button-label = Start Browsing
 
+## Welcome modal dialog strings for pre-trailhead about welcome.
+
+onboarding-control-welcome-header = Take { -brand-product-name } with You
+onboarding-control-welcome-content = Get your bookmarks, history, passwords and other settings on all your devices.
+onboarding-control-welcome-learn-more-link = Learn more about { -brand-product-name } Accounts
+
+onboarding-control-form-privacy-notice = Privacy Notice
+
+onboarding-control-form-invalid-input = Valid email required
+onboarding-control-legal-notice = By proceeding, you agree to the <a data-l10n-name="terms">Terms of Service</a> and <a data-l10n-name="privacy">Privacy Notice</a>.
+
+onboarding-control-form-input =
+    .placeholder = Email
+
+onboarding-control-form-continue-button = Continue
+onboarding-control-form-skip-login-button = Skip this step
+
+## Welcome modal dialog strings for pre-trailhead about welcome. This is part of the line
+## "Enter your email to continue to Firefox Sync"
+onboarding-control-form-header = Enter your email
+onboarding-control-form-sub-header = to continue to { -brand-product-name } Sync
+
+
 ## These are individual benefit messages shown with an image, title and
 ## description.
 
@@ -116,6 +139,7 @@ onboarding-facebook-container-button = Add the Extension
 
 
 ## Message strings belonging to the Return to AMO flow
+
 return-to-amo-sub-header = Great, you’ve got { -brand-short-name }
 
 # <icon></icon> will be replaced with the icon belonging to the extension

--- a/locales-src/onboarding.ftl
+++ b/locales-src/onboarding.ftl
@@ -49,8 +49,9 @@ onboarding-control-form-skip-login-button = Skip this step
 
 ## Welcome modal dialog strings for pre-trailhead about welcome. This is part of the line
 ## "Enter your email to continue to Firefox Sync"
+
 onboarding-control-form-header = Enter your email
-onboarding-control-form-sub-header = to continue to { -brand-product-name } Sync
+onboarding-control-form-sub-header = to continue to { -sync-brand-name }
 
 
 ## These are individual benefit messages shown with an image, title and

--- a/locales-src/onboarding.ftl
+++ b/locales-src/onboarding.ftl
@@ -29,7 +29,7 @@ onboarding-join-form-legal = By proceeding, you agree to the <a data-l10n-name="
 onboarding-join-form-continue = Continue
 
 onboarding-start-browsing-button-label = Start Browsing
-onboarding-menu-dismiss =
+onboarding-cards-dismiss =
     .title = Dismiss
     .aria-label = Dismiss
 
@@ -37,7 +37,7 @@ onboarding-menu-dismiss =
 
 onboarding-sync-welcome-header = Take { -brand-product-name } with You
 onboarding-sync-welcome-content = Get your bookmarks, history, passwords and other settings on all your devices.
-onboarding-sync-welcome-learn-more-link = Learn more about { -brand-product-name } Accounts
+onboarding-sync-welcome-learn-more-link = Learn more about Firefox Accounts
 onboarding-sync-form-invalid-input = Valid email required
 onboarding-sync-legal-notice = By proceeding, you agree to the <a data-l10n-name="terms">Terms of Service</a> and <a data-l10n-name="privacy">Privacy Notice</a>.
 

--- a/test/unit/asrouter/templates/Trailhead.test.jsx
+++ b/test/unit/asrouter/templates/Trailhead.test.jsx
@@ -2,7 +2,7 @@ import {actionCreators as ac, actionTypes as at} from "common/Actions.jsm";
 import {mount} from "enzyme";
 import {OnboardingMessageProvider} from "lib/OnboardingMessageProvider.jsm";
 import React from "react";
-import {_Trailhead as Trailhead} from "content-src/asrouter/templates/Trailhead/Trailhead";
+import {Trailhead} from "content-src/asrouter/templates/Trailhead/Trailhead";
 
 const CARDS = [{
   content: {


### PR DESCRIPTION
Migrating about:welcome strings to fluent
- Migrate old about:welcome (StartupOverlay.jsx) to fluent (Done)
- Update now broken files using about:welcome strings (Done 7/1)