### PR TITLE
Bug 1564124 - Fix eslint issues for no-async-promise-executor and no-misleading-character-class

### DIFF
--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -75,20 +75,13 @@ function CachedTargetingGetter(
       this._lastUpdated = 0;
       this._value = null;
     },
-    get() {
-      return new Promise(async (resolve, reject) => {
-        const now = Date.now();
-        if (now - this._lastUpdated >= updateInterval) {
-          try {
-            this._value = await asProvider[property](options);
-            this._lastUpdated = now;
-          } catch (e) {
-            Cu.reportError(e);
-            reject(e);
-          }
-        }
-        resolve(this._value);
-      });
+    async get() {
+      const now = Date.now();
+      if (now - this._lastUpdated >= updateInterval) {
+        this._value = await asProvider[property](options);
+        this._lastUpdated = now;
+      }
+      return this._value;
     },
   };
 }

--- a/lib/AboutPreferences.jsm
+++ b/lib/AboutPreferences.jsm
@@ -4,14 +4,10 @@
 "use strict";
 
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-const { XPCOMUtils } = ChromeUtils.import(
-  "resource://gre/modules/XPCOMUtils.jsm"
-);
 const { actionTypes: at } = ChromeUtils.import(
   "resource://activity-stream/common/Actions.jsm"
 );
 
-XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 const HTML_NS = "http://www.w3.org/1999/xhtml";
 const PREFERENCES_LOADED_EVENT = "home-pane-loaded";
 
@@ -112,7 +108,7 @@ this.AboutPreferences = class AboutPreferences {
     return sectionsCopy;
   }
 
