### PR TITLE
Bug 1564568 - Hide What's New toolbar button after the user dismisses the panel

### DIFF
--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -68,6 +68,24 @@ class _ToolbarPanelHub {
     );
   }
 
+  // When the panel is hidden we want to run some cleanup
+  _onPanelHidden(win) {
+    const panelContainer = win.document.getElementById(
+      "customizationui-widget-panel"
+    );
+    // When the panel is hidden we want to remove any toolbar buttons that
+    // might have been added as an entry point to the panel
+    const removeToolbarButton = () => {
+      EveryWindow.unregisterCallback(TOOLBAR_BUTTON_ID);
+    };
+    if (!panelContainer) {
+      return;
+    }
+    panelContainer.addEventListener("popuphidden", removeToolbarButton, {
+      once: true,
+    });
+  }
+
   // Render what's new messages into the panel.
   async renderMessages(win, doc, containerId) {
     const messages = (await this._getMessages({
@@ -97,6 +115,7 @@ class _ToolbarPanelHub {
     }
 
     // TODO: TELEMETRY
+    this._onPanelHidden(win);
   }
 
   _createMessageElements(win, doc, content, previousDate) {

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -22,6 +22,7 @@ describe("ToolbarPanelHub", () => {
       removeAttribute: sandbox.stub(),
       querySelector: sandbox.stub().returns(null),
       appendChild: sandbox.stub(),
+      addEventListener: sandbox.stub(),
     };
     fakeDocument = {
       l10n: {
@@ -45,6 +46,7 @@ describe("ToolbarPanelHub", () => {
       },
     };
     fakeWindow = {
+      document: fakeDocument,
       browser: {
         ownerDocument: fakeDocument,
       },
@@ -146,5 +148,45 @@ describe("ToolbarPanelHub", () => {
     });
     await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
     assert.callCount(instance._createDateElement, uniqueDates.length);
+  });
+  it("should listen for panelhidden and remove the toolbar button", async () => {
+    instance.init({
+      getMessages: sandbox.stub().returns([]),
+    });
+    fakeDocument.getElementById
+      .withArgs("customizationui-widget-panel")
+      .returns(null);
+
+    await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+    assert.notCalled(fakeElementById.addEventListener);
+  });
+  it("should listen for panelhidden and remove the toolbar button", async () => {
+    instance.init({
+      getMessages: sandbox.stub().returns([]),
+    });
+
+    await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+    assert.calledOnce(fakeElementById.addEventListener);
+    assert.calledWithExactly(
+      fakeElementById.addEventListener,
+      "popuphidden",
+      sinon.match.func,
+      {
+        once: true,
+      }
+    );
+    const [, cb] = fakeElementById.addEventListener.firstCall.args;
+
+    assert.notCalled(everyWindowStub.unregisterCallback);
+
+    cb();
+
+    assert.calledOnce(everyWindowStub.unregisterCallback);
+    assert.calledWithExactly(
+      everyWindowStub.unregisterCallback,
+      "whats-new-menu-button"
+    );
   });
 });


### PR DESCRIPTION
The branch is on top of #5180 that's why the extra part, only changes in `ib/ToolbarPanelHub.jsm` should be considered. 