### PR TITLE
(nobug) - Use older trimLeft instead of es2019 trimStart

### DIFF
--- a/bin/render-activity-stream-html.js
+++ b/bin/render-activity-stream-html.js
@@ -67,7 +67,7 @@ function templateHTML(options) {
     }
   </body>
 </html>
-`.trimStart();
+`.trimLeft();
 }
 
 /**


### PR DESCRIPTION
bustage fix… oops! 😊 