### PR TITLE
Bug 1566372 - Listen for pref changes as a way to trigger notifications

### DIFF
--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -90,6 +90,7 @@ class _ToolbarBadgeHub {
     switch (id) {
       case "show-whatsnew-button":
         ToolbarPanelHub.enableToolbarButton();
+        ToolbarPanelHub.enableAppmenuButton();
         break;
     }
   }

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -32,14 +32,24 @@ class _ToolbarPanelHub {
 
   init({ getMessages }) {
     this._getMessages = getMessages;
-    if (this.whatsNewPanelEnabled) {
-      this.enableAppmenuButton();
-    }
+    // Listen for pref changes that could turn off the feature
+    Services.prefs.addObserver(WHATSNEW_ENABLED_PREF, this);
   }
 
   uninit() {
     EveryWindow.unregisterCallback(TOOLBAR_BUTTON_ID);
     EveryWindow.unregisterCallback(APPMENU_BUTTON_ID);
+    Services.prefs.removeObserver(WHATSNEW_ENABLED_PREF, this);
+  }
+
+  observe(aSubject, aTopic, aPrefName) {
+    switch (aPrefName) {
+      case WHATSNEW_ENABLED_PREF:
+        if (!this.whatsNewPanelEnabled) {
+          this.uninit();
+        }
+        break;
+    }
   }
 
   get whatsNewPanelEnabled() {

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -32,8 +32,11 @@ class _ToolbarPanelHub {
 
   init({ getMessages }) {
     this._getMessages = getMessages;
-    // Listen for pref changes that could turn off the feature
-    Services.prefs.addObserver(WHATSNEW_ENABLED_PREF, this);
+    if (this.whatsNewPanelEnabled) {
+      this.enableAppmenuButton();
+      // Listen for pref changes that could turn off the feature
+      Services.prefs.addObserver(WHATSNEW_ENABLED_PREF, this);
+    }
   }
 
   uninit() {

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -33,10 +33,12 @@ class _ToolbarPanelHub {
   init({ getMessages }) {
     this._getMessages = getMessages;
     if (this.whatsNewPanelEnabled) {
+      // Enable the application menu button so that the user can access
+      // the panel outside of the toolbar button
       this.enableAppmenuButton();
-      // Listen for pref changes that could turn off the feature
-      Services.prefs.addObserver(WHATSNEW_ENABLED_PREF, this);
     }
+    // Listen for pref changes that could turn off the feature
+    Services.prefs.addObserver(WHATSNEW_ENABLED_PREF, this);
   }
 
   uninit() {

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -293,6 +293,16 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(stub);
     });
+    it("should call ToolbarPanelHub.enableAppmenuButton", () => {
+      const stub = sandbox.stub(
+        _ToolbarPanelHub.prototype,
+        "enableAppmenuButton"
+      );
+
+      instance.executeAction({ id: "show-whatsnew-button" });
+
+      assert.calledOnce(stub);
+    });
   });
   describe("removeToolbarNotification", () => {
     it("should remove the notification", () => {

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -83,11 +83,24 @@ describe("ToolbarPanelHub", () => {
   it("should create an instance", () => {
     assert.ok(instance);
   });
+  it("should not enableAppmenuButton() on init() if pref is not enabled", () => {
+    getBoolPrefStub.returns(false);
+    instance.enableAppmenuButton = sandbox.stub();
+    instance.init({ getMessages: () => {} });
+    assert.notCalled(instance.enableAppmenuButton);
+  });
+  it("should enableAppmenuButton() on init() if pref is enabled", () => {
+    getBoolPrefStub.returns(true);
+    instance.enableAppmenuButton = sandbox.stub();
+    instance.init({ getMessages: () => {} });
+    assert.calledOnce(instance.enableAppmenuButton);
+  });
   it("should unregisterCallback on uninit()", () => {
     instance.uninit();
     assert.calledTwice(everyWindowStub.unregisterCallback);
   });
-  it("should observe pref changes on init", () => {
+  it("should observe pref changes on init if enabled by pref", () => {
+    getBoolPrefStub.returns(true);
     instance.init({});
 
     assert.calledOnce(addObserverStub);
@@ -96,6 +109,12 @@ describe("ToolbarPanelHub", () => {
       "browser.messaging-system.whatsNewPanel.enabled",
       instance
     );
+  });
+  it("should not add a pref listener on init if disabled by pref", () => {
+    getBoolPrefStub.returns(false);
+    instance.init({});
+
+    assert.notCalled(addObserverStub);
   });
   it("should remove the observer on uninit", () => {
     instance.uninit();

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -12,6 +12,9 @@ describe("ToolbarPanelHub", () => {
   let fakeElementById;
   let createdElements = [];
   let eventListeners = {};
+  let addObserverStub;
+  let removeObserverStub;
+  let getBoolPrefStub;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -59,30 +62,76 @@ describe("ToolbarPanelHub", () => {
       registerCallback: sandbox.stub(),
       unregisterCallback: sandbox.stub(),
     };
+    addObserverStub = sandbox.stub();
+    removeObserverStub = sandbox.stub();
+    getBoolPrefStub = sandbox.stub();
     globals.set("EveryWindow", everyWindowStub);
+    globals.set("Services", {
+      ...Services,
+      prefs: {
+        addObserver: addObserverStub,
+        removeObserver: removeObserverStub,
+        getBoolPref: getBoolPrefStub,
+      },
+    });
   });
   afterEach(() => {
     instance.uninit();
     sandbox.restore();
+    globals.restore();
   });
   it("should create an instance", () => {
     assert.ok(instance);
   });
-  it("should not enableAppmenuButton() on init() if pref is not enabled", () => {
-    sandbox.stub(global.Services.prefs, "getBoolPref").returns(false);
-    instance.enableAppmenuButton = sandbox.stub();
-    instance.init({ getMessages: () => {} });
-    assert.notCalled(instance.enableAppmenuButton);
-  });
-  it("should enableAppmenuButton() on init() if pref is enabled", () => {
-    sandbox.stub(global.Services.prefs, "getBoolPref").returns(true);
-    instance.enableAppmenuButton = sandbox.stub();
-    instance.init({ getMessages: () => {} });
-    assert.calledOnce(instance.enableAppmenuButton);
-  });
   it("should unregisterCallback on uninit()", () => {
     instance.uninit();
     assert.calledTwice(everyWindowStub.unregisterCallback);
+  });
+  it("should observe pref changes on init", () => {
+    instance.init({});
+
+    assert.calledOnce(addObserverStub);
+    assert.calledWithExactly(
+      addObserverStub,
+      "browser.messaging-system.whatsNewPanel.enabled",
+      instance
+    );
+  });
+  it("should remove the observer on uninit", () => {
+    instance.uninit();
+
+    assert.calledOnce(removeObserverStub);
+    assert.calledWithExactly(
+      removeObserverStub,
+      "browser.messaging-system.whatsNewPanel.enabled",
+      instance
+    );
+  });
+  describe("#observe", () => {
+    it("should uninit if the pref is turned off", () => {
+      sandbox.stub(instance, "uninit");
+      getBoolPrefStub.returns(false);
+
+      instance.observe(
+        "",
+        "",
+        "browser.messaging-system.whatsNewPanel.enabled"
+      );
+
+      assert.calledOnce(instance.uninit);
+    });
+    it("shouldn't do anything if the pref is true", () => {
+      sandbox.stub(instance, "uninit");
+      getBoolPrefStub.returns(true);
+
+      instance.observe(
+        "",
+        "",
+        "browser.messaging-system.whatsNewPanel.enabled"
+      );
+
+      assert.notCalled(instance.uninit);
+    });
   });
   it("should registerCallback on enableAppmenuButton()", () => {
     instance.enableAppmenuButton();

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -99,8 +99,7 @@ describe("ToolbarPanelHub", () => {
     instance.uninit();
     assert.calledTwice(everyWindowStub.unregisterCallback);
   });
-  it("should observe pref changes on init if enabled by pref", () => {
-    getBoolPrefStub.returns(true);
+  it("should observe pref changes on init", () => {
     instance.init({});
 
     assert.calledOnce(addObserverStub);
@@ -109,12 +108,6 @@ describe("ToolbarPanelHub", () => {
       "browser.messaging-system.whatsNewPanel.enabled",
       instance
     );
-  });
-  it("should not add a pref listener on init if disabled by pref", () => {
-    getBoolPrefStub.returns(false);
-    instance.init({});
-
-    assert.notCalled(addObserverStub);
   });
   it("should remove the observer on uninit", () => {
     instance.uninit();


### PR DESCRIPTION
To test for this have

Pref | Value
--- | ---
browser.newtabpage.activity-stream.asrouter.providers.panel_local_testing | {"id":"panel_local_testing", "cohort": "SHOW_TEST"}
browser.messaging-system.whatsNewPanel.enabled | false

Then when changing `browser.messaging-system.whatsNewPanel.enabled` to `true` the Whats New gift icon should appear.
