### PR TITLE
Bug 1567272 - Enabling DS for CA

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -10,11 +10,6 @@ ChromeUtils.defineModuleGetter(
   "AppConstants",
   "resource://gre/modules/AppConstants.jsm"
 );
-ChromeUtils.defineModuleGetter(
-  this,
-  "UpdateUtils",
-  "resource://gre/modules/UpdateUtils.jsm"
-);
 
 // NB: Eagerly load modules that will be loaded/constructed/initialized in the
 // common case to avoid the overhead of wrapping and detecting lazy loading.
@@ -450,7 +445,8 @@ const PREFS_CONFIG = new Map([
         };
 
         // Verify that the current geo & locale combination is enabled
-        const isEnabled = !!dsEnablementMatrix[geo] && dsEnablementMatrix[geo].includes(locale);
+        const isEnabled =
+          !!dsEnablementMatrix[geo] && dsEnablementMatrix[geo].includes(locale);
 
         return JSON.stringify({
           api_key_pref: "extensions.pocket.oAuthConsumerKey",

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -104,9 +104,6 @@ const DEFAULT_SITES = new Map([
 ]);
 const GEO_PREF = "browser.search.region";
 const SPOCS_GEOS = ["US"];
-const IS_NIGHTLY_OR_UNBRANDED_BUILD = ["nightly", "default"].includes(
-  UpdateUtils.getUpdateChannel(true)
-);
 
 // Determine if spocs should be shown for a geo/locale
 function showSpocs({ geo }) {
@@ -445,19 +442,15 @@ const PREFS_CONFIG = new Map([
     {
       title: "Configuration for the new pocket new tab",
       getValue: ({ geo, locale }) => {
-        // XXX hardcoded_layout only works for en-*, so fix before adding locales
-        const locales = {
-          US: ["en-CA", "en-GB", "en-US", "en-ZA"],
-          CA: ["en-CA", "en-GB", "en-US", "en-ZA"],
-        }[geo];
+        // PLEASE NOTE:
+        // hardcoded_layout in `lib/DiscoveryStreamFeed.jsm` only works for en-* and requires refactoring for non english locales
+        const dsEnablementMatrix = {
+          US: ["en-CA", "en-GB", "en-US"],
+          CA: ["en-CA", "en-GB", "en-US"],
+        };
 
-        // Enable for US/en-US in all channels.
-        // Enable for specific geos and locales for Nightly.
-        const isEnabled =
-          (geo === `US` && locale === `en-US`) ||
-          (IS_NIGHTLY_OR_UNBRANDED_BUILD &&
-            locales &&
-            locales.includes(locale));
+        // Verify that the current geo & locale combination is enabled
+        const isEnabled = !!dsEnablementMatrix[geo] && dsEnablementMatrix[geo].includes(locale);
 
         return JSON.stringify({
           api_key_pref: "extensions.pocket.oAuthConsumerKey",


### PR DESCRIPTION
Testing:

- Set `browser.search.region` to `CA`
- Toggle `extensions.langpacks.signatures.required` to `false`
- Toggle `xpinstall.signatures.required` to `false`
- Toggle `intl.multilingual.downloadEnabled` to `true`
- Toggle `intl.multilingual.enabled` to `true`
- Open `https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/mac/xpi/firefox-70.0a1.en-CA.langpack.xpi` in build and install
- In `about:preferences` click "Set Alternatives" under "Language", move "English (Canada)" to the top position, click OK, click "Apply And Restart"
- Confirm that DS is enabled in new tab

(Repeat for the `en-GB` langpack)

Approved matrix of enabled geo+locale combos: https://docs.google.com/document/d/1EXMtfPOzcgBrYNVjr8rsA0FymCZm7refUcHrUbp2onE/edit#