### PR TITLE
Bug 1561625 - Add telemetry events for What's New panel

### DIFF
--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -1090,6 +1090,7 @@ This reports when a user has seen or clicked a badge/notification in the browser
 ## Panel interaction pings
 
 This reports when a user opens the panel, views messages and clicks on a message.
+For message impressions we concatenate the ids of all messages in the panel.
 
 ```
 {

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -1086,3 +1086,22 @@ This reports when a user has seen or clicked a badge/notification in the browser
   "event": ["CLICK" | "IMPRESSION"],
 }
 ```
+
+## Panel interaction pings
+
+This reports when a user opens the panel, views messages and clicks on a message.
+
+```
+{
+  "locale": "en-US",
+  "client_id": "9da773d8-4356-f54f-b7cf-6134726bcf3d",
+  "version": "70.0a1",
+  "release_channel": "default",
+  "addon_version": "20190712095934",
+  "action": "cfr_user_event",
+  "source": "CFR",
+  "message_id": "WHATS_NEW_70",
+  "event": ["CLICK" | "IMPRESSION"],
+  "value": { "view": ["application_menu" | "toolbar_dropdown"] }
+}
+```

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -732,6 +732,7 @@ class _ASRouter {
     });
     ToolbarPanelHub.init(this.waitForInitialized, {
       getMessages: this.handleMessageRequest,
+      dispatch: this.dispatch,
     });
 
     this._loadLocalProviders();
@@ -1891,6 +1892,7 @@ class _ASRouter {
         break;
       case "DOORHANGER_TELEMETRY":
       case "TOOLBAR_BADGE_TELEMETRY":
+      case "TOOLBAR_PANEL_TELEMETRY":
         if (this.dispatchToAS) {
           this.dispatchToAS(ac.ASRouterUserEvent(action.data));
         }

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -152,7 +152,12 @@ class _ToolbarPanelHub {
     // Panel impressions are not associated with one particular message
     // but with a set of messages. We concatenate message ids and send them
     // back for every impression.
-    const eventId = { id: messages.map(({ id }) => id).join(",") };
+    const eventId = {
+      id: messages
+        .map(({ id }) => id)
+        .sort()
+        .join(","),
+    };
     // Check `mainview` attribute to determine if the panel is shown as a
     // subview (inside the application menu) or as a toolbar dropdown.
     // https://searchfox.org/mozilla-central/rev/07f7390618692fa4f2a674a96b9b677df3a13450/browser/components/customizableui/PanelMultiView.jsm#1268

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -144,15 +144,15 @@ class _ToolbarPanelHub {
           this._createMessageElements(win, doc, message, previousDate)
         );
         previousDate = message.content.published_date;
-        this.sendUserEventTelemetry(win, "IMPRESSION", message);
       }
     }
 
     this._onPanelHidden(win);
 
-    // Panel impressions are not connected to any particular message.
-    // It can be triggered by a feature callout or from the application menu.
-    const eventId = { id: this.triggerId };
+    // Panel impressions are not associated with one particular message
+    // but with a set of messages. We concatenate message ids and send them
+    // back for every impression.
+    const eventId = { id: messages.map(({ id }) => id).join(",") };
     // Check `mainview` attribute to determine if the panel is shown as a
     // subview (inside the application menu) or as a toolbar dropdown.
     // https://searchfox.org/mozilla-central/rev/07f7390618692fa4f2a674a96b9b677df3a13450/browser/components/customizableui/PanelMultiView.jsm#1268

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -13,6 +13,11 @@ ChromeUtils.defineModuleGetter(
   "EveryWindow",
   "resource:///modules/EveryWindow.jsm"
 );
+ChromeUtils.defineModuleGetter(
+  this,
+  "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm"
+);
 
 const WHATSNEW_ENABLED_PREF = "browser.messaging-system.whatsNewPanel.enabled";
 
