### PR TITLE
Bug 1564898 - Use UpdateManager to get the earliest Firefox version used

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -36,7 +36,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [hasPinnedTabs](#haspinnedtabs)
 * [hasAccessedFxAPanel](#hasaccessedfxapanel)
 * [isWhatsNewPanelEnabled](#iswhatsnewpanelenabled)
-* [previousFirefoxVersion](#previousfirefoxversion)
+* [earliestFirefoxVersion](#earliestfirefoxversion)
 
 ## Detailed usage
 
@@ -498,12 +498,12 @@ Boolean pref that controls if the What's New panel feature is enabled
 declare const isWhatsNewPanelEnabled: boolean;
 ```
 
-### `previousFirefoxVersion`
+### `earliestFirefoxVersion`
 
 Integer value of the first Firefox version the profile ran on
 
 #### Definition
 
 ```ts
-declare const previousFirefoxVersion: boolean;
+declare const earliestFirefoxVersion: boolean;
 ```

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -36,7 +36,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [hasPinnedTabs](#haspinnedtabs)
 * [hasAccessedFxAPanel](#hasaccessedfxapanel)
 * [isWhatsNewPanelEnabled](#iswhatsnewpanelenabled)
-* [previousFirefoxVersion](#previousFirefoxVersion)
+* [previousFirefoxVersion](#previousfirefoxversion)
 
 ## Detailed usage
 
@@ -505,5 +505,5 @@ Integer value of the first Firefox version the profile ran on
 #### Definition
 
 ```ts
-declare const isWhatsNewPanelEnabled: number;
+declare const previousFirefoxVersion: boolean;
 ```

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -36,6 +36,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [hasPinnedTabs](#haspinnedtabs)
 * [hasAccessedFxAPanel](#hasaccessedfxapanel)
 * [isWhatsNewPanelEnabled](#iswhatsnewpanelenabled)
+* [previousFirefoxVersion](#previousFirefoxVersion)
 
 ## Detailed usage
 
@@ -495,4 +496,14 @@ Boolean pref that controls if the What's New panel feature is enabled
 
 ```ts
 declare const isWhatsNewPanelEnabled: boolean;
+```
+
+### `previousFirefoxVersion`
+
+Integer value of the first Firefox version the profile ran on
+
+#### Definition
+
+```ts
+declare const isWhatsNewPanelEnabled: number;
 ```

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -753,16 +753,12 @@ class _ASRouter {
       (await this._storage.get("providerImpressions")) || {};
     const previousSessionEnd =
       (await this._storage.get("previousSessionEnd")) || 0;
-    // Infinity so that we default to false (firefoxVersion > previousSessionFirefoxVersion)
-    const previousSessionFirefoxVersion =
-      (await this._storage.get("previousSessionFirefoxVersion")) || Infinity;
     await this.setState({
       messageBlockList,
       providerBlockList,
       messageImpressions,
       providerImpressions,
       previousSessionEnd,
-      previousSessionFirefoxVersion,
     });
     this._updateMessageProviders();
     await this.loadMessagesFromAllProviders();
@@ -782,10 +778,6 @@ class _ASRouter {
 
   uninit() {
     this._storage.set("previousSessionEnd", Date.now());
-    this._storage.set(
-      "previousSessionFirefoxVersion",
-      ASRouterTargeting.Environment.firefoxVersion
-    );
 
     this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
       type: "CLEAR_ALL",
@@ -1048,7 +1040,6 @@ class _ASRouter {
     const {
       messageImpressions,
       previousSessionEnd,
-      previousSessionFirefoxVersion,
       trailheadInterrupt,
       trailheadTriplet,
     } = this.state;
@@ -1059,12 +1050,6 @@ class _ASRouter {
       },
       get previousSessionEnd() {
         return previousSessionEnd;
-      },
-      get previousSessionFirefoxVersion() {
-        // Any comparison with `undefined` will return false
-        return isNaN(previousSessionFirefoxVersion)
-          ? undefined
-          : previousSessionFirefoxVersion;
       },
       get trailheadInterrupt() {
         return trailheadInterrupt;

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -2,6 +2,9 @@ const { FilterExpressions } = ChromeUtils.import(
   "resource://gre/modules/components-utils/FilterExpressions.jsm"
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const { XPCOMUtils } = ChromeUtils.import(
+  "resource://gre/modules/XPCOMUtils.jsm"
+);
 
 ChromeUtils.defineModuleGetter(
   this,

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -43,6 +43,12 @@ ChromeUtils.defineModuleGetter(
   "AttributionCode",
   "resource:///modules/AttributionCode.jsm"
 );
+XPCOMUtils.defineLazyServiceGetter(
+  this,
+  "UpdateManager",
+  "@mozilla.org/updates/update-manager;1",
+  "nsIUpdateManager"
+);
 
 const FXA_USERNAME_PREF = "services.sync.username";
 const FXA_ENABLED_PREF = "identity.fxaccounts.enabled";
@@ -399,6 +405,16 @@ const TargetingGetters = {
       "browser.messaging-system.whatsNewPanel.enabled",
       false
     );
+  },
+  get previousFirefoxVersion() {
+    if (UpdateManager.updateCount) {
+      const previousFirefoxVersion = UpdateManager.getUpdateAt(
+        UpdateManager.updateCount - 1
+      ).previousAppVersion;
+      return parseInt(previousFirefoxVersion.match(/\d+/), 10);
+    }
+
+    return null;
   },
 };
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -409,12 +409,12 @@ const TargetingGetters = {
       false
     );
   },
-  get previousFirefoxVersion() {
+  get earliestFirefoxVersion() {
     if (UpdateManager.updateCount) {
-      const previousFirefoxVersion = UpdateManager.getUpdateAt(
+      const earliestFirefoxVersion = UpdateManager.getUpdateAt(
         UpdateManager.updateCount - 1
       ).previousAppVersion;
-      return parseInt(previousFirefoxVersion.match(/\d+/), 10);
+      return parseInt(earliestFirefoxVersion.match(/\d+/), 10);
     }
 
     return null;

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -492,7 +492,7 @@ const ONBOARDING_MESSAGES = async () => [
     },
     // Never saw this message or saw it in the past 4 days or more recent
     targeting: `isWhatsNewPanelEnabled &&
-      (previousFirefoxVersion && firefoxVersion > previousFirefoxVersion) &&
+      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
         messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
       (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
         currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -492,8 +492,8 @@ const ONBOARDING_MESSAGES = async () => [
     },
     // Never saw this message or saw it in the past 4 days or more recent
     targeting: `isWhatsNewPanelEnabled &&
-      (firefoxVersion > previousSessionFirefoxVersion &&
-        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0) ||
+      (previousFirefoxVersion && firefoxVersion > previousFirefoxVersion) &&
+        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
       (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
         currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
   },

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -60,7 +60,6 @@ describe("ASRouter", () => {
   let messageImpressions;
   let providerImpressions;
   let previousSessionEnd;
-  let previousSessionFirefoxVersion;
   let fetchStub;
   let clock;
   let getStringPrefStub;
@@ -88,9 +87,6 @@ describe("ASRouter", () => {
     getStub
       .withArgs("previousSessionEnd")
       .returns(Promise.resolve(previousSessionEnd));
-    getStub
-      .withArgs("previousSessionFirefoxVersion")
-      .returns(Promise.resolve(previousSessionFirefoxVersion));
     return {
       get: getStub,
       set: sandbox.stub().returns(Promise.resolve()),
@@ -117,7 +113,6 @@ describe("ASRouter", () => {
     messageImpressions = {};
     providerImpressions = {};
     previousSessionEnd = 100;
-    previousSessionFirefoxVersion = 69;
     sandbox = sinon.createSandbox();
 
     sandbox.spy(ASRouterPreferences, "init");
@@ -843,13 +838,6 @@ describe("ASRouter", () => {
 
       assert.deepEqual(result, message1);
     });
-    it("should have previousSessionFirefoxVersion in the message context", () => {
-      assert.propertyVal(
-        Router._getMessagesContext(),
-        "previousSessionFirefoxVersion",
-        parseInt(AppConstants.MOZ_APP_VERSION, 10)
-      );
-    });
     it("should have messageImpressions in the message context", () => {
       assert.propertyVal(
         Router._getMessagesContext(),
@@ -967,15 +955,10 @@ describe("ASRouter", () => {
     it("should save previousSessionEnd", () => {
       Router.uninit();
 
-      assert.calledTwice(Router._storage.set);
+      assert.calledOnce(Router._storage.set);
       assert.calledWithExactly(
         Router._storage.set,
         "previousSessionEnd",
-        sinon.match.number
-      );
-      assert.calledWithExactly(
-        Router._storage.set,
-        "previousSessionFirefoxVersion",
         sinon.match.number
       );
     });


### PR DESCRIPTION
You can see the UpdateManager in action on `about:support` with a real profile 
<img width="311" alt="image" src="https://user-images.githubusercontent.com/810040/60979411-354d8880-a322-11e9-9a01-245603eb6da8.png">
<img width="385" alt="image" src="https://user-images.githubusercontent.com/810040/60979432-40a0b400-a322-11e9-92ab-d650004939ff.png">

`previousFirefoxVersion` will return the very first firefox version used with the current profile (69.0a1 as seen in my screenshot) so it could be named better, I'm open to suggestions.

Testing this might be tricky so I'm thinking we merge `whatsnew-panel` branch into master to get this into Nightly sometime this week. Then QA can verify/validate the method.