### PR TITLE
Pocket New Tab should display "Save to Pocket" for Hero and List components

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter.jsx
@@ -9,13 +9,13 @@ import React from "react";
 // Animation time is mirrored in DSContextFooter.scss
 const ANIMATION_DURATION = 3000;
 
-const StatusMessage = ({ icon, fluentID }) => (
+export const StatusMessage = ({ icon, fluentID }) => (
   <div className="status-message">
     <span
       aria-haspopup="true"
       className={`story-badge-icon icon icon-${icon}`}
     />
-    <div className="story-context-label" data-l10n-id={fluentID} />
+    <div className="story-context-label clamp" data-l10n-id={fluentID} />
   </div>
 );
 
@@ -26,7 +26,7 @@ export class DSContextFooter extends React.PureComponent {
 
     return (
       <div className="story-footer">
-        {context && <p className="story-sponsored-label">{context}</p>}
+        {context && <p className="story-sponsored-label clamp">{context}</p>}
         <TransitionGroup component={null}>
           {!context && context_type && (
             <CSSTransition

--- a/content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter.jsx
@@ -15,7 +15,7 @@ export const StatusMessage = ({ icon, fluentID }) => (
       aria-haspopup="true"
       className={`story-badge-icon icon icon-${icon}`}
     />
-    <div className="story-context-label clamp" data-l10n-id={fluentID} />
+    <div className="story-context-label" data-l10n-id={fluentID} />
   </div>
 );
 

--- a/content-src/components/DiscoveryStreamComponents/DSContextFooter/_DSContextFooter.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSContextFooter/_DSContextFooter.scss
@@ -5,6 +5,7 @@ $status-dark-green: #7C6;
   color: var(--newtab-text-secondary-color);
   inset-inline-start: 0;
   margin-top: 12px;
+  position: relative;
 
   .story-sponsored-label,
   .status-message {

--- a/content-src/components/DiscoveryStreamComponents/DSContextFooter/_DSContextFooter.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSContextFooter/_DSContextFooter.scss
@@ -13,6 +13,7 @@ $status-dark-green: #7C6;
       color: $grey-40;
     }
 
+    -webkit-line-clamp: 1;
     font-size: 13px;
     line-height: 24px;
     color: $grey-50;

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -105,15 +105,14 @@ export class Hero extends React.PureComponent {
             </div>
             <div className="meta">
               <div className="header-and-excerpt">
-                {heroRec.context ? (
-                  <p className="context">{heroRec.context}</p>
-                ) : (
-                  <p className="source clamp">{heroRec.domain}</p>
-                )}
+                <p className="source clamp">{heroRec.domain}</p>
                 <header className="clamp">{heroRec.title}</header>
                 <p className="excerpt clamp">{heroRec.excerpt}</p>
               </div>
-              <DSContextFooter context_type={heroRec.context_type} />
+              <DSContextFooter
+                context={heroRec.context}
+                context_type={heroRec.context_type}
+              />
             </div>
             <ImpressionStats
               campaignId={heroRec.campaign_id}

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -11,6 +11,7 @@ import { ImpressionStats } from "../../DiscoveryStreamImpressionStats/Impression
 import { List } from "../List/List.jsx";
 import React from "react";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
+import { DSContextFooter } from "../DSContextFooter/DSContextFooter.jsx";
 
 export class Hero extends React.PureComponent {
   constructor(props) {
@@ -73,6 +74,7 @@ export class Hero extends React.PureComponent {
             type={this.props.type}
             dispatch={this.props.dispatch}
             context={rec.context}
+            context_type={rec.context_type}
             source={rec.domain}
             pocket_id={rec.pocket_id}
             bookmarkGuid={rec.bookmarkGuid}
@@ -111,6 +113,7 @@ export class Hero extends React.PureComponent {
                 <header className="clamp">{heroRec.title}</header>
                 <p className="excerpt clamp">{heroRec.excerpt}</p>
               </div>
+              <DSContextFooter context_type={heroRec.context_type} />
             </div>
             <ImpressionStats
               campaignId={heroRec.campaign_id}

--- a/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
+++ b/content-src/components/DiscoveryStreamComponents/Hero/_Hero.scss
@@ -27,10 +27,6 @@ $card-header-in-hero-line-height: 20;
     border: 0;
     padding-bottom: 20px;
 
-    p {
-      margin-top: 4px;
-    }
-
     &:hover {
       border: 0;
       box-shadow: none;
@@ -116,6 +112,10 @@ $card-header-in-hero-line-height: 20;
       display: block;
       flex-direction: column;
       justify-content: space-between;
+
+      .header-and-excerpt {
+        flex: 1;
+      }
 
       header {
         @include dark-theme-only {

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -10,6 +10,7 @@ import { DSLinkMenu } from "../DSLinkMenu/DSLinkMenu";
 import { ImpressionStats } from "../../DiscoveryStreamImpressionStats/ImpressionStats";
 import React from "react";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
+import { DSContextFooter } from "../DSContextFooter/DSContextFooter.jsx";
 
 /**
  * @note exported for testing only
@@ -64,14 +65,6 @@ export class ListItem extends React.PureComponent {
           url={this.props.url}
         >
           <div className="ds-list-item-text">
-            <div>
-              <div className="ds-list-item-title clamp">{this.props.title}</div>
-              {this.props.excerpt && (
-                <div className="ds-list-item-excerpt clamp">
-                  {this.props.excerpt}
-                </div>
-              )}
-            </div>
             <p>
               {this.props.context && (
                 <span>
@@ -85,6 +78,15 @@ export class ListItem extends React.PureComponent {
                 {this.props.domain}
               </span>
             </p>
+            <div className="ds-list-item-body">
+              <div className="ds-list-item-title clamp">{this.props.title}</div>
+              {this.props.excerpt && (
+                <div className="ds-list-item-excerpt clamp">
+                  {this.props.excerpt}
+                </div>
+              )}
+            </div>
+            <DSContextFooter context_type={this.props.context_type} />
           </div>
           <DSImage
             extraClassNames="ds-list-image"
@@ -157,6 +159,7 @@ export function _List(props) {
             pos={rec.pos}
             title={rec.title}
             context={rec.context}
+            context_type={rec.context_type}
             type={props.type}
             url={rec.url}
             pocket_id={rec.pocket_id}

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -66,14 +66,6 @@ export class ListItem extends React.PureComponent {
         >
           <div className="ds-list-item-text">
             <p>
-              {this.props.context && (
-                <span>
-                  <span className="ds-list-item-context clamp">
-                    {this.props.context}
-                  </span>
-                  <br />
-                </span>
-              )}
               <span className="ds-list-item-info clamp">
                 {this.props.domain}
               </span>
@@ -86,7 +78,10 @@ export class ListItem extends React.PureComponent {
                 </div>
               )}
             </div>
-            <DSContextFooter context_type={this.props.context_type} />
+            <DSContextFooter
+              context={this.props.context}
+              context_type={this.props.context_type}
+            />
           </div>
           <DSImage
             extraClassNames="ds-list-image"

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -235,6 +235,10 @@ $item-line-height: 20;
     margin-bottom: 4px;
   }
 
+  .ds-list-item-body {
+    flex: 1;
+  }
+
   .ds-list-item-text {
     display: flex;
     flex-direction: column;

--- a/content-src/components/DiscoveryStreamComponents/List/_List.scss
+++ b/content-src/components/DiscoveryStreamComponents/List/_List.scss
@@ -219,8 +219,7 @@ $item-line-height: 20;
     margin: 0;
   }
 
-  .ds-list-item-info,
-  .ds-list-item-context {
+  .ds-list-item-info {
     @include limit-visibile-lines(1, $item-line-height, $item-font-size);
     @include dark-theme-only {
       color: $grey-40;

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -2,6 +2,10 @@ import {
   DSCard,
   PlaceholderDSCard,
 } from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
+import {
+  DSContextFooter,
+  StatusMessage,
+} from "content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter";
 import { actionCreators as ac } from "common/Actions.jsm";
 import { DSLinkMenu } from "content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu";
 import React from "react";
@@ -69,6 +73,22 @@ describe("<DSCard>", () => {
 
   it("should start with no .active class", () => {
     assert.equal(wrapper.find(".active").length, 0);
+  });
+
+  it("should render badges for pocket, bookmark when not a spoc element ", () => {
+    wrapper = shallow(<DSCard context_type="bookmark" />);
+    const contextFooter = wrapper.find(DSContextFooter).shallow();
+
+    assert.lengthOf(contextFooter.find(StatusMessage), 1);
+  });
+
+  it("should render Sponsored Context for a spoc element", () => {
+    const context = "Sponsored by Foo";
+    wrapper = shallow(<DSCard context_type="bookmark" context={context} />);
+    const contextFooter = wrapper.find(DSContextFooter).shallow();
+
+    assert.lengthOf(contextFooter.find(StatusMessage), 0);
+    assert.equal(contextFooter.find(".story-sponsored-label").text(), context);
   });
 
   describe("onLinkClick", () => {

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSContextFooter.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSContextFooter.test.jsx
@@ -1,4 +1,7 @@
-import { DSContextFooter } from "content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter";
+import {
+  DSContextFooter,
+  StatusMessage,
+} from "content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter";
 import React from "react";
 import { mount } from "enzyme";
 import { cardContextTypes } from "content-src/components/Card/types.js";
@@ -8,6 +11,7 @@ describe("<DSContextFooter>", () => {
   let sandbox;
   const bookmarkBadge = "bookmark";
   const removeBookmarkBadge = "removedBookmark";
+  const context = "Sponsored by Babel";
 
   beforeEach(() => {
     wrapper = mount(<DSContextFooter />);
@@ -32,14 +36,11 @@ describe("<DSContextFooter>", () => {
   });
   it("should only render a sponsored context if pass a sponsored context", async () => {
     wrapper = mount(
-      <DSContextFooter
-        context_type={bookmarkBadge}
-        context="Sponsored by Babel"
-      />
+      <DSContextFooter context_type={bookmarkBadge} context={context} />
     );
 
-    assert.isFalse(wrapper.find(".status-message").exists());
-    assert.isTrue(wrapper.find(".story-sponsored-label").exists());
+    assert.lengthOf(wrapper.find(StatusMessage), 0);
+    assert.equal(wrapper.find(".story-sponsored-label").text(), context);
   });
   it("should render a new badge if props change from an old badge to a new one", async () => {
     wrapper = mount(<DSContextFooter context_type={bookmarkBadge} />);

--- a/test/unit/content-src/components/DiscoveryStreamComponents/Hero.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/Hero.test.jsx
@@ -2,6 +2,10 @@ import {
   DSCard,
   PlaceholderDSCard,
 } from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
+import {
+  DSContextFooter,
+  StatusMessage,
+} from "content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter";
 import { actionCreators as ac } from "common/Actions.jsm";
 import { DSEmptyState } from "content-src/components/DiscoveryStreamComponents/DSEmptyState/DSEmptyState";
 import { Hero } from "content-src/components/DiscoveryStreamComponents/Hero/Hero";
@@ -48,6 +52,36 @@ describe("<Hero>", () => {
     assert.equal(
       wrapper.find("SafeAnchor").prop("url"),
       DEFAULT_PROPS.data.recommendations[0].url
+    );
+  });
+
+  it("should render badges for pocket, bookmark when not a spoc element ", () => {
+    const heroProps = {
+      data: { recommendations: [{ context_type: "bookmark" }] },
+      header: { title: "headerTitle" },
+    };
+
+    const wrapper = shallow(<Hero {...heroProps} />);
+    const contextFooter = wrapper.find(DSContextFooter).shallow();
+    assert.lengthOf(contextFooter.find(StatusMessage), 1);
+  });
+
+  it("should render Sponsored Context for a spoc element", () => {
+    const heroProps = {
+      data: {
+        recommendations: [
+          { context_type: "bookmark", context: "Sponsored by Foo" },
+        ],
+      },
+      header: { title: "headerTitle" },
+    };
+    const wrapper = shallow(<Hero {...heroProps} />);
+    const contextFooter = wrapper.find(DSContextFooter).shallow();
+
+    assert.lengthOf(contextFooter.find(StatusMessage), 0);
+    assert.equal(
+      contextFooter.find(".story-sponsored-label").text(),
+      heroProps.data.recommendations[0].context
     );
   });
 

--- a/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
@@ -4,6 +4,10 @@ import {
   PlaceholderListItem,
 } from "content-src/components/DiscoveryStreamComponents/List/List";
 import { actionCreators as ac } from "common/Actions.jsm";
+import {
+  DSContextFooter,
+  StatusMessage,
+} from "content-src/components/DiscoveryStreamComponents/DSContextFooter/DSContextFooter";
 import { DSEmptyState } from "content-src/components/DiscoveryStreamComponents/DSEmptyState/DSEmptyState";
 import { DSLinkMenu } from "content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu";
 import { GlobalOverrider } from "test/unit/utils";
@@ -125,6 +129,15 @@ describe("<ListItem> presentation component", () => {
     title: "FAKE_TITLE",
     domain: "example.com",
     image_src: "FAKE_IMAGE_SRC",
+    context_type: "pocket",
+  };
+  const ValidLSpocListItemProps = {
+    url: "FAKE_URL",
+    title: "FAKE_TITLE",
+    domain: "example.com",
+    image_src: "FAKE_IMAGE_SRC",
+    context_type: "pocket",
+    context: "FAKE_CONTEXT",
   };
   let globals;
 
@@ -143,6 +156,24 @@ describe("<ListItem> presentation component", () => {
       `SafeAnchor.ds-list-item-link[url="${ValidListItemProps.url}"]`
     );
     assert.lengthOf(anchors, 1);
+  });
+
+  it("should render badges for pocket, bookmark when not a spoc element ", () => {
+    const wrapper = shallow(<ListItem {...ValidListItemProps} />);
+    const contextFooter = wrapper.find(DSContextFooter).shallow();
+
+    assert.lengthOf(contextFooter.find(StatusMessage), 1);
+  });
+
+  it("should render Sponsored Context for a spoc element", () => {
+    const wrapper = shallow(<ListItem {...ValidLSpocListItemProps} />);
+    const contextFooter = wrapper.find(DSContextFooter).shallow();
+
+    assert.lengthOf(contextFooter.find(StatusMessage), 0);
+    assert.equal(
+      contextFooter.find(".story-sponsored-label").text(),
+      ValidLSpocListItemProps.context
+    );
   });
 
   describe("onLinkClick", () => {

--- a/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
@@ -131,7 +131,7 @@ describe("<ListItem> presentation component", () => {
     image_src: "FAKE_IMAGE_SRC",
     context_type: "pocket",
   };
-  const ValidLSpocListItemProps = {
+  const ValidSpocListItemProps = {
     url: "FAKE_URL",
     title: "FAKE_TITLE",
     domain: "example.com",
@@ -166,13 +166,13 @@ describe("<ListItem> presentation component", () => {
   });
 
   it("should render Sponsored Context for a spoc element", () => {
-    const wrapper = shallow(<ListItem {...ValidLSpocListItemProps} />);
+    const wrapper = shallow(<ListItem {...ValidSpocListItemProps} />);
     const contextFooter = wrapper.find(DSContextFooter).shallow();
 
     assert.lengthOf(contextFooter.find(StatusMessage), 0);
     assert.equal(
       contextFooter.find(".story-sponsored-label").text(),
-      ValidLSpocListItemProps.context
+      ValidSpocListItemProps.context
     );
   });
 

--- a/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
@@ -126,13 +126,6 @@ describe("<ListItem> presentation component", () => {
     domain: "example.com",
     image_src: "FAKE_IMAGE_SRC",
   };
-  const ValidLSpocListItemProps = {
-    url: "FAKE_URL",
-    title: "FAKE_TITLE",
-    domain: "example.com",
-    image_src: "FAKE_IMAGE_SRC",
-    context: "FAKE_CONTEXT",
-  };
   let globals;
 
   beforeEach(() => {
@@ -150,20 +143,6 @@ describe("<ListItem> presentation component", () => {
       `SafeAnchor.ds-list-item-link[url="${ValidListItemProps.url}"]`
     );
     assert.lengthOf(anchors, 1);
-  });
-
-  it("should not contain 'span.ds-list-item-context' without props.context", () => {
-    const wrapper = shallow(<ListItem {...ValidListItemProps} />);
-
-    const contextEl = wrapper.find("span.ds-list-item-context");
-    assert.lengthOf(contextEl, 0);
-  });
-
-  it("should contain 'span.ds-list-item-context' spoc element", () => {
-    const wrapper = shallow(<ListItem {...ValidLSpocListItemProps} />);
-
-    const contextEl = wrapper.find("span.ds-list-item-context");
-    assert.lengthOf(contextEl, 1);
   });
 
   describe("onLinkClick", () => {


### PR DESCRIPTION
Edit: New animations further down (change to Fade instead of Rotate)
~~*Look at last commit only until I rebase this after b_1540842.~~

Adding the DSContextFooter to the Hero and List components.

Animations
Hero - https://drive.google.com/open?id=1JCpnuzHaLFUJNTvyjfRkvCUFXQALk8ci
List - https://drive.google.com/open?id=1kMHnDZ0zIRczyF4dkcJeVOcbWIR7XV-Y

<img width="1680" alt="List, Hero" src="https://user-images.githubusercontent.com/25225547/62050419-32d2a600-b1df-11e9-8192-95eff6af6b9e.png">
<img width="1680" alt="Other Lists" src="https://user-images.githubusercontent.com/25225547/62050426-349c6980-b1df-11e9-812c-b12f057ca8b3.png">


