### PR TITLE
Bug 1560065 - Refactor first run for skyline, replace modal onboarding with triplets

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,7 +78,7 @@ module.exports = {
 
     "react/jsx-boolean-value": [2, "always"],
     "react/jsx-key": 2,
-    "react/jsx-no-bind": 0,
+    "react/jsx-no-bind": 2,
     "react/jsx-no-comment-textnodes": 2,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-target-blank": 2,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
       // These files use fluent-dom to insert content
       "files": [
         "content-src/asrouter/templates/OnboardingMessage/**",
+        "content-src/asrouter/templates/FirstRun/**",
         "content-src/asrouter/templates/Trailhead/**",
         "content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx",
         "content-src/components/TopSites/**",
@@ -77,7 +78,7 @@ module.exports = {
 
     "react/jsx-boolean-value": [2, "always"],
     "react/jsx-key": 2,
-    "react/jsx-no-bind": 2,
+    "react/jsx-no-bind": 0,
     "react/jsx-no-comment-textnodes": 2,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-target-blank": 2,

--- a/content-src/asrouter/templates/FirstRun/FirstRun.jsx
+++ b/content-src/asrouter/templates/FirstRun/FirstRun.jsx
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { Interrupt } from "./Interrupt";
+import { Triplets } from "./Triplets";
+import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
+import { addUtmParams } from "./addUtmParams";
+
+export const FLUENT_FILES = [
+  "branding/brand.ftl",
+  "browser/branding/brandings.ftl",
+  "browser/branding/sync-brand.ftl",
+  "browser/newtab/onboarding.ftl",
+];
+
+export const helpers = {
+  selectInterruptAndTriplets(message = {}) {
+    const hasInterrupt = Boolean(message.content);
+    const hasTriplets = Boolean(message.bundle && message.bundle.length);
+    const UTMTerm = message.utm_term || "";
+    return {
+      hasTriplets,
+      hasInterrupt,
+      interrupt: hasInterrupt ? message : null,
+      triplets: hasTriplets ? message.bundle : null,
+      UTMTerm,
+    };
+  },
+
+  addFluent(document) {
+    FLUENT_FILES.forEach(file => {
+      const link = document.head.appendChild(document.createElement("link"));
+      link.href = file;
+      link.rel = "localization";
+    });
+  },
+
+  async fetchFlowParams({ fxaEndpoint, UTMTerm, dispatch, setFlowParams }) {
+    try {
+      const url = new URL(
+        `${fxaEndpoint}/metrics-flow?entrypoint=activity-stream-firstrun&form_type=email`
+      );
+      addUtmParams(url, UTMTerm);
+      const response = await fetch(url, { credentials: "omit" });
+      if (response.status === 200) {
+        const { deviceId, flowId, flowBeginTime } = await response.json();
+        setFlowParams({ deviceId, flowId, flowBeginTime });
+      } else {
+        dispatch(
+          ac.OnlyToMain({
+            type: at.TELEMETRY_UNDESIRED_EVENT,
+            data: {
+              event: "FXA_METRICS_FETCH_ERROR",
+              value: response.status,
+            },
+          })
+        );
+      }
+    } catch (error) {
+      dispatch(
+        ac.OnlyToMain({
+          type: at.TELEMETRY_UNDESIRED_EVENT,
+          data: { event: "FXA_METRICS_ERROR" },
+        })
+      );
+    }
+  },
+};
+
+const { useEffect, useState } = React;
+export const FirstRun = props => {
+  const {
+    message,
+    sendUserActionTelemetry,
+    fxaEndpoint,
+    dispatch,
+    executeAction,
+    document,
+  } = props;
+
+  const {
+    hasTriplets,
+    hasInterrupt,
+    interrupt,
+    triplets,
+    UTMTerm,
+  } = helpers.selectInterruptAndTriplets(message);
+
+  const [addedFluent, setAddedFluent] = useState(false);
+  useEffect(() => {
+    helpers.addFluent(document);
+    // We need to remove hide-main since we should show it underneath everything that has rendered
+    props.document.body.classList.remove("hide-main");
+    setAddedFluent(true);
+  }, []);
+
+  const [state, setState] = useState({
+    isInterruptVisible: false,
+    isTripletsContainerVisible: false,
+    isTripletsContentVisible: false,
+  });
+
+  useEffect(() => {
+    setState({
+      isInterruptVisible: hasInterrupt,
+      isTripletsContainerVisible: hasTriplets,
+      isTripletsContentVisible: false,
+    });
+    if (!hasInterrupt) {
+      props.document.body.classList.remove("welcome");
+    }
+  }, [interrupt, triplets, hasInterrupt, hasTriplets]);
+
+  const [flowParams, setFlowParams] = useState();
+  useEffect(() => {
+    if (fxaEndpoint && UTMTerm) {
+      helpers.fetchFlowParams({
+        fxaEndpoint,
+        UTMTerm,
+        dispatch,
+        setFlowParams,
+      });
+    }
+  }, [fxaEndpoint, UTMTerm, dispatch]);
+
+  const {
+    isInterruptVisible,
+    isTripletsContainerVisible,
+    isTripletsContentVisible,
+  } = state;
+
+  const closeInterrupt = () => {
+    setState(prevState => ({
+      isInterruptVisible: false,
+      isTripletsContainerVisible: prevState.hasTriplets,
+      isTripletsContentVisible: prevState.hasTriplets,
+    }));
+  };
+
+  const closeTriplets = () => setState({ isTripletsContainerVisible: false });
+
+  const dismissAndGoNext = () => {
+    // onDismiss();
+    closeInterrupt();
+  };
+
+  // Don't render before we add strings;
+  if (!addedFluent) return null;
+
+  return (
+    <>
+      {isInterruptVisible ? (
+        <Interrupt
+          document={props.document}
+          message={interrupt}
+          onNextScene={closeInterrupt}
+          UTMTerm={UTMTerm}
+          sendUserActionTelemetry={sendUserActionTelemetry}
+          dispatch={dispatch}
+          flowParams={flowParams}
+          onDismiss={dismissAndGoNext}
+          fxaEndpoint={fxaEndpoint}
+        />
+      ) : null}
+      {hasTriplets ? (
+        <Triplets
+          document={props.document}
+          cards={triplets}
+          showCardPanel={isTripletsContainerVisible}
+          showContent={isTripletsContentVisible}
+          hideContainer={closeTriplets}
+          sendUserActionTelemetry={sendUserActionTelemetry}
+          UTMTerm={`${UTMTerm}-card`}
+          flowParams={flowParams}
+          onAction={executeAction}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/content-src/asrouter/templates/FirstRun/Interrupt.jsx
+++ b/content-src/asrouter/templates/FirstRun/Interrupt.jsx
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { Trailhead } from "../Trailhead/Trailhead";
+import { ReturnToAMO } from "../ReturnToAMO/ReturnToAMO";
+import { StartupOverlay } from "../StartupOverlay/StartupOverlay";
+import { LocalizationProvider } from "fluent-react";
+import { generateBundles } from "../../rich-text-strings";
+
+export class Interrupt extends React.PureComponent {
+  render() {
+    const {
+      onDismiss,
+      onNextScene,
+      message,
+      sendUserActionTelemetry,
+      executeAction,
+      dispatch,
+      fxaEndpoint,
+      UTMTerm,
+      flowParams,
+    } = this.props;
+
+    switch (message.template) {
+      case "return_to_amo_overlay":
+        return (
+          <LocalizationProvider
+            bundles={generateBundles({ amo_html: message.content.text })}
+          >
+            <ReturnToAMO
+              {...message}
+              UISurface="NEWTAB_OVERLAY"
+              onBlock={onDismiss}
+              onAction={executeAction}
+              sendUserActionTelemetry={sendUserActionTelemetry}
+            />
+          </LocalizationProvider>
+        );
+      case "fxa_overlay":
+        return (
+          <StartupOverlay
+            onBlock={onDismiss}
+            dispatch={dispatch}
+            fxa_endpoint={fxaEndpoint}
+          />
+        );
+      case "trailhead":
+        return (
+          <Trailhead
+            document={this.props.document}
+            message={message}
+            onNextScene={onNextScene}
+            onAction={executeAction}
+            sendUserActionTelemetry={sendUserActionTelemetry}
+            dispatch={dispatch}
+            fxaEndpoint={fxaEndpoint}
+            UTMTerm={UTMTerm}
+            flowParams={flowParams}
+          />
+        );
+      default:
+        throw new Error(`${message.template} is not a valid FirstRun message`);
+    }
+  }
+}

--- a/content-src/asrouter/templates/FirstRun/Triplets.jsx
+++ b/content-src/asrouter/templates/FirstRun/Triplets.jsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { OnboardingCard } from "../../templates/OnboardingMessage/OnboardingMessage";
+import { addUtmParams } from "./addUtmParams";
+
+export class Triplets extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onCardAction = this.onCardAction.bind(this);
+    this.onHideContainer = this.onHideContainer.bind(this);
+  }
+
+  componentWillMount() {
+    global.document.body.classList.add("inline-onboarding");
+  }
+
+  componentWillUnmount() {
+    this.props.document.body.classList.remove("inline-onboarding");
+  }
+
+  onCardAction(action) {
+    let actionUpdates = {};
+    const { flowParams, UTMTerm } = this.props;
+
+    if (action.type === "OPEN_URL") {
+      let url = new URL(action.data.args);
+      addUtmParams(url, UTMTerm);
+
+      if (action.addFlowParams) {
+        url.searchParams.append("device_id", flowParams.deviceId);
+        url.searchParams.append("flow_id", flowParams.flowId);
+        url.searchParams.append("flow_begin_time", flowParams.flowBeginTime);
+      }
+
+      actionUpdates = { data: { ...action.data, args: url.toString() } };
+    }
+
+    this.props.onAction({ ...action, ...actionUpdates });
+  }
+
+  onHideContainer() {
+    const { sendUserActionTelemetry, cards, hideContainer } = this.props;
+    hideContainer();
+    sendUserActionTelemetry({
+      event: "DISMISS",
+      id: "onboarding-cards",
+      message_id: cards.map(m => m.id).join(","),
+      action: "onboarding_user_event",
+    });
+  }
+
+  render() {
+    const {
+      cards,
+      showCardPanel,
+      showContent,
+      sendUserActionTelemetry,
+    } = this.props;
+    return (
+      <div
+        className={`trailheadCards ${showCardPanel ? "expanded" : "collapsed"}`}
+      >
+        <div className="trailheadCardsInner" aria-hidden={!showContent}>
+          <h1 data-l10n-id="onboarding-welcome-header" />
+          <div className={`trailheadCardGrid${showContent ? " show" : ""}`}>
+            {cards.map(card => (
+              <OnboardingCard
+                key={card.id}
+                className="trailheadCard"
+                sendUserActionTelemetry={sendUserActionTelemetry}
+                onAction={this.onCardAction}
+                UISurface="TRAILHEAD"
+                {...card}
+              />
+            ))}
+          </div>
+          {showCardPanel && (
+            <button
+              className="icon icon-dismiss"
+              onClick={this.onHideContainer}
+              data-l10n-id="onboarding-cards-dismiss"
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/content-src/asrouter/templates/FirstRun/addUtmParams.js
+++ b/content-src/asrouter/templates/FirstRun/addUtmParams.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const BASE_PARAMS = {
+  utm_source: "activity-stream",
+  utm_campaign: "firstrun",
+  utm_medium: "referral",
+};
+
+/**
+ * Takes in a url as a string or URL object and returns a URL object with the
+ * utm_* parameters added to it. If a URL object is passed in, the paraemeters
+ * are added to it (the return value can be ignored in that case as it's the
+ * same object).
+ */
+export function addUtmParams(url, utmTerm) {
+  let returnUrl = url;
+  if (typeof returnUrl === "string") {
+    returnUrl = new URL(url);
+  }
+  Object.keys(BASE_PARAMS).forEach(key => {
+    returnUrl.searchParams.append(key, BASE_PARAMS[key]);
+  });
+  returnUrl.searchParams.append("utm_term", utmTerm);
+  return returnUrl;
+}

--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -2,14 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { ModalOverlay } from "../../components/ModalOverlay/ModalOverlay";
 import React from "react";
-
-const FLUENT_FILES = [
-  "branding/brand.ftl",
-  "browser/branding/sync-brand.ftl",
-  "browser/newtab/onboarding.ftl",
-];
 
 export class OnboardingCard extends React.PureComponent {
   constructor(props) {
@@ -54,36 +47,6 @@ export class OnboardingCard extends React.PureComponent {
           </span>
         </div>
       </div>
-    );
-  }
-}
-
-export class OnboardingMessage extends React.PureComponent {
-  componentWillMount() {
-    FLUENT_FILES.forEach(file => {
-      const link = document.head.appendChild(document.createElement("link"));
-      link.href = file;
-      link.rel = "localization";
-    });
-  }
-
-  render() {
-    const { props } = this;
-    const { button_label, header } = props.extraTemplateStrings;
-    return (
-      <ModalOverlay {...props} button_label={button_label} title={header}>
-        <div className="onboardingMessageContainer">
-          {props.bundle.map(message => (
-            <OnboardingCard
-              key={message.id}
-              sendUserActionTelemetry={props.sendUserActionTelemetry}
-              onAction={props.onAction}
-              UISurface={props.UISurface}
-              {...message}
-            />
-          ))}
-        </div>
-      </ModalOverlay>
     );
   }
 }

--- a/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
+++ b/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
@@ -1,20 +1,3 @@
-.onboardingMessageContainer {
-  display: grid;
-  grid-column-gap: 21px;
-  grid-template-columns: auto auto auto;
-  padding-left: 30px;
-  padding-right: 30px;
-  min-height: 500px;
-
-  // at 850px, the cards go from vertical layout to horizontal layout
-  @media(max-width: 850px) {
-    grid-template-columns: none;
-    grid-template-rows: auto auto auto;
-    padding-left: 110px;
-    padding-right: 110px;
-  }
-}
-
 .onboardingMessage {
   height: 340px;
   text-align: center;

--- a/content-src/asrouter/templates/ReturnToAMO/ReturnToAMO.jsx
+++ b/content-src/asrouter/templates/ReturnToAMO/ReturnToAMO.jsx
@@ -15,8 +15,11 @@ export class ReturnToAMO extends React.PureComponent {
     this.onBlockButton = this.onBlockButton.bind(this);
   }
 
+  componentWillMount() {
+    global.document.body.classList.add("amo");
+  }
+
   componentDidMount() {
-    this.props.onReady();
     this.props.sendUserActionTelemetry({
       event: "IMPRESSION",
       id: this.props.UISurface,

--- a/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
+++ b/content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx
@@ -2,23 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
-import { connect } from "react-redux";
+import { actionCreators as ac } from "common/Actions.jsm";
 import React from "react";
 
-const FLUENT_FILES = [
-  "branding/brand.ftl",
-  "browser/branding/sync-brand.ftl",
-  "browser/newtab/onboarding.ftl",
-];
-
-export class _StartupOverlay extends React.PureComponent {
+export class StartupOverlay extends React.PureComponent {
   constructor(props) {
     super(props);
     this.onInputChange = this.onInputChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.clickSkip = this.clickSkip.bind(this);
-    this.initScene = this.initScene.bind(this);
     this.removeOverlay = this.removeOverlay.bind(this);
     this.onInputInvalid = this.onInputInvalid.bind(this);
 
@@ -26,71 +18,20 @@ export class _StartupOverlay extends React.PureComponent {
       "utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-control";
 
     this.state = {
+      show: false,
       emailInput: "",
-      overlayRemoved: false,
-      deviceId: "",
-      flowId: "",
-      flowBeginTime: 0,
     };
-    this.didFetch = false;
   }
 
-  async componentWillUpdate() {
-    if (this.props.fxa_endpoint && !this.didFetch) {
-      try {
-        this.didFetch = true;
-        const fxaParams = "entrypoint=activity-stream-firstrun&form_type=email";
-        const response = await fetch(
-          `${this.props.fxa_endpoint}/metrics-flow?${fxaParams}&${
-            this.utmParams
-          }`,
-          { credentials: "omit" }
-        );
-        if (response.status === 200) {
-          const { deviceId, flowId, flowBeginTime } = await response.json();
-          this.setState({ deviceId, flowId, flowBeginTime });
-        } else {
-          this.props.dispatch(
-            ac.OnlyToMain({
-              type: at.TELEMETRY_UNDESIRED_EVENT,
-              data: {
-                event: "FXA_METRICS_FETCH_ERROR",
-                value: response.status,
-              },
-            })
-          );
-        }
-      } catch (error) {
-        this.props.dispatch(
-          ac.OnlyToMain({
-            type: at.TELEMETRY_UNDESIRED_EVENT,
-            data: { event: "FXA_METRICS_ERROR" },
-          })
-        );
-      }
-    }
-  }
-
-  async componentWillMount() {
-    FLUENT_FILES.forEach(file => {
-      const link = document.head.appendChild(document.createElement("link"));
-      link.href = file;
-      link.rel = "localization";
-    });
-
-    await this.componentWillUpdate(this.props);
+  componentWillMount() {
+    global.document.body.classList.add("fxa");
   }
 
   componentDidMount() {
-    this.initScene();
-  }
-
-  initScene() {
     // Timeout to allow the scene to render once before attaching the attribute
     // to trigger the animation.
     setTimeout(() => {
       this.setState({ show: true });
-      this.props.onReady();
     }, 10);
   }
 
@@ -98,11 +39,11 @@ export class _StartupOverlay extends React.PureComponent {
     window.removeEventListener("visibilitychange", this.removeOverlay);
     document.body.classList.remove("hide-main", "fxa");
     this.setState({ show: false });
-    this.props.onBlock();
+
     setTimeout(() => {
       // Allow scrolling and fully remove overlay after animation finishes.
+      this.props.onBlock();
       document.body.classList.remove("welcome");
-      this.setState({ overlayRemoved: true });
     }, 400);
   }
 
@@ -132,7 +73,9 @@ export class _StartupOverlay extends React.PureComponent {
    * Report to telemetry additional information about the form submission.
    */
   _getFormInfo() {
-    const value = { has_flow_params: this.state.flowId.length > 0 };
+    const value = {
+      has_flow_params: this.props.flowParams.flowId.length > 0,
+    };
     return { value };
   }
 
@@ -145,12 +88,6 @@ export class _StartupOverlay extends React.PureComponent {
   }
 
   render() {
-    // When skipping the onboarding tour we show AS but we are still on
-    // about:welcome, prop.isFirstrun is true and StartupOverlay is rendered
-    if (this.state.overlayRemoved) {
-      return null;
-    }
-
     return (
       <div className={`overlay-wrapper ${this.state.show ? "show" : ""}`}>
         <div className="background" />
@@ -213,13 +150,17 @@ export class _StartupOverlay extends React.PureComponent {
                 <input
                   name="device_id"
                   type="hidden"
-                  value={this.state.deviceId}
+                  value={this.props.flowParams.deviceId}
                 />
-                <input name="flow_id" type="hidden" value={this.state.flowId} />
+                <input
+                  name="flow_id"
+                  type="hidden"
+                  value={this.props.flowParams.flowId}
+                />
                 <input
                   name="flow_begin_time"
                   type="hidden"
-                  value={this.state.flowBeginTime}
+                  value={this.props.flowParams.flowBeginTime}
                 />
                 <span
                   className="error"
@@ -229,7 +170,7 @@ export class _StartupOverlay extends React.PureComponent {
                   className="email-input"
                   name="email"
                   type="email"
-                  required="true"
+                  required={true}
                   onInvalid={this.onInputInvalid}
                   onChange={this.onInputChange}
                   data-l10n-id="onboarding-sync-form-input"
@@ -274,5 +215,6 @@ export class _StartupOverlay extends React.PureComponent {
   }
 }
 
-const getState = state => ({ fxa_endpoint: state.Prefs.values.fxa_endpoint });
-export const StartupOverlay = connect(getState)(_StartupOverlay);
+StartupOverlay.defaultProps = {
+  flowParams: { deviceId: "", flowId: "", flowBeginTime: "" },
+};

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -2,17 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
+import { actionCreators as ac } from "common/Actions.jsm";
 import { ModalOverlayWrapper } from "../../components/ModalOverlay/ModalOverlay";
-import { OnboardingCard } from "../OnboardingMessage/OnboardingMessage";
+import { addUtmParams } from "../FirstRun/addUtmParams";
 import React from "react";
-
-const FLUENT_FILES = [
-  "branding/brand.ftl",
-  "browser/branding/brandings.ftl",
-  "browser/branding/sync-brand.ftl",
-  "browser/newtab/onboarding.ftl",
-];
 
 // From resource://devtools/client/shared/focus.js
 const FOCUSABLE_SELECTOR = [
@@ -29,104 +22,30 @@ export class Trailhead extends React.PureComponent {
   constructor(props) {
     super(props);
     this.closeModal = this.closeModal.bind(this);
-    this.hideCardPanel = this.hideCardPanel.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
     this.onStartBlur = this.onStartBlur.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.onInputInvalid = this.onInputInvalid.bind(this);
-    this.onCardAction = this.onCardAction.bind(this);
 
     this.state = {
       emailInput: "",
-      isModalOpen: true,
-      showCardPanel: true,
-      showCards: false,
-      // The params below are for FxA metrics
-      deviceId: "",
-      flowId: "",
-      flowBeginTime: 0,
     };
-    this.fxaMetricsInitialized = false;
   }
 
   get dialog() {
     return this.props.document.getElementById("trailheadDialog");
   }
 
-  async componentWillMount() {
-    FLUENT_FILES.forEach(file => {
-      const link = document.head.appendChild(document.createElement("link"));
-      link.href = file;
-      link.rel = "localization";
-    });
-
-    await this.componentWillUpdate(this.props);
-  }
-
-  // Get the fxa data if we don't have it yet from mount or update
-  async componentWillUpdate(props) {
-    if (props.fxaEndpoint && !this.fxaMetricsInitialized) {
-      try {
-        this.fxaMetricsInitialized = true;
-        const url = new URL(
-          `${
-            props.fxaEndpoint
-          }/metrics-flow?entrypoint=activity-stream-firstrun&form_type=email`
-        );
-        this.addUtmParams(url);
-        const response = await fetch(url, { credentials: "omit" });
-        if (response.status === 200) {
-          const { deviceId, flowId, flowBeginTime } = await response.json();
-          this.setState({ deviceId, flowId, flowBeginTime });
-        } else {
-          props.dispatch(
-            ac.OnlyToMain({
-              type: at.TELEMETRY_UNDESIRED_EVENT,
-              data: {
-                event: "FXA_METRICS_FETCH_ERROR",
-                value: response.status,
-              },
-            })
-          );
-        }
-      } catch (error) {
-        props.dispatch(
-          ac.OnlyToMain({
-            type: at.TELEMETRY_UNDESIRED_EVENT,
-            data: { event: "FXA_METRICS_ERROR" },
-          })
-        );
-      }
-    }
-  }
-
   componentDidMount() {
-    // We need to remove hide-main since we should show it underneath everything that has rendered
-    this.props.document.body.classList.remove("hide-main");
-
-    // Add inline-onboarding class to disable fixed search header and fixed positioned settings icon
-    this.props.document.body.classList.add("inline-onboarding");
-
-    // The rest of the page is "hidden" when the modal is open
-    if (this.props.message.content) {
-      this.props.document
-        .getElementById("root")
-        .setAttribute("aria-hidden", "true");
-
-      // Start with focus in the email input box
-      this.dialog.querySelector("input[name=email]").focus();
-    } else {
-      // No modal overlay, let the user scroll and deal them some cards.
-      this.props.document.body.classList.remove("welcome");
-
-      if (this.props.message.includeBundle || this.props.message.cards) {
-        this.revealCards();
-      }
+    // The rest of the page is "hidden" to screen readers when the modal is open
+    this.props.document
+      .getElementById("root")
+      .setAttribute("aria-hidden", "true");
+    // Start with focus in the email input box
+    const input = this.dialog.querySelector("input[name=email]");
+    if (input) {
+      input.focus();
     }
-  }
-
-  componentWillUnmount() {
-    this.props.document.body.classList.remove("inline-onboarding");
   }
 
   onInputChange(e) {
@@ -172,8 +91,7 @@ export class Trailhead extends React.PureComponent {
     global.removeEventListener("visibilitychange", this.closeModal);
     this.props.document.body.classList.remove("welcome");
     this.props.document.getElementById("root").removeAttribute("aria-hidden");
-    this.setState({ isModalOpen: false });
-    this.revealCards();
+    this.props.onNextScene();
 
     // If closeModal() was triggered by a visibilitychange event, the user actually
     // submitted the email form so we don't send a SKIPPED_SIGNIN ping.
@@ -191,7 +109,7 @@ export class Trailhead extends React.PureComponent {
    * Report to telemetry additional information about the form submission.
    */
   _getFormInfo() {
-    const value = { has_flow_params: this.state.flowId.length > 0 };
+    const value = { has_flow_params: this.props.flowParams.flowId.length > 0 };
     return { value };
   }
 
@@ -203,234 +121,141 @@ export class Trailhead extends React.PureComponent {
     e.target.focus();
   }
 
-  hideCardPanel() {
-    this.setState({ showCardPanel: false });
-    this.props.onDismissBundle();
-  }
-
-  revealCards() {
-    this.setState({ showCards: true });
-  }
-
-  /**
-   * Takes in a url as a string or URL object and returns a URL object with the
-   * utm_* parameters added to it. If a URL object is passed in, the paraemeters
-   * are added to it (the return value can be ignored in that case as it's the
-   * same object).
-   */
-  addUtmParams(url, isCard = false) {
-    let returnUrl = url;
-    if (typeof returnUrl === "string") {
-      returnUrl = new URL(url);
-    }
-    returnUrl.searchParams.append("utm_source", "activity-stream");
-    returnUrl.searchParams.append("utm_campaign", "firstrun");
-    returnUrl.searchParams.append("utm_medium", "referral");
-    returnUrl.searchParams.append(
-      "utm_term",
-      `${this.props.message.utm_term}${isCard ? "-card" : ""}`
-    );
-    return returnUrl;
-  }
-
-  onCardAction(action) {
-    let actionUpdates = {};
-
-    if (action.type === "OPEN_URL") {
-      let url = new URL(action.data.args);
-      this.addUtmParams(url, true);
-
-      if (action.addFlowParams) {
-        url.searchParams.append("device_id", this.state.deviceId);
-        url.searchParams.append("flow_id", this.state.flowId);
-        url.searchParams.append("flow_begin_time", this.state.flowBeginTime);
-      }
-
-      actionUpdates = { data: { ...action.data, args: url } };
-    }
-
-    this.props.onAction({ ...action, ...actionUpdates });
-  }
-
   render() {
     const { props } = this;
-    const { bundle: cards, content, utm_term } = props.message;
+    const { UTMTerm } = props;
+    const { content } = props.message;
     const innerClassName = ["trailhead", content && content.className]
       .filter(v => v)
       .join(" ");
 
     return (
-      <>
-        {this.state.isModalOpen && content ? (
-          <ModalOverlayWrapper
-            innerClassName={innerClassName}
-            onClose={this.closeModal}
-            id="trailheadDialog"
-            headerId="trailheadHeader"
-          >
-            <div className="trailheadInner">
-              <div className="trailheadContent">
-                <h1
-                  data-l10n-id={content.title.string_id}
-                  id="trailheadHeader"
-                />
-                {content.subtitle && (
-                  <p data-l10n-id={content.subtitle.string_id} />
-                )}
-                <ul className="trailheadBenefits">
-                  {content.benefits.map(item => (
-                    <li key={item.id} className={item.id}>
-                      <h3 data-l10n-id={item.title.string_id} />
-                      <p data-l10n-id={item.text.string_id} />
-                    </li>
-                  ))}
-                </ul>
-                <a
-                  className="trailheadLearn"
-                  data-l10n-id={content.learn.text.string_id}
-                  href={this.addUtmParams(content.learn.url)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              </div>
-              <div
-                role="group"
-                aria-labelledby="joinFormHeader"
-                aria-describedby="joinFormBody"
-                className="trailheadForm"
-              >
-                <h3
-                  id="joinFormHeader"
-                  data-l10n-id={content.form.title.string_id}
-                />
-                <p
-                  id="joinFormBody"
-                  data-l10n-id={content.form.text.string_id}
-                />
-                <form
-                  method="get"
-                  action={this.props.fxaEndpoint}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onSubmit={this.onSubmit}
-                >
-                  <input name="service" type="hidden" value="sync" />
-                  <input name="action" type="hidden" value="email" />
-                  <input name="context" type="hidden" value="fx_desktop_v3" />
-                  <input
-                    name="entrypoint"
-                    type="hidden"
-                    value="activity-stream-firstrun"
-                  />
-                  <input
-                    name="utm_source"
-                    type="hidden"
-                    value="activity-stream"
-                  />
-                  <input name="utm_campaign" type="hidden" value="firstrun" />
-                  <input name="utm_term" type="hidden" value={utm_term} />
-                  <input
-                    name="device_id"
-                    type="hidden"
-                    value={this.state.deviceId}
-                  />
-                  <input
-                    name="flow_id"
-                    type="hidden"
-                    value={this.state.flowId}
-                  />
-                  <input
-                    name="flow_begin_time"
-                    type="hidden"
-                    value={this.state.flowBeginTime}
-                  />
-                  <input name="style" type="hidden" value="trailhead" />
-                  <p
-                    data-l10n-id="onboarding-join-form-email-error"
-                    className="error"
-                  />
-                  <input
-                    data-l10n-id={content.form.email.string_id}
-                    name="email"
-                    type="email"
-                    onInvalid={this.onInputInvalid}
-                    onChange={this.onInputChange}
-                  />
-                  <p
-                    className="trailheadTerms"
-                    data-l10n-id="onboarding-join-form-legal"
-                  >
-                    <a
-                      data-l10n-name="terms"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={this.addUtmParams(
-                        "https://accounts.firefox.com/legal/terms"
-                      )}
-                    />
-                    <a
-                      data-l10n-name="privacy"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={this.addUtmParams(
-                        "https://accounts.firefox.com/legal/privacy"
-                      )}
-                    />
-                  </p>
-                  <button
-                    data-l10n-id={content.form.button.string_id}
-                    type="submit"
-                  />
-                </form>
-              </div>
-            </div>
-
-            <button
-              className="trailheadStart"
-              data-l10n-id={content.skipButton.string_id}
-              onBlur={this.onStartBlur}
-              onClick={this.closeModal}
+      <ModalOverlayWrapper
+        innerClassName={innerClassName}
+        onClose={this.closeModal}
+        id="trailheadDialog"
+        headerId="trailheadHeader"
+      >
+        <div className="trailheadInner">
+          <div className="trailheadContent">
+            <h1 data-l10n-id={content.title.string_id} id="trailheadHeader" />
+            {content.subtitle && (
+              <p data-l10n-id={content.subtitle.string_id} />
+            )}
+            <ul className="trailheadBenefits">
+              {content.benefits.map(item => (
+                <li key={item.id} className={item.id}>
+                  <h3 data-l10n-id={item.title.string_id} />
+                  <p data-l10n-id={item.text.string_id} />
+                </li>
+              ))}
+            </ul>
+            <a
+              className="trailheadLearn"
+              data-l10n-id={content.learn.text.string_id}
+              href={addUtmParams(content.learn.url, UTMTerm)}
+              target="_blank"
+              rel="noopener noreferrer"
             />
-          </ModalOverlayWrapper>
-        ) : null}
-        {cards && cards.length ? (
-          <div
-            className={`trailheadCards ${
-              this.state.showCardPanel ? "expanded" : "collapsed"
-            }`}
-          >
-            <div
-              className="trailheadCardsInner"
-              aria-hidden={!this.state.showCards}
-            >
-              <h1 data-l10n-id="onboarding-welcome-header" />
-              <div
-                className={`trailheadCardGrid${
-                  this.state.showCards ? " show" : ""
-                }`}
-              >
-                {cards.map(card => (
-                  <OnboardingCard
-                    key={card.id}
-                    className="trailheadCard"
-                    sendUserActionTelemetry={props.sendUserActionTelemetry}
-                    onAction={this.onCardAction}
-                    UISurface="TRAILHEAD"
-                    {...card}
-                  />
-                ))}
-              </div>
-              {this.state.showCardPanel && (
-                <button
-                  className="icon icon-dismiss"
-                  onClick={this.hideCardPanel}
-                  data-l10n-id="onboarding-cards-dismiss"
-                />
-              )}
-            </div>
           </div>
-        ) : null}
-      </>
+          <div
+            role="group"
+            aria-labelledby="joinFormHeader"
+            aria-describedby="joinFormBody"
+            className="trailheadForm"
+          >
+            <h3
+              id="joinFormHeader"
+              data-l10n-id={content.form.title.string_id}
+            />
+            <p id="joinFormBody" data-l10n-id={content.form.text.string_id} />
+            <form
+              method="get"
+              action={this.props.fxaEndpoint}
+              target="_blank"
+              rel="noopener noreferrer"
+              onSubmit={this.onSubmit}
+            >
+              <input name="service" type="hidden" value="sync" />
+              <input name="action" type="hidden" value="email" />
+              <input name="context" type="hidden" value="fx_desktop_v3" />
+              <input
+                name="entrypoint"
+                type="hidden"
+                value="activity-stream-firstrun"
+              />
+              <input name="utm_source" type="hidden" value="activity-stream" />
+              <input name="utm_campaign" type="hidden" value="firstrun" />
+              <input name="utm_term" type="hidden" value={UTMTerm} />
+              <input
+                name="device_id"
+                type="hidden"
+                value={this.props.flowParams.deviceId}
+              />
+              <input
+                name="flow_id"
+                type="hidden"
+                value={this.props.flowParams.flowId}
+              />
+              <input
+                name="flow_begin_time"
+                type="hidden"
+                value={this.props.flowParams.flowBeginTime}
+              />
+              <input name="style" type="hidden" value="trailhead" />
+              <p
+                data-l10n-id="onboarding-join-form-email-error"
+                className="error"
+              />
+              <input
+                data-l10n-id={content.form.email.string_id}
+                name="email"
+                type="email"
+                onInvalid={this.onInputInvalid}
+                onChange={this.onInputChange}
+              />
+              <p
+                className="trailheadTerms"
+                data-l10n-id="onboarding-join-form-legal"
+              >
+                <a
+                  data-l10n-name="terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={addUtmParams(
+                    "https://accounts.firefox.com/legal/terms",
+                    UTMTerm
+                  )}
+                />
+                <a
+                  data-l10n-name="privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={addUtmParams(
+                    "https://accounts.firefox.com/legal/privacy",
+                    UTMTerm
+                  )}
+                />
+              </p>
+              <button
+                data-l10n-id={content.form.button.string_id}
+                type="submit"
+              />
+            </form>
+          </div>
+        </div>
+
+        <button
+          className="trailheadStart"
+          data-l10n-id={content.skipButton.string_id}
+          onBlur={this.onStartBlur}
+          onClick={this.closeModal}
+        />
+      </ModalOverlayWrapper>
     );
   }
 }
+
+Trailhead.defaultProps = {
+  flowParams: { deviceId: "", flowId: "", flowBeginTime: "" },
+};

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -37,6 +37,9 @@ export class Trailhead extends React.PureComponent {
   }
 
   componentDidMount() {
+    // We need to remove hide-main since we should show it underneath everything that has rendered
+    this.props.document.body.classList.remove("hide-main");
+
     // The rest of the page is "hidden" to screen readers when the modal is open
     this.props.document
       .getElementById("root")

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -899,18 +899,25 @@ class _ASRouter {
     let interrupt;
     let triplet;
 
-    // Use control Trailhead Branch (for cards) if we are showing RTAMO.
-    if (await this._hasAddonAttributionData()) {
-      return { experiment, interrupt: "control", triplet: "" };
-    }
-
-    // If a value is set in TRAILHEAD_OVERRIDE_PREF, it will be returned and no experiment will be set.
     const overrideValue = Services.prefs.getStringPref(
       TRAILHEAD_CONFIG.OVERRIDE_PREF,
       ""
     );
     if (overrideValue) {
       [interrupt, triplet] = overrideValue.split("-");
+    }
+
+    // Use control Trailhead Branch (for cards) if we are showing RTAMO.
+    if (await this._hasAddonAttributionData()) {
+      return {
+        experiment,
+        interrupt: "control",
+        triplet: triplet || "privacy",
+      };
+    }
+
+    // If a value is set in TRAILHEAD_OVERRIDE_PREF, it will be returned and no experiment will be set.
+    if (overrideValue) {
       return { experiment, interrupt, triplet: triplet || "" };
     }
 
@@ -976,6 +983,7 @@ class _ASRouter {
       interrupt,
       triplet,
     } = await this._generateTrailheadBranches();
+
     await this.setState({
       trailheadInitialized: true,
       trailheadInterrupt: interrupt,
@@ -1830,11 +1838,6 @@ class _ASRouter {
         this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
           type: "CLEAR_PROVIDER",
           data: { id: action.data.id },
-        });
-        break;
-      case "DISMISS_BUNDLE":
-        this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
-          type: "CLEAR_BUNDLE",
         });
         break;
       case "BLOCK_BUNDLE":

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -3,9 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 /* globals Localization */
-const { FxAccountsConfig } = ChromeUtils.import(
-  "resource://gre/modules/FxAccountsConfig.jsm"
-);
 const { AttributionCode } = ChromeUtils.import(
   "resource:///modules/AttributionCode.jsm"
 );
@@ -21,114 +18,7 @@ const L10N = new Localization([
   "browser/newtab/onboarding.ftl",
 ]);
 
-const ONBOARDING_MESSAGES = async () => [
-  {
-    id: "ONBOARDING_1",
-    template: "onboarding",
-    bundled: 3,
-    order: 2,
-    content: {
-      title: { string_id: "onboarding-private-browsing-title" },
-      text: { string_id: "onboarding-private-browsing-text" },
-      icon: "privatebrowsing",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: { type: "OPEN_PRIVATE_BROWSER_WINDOW" },
-      },
-    },
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_2",
-    template: "onboarding",
-    bundled: 3,
-    order: 3,
-    content: {
-      title: { string_id: "onboarding-screenshots-title" },
-      text: { string_id: "onboarding-screenshots-text" },
-      icon: "screenshots",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: {
-          type: "OPEN_URL",
-          data: {
-            args: "https://screenshots.firefox.com/#tour",
-            where: "tabshifted",
-          },
-        },
-      },
-    },
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_3",
-    template: "onboarding",
-    bundled: 3,
-    order: 1,
-    content: {
-      title: { string_id: "onboarding-addons-title" },
-      text: { string_id: "onboarding-addons-text" },
-      icon: "addons",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: {
-          type: "OPEN_ABOUT_PAGE",
-          data: { args: "addons" },
-        },
-      },
-    },
-    targeting:
-      "trailheadInterrupt == 'control' && attributionData.campaign != 'non-fx-button' && attributionData.source != 'addons.mozilla.org'",
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_4",
-    template: "onboarding",
-    bundled: 3,
-    order: 1,
-    content: {
-      title: { string_id: "onboarding-ghostery-title" },
-      text: { string_id: "onboarding-ghostery-text" },
-      icon: "gift",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: {
-          type: "OPEN_URL",
-          data: {
-            args: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/",
-            where: "tabshifted",
-          },
-        },
-      },
-    },
-    targeting:
-      "trailheadInterrupt == 'control' && providerCohorts.onboarding == 'ghostery'",
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_5",
-    template: "onboarding",
-    bundled: 3,
-    order: 4,
-    content: {
-      title: { string_id: "onboarding-fxa-title" },
-      text: { string_id: "onboarding-fxa-text" },
-      icon: "sync",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-get-started" },
-        action: {
-          type: "OPEN_URL",
-          data: {
-            args: await FxAccountsConfig.promiseEmailFirstURI("onboarding"),
-            where: "tabshifted",
-          },
-        },
-      },
-    },
-    targeting:
-      "trailheadInterrupt == 'control' && attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",
-    trigger: { id: "showOnboarding" },
-  },
+const ONBOARDING_MESSAGES = () => [
   {
     id: "TRAILHEAD_1",
     template: "trailhead",
@@ -436,7 +326,13 @@ const ONBOARDING_MESSAGES = async () => [
   {
     id: "FXA_1",
     template: "fxa_overlay",
+    content: {},
     trigger: { id: "firstRun" },
+    includeBundle: {
+      length: 3,
+      template: "onboarding",
+      trigger: { id: "showOnboarding" },
+    },
   },
   {
     id: "RETURN_TO_AMO_1",
@@ -460,6 +356,11 @@ const ONBOARDING_MESSAGES = async () => [
       secondary_button: {
         label: { string_id: "return-to-amo-get-started-button" },
       },
+    },
+    includeBundle: {
+      length: 3,
+      template: "onboarding",
+      trigger: { id: "showOnboarding" },
     },
     targeting:
       "attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",

--- a/test/browser/browser_onboarding_rtamo.js
+++ b/test/browser/browser_onboarding_rtamo.js
@@ -83,9 +83,6 @@ add_task(async () => {
       ".ReturnToAMOContainer",
       ".ReturnToAMOAddonContents",
       ".ReturnToAMOIcon",
-      // Regular onboarding cards
-      ".onboardingMessageContainer",
-      ".onboardingMessage",
     ]) {
       ok(content.document.querySelector(selector), `Should render ${selector}`);
     }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1301,23 +1301,6 @@ describe("ASRouter", () => {
       });
     });
 
-    describe("#onMessage: DISMISS_BUNDLE", () => {
-      it("should add all the ids in the bundle to the messageBlockList and send a CLEAR_BUNDLE message", async () => {
-        await Router.setState({ lastMessageId: "foo" });
-        const msg = fakeAsyncMessage({
-          type: "DISMISS_BUNDLE",
-          data: { bundle: FAKE_BUNDLE },
-        });
-        await Router.onMessage(msg);
-
-        assert.calledWith(
-          channel.sendAsyncMessage,
-          PARENT_TO_CHILD_MESSAGE_NAME,
-          { type: "CLEAR_BUNDLE" }
-        );
-      });
-    });
-
     describe("#onMessage: UNBLOCK_MESSAGE_BY_ID", () => {
       it("should remove the id from the messageBlockList", async () => {
         await Router.onMessage(

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -20,21 +20,6 @@ const FAKE_BELOW_SEARCH_SNIPPET = FAKE_LOCAL_MESSAGES.find(
 );
 
 FAKE_MESSAGE = Object.assign({}, FAKE_MESSAGE, { provider: "fakeprovider" });
-const FAKE_BUNDLED_MESSAGE = {
-  bundle: [
-    {
-      id: "foo",
-      template: "onboarding",
-      content: {
-        title: "Foo",
-        primary_button: { label: "Bar" },
-        text: "Foo123",
-      },
-    },
-  ],
-  extraTemplateStrings: {},
-  template: "onboarding",
-};
 
 describe("ASRouterUtils", () => {
   let global;
@@ -78,6 +63,11 @@ describe("ASRouterUISurface", () => {
       location: { href: "" },
       _listeners: new Set(),
       _visibilityState: "hidden",
+      head: {
+        appendChild(el) {
+          return el;
+        },
+      },
       get visibilityState() {
         return this._visibilityState;
       },
@@ -98,7 +88,15 @@ describe("ASRouterUISurface", () => {
         return document.createElement("body");
       },
       getElementById(id) {
-        return id === "header-asrouter-container" ? headerPortal : footerPortal;
+        switch (id) {
+          case "header-asrouter-container":
+            return headerPortal;
+          default:
+            return footerPortal;
+        }
+      },
+      createElement(tag) {
+        return document.createElement(tag);
       },
     };
     global = new GlobalOverrider();
@@ -145,11 +143,6 @@ describe("ASRouterUISurface", () => {
     );
   });
 
-  it("should render the component if a bundle of messages is defined", () => {
-    wrapper.setState({ bundle: FAKE_BUNDLED_MESSAGE });
-    assert.isTrue(wrapper.exists());
-  });
-
   it("should render a preview banner if message provider is preview", () => {
     wrapper.setState({ message: { ...FAKE_MESSAGE, provider: "preview" } });
     assert.isTrue(wrapper.find(".snippets-preview-banner").exists());
@@ -173,10 +166,13 @@ describe("ASRouterUISurface", () => {
   });
 
   it("should render a trailhead message in the header portal", async () => {
+    // wrapper = shallow(<ASRouterUISurface document={fakeDocument} />);
     const message = (await OnboardingMessageProvider.getUntranslatedMessages()).find(
       msg => msg.template === "trailhead"
     );
+
     wrapper.setState({ message });
+
     assert.isTrue(headerPortal.childElementCount > 0);
     assert.equal(footerPortal.childElementCount, 0);
   });
@@ -369,19 +365,6 @@ describe("ASRouterUISurface", () => {
         `${FAKE_MESSAGE.provider}_user_event`
       );
       assert.propertyVal(payload, "source", "NEWTAB_FOOTER_BAR");
-    });
-
-    it("should call .sendTelemetry with the right message data when a bundle is dismissed", () => {
-      wrapper.instance().dismissBundle([{ id: 1 }, { id: 2 }, { id: 3 }])();
-
-      assert.calledOnce(ASRouterUtils.sendTelemetry);
-      assert.calledWith(ASRouterUtils.sendTelemetry, {
-        action: "onboarding_user_event",
-        event: "DISMISS",
-        id: "onboarding-cards",
-        message_id: "1,2,3",
-        source: "onboarding-cards",
-      });
     });
   });
 });

--- a/test/unit/asrouter/constants.js
+++ b/test/unit/asrouter/constants.js
@@ -4,12 +4,14 @@ export const PARENT_TO_CHILD_MESSAGE_NAME = "ASRouter:parent-to-child";
 export const FAKE_LOCAL_MESSAGES = [
   {
     id: "foo",
+    provider: "snippets",
     template: "simple_snippet",
     content: { title: "Foo", body: "Foo123" },
   },
   {
     id: "foo1",
     template: "simple_snippet",
+    provider: "snippets",
     bundled: 2,
     order: 1,
     content: { title: "Foo1", body: "Foo123-1" },
@@ -17,6 +19,7 @@ export const FAKE_LOCAL_MESSAGES = [
   {
     id: "foo2",
     template: "simple_snippet",
+    provider: "snippets",
     bundled: 2,
     order: 2,
     content: { title: "Foo2", body: "Foo123-2" },
@@ -29,16 +32,19 @@ export const FAKE_LOCAL_MESSAGES = [
   { id: "baz", content: { title: "Foo", body: "Foo123" } },
   {
     id: "newsletter",
+    provider: "snippets",
     template: "newsletter_snippet",
     content: { title: "Foo", body: "Foo123" },
   },
   {
     id: "fxa",
+    provider: "snippets",
     template: "fxa_signup_snippet",
     content: { title: "Foo", body: "Foo123" },
   },
   {
     id: "belowsearch",
+    provider: "snippets",
     template: "simple_below_search_snippet",
     content: { text: "Foo" },
   },

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -1,0 +1,210 @@
+import {
+  helpers,
+  FirstRun,
+  FLUENT_FILES,
+} from "content-src/asrouter/templates/FirstRun/FirstRun";
+import { Interrupt } from "content-src/asrouter/templates/FirstRun/Interrupt";
+import { Triplets } from "content-src/asrouter/templates/FirstRun/Triplets";
+import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
+import { mount } from "enzyme";
+import React from "react";
+
+const FAKE_TRIPLETS = [
+  {
+    id: "CARD_1",
+    content: {
+      title: { string_id: "onboarding-private-browsing-title" },
+      text: { string_id: "onboarding-private-browsing-text" },
+      icon: "icon",
+      primary_button: {
+        label: { string_id: "onboarding-button-label-try-now" },
+        action: {
+          type: "OPEN_URL",
+          data: { args: "https://example.com/" },
+        },
+      },
+    },
+  },
+];
+
+const FAKE_FLOW_PARAMS = {
+  deviceId: "foo",
+  flowId: "abc1",
+  flowBeginTime: 1234,
+};
+
+async function getTestMessage(id) {
+  const message = (await OnboardingMessageProvider.getUntranslatedMessages()).find(
+    msg => msg.id === id
+  );
+  return { ...message, bundle: FAKE_TRIPLETS };
+}
+
+describe("<FirstRun>", () => {
+  let wrapper;
+  let message;
+  let fakeDoc;
+  let sandbox;
+
+  async function setup() {
+    sandbox = sinon.createSandbox();
+    message = await getTestMessage("TRAILHEAD_1");
+    fakeDoc = {
+      body: document.createElement("body"),
+      head: document.createElement("head"),
+      createElement: type => document.createElement(type),
+      getElementById: () => document.createElement("div"),
+      activeElement: document.createElement("div"),
+    };
+
+    sandbox
+      .stub(global, "fetch")
+      .withArgs("http://fake.com/endpoint")
+      .resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_FLOW_PARAMS),
+      });
+
+    wrapper = mount(
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        dispatch={() => {}}
+        sendUserActionTelemetry={() => {}}
+      />
+    );
+  }
+
+  beforeEach(setup);
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper);
+  });
+  describe("with both interrupt and triplets", () => {
+    it("should render interrupt and triplets", () => {
+      assert.lengthOf(wrapper.find(Interrupt), 1, "<Interrupt>");
+      assert.lengthOf(wrapper.find(Triplets), 1, "<Triplets>");
+    });
+    it("should show the card panel and hide the content on the Triplets", () => {
+      // This is so the container shows up in the background but we can fade in the content when intterupt is closed.
+      const tripletsProps = wrapper.find(Triplets).props();
+      assert.propertyVal(tripletsProps, "showCardPanel", true);
+      assert.propertyVal(tripletsProps, "showContent", false);
+    });
+    it("should set the UTM term to trailhead-join (for the traihead-join message)", () => {
+      const iProps = wrapper.find(Interrupt).props();
+      const tProps = wrapper.find(Triplets).props();
+      assert.propertyVal(iProps, "UTMTerm", "trailhead-join");
+      assert.propertyVal(tProps, "UTMTerm", "trailhead-join-card");
+    });
+  });
+
+  describe("with an interrupt but no triplets", () => {
+    beforeEach(() => {
+      message.bundle = []; // Empty triplets
+      wrapper = mount(<FirstRun message={message} document={fakeDoc} />);
+    });
+    it("should render interrupt but no triplets", () => {
+      assert.lengthOf(wrapper.find(Interrupt), 1, "<Interrupt>");
+      assert.lengthOf(wrapper.find(Triplets), 0, "<Triplets>");
+    });
+  });
+
+  describe("with triplets but no interrupt", () => {
+    it("should render interrupt but no triplets", () => {
+      delete message.content; // Empty interrupt
+      wrapper = mount(<FirstRun message={message} document={fakeDoc} />);
+
+      assert.lengthOf(wrapper.find(Interrupt), 0, "<Interrupt>");
+      assert.lengthOf(wrapper.find(Triplets), 1, "<Triplets>");
+    });
+  });
+
+  describe("with no triplets or interrupt", () => {
+    it("should render empty", () => {
+      message = { type: "FOO_123" };
+      wrapper = mount(<FirstRun message={message} document={fakeDoc} />);
+
+      assert.isTrue(wrapper.isEmptyRender());
+    });
+  });
+
+  it("should load flow params on mount if fxaEndpoint is defined", () => {
+    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    wrapper = mount(
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        dispatch={() => {}}
+        fxaEndpoint="https://foo.com"
+      />
+    );
+    assert.calledOnce(spy);
+  });
+
+  it("should load flow params onUpdate if fxaEndpoint is not defined on mount and then later defined", () => {
+    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    wrapper = mount(
+      <FirstRun message={message} document={fakeDoc} dispatch={() => {}} />
+    );
+    assert.notCalled(spy);
+    wrapper.setProps({ fxaEndpoint: "https://foo.com" });
+    assert.calledOnce(spy);
+  });
+
+  it("should not load flow params again onUpdate if they were already set", () => {
+    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    wrapper = mount(
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        dispatch={() => {}}
+        fxaEndpoint="https://foo.com"
+      />
+    );
+    wrapper.setProps({ foo: "bar" });
+    wrapper.setProps({ foo: "baz" });
+    assert.calledOnce(spy);
+  });
+
+  it("should load fluent files on mount", () => {
+    assert.lengthOf(fakeDoc.head.querySelectorAll("link"), FLUENT_FILES.length);
+  });
+
+  it("should hide the interrupt and show the triplets when onNextScene is called", () => {
+    // Simulate calling next scene
+    wrapper
+      .find(Interrupt)
+      .find(".trailheadStart")
+      .simulate("click");
+
+    assert.lengthOf(wrapper.find(Interrupt), 0, "Interrupt hidden");
+    assert.isTrue(
+      wrapper
+        .find(Triplets)
+        .find(".trailheadCardGrid")
+        .hasClass("show"),
+      "Show triplet content"
+    );
+  });
+
+  it("should hide triplets when closeTriplets is called", () => {
+    // Simulate calling next scene
+    wrapper
+      .find(Triplets)
+      .find(".icon-dismiss")
+      .simulate("click");
+
+    assert.isFalse(
+      wrapper
+        .find(Triplets)
+        .find(".trailheadCardGrid")
+        .hasClass("show"),
+      "Show triplet content"
+    );
+  });
+});

--- a/test/unit/asrouter/templates/Interrupt.test.jsx
+++ b/test/unit/asrouter/templates/Interrupt.test.jsx
@@ -1,0 +1,37 @@
+import { Interrupt } from "content-src/asrouter/templates/FirstRun/Interrupt";
+import { ReturnToAMO } from "content-src/asrouter/templates/ReturnToAMO/ReturnToAMO";
+import { StartupOverlay } from "content-src/asrouter/templates/StartupOverlay/StartupOverlay";
+import { Trailhead } from "content-src/asrouter/templates//Trailhead/Trailhead";
+import { shallow } from "enzyme";
+import React from "react";
+
+describe("<Interrupt>", () => {
+  let wrapper;
+  it("should render Return TO AMO when the message has a template of return_to_amo_overlay", () => {
+    wrapper = shallow(
+      <Interrupt
+        message={{ id: "FOO", content: {}, template: "return_to_amo_overlay" }}
+      />
+    );
+    assert.lengthOf(wrapper.find(ReturnToAMO), 1);
+  });
+  it("should render Trailhead when the message has a template of trailhead", () => {
+    wrapper = shallow(
+      <Interrupt message={{ id: "FOO", content: {}, template: "trailhead" }} />
+    );
+    assert.lengthOf(wrapper.find(Trailhead), 1);
+  });
+  it("should render StartupOverlay when the message has a template of fxa_overlay", () => {
+    wrapper = shallow(
+      <Interrupt message={{ id: "FOO", template: "fxa_overlay" }} />
+    );
+    assert.lengthOf(wrapper.find(StartupOverlay), 1);
+  });
+  it("should throw an error if another type of message is dispatched", () => {
+    assert.throws(() => {
+      wrapper = shallow(
+        <Interrupt message={{ id: "FOO", template: "something" }} />
+      );
+    });
+  });
+});

--- a/test/unit/asrouter/templates/Trailhead.test.jsx
+++ b/test/unit/asrouter/templates/Trailhead.test.jsx
@@ -4,7 +4,7 @@ import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
 import React from "react";
 import { Trailhead } from "content-src/asrouter/templates/Trailhead/Trailhead";
 
-const CARDS = [
+export const CARDS = [
   {
     content: {
       title: { string_id: "onboarding-private-browsing-title" },
@@ -27,11 +27,13 @@ describe("<Trailhead>", () => {
   let dispatch;
   let onAction;
   let sandbox;
+  let onNextScene;
 
   beforeEach(async () => {
     sandbox = sinon.sandbox.create();
     dispatch = sandbox.stub();
     onAction = sandbox.stub();
+    onNextScene = sandbox.stub();
     sandbox.stub(global, "fetch").resolves({
       ok: true,
       status: 200,
@@ -59,10 +61,12 @@ describe("<Trailhead>", () => {
     wrapper = mount(
       <Trailhead
         message={message}
+        UTMTerm={message.utm_term}
         fxaEndpoint="https://accounts.firefox.com/endpoint"
         dispatch={dispatch}
         onAction={onAction}
         document={fakeDocument}
+        onNextScene={onNextScene}
       />
     );
   });
@@ -71,10 +75,12 @@ describe("<Trailhead>", () => {
     sandbox.restore();
   });
 
-  it("should emit UserEvent SKIPPED_SIGNIN when you click the start browsing button", () => {
+  it("should emit UserEvent SKIPPED_SIGNIN and call nextScene when you click the start browsing button", () => {
     let skipButton = wrapper.find(".trailheadStart");
     assert.ok(skipButton.exists());
     skipButton.simulate("click");
+
+    assert.calledOnce(onNextScene);
 
     assert.calledOnce(dispatch);
     assert.isUserEventAction(dispatch.firstCall.args[0]);
@@ -116,37 +122,6 @@ describe("<Trailhead>", () => {
         event: at.SUBMIT_EMAIL,
         value: { has_flow_params: false },
       })
-    );
-  });
-
-  it("should add utm_* query params to card actions", () => {
-    let { action } = CARDS[0].content.primary_button;
-    wrapper.instance().onCardAction(action);
-    assert.calledOnce(onAction);
-    const url = onAction.firstCall.args[0].data.args;
-    assert.equal(
-      url,
-      "https://example.com/?utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card"
-    );
-  });
-
-  it("should add flow parameters to card action urls if addFlowParams is true", () => {
-    let action = {
-      type: "OPEN_URL",
-      addFlowParams: true,
-      data: { args: "https://example.com/path?foo=bar" },
-    };
-    wrapper.setState({
-      deviceId: "abc",
-      flowId: "123",
-      flowBeginTime: 456,
-    });
-    wrapper.instance().onCardAction(action);
-    assert.calledOnce(onAction);
-    const url = onAction.firstCall.args[0].data.args;
-    assert.equal(
-      url,
-      "https://example.com/path?foo=bar&utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card&device_id=abc&flow_id=123&flow_begin_time=456"
     );
   });
 

--- a/test/unit/asrouter/templates/Triplets.test.jsx
+++ b/test/unit/asrouter/templates/Triplets.test.jsx
@@ -1,0 +1,96 @@
+import { mount } from "enzyme";
+import { Triplets } from "content-src/asrouter/templates/FirstRun/Triplets";
+import { OnboardingCard } from "content-src/asrouter/templates/OnboardingMessage/OnboardingMessage";
+import React from "react";
+
+const CARDS = [
+  {
+    id: "CARD_1",
+    content: {
+      title: { string_id: "onboarding-private-browsing-title" },
+      text: { string_id: "onboarding-private-browsing-text" },
+      icon: "icon",
+      primary_button: {
+        label: { string_id: "onboarding-button-label-try-now" },
+        action: {
+          type: "OPEN_URL",
+          data: { args: "https://example.com/" },
+        },
+      },
+    },
+  },
+];
+
+describe("<Triplets>", () => {
+  let wrapper;
+  let sandbox;
+  let sendTelemetryStub;
+  let onAction;
+  let onHide;
+
+  async function setup() {
+    sandbox = sinon.createSandbox();
+    sendTelemetryStub = sandbox.stub();
+    onAction = sandbox.stub();
+    onHide = sandbox.stub();
+
+    wrapper = mount(
+      <Triplets
+        cards={CARDS}
+        showCardPanel={true}
+        showContent={true}
+        hideContainer={onHide}
+        onAction={onAction}
+        UTMTerm="trailhead-join-card"
+        sendUserActionTelemetry={sendTelemetryStub}
+      />
+    );
+  }
+
+  beforeEach(setup);
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should add an expanded class to container if props.showCardPanel is true", () => {
+    wrapper.setProps({ showCardPanel: true });
+    assert.isTrue(
+      wrapper.find(".trailheadCards").hasClass("expanded"),
+      "has .expanded)"
+    );
+  });
+  it("should add a collapsed class to container if props.showCardPanel is true", () => {
+    wrapper.setProps({ showCardPanel: false });
+    assert.isFalse(
+      wrapper.find(".trailheadCards").hasClass("expanded"),
+      "has .expanded)"
+    );
+  });
+  it("should send telemetry and call props.hideContainer when the dismiss button is clicked", () => {
+    wrapper.find("button.icon-dismiss").simulate("click");
+    assert.calledOnce(onHide);
+    assert.calledWith(sendTelemetryStub, {
+      event: "DISMISS",
+      message_id: CARDS[0].id,
+      id: "onboarding-cards",
+      action: "onboarding_user_event",
+    });
+  });
+  it("should add utm_* query params to card actions and send the right ping when a card button is clicked", () => {
+    wrapper
+      .find(OnboardingCard)
+      .find("button.onboardingButton")
+      .simulate("click");
+    assert.calledOnce(onAction);
+    const url = onAction.firstCall.args[0].data.args;
+    assert.equal(
+      url,
+      "https://example.com/?utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card"
+    );
+    assert.calledWith(sendTelemetryStub, {
+      event: "CLICK_BUTTON",
+      message_id: CARDS[0].id,
+      id: "TRAILHEAD",
+    });
+  });
+});

--- a/test/unit/content-src/components/ReturnToAMO.test.jsx
+++ b/test/unit/content-src/components/ReturnToAMO.test.jsx
@@ -66,10 +66,6 @@ describe("<ReturnToAMO>", () => {
       sendUserActionTelemetryStub.reset();
     });
 
-    it("should call onReady on componentDidMount", () => {
-      assert.calledOnce(onReady);
-    });
-
     it("should send telemetry on block", () => {
       wrapper.instance().onBlockButton();
 

--- a/test/unit/content-src/components/StartupOverlay.test.jsx
+++ b/test/unit/content-src/components/StartupOverlay.test.jsx
@@ -1,44 +1,40 @@
 import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
 import { mount } from "enzyme";
 import React from "react";
-import { _StartupOverlay as StartupOverlay } from "content-src/asrouter/templates/StartupOverlay/StartupOverlay";
+import { StartupOverlay } from "content-src/asrouter/templates/StartupOverlay/StartupOverlay";
 
 describe("<StartupOverlay>", () => {
   let wrapper;
   let dispatch;
-  let onReady;
   let onBlock;
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     dispatch = sandbox.stub();
-    onReady = sandbox.stub();
     onBlock = sandbox.stub();
 
-    wrapper = mount(
-      <StartupOverlay onBlock={onBlock} onReady={onReady} dispatch={dispatch} />
-    );
+    wrapper = mount(<StartupOverlay onBlock={onBlock} dispatch={dispatch} />);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it("should not render if state.show is false", () => {
-    wrapper.setState({ overlayRemoved: true });
-    assert.isTrue(wrapper.isEmptyRender());
-  });
-
-  it("should call prop.onReady after mount + timeout", async () => {
+  it("should add show class after mount and timeout", async () => {
     const clock = sandbox.useFakeTimers();
-    wrapper = mount(
-      <StartupOverlay onBlock={onBlock} onReady={onReady} dispatch={dispatch} />
+    wrapper = mount(<StartupOverlay onBlock={onBlock} dispatch={dispatch} />);
+    assert.isFalse(
+      wrapper.find(".overlay-wrapper").hasClass("show"),
+      ".overlay-wrapper does not have .show class"
     );
-    wrapper.setState({ overlayRemoved: false });
 
     clock.tick(10);
+    wrapper.update();
 
-    assert.calledOnce(onReady);
+    assert.isTrue(
+      wrapper.find(".overlay-wrapper").hasClass("show"),
+      ".overlay-wrapper has .show class"
+    );
   });
 
   it("should emit UserEvent SKIPPED_SIGNIN when you click the skip button", () => {

--- a/test/unit/content-src/components/addUtmParams.test.js
+++ b/test/unit/content-src/components/addUtmParams.test.js
@@ -1,0 +1,18 @@
+import { addUtmParams } from "content-src/asrouter/templates/FirstRun/addUtmParams";
+
+describe("addUtmParams", () => {
+  it("should convert a string URL", () => {
+    const result = addUtmParams("https://foo.com", "foo");
+    assert.equal(result.hostname, "foo.com");
+  });
+  it("should add all base params", () => {
+    assert.match(
+      addUtmParams(new URL("https://foo.com"), "foo").toString(),
+      /utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral/
+    );
+  });
+  it("should add utm_term", () => {
+    const params = addUtmParams(new URL("https://foo.com"), "foo").searchParams;
+    assert.equal(params.get("utm_term"), "foo", "utm_term");
+  });
+});


### PR DESCRIPTION
### Scope
In this PR I refactored the first run experience to:
* Remove the old modal onboarding code
* Make the triplets independent of the trailhead modal / i.e. work with return to AMO and the overlay experience (so we can experiment with any combination)
* Move some of the shared logic around hiding/showing/adding fluent files etc. into a single `FirstRun` component.

I wrote it with hooks initially (see ff9a667) but I encountered some weird test failures around portals that I think are because of enzyme. Maybe in a future PR we could try restoring it.

### Basic structure

Whereas the old code in `asrouter-content.jsx` had different methods for rendering the various onboarding experiences, I've refactored it to have a more component-based structure

```jsx
<FirstRun> 
  <Interrupt />
  <Triplets />
</FirstRun>
```
Where `Interrupt` contains the logic for whether to show the fxa overlay, return to amo, or trailhead,  and `Triplets` renders the cards on the new tab page. Both can be omitted.

### Manual testing

You can test all the variants by changing the `trailhead.firstrun.branches` pref and restarting the browser. Please test the following values:

* `join-privacy`: the trailhead modal + triplets
* `sync`: just trailhead modal
* `control`: This is just the fxa overlay
* `control-privacy`: fxa overlay + triplets

To test return to amo, open `about:newtab#devtools-targeting`, scroll to the bottom and press Force Attribution, and restart the browser. If you have `join-privacy` or `control-privacy` set, you should see triplets.

cc @AllegroFox @JeaneC if you'd like to help review!

### TODO
* [ ] Remove strings for old onboarding stuff