### PR TITLE
(no bug) - Fixing browser.ini to fix mochitests logging fluent ReferenceErrors

### DIFF
--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -7,7 +7,7 @@ prefs =
   browser.newtabpage.activity-stream.debug=false
   browser.newtabpage.activity-stream.discoverystream.endpoints=data:
   browser.newtabpage.activity-stream.feeds.section.topstories=true
-  browser.newtabpage.activity-stream.feeds.section.topstories.options={}
+  browser.newtabpage.activity-stream.feeds.section.topstories.options={"provider_name":""}
 
 [browser_aboutwelcome.js]
 [browser_activity_stream_strings.js]


### PR DESCRIPTION
Our mochitests were logging errors like

```
GECKO(27292) JavaScript error: , line 0: uncaught exception: [fluent][resolver] errors in en-US/newtab-section-header-pocket: ReferenceError: Unknown variable: provider.
 0:07.55 INFO Console message: [JavaScript Error: "uncaught exception: [fluent][resolver] errors in en-US/newtab-section-header-pocket: ReferenceError: Unknown variable: provider."]
```

These didn't prevent any builds from failing but were appearing frequently in terminal.  Previously, we weren't providing a provider in browser.ini which caused an appropriate reference error.

Tests:
./mach mochitest browser/components/newtab/test/browser 
