### PR TITLE
Bug 1554666 - Updated image resizing breakpoint and added grid-auto-rows to keep equal row height

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
+++ b/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
@@ -139,6 +139,7 @@
   display: inline-block;
   vertical-align: middle;
 
+  // Cards will wrap into the next line after this breakpoint
   @media(max-width: 865px) {
     height: 75px;
     min-width: 80px;

--- a/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
+++ b/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
@@ -139,7 +139,7 @@
   display: inline-block;
   vertical-align: middle;
 
-  @media(max-width: 850px) {
+  @media(max-width: 865px) {
     height: 75px;
     min-width: 80px;
     background-size: 80px;

--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -320,6 +320,7 @@
   opacity: 0;
   transition: opacity 0.4s;
   transition-delay: 0.1s;
+  grid-auto-rows: 1fr;
 
   &.show {
     opacity: 1;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1554666

In the codebase there's a media query to shrink the size of this image after 850px break point, so looks like the images are supposed to shrink. Though, the cards going into a different row should probably have a consistent height.

Commit will keep consistent height if a card breaks into a new row and the image shrinking break point is updated.

https://drive.google.com/open?id=1EGgdmOMFlSu7LoyNNWK-mhpt6qNOp51O