-  async observe(window) {
+  observe(window) {
     const discoveryStreamConfig = this.store.getState().DiscoveryStream.config;
     let sections = this.store.getState().Sections;
 
@@ -120,7 +116,7 @@ this.AboutPreferences = class AboutPreferences {
       sections = this.handleDiscoverySettings(sections);
     }
 
-    this.renderPreferences(window, await this.strings, [
+    this.renderPreferences(window, [
       ...PREFS_BEFORE_SECTIONS,
       ...sections,
       ...PREFS_AFTER_SECTIONS,
@@ -128,43 +124,10 @@ this.AboutPreferences = class AboutPreferences {
   }
 
   /**
-   * Get strings from a js file that the content page would have loaded. The
-   * file should be a single variable assignment of a JSON/JS object of strings.
-   */
-  get strings() {
-    return (
-      this._strings ||
-      (this._strings = new Promise(async resolve => {
-        let data = {};
-        try {
-          const locale = Cc[
-            "@mozilla.org/browser/aboutnewtab-service;1"
-          ].getService(Ci.nsIAboutNewTabService).activityStreamLocale;
-          const request = await fetch(
-            `resource://activity-stream/prerendered/${locale}/activity-stream-strings.js`
-          );
-          const text = await request.text();
-          const [json] = text.match(/{[^]*}/);
-          data = JSON.parse(json);
-        } catch (ex) {
-          Cu.reportError(
-            "Failed to load strings for Activity Stream about:preferences"
-          );
-        }
-        resolve(data);
-      }))
-    );
-  }
-
-  /**
    * Render preferences to an about:preferences content window with the provided
-   * strings and preferences structure.
+   * preferences structure.
    */
-  renderPreferences(
-    { document, Preferences, gHomePane },
-    strings,
-    prefStructure
-  ) {
+  renderPreferences({ document, Preferences, gHomePane }, prefStructure) {
     // Helper to create a new element and append it
     const createAppend = (tag, parent, options) =>
       parent.appendChild(document.createXULElement(tag, options));

--- a/lib/LinksCache.jsm
+++ b/lib/LinksCache.jsm
@@ -83,45 +83,50 @@ this.LinksCache = class LinksCache {
       this.lastUpdate = now;
 
       // Save a promise before awaits, so other requests wait for correct data
-      this.cache = new Promise(async resolve => {
-        // Allow fast lookup of old links by url that might need to migrate
-        const toMigrate = new Map();
-        for (const oldLink of await this.cache) {
-          if (oldLink) {
-            toMigrate.set(oldLink.url, oldLink);
-          }
-        }
-
-        // Update the cache with migrated links without modifying source objects
-        resolve(
-          (await this.linkGetter(options)).map(link => {
-            // Keep original array hole positions
-            if (!link) {
-              return link;
-            }
-
-            // Migrate data to the new link copy if we have an old link
-            const newLink = Object.assign({}, link);
-            const oldLink = toMigrate.get(newLink.url);
+      // eslint-disable-next-line no-async-promise-executor
+      this.cache = new Promise(async (resolve, reject) => {
+        try {
+          // Allow fast lookup of old links by url that might need to migrate
+          const toMigrate = new Map();
+          for (const oldLink of await this.cache) {
             if (oldLink) {
-              for (const property of this.migrateProperties) {
-                const oldValue = oldLink[property];
-                if (oldValue !== undefined) {
-                  newLink[property] = oldValue;
-                }
-              }
-            } else {
-              // Share data among link copies and new links from future requests
-              newLink.__sharedCache = {};
+              toMigrate.set(oldLink.url, oldLink);
             }
-            // Provide a helper to update the cached link
-            newLink.__sharedCache.updateLink = (property, value) => {
-              newLink[property] = value;
-            };
+          }
 
-            return newLink;
-          })
-        );
+          // Update the cache with migrated links without modifying source objects
+          resolve(
+            (await this.linkGetter(options)).map(link => {
+              // Keep original array hole positions
+              if (!link) {
+                return link;
+              }
+
+              // Migrate data to the new link copy if we have an old link
+              const newLink = Object.assign({}, link);
+              const oldLink = toMigrate.get(newLink.url);
+              if (oldLink) {
+                for (const property of this.migrateProperties) {
+                  const oldValue = oldLink[property];
+                  if (oldValue !== undefined) {
+                    newLink[property] = oldValue;
+                  }
+                }
+              } else {
+                // Share data among link copies and new links from future requests
+                newLink.__sharedCache = {};
+              }
+              // Provide a helper to update the cached link
+              newLink.__sharedCache.updateLink = (property, value) => {
+                newLink[property] = value;
+              };
+
+              return newLink;
+            })
+          );
+        } catch (error) {
+          reject(error);
+        }
       });
     }
 

--- a/lib/PersistentCache.jsm
+++ b/lib/PersistentCache.jsm
@@ -57,18 +57,25 @@ this.PersistentCache = class PersistentCache {
   _load() {
     return (
       this._cache ||
-      (this._cache = new Promise(async resolve => {
-        let file;
-        let data = {};
-        const filepath = OS.Path.join(
-          OS.Constants.Path.localProfileDir,
-          this._filename
-        );
+      // eslint-disable-next-line no-async-promise-executor
+      (this._cache = new Promise(async (resolve, reject) => {
+        let filepath;
+        try {
+          filepath = OS.Path.join(
+            OS.Constants.Path.localProfileDir,
+            this._filename
+          );
+        } catch (error) {
+          reject(error);
+          return;
+        }
 
+        let file;
         try {
           file = await fetch(`file://${filepath}`);
         } catch (error) {} // Cache file doesn't exist yet.
 
+        let data = {};
         if (file) {
           try {
             data = await file.json();

--- a/lib/Tokenize.jsm
+++ b/lib/Tokenize.jsm
@@ -29,6 +29,8 @@ const UNICODE_LETTER =
 const REGEXP_SPLITS = new RegExp(
   `[${UNICODE_SPACE}${UNICODE_SYMBOL}${UNICODE_PUNCT}]+`
 );
+// Match all token characters, so okay for regex to split multiple code points
+// eslint-disable-next-line no-misleading-character-class
 const REGEXP_ALPHANUMS = new RegExp(
   `^[${UNICODE_NUMBER}${UNICODE_MARK}${UNICODE_LETTER}]+$`
 );

--- a/test/unit/asrouter/ASRouterTargeting.test.js
+++ b/test/unit/asrouter/ASRouterTargeting.test.js
@@ -48,18 +48,20 @@ describe("#CachedTargetingGetter", () => {
       global.NewTabUtils.activityStreamProvider.getTopFrecentSites
     );
   });
-  it("should report errors", async () => {
+  it("throws when failing getter", async () => {
     frecentStub.rejects(new Error("fake error"));
     clock.tick(sixHours);
 
     // assert.throws expect a function as the first parameter, try/catch is a
     // workaround
+    let rejected = false;
     try {
       await topsitesCache.get();
-      assert.isTrue(false);
     } catch (e) {
-      assert.calledOnce(global.Cu.reportError);
+      rejected = true;
     }
+
+    assert(rejected);
   });
   it("should check targeted message before message without targeting", async () => {
     const messages = await OnboardingMessageProvider.getUntranslatedMessages();

--- a/test/unit/lib/AboutPreferences.test.js
+++ b/test/unit/lib/AboutPreferences.test.js
@@ -93,19 +93,16 @@ describe("AboutPreferences Feed", () => {
     });
     it("should try to render on event", async () => {
       const stub = sandbox.stub(instance, "renderPreferences");
-      instance._strings = {};
       Sections.push({});
 
       await instance.observe(window, PREFERENCES_LOADED_EVENT);
 
       assert.calledOnce(stub);
       assert.equal(stub.firstCall.args[0], window);
-      assert.deepEqual(stub.firstCall.args[1], instance._strings);
-      assert.include(stub.firstCall.args[2], Sections[0]);
+      assert.include(stub.firstCall.args[1], Sections[0]);
     });
     it("Hide topstories rows select in sections if discovery stream is enabled", async () => {
       const stub = sandbox.stub(instance, "renderPreferences");
-      instance._strings = {};
 
       Sections.push({
         rowsPref: "row_pref",
@@ -119,62 +116,15 @@ describe("AboutPreferences Feed", () => {
       await instance.observe(window, PREFERENCES_LOADED_EVENT);
 
       assert.calledOnce(stub);
-      assert.equal(stub.firstCall.args[2][0].id, "search");
-      assert.equal(stub.firstCall.args[2][1].id, "topsites");
-      assert.equal(stub.firstCall.args[2][2].id, "topstories");
-      assert.isEmpty(stub.firstCall.args[2][2].rowsPref);
-    });
-  });
-  describe("#strings", () => {
-    let activityStreamLocale;
-    let fetchStub;
-    let fetchText;
-    beforeEach(() => {
-      global.Cc["@mozilla.org/browser/aboutnewtab-service;1"] = {
-        getService() {
-          return { activityStreamLocale };
-        },
-      };
-      fetchStub = sandbox
-        .stub()
-        .resolves({ text: () => Promise.resolve(fetchText) });
-      globals.set("fetch", fetchStub);
-    });
-    it("should use existing strings if they exist", async () => {
-      instance._strings = {};
-
-      const strings = await instance.strings;
-
-      assert.equal(strings, instance._strings);
-    });
-    it("should report failure if missing", async () => {
-      sandbox.stub(Cu, "reportError");
-
-      const strings = await instance.strings;
-
-      assert.calledOnce(Cu.reportError);
-      assert.deepEqual(strings, {});
-    });
-    it("should fetch with the appropriate locale", async () => {
-      activityStreamLocale = "en-TEST";
-
-      await instance.strings;
-
-      assert.calledOnce(fetchStub);
-      assert.include(fetchStub.firstCall.args[0], activityStreamLocale);
-    });
-    it("should extract strings from js text", async () => {
-      const testStrings = { hello: "world" };
-      fetchText = `var strings = ${JSON.stringify(testStrings)};`;
-
-      const strings = await instance.strings;
-
-      assert.deepEqual(strings, testStrings);
+      const [, structure] = stub.firstCall.args;
+      assert.equal(structure[0].id, "search");
+      assert.equal(structure[1].id, "topsites");
+      assert.equal(structure[2].id, "topstories");
+      assert.isEmpty(structure[2].rowsPref);
     });
   });
   describe("#renderPreferences", () => {
     let node;
-    let strings;
     let prefStructure;
     let Preferences;
     let gHomePane;
@@ -200,7 +150,6 @@ describe("AboutPreferences Feed", () => {
           Preferences,
           gHomePane,
         },
-        strings,
         prefStructure,
         DiscoveryStream.config
       );
@@ -215,7 +164,6 @@ describe("AboutPreferences Feed", () => {
         remove: sandbox.stub(),
         style: {},
       };
-      strings = {};
       prefStructure = [];
       Preferences = {
         add: sandbox.stub(),

--- a/test/unit/lib/LinksCache.test.js
+++ b/test/unit/lib/LinksCache.test.js
@@ -1,0 +1,16 @@
+import { LinksCache } from "lib/LinksCache.jsm";
+
+describe("LinksCache", () => {
+  it("throws when failing request", async () => {
+    const cache = new LinksCache();
+
+    let rejected = false;
+    try {
+      await cache.request();
+    } catch (error) {
+      rejected = true;
+    }
+
+    assert(rejected);
+  });
+});

--- a/test/unit/lib/PersistentCache.test.js
+++ b/test/unit/lib/PersistentCache.test.js
@@ -115,5 +115,17 @@ describe("PersistentCache", () => {
         { tmpPath: `${filename}.tmp` }
       );
     });
+    it("throws when failing the file", async () => {
+      sandbox.stub(OS.Path, "join").throws("bad file");
+
+      let rejected = false;
+      try {
+        await cache.set("key", "val");
+      } catch (error) {
+        rejected = true;
+      }
+
+      assert(rejected);
+    });
   });
 });


### PR DESCRIPTION
r?@piatra (Generally good to look at PRs ignoring whitespace now with prettier. From Files changed -> gear icon -> Just for now Hide whitespace changes)

- ASRouterTargeting: converted to plain async dropping the explicit reportError
- AboutPreferences: deleted `strings` helper and related cleanup
- LinksCache: kept async but added try/catch to reject
- PersistentCache: kept async but added try/catch around remaining potential failure
- Tokenize: eslint rule says regex `/[MCP]/` (pretend MCP is a visually single unicode character but actually multiple characters) is dangerous because it matches on the individual "M" "C" or "P" characters, but in this case, we're matching the whole token anyway, so ignore