@@ -24,14 +29,16 @@ const BUTTON_STRING_ID = "cfr-whatsnew-button";
 
 class _ToolbarPanelHub {
   constructor() {
+    this.triggerId = "whatsNewPanelOpened";
     this._showAppmenuButton = this._showAppmenuButton.bind(this);
     this._hideAppmenuButton = this._hideAppmenuButton.bind(this);
     this._showToolbarButton = this._showToolbarButton.bind(this);
     this._hideToolbarButton = this._hideToolbarButton.bind(this);
   }
 
-  async init(waitForInitialized, { getMessages }) {
+  async init(waitForInitialized, { getMessages, dispatch }) {
     this._getMessages = getMessages;
+    this._dispatch = dispatch;
     // Wait for ASRouter messages to become available in order to know
     // if we can show the What's New panel
     await waitForInitialized;
@@ -132,19 +139,30 @@ class _ToolbarPanelHub {
 
     if (messages && !container.querySelector(".whatsNew-message")) {
       let previousDate = 0;
-      for (let { content } of messages) {
+      for (let message of messages) {
         container.appendChild(
-          this._createMessageElements(win, doc, content, previousDate)
+          this._createMessageElements(win, doc, message, previousDate)
         );
-        previousDate = content.published_date;
+        previousDate = message.content.published_date;
       }
     }
 
-    // TODO: TELEMETRY
     this._onPanelHidden(win);
+
+    // Panel impressions are not connected to any particular message.
+    // It can be triggered by a feature callout or from the application menu.
+    const eventId = { id: this.triggerId };
+    // Check `mainview` attribute to determine if the panel is shown as a
+    // subview (inside the application menu) or as a toolbar dropdown.
+    // https://searchfox.org/mozilla-central/rev/07f7390618692fa4f2a674a96b9b677df3a13450/browser/components/customizableui/PanelMultiView.jsm#1268
+    const mainview = win.PanelUI.whatsNewPanel.hasAttribute("mainview");
+    this.sendUserEventTelemetry(win, "IMPRESSION", eventId, {
+      value: { view: mainview ? "toolbar_dropdown" : "application_menu" },
+    });
   }
 
-  _createMessageElements(win, doc, content, previousDate) {
+  _createMessageElements(win, doc, message, previousDate) {
+    const { content } = message;
     const messageEl = this._createElement(doc, "div");
     messageEl.classList.add("whatsNew-message");
 
@@ -167,7 +185,7 @@ class _ToolbarPanelHub {
         csp: null,
       });
 
-      // TODO: TELEMETRY
+      this.sendUserEventTelemetry(win, "CLICK", message);
     });
 
     if (content.icon_url) {
@@ -260,6 +278,30 @@ class _ToolbarPanelHub {
 
   _hideElement(document, id) {
     document.getElementById(id).setAttribute("hidden", true);
+  }
+
+  _sendTelemetry(ping) {
+    this._dispatch({
+      type: "TOOLBAR_PANEL_TELEMETRY",
+      data: { action: "cfr_user_event", source: "CFR", ...ping },
+    });
+  }
+
+  sendUserEventTelemetry(win, event, message, options = {}) {
+    // Only send pings for non private browsing windows
+    if (
+      win &&
+      !PrivateBrowsingUtils.isBrowserPrivate(
+        win.ownerGlobal.gBrowser.selectedBrowser
+      )
+    ) {
+      this._sendTelemetry({
+        message_id: message.id,
+        bucket_id: message.id,
+        event,
+        value: options.value,
+      });
+    }
   }
 }
 

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -144,6 +144,7 @@ class _ToolbarPanelHub {
           this._createMessageElements(win, doc, message, previousDate)
         );
         previousDate = message.content.published_date;
+        this.sendUserEventTelemetry(win, "IMPRESSION", message);
       }
     }
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -215,6 +215,7 @@ describe("ASRouter", () => {
         Router.waitForInitialized,
         {
           getMessages: Router.handleMessageRequest,
+          dispatch: Router.dispatch,
         }
       );
 

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -330,7 +330,10 @@ describe("ToolbarPanelHub", () => {
         assert.propertyVal(
           spy.firstCall.args[2],
           "id",
-          messages.map(({ id }) => id).join(",")
+          messages
+            .map(({ id }) => id)
+            .sort()
+            .join(",")
         );
       });
       it("should dispatch a CLICK for clicking a message", async () => {
@@ -365,7 +368,10 @@ describe("ToolbarPanelHub", () => {
         );
         getMessagesStub.resolves(messages);
         const spy = sandbox.spy(instance, "sendUserEventTelemetry");
-        const panelPingId = messages.map(({ id }) => id).join(",");
+        const panelPingId = messages
+          .map(({ id }) => id)
+          .sort()
+          .join(",");
 
         await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
 
@@ -403,7 +409,10 @@ describe("ToolbarPanelHub", () => {
         );
         getMessagesStub.resolves(messages);
         const spy = sandbox.spy(instance, "sendUserEventTelemetry");
-        const panelPingId = messages.map(({ id }) => id).join(",");
+        const panelPingId = messages
+          .map(({ id }) => id)
+          .sort()
+          .join(",");
 
         await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
 

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -16,6 +16,8 @@ describe("ToolbarPanelHub", () => {
   let removeObserverStub;
   let getBoolPrefStub;
   let waitForInitializedStub;
+  let isBrowserPrivateStub;
+  let fakeDispatch;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -28,6 +30,7 @@ describe("ToolbarPanelHub", () => {
       querySelector: sandbox.stub().returns(null),
       appendChild: sandbox.stub(),
       addEventListener: sandbox.stub(),
+      hasAttribute: sandbox.stub(),
     };
     fakeDocument = {
       l10n: {
@@ -58,6 +61,10 @@ describe("ToolbarPanelHub", () => {
       MozXULElement: { insertFTLIfNeeded: sandbox.stub() },
       ownerGlobal: {
         openLinkIn: sandbox.stub(),
+        gBrowser: "gBrowser",
+      },
+      PanelUI: {
+        whatsNewPanel: fakeElementById,
       },
     };
     everyWindowStub = {
@@ -67,6 +74,8 @@ describe("ToolbarPanelHub", () => {
     addObserverStub = sandbox.stub();
     removeObserverStub = sandbox.stub();
     getBoolPrefStub = sandbox.stub();
+    fakeDispatch = sandbox.stub();
+    isBrowserPrivateStub = sandbox.stub();
     globals.set("EveryWindow", everyWindowStub);
     globals.set("Services", {
       ...Services,
@@ -75,6 +84,9 @@ describe("ToolbarPanelHub", () => {
         removeObserver: removeObserverStub,
         getBoolPref: getBoolPrefStub,
       },
+    });
+    globals.set("PrivateBrowsingUtils", {
+      isBrowserPrivate: isBrowserPrivateStub,
     });
   });
   afterEach(() => {
@@ -215,85 +227,169 @@ describe("ToolbarPanelHub", () => {
     instance._hideToolbarButton(fakeWindow);
     assert.calledWith(fakeElementById.setAttribute, "hidden", true);
   });
-  it("should render messages to the panel on renderMessages()", async () => {
-    const messages = (await PanelTestProvider.getMessages()).filter(
-      m => m.template === "whatsnew_panel_message"
-    );
-    messages[0].content.link_text = { string_id: "link_text_id" };
-    instance.init(waitForInitializedStub, {
-      getMessages: sandbox
-        .stub()
-        .returns([messages[0], messages[2], messages[1]]),
+  describe("#renderMessages", () => {
+    let getMessagesStub;
+    beforeEach(() => {
+      getMessagesStub = sandbox.stub();
+      instance.init(waitForInitializedStub, {
+        getMessages: getMessagesStub,
+        dispatch: fakeDispatch,
+      });
     });
-    await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
-    for (let message of messages) {
-      assert.ok(
-        createdElements.find(
-          el => el.tagName === "h2" && el.textContent === message.content.title
-        )
+    it("should render messages to the panel on renderMessages()", async () => {
+      const messages = (await PanelTestProvider.getMessages()).filter(
+        m => m.template === "whatsnew_panel_message"
       );
-      assert.ok(
-        createdElements.find(
-          el => el.tagName === "p" && el.textContent === message.content.body
-        )
-      );
-    }
-    // Call the click handler to make coverage happy.
-    eventListeners.click();
-    assert.calledOnce(fakeWindow.ownerGlobal.openLinkIn);
-  });
-  it("should only render unique dates (no duplicates)", async () => {
-    instance._createDateElement = sandbox.stub();
-    const messages = (await PanelTestProvider.getMessages()).filter(
-      m => m.template === "whatsnew_panel_message"
-    );
-    const uniqueDates = [
-      ...new Set(messages.map(m => m.content.published_date)),
-    ];
-    instance.init(waitForInitializedStub, {
-      getMessages: sandbox.stub().returns(messages),
-    });
-    await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
-    assert.callCount(instance._createDateElement, uniqueDates.length);
-  });
-  it("should listen for panelhidden and remove the toolbar button", async () => {
-    instance.init(waitForInitializedStub, {
-      getMessages: sandbox.stub().returns([]),
-    });
-    fakeDocument.getElementById
-      .withArgs("customizationui-widget-panel")
-      .returns(null);
+      messages[0].content.link_text = { string_id: "link_text_id" };
 
-    await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+      getMessagesStub.returns([messages[0], messages[2], messages[1]]);
 
-    assert.notCalled(fakeElementById.addEventListener);
-  });
-  it("should listen for panelhidden and remove the toolbar button", async () => {
-    instance.init(waitForInitializedStub, {
-      getMessages: sandbox.stub().returns([]),
-    });
+      await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
 
-    await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
-
-    assert.calledOnce(fakeElementById.addEventListener);
-    assert.calledWithExactly(
-      fakeElementById.addEventListener,
-      "popuphidden",
-      sinon.match.func,
-      {
-        once: true,
+      for (let message of messages) {
+        assert.ok(
+          createdElements.find(
+            el =>
+              el.tagName === "h2" && el.textContent === message.content.title
+          )
+        );
+        assert.ok(
+          createdElements.find(
+            el => el.tagName === "p" && el.textContent === message.content.body
+          )
+        );
       }
-    );
-    const [, cb] = fakeElementById.addEventListener.firstCall.args;
+      // Call the click handler to make coverage happy.
+      eventListeners.click();
+      assert.calledOnce(fakeWindow.ownerGlobal.openLinkIn);
+    });
+    it("should only render unique dates (no duplicates)", async () => {
+      instance._createDateElement = sandbox.stub();
+      const messages = (await PanelTestProvider.getMessages()).filter(
+        m => m.template === "whatsnew_panel_message"
+      );
+      const uniqueDates = [
+        ...new Set(messages.map(m => m.content.published_date)),
+      ];
+      getMessagesStub.returns(messages);
 
-    assert.notCalled(everyWindowStub.unregisterCallback);
+      await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
 
-    cb();
+      assert.callCount(instance._createDateElement, uniqueDates.length);
+    });
+    it("should listen for panelhidden and remove the toolbar button", async () => {
+      getMessagesStub.returns([]);
+      fakeDocument.getElementById
+        .withArgs("customizationui-widget-panel")
+        .returns(null);
 
-    assert.calledOnce(everyWindowStub.unregisterCallback);
-    assert.calledWithExactly(
-      everyWindowStub.unregisterCallback,
-      "whats-new-menu-button"
-    );
+      await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+      assert.notCalled(fakeElementById.addEventListener);
+    });
+    it("should listen for panelhidden and remove the toolbar button", async () => {
+      getMessagesStub.returns([]);
+
+      await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+      assert.calledOnce(fakeElementById.addEventListener);
+      assert.calledWithExactly(
+        fakeElementById.addEventListener,
+        "popuphidden",
+        sinon.match.func,
+        {
+          once: true,
+        }
+      );
+      const [, cb] = fakeElementById.addEventListener.firstCall.args;
+
+      assert.notCalled(everyWindowStub.unregisterCallback);
+
+      cb();
+
+      assert.calledOnce(everyWindowStub.unregisterCallback);
+      assert.calledWithExactly(
+        everyWindowStub.unregisterCallback,
+        "whats-new-menu-button"
+      );
+    });
+    describe("#IMPRESSION", () => {
+      it("should dispatch a IMPRESSION with toolbar_dropdown", async () => {
+        // means panel is triggered from the toolbar button
+        fakeElementById.hasAttribute.returns(true);
+        getMessagesStub.returns([]);
+        const spy = sandbox.spy(instance, "sendUserEventTelemetry");
+
+        await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+        assert.calledOnce(spy);
+        assert.calledWithExactly(
+          spy,
+          fakeWindow,
+          "IMPRESSION",
+          {
+            id: instance.triggerId,
+          },
+          {
+            value: {
+              view: "toolbar_dropdown",
+            },
+          }
+        );
+        assert.calledOnce(fakeDispatch);
+        const {
+          args: [dispatchPayload],
+        } = fakeDispatch.firstCall;
+        assert.propertyVal(dispatchPayload, "type", "TOOLBAR_PANEL_TELEMETRY");
+        assert.propertyVal(
+          dispatchPayload.data,
+          "message_id",
+          instance.triggerId
+        );
+        assert.propertyVal(
+          dispatchPayload.data.value,
+          "view",
+          "toolbar_dropdown"
+        );
+      });
+      it("should dispatch a IMPRESSION with application_menu", async () => {
+        // means panel is triggered as a subview in the application menu
+        fakeElementById.hasAttribute.returns(false);
+        getMessagesStub.returns([]);
+        const spy = sandbox.spy(instance, "sendUserEventTelemetry");
+
+        await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+        assert.calledOnce(spy);
+        assert.calledWithExactly(
+          spy,
+          fakeWindow,
+          "IMPRESSION",
+          {
+            id: instance.triggerId,
+          },
+          {
+            value: {
+              view: "application_menu",
+            },
+          }
+        );
+        assert.calledOnce(fakeDispatch);
+        const {
+          args: [dispatchPayload],
+        } = fakeDispatch.firstCall;
+        assert.propertyVal(dispatchPayload, "type", "TOOLBAR_PANEL_TELEMETRY");
+        assert.propertyVal(
+          dispatchPayload.data,
+          "message_id",
+          instance.triggerId
+        );
+        assert.propertyVal(
+          dispatchPayload.data.value,
+          "view",
+          "application_menu"
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds pings for:
* Showing the panel 
  * Either from the application menu
  * or from the toolbar button
* Clicking on a message
* Seeing a message (impression)
  * the idea here is that messages could be user targeted (not everyone sees the same set)
  * my current implementation sends 1 ping per message with the `message.id` and the `IMPRESSION` event the very first time you open the panel (no mater how many times you open the panel)
  * @ncloudioj is there a different way to report on this that would make it easier for data reporting?