### PR TITLE
(nobug) - Add mochitest for toolbar badging behavior

### DIFF
--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -28,3 +28,4 @@ skip-if = (os == "linux") # Test setup only implemented for OSX and Windows
 [browser_asrouter_cfr.js]
 skip-if = fission
 [browser_asrouter_bookmarkpanel.js]
+[browser_asrouter_toolbarbadge.js]

--- a/test/browser/browser_asrouter_bookmarkpanel.js
+++ b/test/browser/browser_asrouter_bookmarkpanel.js
@@ -16,11 +16,6 @@ add_task(async function test_fxa_message_shown() {
   const testURL = "data:text/plain,test cfr fxa bookmark panel message";
   const browser = gBrowser.selectedBrowser;
 
-  await SpecialPowers.pushPrefEnv({
-    set: [
-      ["browser.newtabpage.activity-stream.asrouter.devtoolsEnabled", false],
-    ],
-  });
   BrowserTestUtils.loadURI(browser, testURL);
   await BrowserTestUtils.browserLoaded(browser, false, testURL);
 

--- a/test/browser/browser_asrouter_toolbarbadge.js
+++ b/test/browser/browser_asrouter_toolbarbadge.js
@@ -1,0 +1,135 @@
+const { PanelTestProvider } = ChromeUtils.import(
+  "resource://activity-stream/lib/PanelTestProvider.jsm"
+);
+const { ToolbarBadgeHub } = ChromeUtils.import(
+  "resource://activity-stream/lib/ToolbarBadgeHub.jsm"
+);
+
+add_task(async function test_setup() {
+  // Cleanup pref value because we click the fxa accounts button.
+  // This is not required during tests because we "force show" the message
+  // by sending it directly to the Hub bypassing targeting.
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref("identity.fxaccounts.toolbar.accessed");
+  });
+});
+
+add_task(async function test_fxa_badge_shown_nodelay() {
+  const [msg] = (await PanelTestProvider.getMessages()).filter(
+    ({ id }) => id === "FXA_ACCOUNTS_BADGE"
+  );
+
+  Assert.ok(msg, "FxA test message exists");
+
+  // Ensure we badge immediately
+  msg.content.delay = undefined;
+
+  let browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+
+  Assert.ok(
+    !browserWindow.document
+      .getElementById(msg.content.target)
+      .querySelector(".toolbarbutton-badge")
+      .classList.contains("feature-callout"),
+    "Initially element is not badged"
+  );
+
+  ToolbarBadgeHub.registerBadgeNotificationListener(msg);
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      browserWindow.document
+        .getElementById(msg.content.target)
+        .querySelector(".toolbarbutton-badge")
+        .classList.contains("feature-callout"),
+    "Wait for element to be badged"
+  );
+
+  let newWin = await BrowserTestUtils.openNewBrowserWindow();
+  browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      browserWindow.document
+        .getElementById(msg.content.target)
+        .querySelector(".toolbarbutton-badge")
+        .classList.contains("feature-callout"),
+    "Wait for element to be badged"
+  );
+
+  await BrowserTestUtils.closeWindow(newWin);
+  browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+
+  // Click the button and clear the badge
+  let fxaButton = document.getElementById(msg.content.target);
+  fxaButton.click();
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      !browserWindow.document
+        .getElementById(msg.content.target)
+        .querySelector(".toolbarbutton-badge")
+        .classList.contains("feature-callout"),
+    "Button should no longer be badged"
+  );
+});
+
+add_task(async function test_fxa_badge_shown_withdelay() {
+  const [msg] = (await PanelTestProvider.getMessages()).filter(
+    ({ id }) => id === "FXA_ACCOUNTS_BADGE"
+  );
+
+  Assert.ok(msg, "FxA test message exists");
+
+  // Enough to trigger the setTimeout badging
+  msg.content.delay = 1;
+
+  let browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+
+  Assert.ok(
+    !browserWindow.document
+      .getElementById(msg.content.target)
+      .querySelector(".toolbarbutton-badge")
+      .classList.contains("feature-callout"),
+    "Initially element is not badged"
+  );
+
+  ToolbarBadgeHub.registerBadgeNotificationListener(msg);
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      browserWindow.document
+        .getElementById(msg.content.target)
+        .querySelector(".toolbarbutton-badge")
+        .classList.contains("feature-callout"),
+    "Wait for element to be badged"
+  );
+
+  let newWin = await BrowserTestUtils.openNewBrowserWindow();
+  browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      browserWindow.document
+        .getElementById(msg.content.target)
+        .querySelector(".toolbarbutton-badge")
+        .classList.contains("feature-callout"),
+    "Wait for element to be badged"
+  );
+
+  await BrowserTestUtils.closeWindow(newWin);
+  browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+
+  // Click the button and clear the badge
+  let fxaButton = document.getElementById(msg.content.target);
+  fxaButton.click();
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      !browserWindow.document
+        .getElementById(msg.content.target)
+        .querySelector(".toolbarbutton-badge")
+        .classList.contains("feature-callout"),
+    "Button should no longer be badged"
+  );
+});


### PR DESCRIPTION
Some basic mochitest coverage for the `ToolbarBadgeHub`. It badges the fxa button (with and without delay) and checks that clicking the button dismisses the badge.