### PR TITLE
Bug 1557304 - “About:welcome” cards overlapping issue with the browser resized to minimum width

### DIFF
--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -264,7 +264,6 @@
 
 .trailheadCards {
   background: var(--trailhead-cards-background-color);
-  max-height: 1000px;
   overflow: hidden;
   text-align: center;
   transition: max-height 0.5s $photon-easing;


### PR DESCRIPTION
Removed max-height css rule for trailhead cards to prevent the cards from overlapping with the main page body.