### PR TITLE
Bug 1563741 - Keeping body scroll static, but welcome modal centered …

### DIFF
--- a/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
+++ b/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
@@ -19,21 +19,26 @@ export class ModalOverlayWrapper extends React.PureComponent {
   componentWillMount() {
     this.props.document.addEventListener("keydown", this.onKeyDown);
     this.props.document.body.classList.add("modal-open");
+    this.header = this.props.document.getElementById(
+      "header-asrouter-container"
+    );
 
-    this.props.document
-      .getElementById("header-asrouter-container")
-      .classList.add("modal-scroll");
-    this.props.document.getElementById("root").classList.add("modal-height");
+    if (this.header) {
+      this.header.classList.add("modal-scroll");
+      this.props.document.getElementById("root").classList.add("modal-height");
+    }
   }
 
   componentWillUnmount() {
     this.props.document.removeEventListener("keydown", this.onKeyDown);
     this.props.document.body.classList.remove("modal-open");
 
-    this.props.document
-      .getElementById("header-asrouter-container")
-      .classList.remove("modal-scroll");
-    this.props.document.getElementById("root").classList.remove("modal-height");
+    if (this.header) {
+      this.header.classList.remove("modal-scroll");
+      this.props.document
+        .getElementById("root")
+        .classList.remove("modal-height");
+    }
   }
 
   render() {

--- a/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
+++ b/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
@@ -32,7 +32,7 @@ export class ModalOverlayWrapper extends React.PureComponent {
 
     this.props.document
       .getElementById("header-asrouter-container")
-      .classList.remove(".modal-scroll");
+      .classList.remove("modal-scroll");
     this.props.document.getElementById("root").classList.remove("modal-height");
   }
 

--- a/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
+++ b/content-src/asrouter/components/ModalOverlay/ModalOverlay.jsx
@@ -19,11 +19,21 @@ export class ModalOverlayWrapper extends React.PureComponent {
   componentWillMount() {
     this.props.document.addEventListener("keydown", this.onKeyDown);
     this.props.document.body.classList.add("modal-open");
+
+    this.props.document
+      .getElementById("header-asrouter-container")
+      .classList.add("modal-scroll");
+    this.props.document.getElementById("root").classList.add("modal-height");
   }
 
   componentWillUnmount() {
     this.props.document.removeEventListener("keydown", this.onKeyDown);
     this.props.document.body.classList.remove("modal-open");
+
+    this.props.document
+      .getElementById("header-asrouter-container")
+      .classList.remove(".modal-scroll");
+    this.props.document.getElementById("root").classList.remove("modal-height");
   }
 
   render() {

--- a/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
+++ b/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
@@ -19,6 +19,19 @@
   }
 }
 
+.modal-scroll {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.modal-height {
+  // "Welcome header" has 40px of padding and 36px font size that get neglected using position absolute
+  // causing this to visually collide with the newtab searchbar
+  padding-top: 80px;
+}
+
 .modalOverlayInner {
   width: 960px;
   position: fixed;
@@ -29,8 +42,6 @@
   border-radius: 4px;
   display: none;
   z-index: 1101;
-  overflow: scroll;
-
 
   // modal takes over entire screen
   @media(max-width: 960px) {
@@ -45,7 +56,6 @@
   // if modal is short enough, reduce the top margin
   @media(max-height: 730px) {
     top: 5%;
-    bottom: 5%;
   }
 
   &.active {

--- a/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
+++ b/content-src/asrouter/components/ModalOverlay/_ModalOverlay.scss
@@ -29,6 +29,7 @@
   border-radius: 4px;
   display: none;
   z-index: 1101;
+  overflow: scroll;
 
 
   // modal takes over entire screen
@@ -44,6 +45,7 @@
   // if modal is short enough, reduce the top margin
   @media(max-height: 730px) {
     top: 5%;
+    bottom: 5%;
   }
 
   &.active {

--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -401,7 +401,7 @@
 
 .inline-onboarding {
   &.activity-stream.welcome {
-    overflow-y: scroll;
+    overflow-y: hidden;
   }
 
   .modalOverlayInner {

--- a/test/unit/asrouter/ModalOverlay.test.jsx
+++ b/test/unit/asrouter/ModalOverlay.test.jsx
@@ -11,6 +11,9 @@ describe("ModalOverlayWrapper", () => {
       addEventListener: sandbox.stub(),
       removeEventListener: sandbox.stub(),
       body: { classList: { add: sandbox.stub(), remove: sandbox.stub() } },
+      getElementById() {
+        return { classList: { add: sandbox.stub(), remove: sandbox.stub() } };
+      },
     };
   });
   afterEach(() => {

--- a/test/unit/asrouter/ModalOverlay.test.jsx
+++ b/test/unit/asrouter/ModalOverlay.test.jsx
@@ -5,14 +5,17 @@ import React from "react";
 describe("ModalOverlayWrapper", () => {
   let fakeDoc;
   let sandbox;
+  let header;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    header = document.createElement("div");
+
     fakeDoc = {
       addEventListener: sandbox.stub(),
       removeEventListener: sandbox.stub(),
       body: { classList: { add: sandbox.stub(), remove: sandbox.stub() } },
       getElementById() {
-        return { classList: { add: sandbox.stub(), remove: sandbox.stub() } };
+        return header;
       },
     };
   });


### PR DESCRIPTION
Description: When the about:welcome is opened the user can scroll past the modal.
Changes: Disabled scrolling for about:welcome and fixed modal to stay centered. If there's an overflow, then the actual modal itself is scrollable.

For the cases of low display resolution or the user is zoomed in, pending design feedback from @aaronrbenson. Would it be better to have the page overflow instead of the modal (scrollbar on the page and not modal).

Original
https://drive.google.com/open?id=1rDg9O7iouAgigjxRpHUdfR97N6iGUBZx

New Changes
https://drive.google.com/open?id=1AtQF14SAYbGwUwwP3nBe1os5kd3yn6JI