### PR TITLE
(nobug) - Fix What's New badge targeting expression

### DIFF
--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -79,7 +79,7 @@ const MESSAGES = () => [
     // Never saw this message or saw it in the past 4 days or more recent
     targeting: `isWhatsNewPanelEnabled &&
       (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
-        (messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'] ||
+        (!messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'] ||
       (messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
         currentDate|date - messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000))`,
   },

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -79,9 +79,9 @@ const MESSAGES = () => [
     // Never saw this message or saw it in the past 4 days or more recent
     targeting: `isWhatsNewPanelEnabled &&
       (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
-        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
-      (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
-        currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
+        (messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'] ||
+      (messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
+        currentDate|date - messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000))`,
   },
   {
     id: "WHATS_NEW_70_1",


### PR DESCRIPTION
QA noticed the badge wasn't going away after 4 days.

The `foo[.method == ...]` syntax is used to filter an array of objects that have the `method` property.
```
[{method: "foo", ...}, {method: "bar", ...}]
```

In this case `messageImpressions` is an `Object` where the keys are the message ids so we can use the regular methods to access object values.
```
{"WHATS_NEW": [...], "BAR": ...}
```