### PR TITLE
Bug 1565088 - Add AUTO-GENERATED message to top of bundle.js to satisfy license lint

### DIFF
--- a/webpack.system-addon.config.js
+++ b/webpack.system-addon.config.js
@@ -18,7 +18,12 @@ module.exports = (env = {}) => ({
   },
   // TODO: switch to eval-source-map for faster builds. Requires CSP changes
   devtool: env.development ? "inline-source-map" : false,
-  plugins: [new webpack.optimize.ModuleConcatenationPlugin()],
+  plugins: [
+    new webpack.BannerPlugin(
+      `THIS FILE IS AUTO-GENERATED: ${path.basename(__filename)}`
+    ),
+    new webpack.optimize.ModuleConcatenationPlugin(),
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
r? @k88hudson Adds a banner satisfying a valid "license" https://searchfox.org/mozilla-central/source/tools/lint/license/valid-licenses.txt

Diff on m-c side:
```diff
diff --git a/browser/components/newtab/data/content/activity-stream.bundle.js b/browser/components/newtab/data/content/activity-stream.bundle.js
--- a/browser/components/newtab/data/content/activity-stream.bundle.js
+++ b/browser/components/newtab/data/content/activity-stream.bundle.js
@@ -1 +1,2 @@
+/*! THIS FILE IS AUTO-GENERATED: webpack.system-addon.config.js */
 /******/ (function(modules) { // webpackBootstrap
```

(Note if testing locally, you'll need to enable license linting of .js files https://searchfox.org/mozilla-central/rev/15be167a5b436b57fef944b84eef061d24c1af8c/tools/lint/license.yml#23-24 )