### PR TITLE
(nobug) Move the What's New and Badge test messages to PanelTestProvider.jsm

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -14,7 +14,6 @@ const { AddonRepository } = ChromeUtils.import(
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
 const L10N = new Localization([
   "branding/brand.ftl",
   "browser/branding/brandings.ftl",
@@ -465,82 +464,6 @@ const ONBOARDING_MESSAGES = async () => [
     targeting:
       "attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",
     trigger: { id: "firstRun" },
-  },
-  {
-    id: "FXA_ACCOUNTS_BADGE",
-    template: "toolbar_badge",
-    content: {
-      target: "fxa-toolbar-menu-button",
-    },
-    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
-    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
-    trigger: { id: "toolbarBadgeUpdate" },
-  },
-  {
-    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
-    template: "toolbar_badge",
-    content: {
-      // delay: 5 * 3600 * 1000,
-      delay: 5000,
-      target: "whats-new-menu-button",
-      action: { id: "show-whatsnew-button" },
-    },
-    priority: 1,
-    trigger: { id: "toolbarBadgeUpdate" },
-    frequency: {
-      // Makes it so that we track impressions for this message while at the
-      // same time it can have unlimited impressions
-      lifetime: Infinity,
-    },
-    // Never saw this message or saw it in the past 4 days or more recent
-    targeting: `isWhatsNewPanelEnabled &&
-      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
-        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
-      (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
-        currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
-  },
-  {
-    id: "WHATS_NEW_70_1",
-    template: "whatsnew_panel_message",
-    content: {
-      published_date: 1560969794394,
-      title: "Protection Is Our Focus",
-      icon_url:
-        "resource://activity-stream/data/content/assets/whatsnew-send-icon.png",
-      body:
-        "The New Enhanced Tracking Protection, gives you the best level of protection and performance. Discover how this version is the safest version of firefox ever made.",
-      cta_url: "https://blog.mozilla.org/",
-    },
-    targeting: `firefoxVersion > 69`,
-    trigger: { id: "whatsNewPanelOpened" },
-  },
-  {
-    id: "WHATS_NEW_70_2",
-    template: "whatsnew_panel_message",
-    content: {
-      published_date: 1560969794394,
-      title: "Another thing new in Firefox 70",
-      body:
-        "The New Enhanced Tracking Protection, gives you the best level of protection and performance. Discover how this version is the safest version of firefox ever made.",
-      link_text: "Learn more on our blog",
-      cta_url: "https://blog.mozilla.org/",
-    },
-    targeting: `firefoxVersion > 69`,
-    trigger: { id: "whatsNewPanelOpened" },
-  },
-  {
-    id: "WHATS_NEW_69_1",
-    template: "whatsnew_panel_message",
-    content: {
-      published_date: 1557346235089,
-      title: "Something new in Firefox 69",
-      body:
-        "The New Enhanced Tracking Protection, gives you the best level of protection and performance. Discover how this version is the safest version of firefox ever made.",
-      link_text: "Learn more on our blog",
-      cta_url: "https://blog.mozilla.org/",
-    },
-    targeting: `firefoxVersion > 68`,
-    trigger: { id: "whatsNewPanelOpened" },
   },
 ];
 

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
+
 const MESSAGES = () => [
   {
     id: "SIMPLE_FXA_BOOKMARK_TEST_FLUENT",
@@ -45,6 +49,82 @@ const MESSAGES = () => [
       },
     },
     trigger: { id: "bookmark-panel" },
+  },
+  {
+    id: "FXA_ACCOUNTS_BADGE",
+    template: "toolbar_badge",
+    content: {
+      target: "fxa-toolbar-menu-button",
+    },
+    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
+    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
+    trigger: { id: "toolbarBadgeUpdate" },
+  },
+  {
+    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
+    template: "toolbar_badge",
+    content: {
+      // delay: 5 * 3600 * 1000,
+      delay: 5000,
+      target: "whats-new-menu-button",
+      action: { id: "show-whatsnew-button" },
+    },
+    priority: 1,
+    trigger: { id: "toolbarBadgeUpdate" },
+    frequency: {
+      // Makes it so that we track impressions for this message while at the
+      // same time it can have unlimited impressions
+      lifetime: Infinity,
+    },
+    // Never saw this message or saw it in the past 4 days or more recent
+    targeting: `isWhatsNewPanelEnabled &&
+      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
+        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
+      (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
+        currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
+  },
+  {
+    id: "WHATS_NEW_70_1",
+    template: "whatsnew_panel_message",
+    content: {
+      published_date: 1560969794394,
+      title: "Protection Is Our Focus",
+      icon_url:
+        "resource://activity-stream/data/content/assets/whatsnew-send-icon.png",
+      body:
+        "The New Enhanced Tracking Protection, gives you the best level of protection and performance. Discover how this version is the safest version of firefox ever made.",
+      cta_url: "https://blog.mozilla.org/",
+    },
+    targeting: `firefoxVersion > 69`,
+    trigger: { id: "whatsNewPanelOpened" },
+  },
+  {
+    id: "WHATS_NEW_70_2",
+    template: "whatsnew_panel_message",
+    content: {
+      published_date: 1560969794394,
+      title: "Another thing new in Firefox 70",
+      body:
+        "The New Enhanced Tracking Protection, gives you the best level of protection and performance. Discover how this version is the safest version of firefox ever made.",
+      link_text: "Learn more on our blog",
+      cta_url: "https://blog.mozilla.org/",
+    },
+    targeting: `firefoxVersion > 69`,
+    trigger: { id: "whatsNewPanelOpened" },
+  },
+  {
+    id: "WHATS_NEW_69_1",
+    template: "whatsnew_panel_message",
+    content: {
+      published_date: 1557346235089,
+      title: "Something new in Firefox 69",
+      body:
+        "The New Enhanced Tracking Protection, gives you the best level of protection and performance. Discover how this version is the safest version of firefox ever made.",
+      link_text: "Learn more on our blog",
+      cta_url: "https://blog.mozilla.org/",
+    },
+    targeting: `firefoxVersion > 68`,
+    trigger: { id: "whatsNewPanelOpened" },
   },
 ];
 

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -4,7 +4,7 @@ const messages = PanelTestProvider.getMessages();
 
 describe("PanelTestProvider", () => {
   it("should have a message", () => {
-    assert.lengthOf(messages, 2);
+    assert.lengthOf(messages, 7);
   });
   it("should be a valid message", () => {
     assert.jsonSchema(messages[0].content, schema);

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -1,6 +1,6 @@
 import { _ToolbarBadgeHub } from "lib/ToolbarBadgeHub.jsm";
 import { GlobalOverrider } from "test/unit/utils";
-import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
+import { PanelTestProvider } from "lib/PanelTestProvider.jsm";
 import { _ToolbarPanelHub } from "lib/ToolbarPanelHub.jsm";
 
 describe("ToolbarBadgeHub", () => {
@@ -19,7 +19,7 @@ describe("ToolbarBadgeHub", () => {
     sandbox = sinon.createSandbox();
     instance = new _ToolbarBadgeHub();
     fakeAddImpression = sandbox.stub();
-    const msgs = await OnboardingMessageProvider.getUntranslatedMessages();
+    const msgs = await PanelTestProvider.getMessages();
     fxaMessage = msgs.find(({ id }) => id === "FXA_ACCOUNTS_BADGE");
     whatsnewMessage = msgs.find(({ id }) => id.includes("WHATS_NEW_BADGE_"));
     fakeElement = {

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -1,6 +1,6 @@
 import { _ToolbarPanelHub } from "lib/ToolbarPanelHub.jsm";
 import { GlobalOverrider } from "test/unit/utils";
-import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
+import { PanelTestProvider } from "lib/PanelTestProvider.jsm";
 
 describe("ToolbarPanelHub", () => {
   let globals;
@@ -107,7 +107,7 @@ describe("ToolbarPanelHub", () => {
     assert.calledWith(fakeElementById.setAttribute, "hidden", true);
   });
   it("should render messages to the panel on renderMessages()", async () => {
-    const messages = (await OnboardingMessageProvider.getMessages()).filter(
+    const messages = (await PanelTestProvider.getMessages()).filter(
       m => m.template === "whatsnew_panel_message"
     );
     messages[0].content.link_text = { string_id: "link_text_id" };
@@ -135,7 +135,7 @@ describe("ToolbarPanelHub", () => {
   });
   it("should only render unique dates (no duplicates)", async () => {
     instance._createDateElement = sandbox.stub();
-    const messages = (await OnboardingMessageProvider.getMessages()).filter(
+    const messages = (await PanelTestProvider.getMessages()).filter(
       m => m.template === "whatsnew_panel_message"
     );
     const uniqueDates = [


### PR DESCRIPTION
With this patch you can still trigger the badging from devtools, but the actual messages don't show up in the panel. I guess because they aren't really loaded into ASRouter (?).