### PR TITLE
Bug 1569020 - Add a new badge action for setting homepage_override pref

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -23,5 +23,6 @@
       "description": "Optional delay in ms after which to show the notification"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "required": ["target"]
 }

--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -23,6 +23,5 @@
       "description": "Optional delay in ms after which to show the notification"
     }
   },
-  "additionalProperties": false,
-  "required": ["target"]
+  "additionalProperties": false
 }

--- a/content-src/asrouter/templates/OnboardingMessage/UpdateAction.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/UpdateAction.schema.json
@@ -1,0 +1,36 @@
+{
+  "title": "UpdateActionMessage",
+  "description": "A template for messages that execute predetermined actions.",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL data to be used as argument to the action"
+            },
+            "expireDelta": {
+              "type": "number",
+              "description": "Expiration timestamp to be used as argument to the action"
+            }
+          }
+        },
+        "description": "Additional data provided as argument when executing the action"
+      },
+      "additionalProperties": false,
+      "description": "Optional action to take in addition to showing the notification"
+    },
+    "additionalProperties": false,
+    "required": ["id", "action"]
+  },
+  "additionalProperties": false,
+  "required": ["action"]
+}

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -1296,6 +1296,7 @@ class _ASRouter {
         }
         break;
       case "toolbar_badge":
+      case "update_action":
         ToolbarBadgeHub.registerBadgeNotificationListener(message, { force });
         break;
       default:

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -728,6 +728,7 @@ class _ASRouter {
       handleMessageRequest: this.handleMessageRequest,
       addImpression: this.addImpression,
       blockMessageById: this.blockMessageById,
+      unblockMessageById: this.unblockMessageById,
       dispatch: this.dispatch,
     });
     ToolbarPanelHub.init(this.waitForInitialized, {
@@ -1540,6 +1541,17 @@ class _ASRouter {
     });
   }
 
+  unblockMessageById(id) {
+    return this.setState(state => {
+      const messageBlockList = [...state.messageBlockList];
+      const message = state.messages.find(m => m.id === id);
+      const idToUnblock = message && message.campaign ? message.campaign : id;
+      messageBlockList.splice(messageBlockList.indexOf(idToUnblock), 1);
+      this._storage.set("messageBlockList", messageBlockList);
+      return { messageBlockList };
+    });
+  }
+
   async blockProviderById(idOrIds) {
     const idsToBlock = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
 
@@ -1848,15 +1860,7 @@ class _ASRouter {
         });
         break;
       case "UNBLOCK_MESSAGE_BY_ID":
