### PR TITLE
Bug 1562009 - Turn on ad server

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -240,7 +240,7 @@ const PREFS_CONFIG = new Map([
   }],
   ["discoverystream.endpoints", {
     title: "Endpoint prefixes (comma-separated) that are allowed to be requested",
-    value: "https://getpocket.cdn.mozilla.net/",
+    value: "https://getpocket.cdn.mozilla.net/,https://spocs.getpocket.com",
   }],
   ["discoverystream.spoc.impressions", {
     title: "Track spoc impressions",
@@ -249,7 +249,7 @@ const PREFS_CONFIG = new Map([
   }],
   ["discoverystream.endpointSpocsClear", {
     title: "Endpoint for when a user opts-out of sponsored content to delete the user's data from the ad server.",
-    value: "",
+    value: "https://spocs.getpocket.com/user",
   }],
   ["discoverystream.rec.impressions", {
     title: "Track rec impressions",

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -240,7 +240,7 @@ const PREFS_CONFIG = new Map([
   }],
   ["discoverystream.endpoints", {
     title: "Endpoint prefixes (comma-separated) that are allowed to be requested",
-    value: "https://getpocket.cdn.mozilla.net/,https://spocs.getpocket.com",
+    value: "https://getpocket.cdn.mozilla.net/,https://spocs.getpocket.com/",
   }],
   ["discoverystream.spoc.impressions", {
     title: "Track spoc impressions",

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -1076,7 +1076,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 // Hardcoded version of layout_variant `3-col-7-row-octr`
 defaultLayoutResp = {
   "spocs": {
-    "url": "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs",
+    "url": "https://spocs.getpocket.com/spocs",
     "spocs_per_domain": 1
   },
   "layout": [

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -252,7 +252,7 @@ describe("DiscoveryStreamFeed", () => {
       await feed.loadLayout(feed.store.dispatch);
 
       assert.notCalled(feed.fetchLayout);
-      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs");
+      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://spocs.getpocket.com/spocs");
     });
     it("should fetch local layout for invalid layout endpoint or when fetch layout fails", async () => {
       feed.config.hardcoded_layout = false;
@@ -261,7 +261,7 @@ describe("DiscoveryStreamFeed", () => {
       await feed.loadLayout(feed.store.dispatch, true);
 
       assert.calledOnce(fetchStub);
-      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs");
+      assert.equal(feed.store.getState().DiscoveryStream.spocs.spocs_endpoint, "https://spocs.getpocket.com/spocs");
     });
   });
 


### PR DESCRIPTION
To test:

1. Set `browser.newtabpage.activity-stream.discoverystream.config` to `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":true,"personalized":false,"layout_endpoint":"https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=basic"}`
2. Load a new tab

Ensure you see spocs.
Also try opting out of spocs, ensure that works.

For the most part you shouldn't notice anything changing.