### PR TITLE
Bug 1561554 - Add telemetry events for notification badges

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -1068,3 +1068,21 @@ This reports an enrollment ping when a user gets enrolled in a Trailhead experim
   }
 }
 ```
+
+## Feature Callouts interaction pings
+
+This reports when a user has seen a badge/notification in the browser toolbar in a non-PBM window
+
+```
+{
+  "locale": "en-US",
+  "client_id": "9da773d8-4356-f54f-b7cf-6134726bcf3d",
+  "version": "70.0a1",
+  "release_channel": "default",
+  "addon_version": "20190712095934",
+  "action": "cfr_user_event",
+  "source": "CFR",
+  "message_id": "FXA_ACCOUNTS_BADGE",
+  "event": ["CLICK" | "IMPRESSION"],
+}
+```

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -1071,7 +1071,7 @@ This reports an enrollment ping when a user gets enrolled in a Trailhead experim
 
 ## Feature Callouts interaction pings
 
-This reports when a user has seen a badge/notification in the browser toolbar in a non-PBM window
+This reports when a user has seen or clicked a badge/notification in the browser toolbar in a non-PBM window
 
 ```
 {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -728,6 +728,7 @@ class _ASRouter {
       handleMessageRequest: this.handleMessageRequest,
       addImpression: this.addImpression,
       blockMessageById: this.blockMessageById,
+      dispatch: this.dispatch,
     });
     ToolbarPanelHub.init({
       getMessages: this.handleMessageRequest,
@@ -1889,6 +1890,7 @@ class _ASRouter {
         await this.addImpression(action.data);
         break;
       case "DOORHANGER_TELEMETRY":
+      case "TOOLBAR_BADGE_TELEMETRY":
         if (this.dispatchToAS) {
           this.dispatchToAS(ac.ASRouterUserEvent(action.data));
         }

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -23,6 +23,16 @@ ChromeUtils.defineModuleGetter(
   "clearTimeout",
   "resource://gre/modules/Timer.jsm"
 );
+ChromeUtils.defineModuleGetter(
+  this,
+  "Services",
+  "resource://gre/modules/Services.jsm"
+);
+ChromeUtils.defineModuleGetter(
+  this,
+  "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm"
+);
 
 const notificationsByWindow = new WeakMap();
 
@@ -35,19 +45,23 @@ class _ToolbarBadgeHub {
     this.removeToolbarNotification = this.removeToolbarNotification.bind(this);
     this.addToolbarNotification = this.addToolbarNotification.bind(this);
     this.registerBadgeToAllWindows = this.registerBadgeToAllWindows.bind(this);
+    this._sendTelemetry = this._sendTelemetry.bind(this);
+    this.sendUserEventTelemetry = this.sendUserEventTelemetry.bind(this);
 
     this._handleMessageRequest = null;
     this._addImpression = null;
     this._blockMessageById = null;
+    this._dispatch = null;
   }
 
   async init(
     waitForInitialized,
-    { handleMessageRequest, addImpression, blockMessageById }
+    { handleMessageRequest, addImpression, blockMessageById, dispatch }
   ) {
     this._handleMessageRequest = handleMessageRequest;
     this._blockMessageById = blockMessageById;
     this._addImpression = addImpression;
+    this._dispatch = dispatch;
     this.state = {};
     // Need to wait for ASRouter to initialize before trying to fetch messages
     await waitForInitialized;
@@ -91,6 +105,11 @@ class _ToolbarBadgeHub {
         this.removeAllNotifications
       );
       event.target.removeEventListener("click", this.removeAllNotifications);
+      // If we have an event it means the user interacted with the badge
+      // we should send telemetry
+      if (this.state.notification) {
+        this.sendUserEventTelemetry("CLICK", this.state.notification);
+      }
     }
     // Will call uninit on every window
     EveryWindow.unregisterCallback(this.id);
@@ -136,6 +155,8 @@ class _ToolbarBadgeHub {
   registerBadgeToAllWindows(message) {
     // Impression should be added when the badge becomes visible
     this._addImpression(message);
+    // Send a telemetry ping when adding the notification badge
+    this.sendUserEventTelemetry("IMPRESSION", message);
 
     EveryWindow.registerCallback(
       this.id,
@@ -178,6 +199,30 @@ class _ToolbarBadgeHub {
     });
     if (message) {
       this.registerBadgeNotificationListener(message);
+    }
+  }
+
+  _sendTelemetry(ping) {
+    this._dispatch({
+      type: "TOOLBAR_BADGE_TELEMETRY",
+      data: { action: "cfr_user_event", source: "CFR", ...ping },
+    });
+  }
+
+  sendUserEventTelemetry(event, message) {
+    const win = Services.wm.getMostRecentWindow("navigator:browser");
+    // Only send pings for non private browsing windows
+    if (
+      win &&
+      !PrivateBrowsingUtils.isBrowserPrivate(
+        win.ownerGlobal.gBrowser.selectedBrowser
+      )
+    ) {
+      this._sendTelemetry({
+        message_id: message.id,
+        bucket_id: message.id,
+        event,
+      });
     }
   }
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -206,6 +206,7 @@ describe("ASRouter", () => {
           handleMessageRequest: Router.handleMessageRequest,
           addImpression: Router.addImpression,
           blockMessageById: Router.blockMessageById,
+          dispatch: Router.dispatch,
         }
       );
 


### PR DESCRIPTION
I'll follow up with a data review as well. This PR adds 2 events for `IMPRESSION` and `CLICK` for the toolbar badges.
To test this you can enable the badge in ASR admin under `panel_test_provider` -> `FXA_ACCOUNTS_BADGE`.