-        await this.setState(state => {
-          const messageBlockList = [...state.messageBlockList];
-          const message = state.messages.find(m => m.id === action.data.id);
-          const idToUnblock =
-            message && message.campaign ? message.campaign : action.data.id;
-          messageBlockList.splice(messageBlockList.indexOf(idToUnblock), 1);
-          this._storage.set("messageBlockList", messageBlockList);
-          return { messageBlockList };
-        });
+        this.unblockMessageById(action.data.id);
         break;
       case "UNBLOCK_PROVIDER_BY_ID":
         await this.setState(state => {

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -63,7 +63,7 @@ const MESSAGES = () => [
   },
   {
     id: "WNP_PROFILE_AGE",
-    template: "toolbar_badge",
+    template: "update_action",
     content: {
       action: {
         id: "moments-wnp",
@@ -74,8 +74,6 @@ const MESSAGES = () => [
         },
       },
     },
-    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
-    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
     trigger: { id: "momentsUpdate" },
   },
   {

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -69,8 +69,8 @@ const MESSAGES = () => [
         id: "moments-wnp",
         data: {
           url:
-            "https://www.mozilla.org/en-US/firefox/80.0a1/whatsnew/?oldversion=50.0a2",
-          expire: Date.now() + TWO_DAYS,
+            "https://www.mozilla.org/%LOCALE%/etc/firefox/retention/thank-you-a/",
+          expireDelta: TWO_DAYS,
         },
       },
     },

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -68,13 +68,13 @@ const MESSAGES = () => [
         id: "moments-wnp",
         data: {
           url: "foo.com",
-          expire: 0,
+          expire: 100,
         },
       },
     },
     // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
     targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
-    trigger: { id: "toolbarBadgeUpdate" },
+    trigger: { id: "momentsUpdate" },
   },
   {
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -61,6 +61,22 @@ const MESSAGES = () => [
     trigger: { id: "toolbarBadgeUpdate" },
   },
   {
+    id: "WNP_PROFILE_AGE",
+    template: "toolbar_badge",
+    content: {
+      action: {
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expire: 0,
+        },
+      },
+    },
+    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
+    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
+    trigger: { id: "toolbarBadgeUpdate" },
+  },
+  {
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -6,6 +6,7 @@
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
+const TWO_DAYS = 2 * 24 * 3600 * 1000;
 
 const MESSAGES = () => [
   {
@@ -67,8 +68,9 @@ const MESSAGES = () => [
       action: {
         id: "moments-wnp",
         data: {
-          url: "foo.com",
-          expire: 100,
+          url:
+            "https://www.mozilla.org/en-US/firefox/80.0a1/whatsnew/?oldversion=50.0a2",
+          expire: Date.now() + TWO_DAYS,
         },
       },
     },

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -62,7 +62,7 @@ const MESSAGES = () => [
     trigger: { id: "toolbarBadgeUpdate" },
   },
   {
-    id: "WNP_PROFILE_AGE",
+    id: "WNP_THANK_YOU",
     template: "update_action",
     content: {
       action: {

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -51,7 +51,6 @@ ChromeUtils.defineModuleGetter(
 
 // Frequency at which to check for new messages
 const SYSTEM_TICK_INTERVAL = 5 * 60 * 1000;
-const HOMEPAGE_OVERRIDE_PREF = "browser.startup.homepage_override.once";
 const notificationsByWindow = new WeakMap();
 
 class _ToolbarBadgeHub {
@@ -61,6 +60,7 @@ class _ToolbarBadgeHub {
     this.state = null;
     this.prefs = {
       WHATSNEW_TOOLBAR_PANEL: "browser.messaging-system.whatsNewPanel.enabled",
+      HOMEPAGE_OVERRIDE_PREF: "browser.startup.homepage_override.once",
     };
     this.removeAllNotifications = this.removeAllNotifications.bind(this);
     this.removeToolbarNotification = this.removeToolbarNotification.bind(this);
@@ -68,6 +68,7 @@ class _ToolbarBadgeHub {
     this.registerBadgeToAllWindows = this.registerBadgeToAllWindows.bind(this);
     this._sendTelemetry = this._sendTelemetry.bind(this);
     this.sendUserEventTelemetry = this.sendUserEventTelemetry.bind(this);
+    this.checkHomepageOverridePref = this.checkHomepageOverridePref.bind(this);
 
     this._handleMessageRequest = null;
     this._addImpression = null;
@@ -77,10 +78,17 @@ class _ToolbarBadgeHub {
 
   async init(
     waitForInitialized,
-    { handleMessageRequest, addImpression, blockMessageById, dispatch }
+    {
+      handleMessageRequest,
+      addImpression,
+      blockMessageById,
+      unblockMessageById,
+      dispatch,
+    }
   ) {
     this._handleMessageRequest = handleMessageRequest;
     this._blockMessageById = blockMessageById;
+    this._unblockMessageBy = unblockMessageById;
     this._addImpression = addImpression;
     this._dispatch = dispatch;
     // Need to wait for ASRouter to initialize before trying to fetch messages
@@ -89,10 +97,37 @@ class _ToolbarBadgeHub {
     // Listen for pref changes that could trigger new badges
     Services.prefs.addObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
     const _intervalId = setInterval(
-      () => this.messageRequest("toolbarBadgeUpdate"),
+      () => this.checkHomepageOverridePref(),
       SYSTEM_TICK_INTERVAL
     );
     this.state = { _intervalId };
+  }
+
+  /**
+   * Pref is set via Remote Settings message. We want to continously
+   * monitor new messages that come in to ensure the one with the
+   * highest priority is set.
+   */
+  checkHomepageOverridePref() {
+    const prefValue = Services.prefs.getStringPref(
+      this.prefs.HOMEPAGE_OVERRIDE_PREF,
+      ""
+    );
+    if (prefValue) {
+      // If the pref is set it means the user has not yet seen this message.
+      // We clear the pref value and re-evaluate all possible messages to ensure
+      // we don't have a higher priority message to show.
+      Services.prefs.clearUserPref(this.prefs.HOMEPAGE_OVERRIDE_PREF);
+      let message_id;
+      try {
+        message_id = JSON.parse(prefValue).message_id;
+      } catch (e) {}
+      if (message_id) {
+        this._unblockMessageById(message_id);
+      }
+    }
+
+    this.messageRequest("momentsUpdate");
   }
 
   observe(aSubject, aTopic, aPrefName) {
@@ -103,20 +138,35 @@ class _ToolbarBadgeHub {
     }
   }
 
-  executeAction({ id, data }) {
+  executeAction({ id, data, message_id }) {
     switch (id) {
       case "show-whatsnew-button":
         ToolbarPanelHub.enableToolbarButton();
         ToolbarPanelHub.enableAppmenuButton();
         break;
       case "moments-wnp":
-        const { url, expire } = data;
+        const { url, expireDelta } = data;
+        let { expire } = data;
+        if (!expire) {
+          expire = this.getExpirationDate(expireDelta);
+        }
         Services.prefs.setStringPref(
-          HOMEPAGE_OVERRIDE_PREF,
-          JSON.stringify({ url, expire })
+          this.prefs.HOMEPAGE_OVERRIDE_PREF,
+          JSON.stringify({ message_id, url, expire })
         );
         break;
     }
+  }
+
+  /**
+   * If we don't have `expire` defined with the message it could be because
+   * it depends on user dependent parameters. Since the message matched
+   * targeting we calculate `expire` based on the current timestamp and the
+   * `expireDelta` which defines for how long it should be available.
+   * @param expireDelta {number} - Offset in milliseconds from the current date
+   */
+  getExpirationDate(expireDelta) {
+    return Date.now() + expireDelta;
   }
 
   _clearBadgeTimeout() {
@@ -178,7 +228,7 @@ class _ToolbarBadgeHub {
   addToolbarNotification(win, message) {
     const document = win.browser.ownerDocument;
     if (message.content.action) {
-      this.executeAction(message.content.action);
+      this.executeAction({ ...message.content.action, message_id: message.id });
     }
     let toolbarbutton = document.getElementById(message.content.target);
     if (toolbarbutton) {

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -154,6 +154,8 @@ class _ToolbarBadgeHub {
           this.prefs.HOMEPAGE_OVERRIDE_PREF,
           JSON.stringify({ message_id, url, expire })
         );
+        // Block immediately after taking the action
+        this._blockMessageById(message_id);
         break;
     }
   }

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -88,7 +88,7 @@ class _ToolbarBadgeHub {
   ) {
     this._handleMessageRequest = handleMessageRequest;
     this._blockMessageById = blockMessageById;
-    this._unblockMessageBy = unblockMessageById;
+    this._unblockMessageById = unblockMessageById;
     this._addImpression = addImpression;
     this._dispatch = dispatch;
     // Need to wait for ASRouter to initialize before trying to fetch messages

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -207,6 +207,7 @@ describe("ASRouter", () => {
           addImpression: Router.addImpression,
           blockMessageById: Router.blockMessageById,
           dispatch: Router.dispatch,
+          unblockMessageById: Router.unblockMessageById,
         }
       );
 

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -4,7 +4,7 @@ const messages = PanelTestProvider.getMessages();
 
 describe("PanelTestProvider", () => {
   it("should have a message", () => {
-    assert.lengthOf(messages, 7);
+    assert.lengthOf(messages, 8);
   });
   it("should be a valid message", () => {
     assert.jsonSchema(messages[0].content, schema);

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -1,12 +1,28 @@
 import { PanelTestProvider } from "lib/PanelTestProvider.jsm";
 import schema from "content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json";
+import update_schema from "content-src/asrouter/templates/OnboardingMessage/UpdateAction.schema.json";
 const messages = PanelTestProvider.getMessages();
 
 describe("PanelTestProvider", () => {
   it("should have a message", () => {
+    // Careful: when changing this number make sure that new messages also go
+    // through schema verifications.
     assert.lengthOf(messages, 8);
   });
   it("should be a valid message", () => {
-    assert.jsonSchema(messages[0].content, schema);
+    const fxaMessages = messages.filter(
+      ({ template }) => template === "fxa_bookmark_panel"
+    );
+    for (let message of fxaMessages) {
+      assert.jsonSchema(message.content, schema);
+    }
+  });
+  it("should be a valid message", () => {
+    const updateMessages = messages.filter(
+      ({ template }) => template === "update_action"
+    );
+    for (let message of updateMessages) {
+      assert.jsonSchema(message.content, update_schema);
+    }
   });
 });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -313,6 +313,13 @@ describe("ToolbarBadgeHub", () => {
     });
   });
   describe("executeAction", () => {
+    let blockMessageByIdStub;
+    beforeEach(async () => {
+      blockMessageByIdStub = sandbox.stub();
+      await instance.init(sandbox.stub().resolves(), {
+        blockMessageById: blockMessageByIdStub,
+      });
+    });
     it("should call ToolbarPanelHub.enableToolbarButton", () => {
       const stub = sandbox.stub(
         _ToolbarPanelHub.prototype,
@@ -349,6 +356,19 @@ describe("ToolbarBadgeHub", () => {
         instance.prefs.HOMEPAGE_OVERRIDE_PREF,
         JSON.stringify({ message_id: "bar", url: "foo.com", expire: 1 })
       );
+    });
+    it("should block after taking the action", () => {
+      instance.executeAction({
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expire: 1,
+        },
+        message_id: "bar",
+      });
+
+      assert.calledOnce(blockMessageByIdStub);
+      assert.calledWithExactly(blockMessageByIdStub, "bar");
     });
     it("should compute expire based on expireDelta", () => {
       sandbox.spy(instance, "getExpirationDate");

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -16,8 +16,12 @@ describe("ToolbarBadgeHub", () => {
   let everyWindowStub;
   let clearTimeoutStub;
   let setTimeoutStub;
+  let setIntervalStub;
   let addObserverStub;
   let removeObserverStub;
+  let getStringPrefStub;
+  let clearUserPrefStub;
+  let setStringPrefStub;
   beforeEach(async () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
@@ -46,6 +50,7 @@ describe("ToolbarBadgeHub", () => {
     };
     clearTimeoutStub = sandbox.stub();
     setTimeoutStub = sandbox.stub();
+    setIntervalStub = sandbox.stub();
     const fakeWindow = {
       ownerGlobal: {
         gBrowser: {
@@ -55,11 +60,15 @@ describe("ToolbarBadgeHub", () => {
     };
     addObserverStub = sandbox.stub();
     removeObserverStub = sandbox.stub();
+    getStringPrefStub = sandbox.stub();
+    clearUserPrefStub = sandbox.stub();
+    setStringPrefStub = sandbox.stub();
     globals.set({
       EveryWindow: everyWindowStub,
       PrivateBrowsingUtils: { isBrowserPrivate: isBrowserPrivateStub },
       setTimeout: setTimeoutStub,
       clearTimeout: clearTimeoutStub,
+      setInterval: setIntervalStub,
       Services: {
         wm: {
           getMostRecentWindow: () => fakeWindow,
@@ -67,6 +76,9 @@ describe("ToolbarBadgeHub", () => {
         prefs: {
           addObserver: addObserverStub,
           removeObserver: removeObserverStub,
+          getStringPref: getStringPrefStub,
+          clearUserPref: clearUserPrefStub,
+          setStringPref: setStringPrefStub,
         },
       },
     });
@@ -97,13 +109,31 @@ describe("ToolbarBadgeHub", () => {
         instance
       );
     });
+    it("should setInterval for `checkHomepageOverridePref`", async () => {
+      await instance.init(sandbox.stub().resolves(), {});
+      sandbox.stub(instance, "checkHomepageOverridePref");
+
+      assert.calledOnce(setIntervalStub);
+      assert.calledWithExactly(
+        setIntervalStub,
+        sinon.match.func,
+        5 * 60 * 1000
+      );
+
+      assert.notCalled(instance.checkHomepageOverridePref);
+      const [cb] = setIntervalStub.firstCall.args;
+
+      cb();
+
+      assert.calledOnce(instance.checkHomepageOverridePref);
+    });
   });
   describe("#uninit", () => {
     beforeEach(async () => {
-      instance.init(sandbox.stub().resolves(), {});
+      await instance.init(sandbox.stub().resolves(), {});
     });
-    it("should clear any setTimeout cbs", () => {
-      instance.init(sandbox.stub().resolves(), {});
+    it("should clear any setTimeout cbs", async () => {
+      await instance.init(sandbox.stub().resolves(), {});
 
       instance.state.showBadgeTimeoutId = 2;
 
@@ -206,15 +236,15 @@ describe("ToolbarBadgeHub", () => {
       instance.addToolbarNotification(target, whatsnewMessage);
 
       assert.calledOnce(instance.executeAction);
-      assert.calledWithExactly(
-        instance.executeAction,
-        whatsnewMessage.content.action
-      );
+      assert.calledWithExactly(instance.executeAction, {
+        ...whatsnewMessage.content.action,
+        message_id: whatsnewMessage.id,
+      });
     });
   });
   describe("registerBadgeNotificationListener", () => {
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), {
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
         addImpression: fakeAddImpression,
         dispatch: fakeDispatch,
       });
@@ -303,6 +333,38 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(stub);
     });
+    it("should set HOMEPAGE_OVERRIDE_PREF on `moments-wnp` action", () => {
+      instance.executeAction({
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expire: 1,
+        },
+        message_id: "bar",
+      });
+
+      assert.calledOnce(setStringPrefStub);
+      assert.calledWithExactly(
+        setStringPrefStub,
+        instance.prefs.HOMEPAGE_OVERRIDE_PREF,
+        JSON.stringify({ message_id: "bar", url: "foo.com", expire: 1 })
+      );
+    });
+    it("should compute expire based on expireDelta", () => {
+      sandbox.spy(instance, "getExpirationDate");
+
+      instance.executeAction({
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expireDelta: 10,
+        },
+        message_id: "bar",
+      });
+
+      assert.calledOnce(instance.getExpirationDate);
+      assert.calledWithExactly(instance.getExpirationDate, 10);
+    });
   });
   describe("removeToolbarNotification", () => {
     it("should remove the notification", () => {
@@ -317,8 +379,10 @@ describe("ToolbarBadgeHub", () => {
   describe("removeAllNotifications", () => {
     let blockMessageByIdStub;
     let fakeEvent;
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), { dispatch: fakeDispatch });
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
+        dispatch: fakeDispatch,
+      });
       blockMessageByIdStub = sandbox.stub();
       sandbox.stub(instance, "_blockMessageById").value(blockMessageByIdStub);
       instance.state = { notification: { id: fxaMessage.id } };
@@ -414,8 +478,8 @@ describe("ToolbarBadgeHub", () => {
   });
   describe("message with delay", () => {
     let msg_with_delay;
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), {
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
         addImpression: fakeAddImpression,
       });
       msg_with_delay = {
@@ -454,8 +518,10 @@ describe("ToolbarBadgeHub", () => {
     });
   });
   describe("#sendUserEventTelemetry", () => {
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), { dispatch: fakeDispatch });
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
+        dispatch: fakeDispatch,
+      });
     });
     it("should check for private window and not send", () => {
       isBrowserPrivateStub.returns(true);
@@ -490,6 +556,51 @@ describe("ToolbarBadgeHub", () => {
       instance.observe("", "", "foo");
 
       assert.notCalled(instance.messageRequest);
+    });
+  });
+  describe("#checkHomepageOverridePref", () => {
+    let messageRequestStub;
+    let unblockMessageByIdStub;
+    beforeEach(async () => {
+      unblockMessageByIdStub = sandbox.stub();
+      await instance.init(sandbox.stub().resolves(), {
+        unblockMessageById: unblockMessageByIdStub,
+      });
+      messageRequestStub = sandbox.stub(instance, "messageRequest");
+    });
+    it("should reset HOMEPAGE_OVERRIDE_PREF if set", () => {
+      getStringPrefStub.returns(true);
+
+      instance.checkHomepageOverridePref();
+
+      assert.calledOnce(getStringPrefStub);
+      assert.calledWithExactly(
+        getStringPrefStub,
+        instance.prefs.HOMEPAGE_OVERRIDE_PREF,
+        ""
+      );
+      assert.calledOnce(clearUserPrefStub);
+      assert.calledWithExactly(
+        clearUserPrefStub,
+        instance.prefs.HOMEPAGE_OVERRIDE_PREF
+      );
+    });
+    it("should unblock the message set in the pref", () => {
+      getStringPrefStub.returns(JSON.stringify({ message_id: "foo" }));
+
+      instance.checkHomepageOverridePref();
+
+      assert.calledOnce(unblockMessageByIdStub);
+      assert.calledWithExactly(unblockMessageByIdStub, "foo");
+    });
+    it("should catch parse errors", () => {
+      getStringPrefStub.returns({});
+
+      instance.checkHomepageOverridePref();
+
+      assert.notCalled(unblockMessageByIdStub);
+      assert.calledOnce(messageRequestStub);
+      assert.calledWithExactly(messageRequestStub, "momentsUpdate");
     });
   });
 });


### PR DESCRIPTION
Adds a new action id `"moments-wnp"` that can set the value of `.homepage_override.once` pref.
Values to be set are defined through the `data` field of the `content.action` payload in the message.

Not sure if for messages such as `profile age == ONE_YEAR` where `expire` would not be defined in the message we have to set it when the message is selected.

Do we have other/more scenarios we want to handle?