### PR TITLE
Bug 1554961 - Adding a Top Site/Search Engine in a collapsed section is buggy.

### DIFF
--- a/content-src/components/SectionMenu/SectionMenu.jsx
+++ b/content-src/components/SectionMenu/SectionMenu.jsx
@@ -26,6 +26,18 @@ const WEBEXT_SECTION_MENU_OPTIONS = [
 ];
 
 export class _SectionMenu extends React.PureComponent {
+  dispatchAction(action, userEvent) {
+    this.props.dispatch(action);
+    if (userEvent) {
+      this.props.dispatch(
+        ac.UserEvent({
+          event: userEvent,
+          source: this.props.source,
+        })
+      );
+    }
+  }
+
   getOptions() {
     const { props } = this;
 
@@ -51,15 +63,19 @@ export class _SectionMenu extends React.PureComponent {
         const { action, id, type, userEvent } = option;
         if (!type && id) {
           option.onClick = () => {
-            props.dispatch(action);
-            if (userEvent) {
-              props.dispatch(
-                ac.UserEvent({
-                  event: userEvent,
-                  source: props.source,
-                })
-              );
+            const addingElements =
+              userEvent === "MENU_ADD_TOPSITE" ||
+              userEvent === "MENU_ADD_SEARCH";
+
+            if (props.collapsed && addingElements) {
+              const {
+                action: expandAction,
+                userEvent: expandEvent,
+              } = SectionMenuOptions.ExpandSection(props);
+              this.dispatchAction(expandAction, expandEvent);
             }
+
+            this.dispatchAction(action, userEvent);
           };
         }
         return option;

--- a/content-src/components/SectionMenu/SectionMenu.jsx
+++ b/content-src/components/SectionMenu/SectionMenu.jsx
@@ -26,7 +26,8 @@ const WEBEXT_SECTION_MENU_OPTIONS = [
 ];
 
 export class _SectionMenu extends React.PureComponent {
-  dispatchAction(action, userEvent) {
+  handleAddWhileCollapsed() {
+    const { action, userEvent } = SectionMenuOptions.ExpandSection(this.props);
     this.props.dispatch(action);
     if (userEvent) {
       this.props.dispatch(
@@ -63,19 +64,23 @@ export class _SectionMenu extends React.PureComponent {
         const { action, id, type, userEvent } = option;
         if (!type && id) {
           option.onClick = () => {
-            const addingElements =
+            const hasAddEvent =
               userEvent === "MENU_ADD_TOPSITE" ||
               userEvent === "MENU_ADD_SEARCH";
 
-            if (props.collapsed && addingElements) {
-              const {
-                action: expandAction,
-                userEvent: expandEvent,
-              } = SectionMenuOptions.ExpandSection(props);
-              this.dispatchAction(expandAction, expandEvent);
+            if (props.collapsed && hasAddEvent) {
+              this.handleAddWhileCollapsed();
             }
 
-            this.dispatchAction(action, userEvent);
+            props.dispatch(action);
+            if (userEvent) {
+              props.dispatch(
+                ac.UserEvent({
+                  event: userEvent,
+                  source: props.source,
+                })
+              );
+            }
           };
         }
         return option;

--- a/test/unit/content-src/components/SectionMenu.test.jsx
+++ b/test/unit/content-src/components/SectionMenu.test.jsx
@@ -164,17 +164,6 @@ describe("<SectionMenu>", () => {
   });
   describe(".onClick", () => {
     const dispatch = sinon.stub();
-    const propOptions = [
-      "Separator",
-      "MoveUp",
-      "MoveDown",
-      "RemoveSection",
-      "CollapseSection",
-      "ExpandSection",
-      "ManageSection",
-      "AddTopSite",
-      "PrivacyNotice",
-    ];
     const expectedActionData = {
       "newtab-section-menu-move-up": { id: "sectionId", direction: -1 },
       "newtab-section-menu-move-down": { id: "sectionId", direction: +1 },
@@ -197,11 +186,7 @@ describe("<SectionMenu>", () => {
       },
     };
     const { options } = shallow(
-      <SectionMenu
-        {...DEFAULT_PROPS}
-        dispatch={dispatch}
-        options={propOptions}
-      />
+      <SectionMenu {...DEFAULT_PROPS} dispatch={dispatch} />
     )
       .find(ContextMenu)
       .props();
@@ -235,6 +220,42 @@ describe("<SectionMenu>", () => {
             assert.isUserEventAction(action);
             assert.propertyVal(action.data, "source", DEFAULT_PROPS.source);
           }
+        });
+      });
+  });
+  describe("dispatch expand section if section is collapsed and adding top site", () => {
+    const dispatch = sinon.stub();
+    const expectedExpandData = {
+      id: DEFAULT_PROPS.id,
+      value: { collapsed: false },
+    };
+    const { options } = shallow(
+      <SectionMenu
+        {...DEFAULT_PROPS}
+        collapsed={true}
+        dispatch={dispatch}
+        extraOptions={["AddTopSite"]}
+      />
+    )
+      .find(ContextMenu)
+      .props();
+    afterEach(() => dispatch.reset());
+
+    assert.equal(options[0].id, "newtab-section-menu-add-topsite");
+    options
+      .filter(o => o.id === "newtab-section-menu-add-topsite")
+      .forEach(option => {
+        it(`should dispatch an action to expand the seciton`, () => {
+          option.onClick();
+
+          const [expandCallArgs] = dispatch.firstCall.args;
+          const { type, data } = expandCallArgs;
+          assert.ok(type === "UPDATE_SECTION_PREFS");
+          assert.deepEqual(data, expectedExpandData);
+        });
+        it(`should dispatch the add topsite action after`, () => {
+          option.onClick();
+          assert.ok(dispatch.thirdCall.calledWith(option.action));
         });
       });
   });

--- a/test/unit/content-src/components/SectionMenu.test.jsx
+++ b/test/unit/content-src/components/SectionMenu.test.jsx
@@ -229,6 +229,7 @@ describe("<SectionMenu>", () => {
       id: DEFAULT_PROPS.id,
       value: { collapsed: false },
     };
+    const expectedAddData = { index: -1 };
     const { options } = shallow(
       <SectionMenu
         {...DEFAULT_PROPS}
@@ -245,17 +246,30 @@ describe("<SectionMenu>", () => {
     options
       .filter(o => o.id === "newtab-section-menu-add-topsite")
       .forEach(option => {
-        it(`should dispatch an action to expand the seciton`, () => {
+        it(`should dispatch an action to expand the section and to add a topsite after expanding`, () => {
           option.onClick();
 
-          const [expandCallArgs] = dispatch.firstCall.args;
-          const { type, data } = expandCallArgs;
-          assert.ok(type === "UPDATE_SECTION_PREFS");
-          assert.deepEqual(data, expectedExpandData);
+          const [expandAction] = dispatch.firstCall.args;
+          assert.deepEqual(expandAction.data, expectedExpandData);
+
+          const [addAction] = dispatch.thirdCall.args;
+          assert.deepEqual(addAction.data, expectedAddData);
         });
-        it(`should dispatch the add topsite action after`, () => {
+        it(`should dispatch the expand userEvent and add topsite userEvent after expanding`, () => {
           option.onClick();
           assert.ok(dispatch.thirdCall.calledWith(option.action));
+
+          const [expandUserEvent] = dispatch.secondCall.args;
+          assert.isUserEventAction(expandUserEvent);
+          assert.propertyVal(
+            expandUserEvent.data,
+            "source",
+            DEFAULT_PROPS.source
+          );
+
+          const [addUserEvent] = dispatch.lastCall.args;
+          assert.isUserEventAction(addUserEvent);
+          assert.propertyVal(addUserEvent.data, "source", DEFAULT_PROPS.source);
         });
       });
   });


### PR DESCRIPTION
Original bug
https://bug1554961.bmoattachments.org/attachment.cgi?id=9067993

Dispatching an additional action to expand if the current action is adding a top site or search engine.
https://drive.google.com/file/d/1GpSV2pAJ2sMCBbHaqoGXqN1J5v_M29Fs/view?usp=sharing