### PR TITLE
(nobug) - Ignore whatsnew when rendering snippets

### DIFF
--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -269,9 +269,12 @@ export class ASRouterUISurface extends React.PureComponent {
   renderSnippets() {
     if (
       this.state.bundle.template === "onboarding" ||
-      this.state.message.template === "fxa_overlay" ||
-      this.state.message.template === "return_to_amo_overlay" ||
-      this.state.message.template === "trailhead"
+      [
+        "fxa_overlay",
+        "return_to_amo_overlay",
+        "trailhead",
+        "whatsnew_panel_message",
+      ].includes(this.state.message.template)
     ) {
       return null;
     }


### PR DESCRIPTION
r?@rlr or @piatra I clicked the [Show] button for WHATS_NEW_70_1 in devtools and it resulted in a react failure "Oops, something went wrong loading this content."