### PR TITLE
Bug 1570026 - Monitor action for snippets

### DIFF
--- a/common/Actions.jsm
+++ b/common/Actions.jsm
@@ -159,6 +159,7 @@ for (const type of [
   "OPEN_PREFERENCES_PAGE",
   "SHOW_FIREFOX_ACCOUNTS",
   "PIN_CURRENT_TAB",
+  "ENABLE_FIREFOX_MONITOR",
 ]) {
   ASRouterActions[type] = type;
 }

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { actionCreators as ac } from "common/Actions.jsm";
+import {
+  actionCreators as ac,
+  actionTypes as at,
+  ASRouterActions as ra,
+} from "common/Actions.jsm";
 import { OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME } from "content-src/lib/init-store";
 import { generateBundles } from "./rich-text-strings";
 import { ImpressionsWrapper } from "./components/ImpressionsWrapper/ImpressionsWrapper";
@@ -109,6 +113,7 @@ export class ASRouterUISurface extends React.PureComponent {
     this.sendClick = this.sendClick.bind(this);
     this.sendImpression = this.sendImpression.bind(this);
     this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
+    this.onUserAction = this.onUserAction.bind(this);
     this.state = { message: {} };
     if (props.document) {
       this.headerPortal = props.document.getElementById(
@@ -118,6 +123,49 @@ export class ASRouterUISurface extends React.PureComponent {
         "footer-asrouter-container"
       );
     }
+  }
+
+  async fetchFlowParams(params = {}) {
+    let result = {};
+    const { fxaEndpoint, dispatch } = this.props;
+    if (!fxaEndpoint) {
+      const err =
+        "Tried to fetch flow params before fxaEndpoint pref was ready";
+      console.error(err); // eslint-disable-line no-console
+    }
+
+    try {
+      const urlObj = new URL(fxaEndpoint);
+      urlObj.pathname = "metrics-flow";
+      Object.keys(params).forEach(key => {
+        urlObj.searchParams.append(key, params[key]);
+      });
+      const response = await fetch(urlObj.toString(), { credentials: "omit" });
+      if (response.status === 200) {
+        const { deviceId, flowId, flowBeginTime } = await response.json();
+        result = { deviceId, flowId, flowBeginTime };
+      } else {
+        console.error("Non-200 response", response); // eslint-disable-line no-console
+        dispatch(
+          ac.OnlyToMain({
+            type: at.TELEMETRY_UNDESIRED_EVENT,
+            data: {
+              event: "FXA_METRICS_FETCH_ERROR",
+              value: response.status,
+            },
+          })
+        );
+      }
+    } catch (error) {
+      console.error(error);
+      dispatch(
+        ac.OnlyToMain({
+          type: at.TELEMETRY_UNDESIRED_EVENT,
+          data: { event: "FXA_METRICS_ERROR" },
+        })
+      );
+    }
+    return result;
   }
 
   sendUserActionTelemetry(extraProps = {}) {
@@ -238,6 +286,32 @@ export class ASRouterUISurface extends React.PureComponent {
     ASRouterUtils.removeListener(this.onMessageFromParent);
   }
 
+  async getMonitorUrl({ url, flowRequestParams = {} }) {
+    const flowValues = await this.fetchFlowParams(flowRequestParams);
+
+    // Note that flowParams are actually added dynamically on the page
+    const urlObj = new URL(url);
+    ["deviceId", "flowId", "flowBeginTime"].forEach(key => {
+      if (key in flowValues) {
+        urlObj.searchParams.append(key, flowValues[key]);
+      }
+    });
+
+    return urlObj.toString();
+  }
+
+  async onUserAction(action) {
+    switch (action.type) {
+      // This needs to be handled locally because its
+      case ra.ENABLE_FIREFOX_MONITOR:
+        const url = await this.getMonitorUrl(action.data.args);
+        ASRouterUtils.executeAction({ type: ra.OPEN_URL, data: { args: url } });
+        break;
+      default:
+        ASRouterUtils.executeAction(action);
+    }
+  }
+
   renderSnippets() {
     const { message } = this.state;
     if (!SnippetsTemplates[message.template]) {
@@ -261,7 +335,7 @@ export class ASRouterUISurface extends React.PureComponent {
             UISurface="NEWTAB_FOOTER_BAR"
             onBlock={this.onBlockById(this.state.message.id)}
             onDismiss={this.onDismissById(this.state.message.id)}
-            onAction={ASRouterUtils.executeAction}
+            onAction={this.onUserAction}
             sendClick={this.sendClick}
             sendUserActionTelemetry={this.sendUserActionTelemetry}
           />

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -114,6 +114,8 @@ export class ASRouterUISurface extends React.PureComponent {
     this.sendImpression = this.sendImpression.bind(this);
     this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
     this.onUserAction = this.onUserAction.bind(this);
+    this.fetchFlowParams = this.fetchFlowParams.bind(this);
+
     this.state = { message: {} };
     if (props.document) {
       this.headerPortal = props.document.getElementById(
@@ -157,7 +159,7 @@ export class ASRouterUISurface extends React.PureComponent {
         );
       }
     } catch (error) {
-      console.error(error);
+      console.error(error); // eslint-disable-line no-console
       dispatch(
         ac.OnlyToMain({
           type: at.TELEMETRY_UNDESIRED_EVENT,
@@ -378,6 +380,7 @@ export class ASRouterUISurface extends React.PureComponent {
             onBlock={this.onBlockById(this.state.message.id)}
             onDismiss={this.onDismissById(this.state.message.id)}
             fxaEndpoint={this.props.fxaEndpoint}
+            fetchFlowParams={this.fetchFlowParams}
           />
         </ImpressionsWrapper>
       );

--- a/content-src/asrouter/templates/FirstRun/addUtmParams.js
+++ b/content-src/asrouter/templates/FirstRun/addUtmParams.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const BASE_PARAMS = {
+export const BASE_PARAMS = {
   utm_source: "activity-stream",
   utm_campaign: "firstrun",
   utm_medium: "referral",

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
@@ -42,7 +42,7 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
     ) : null;
   }
 
-  onButtonClick() {
+  async onButtonClick() {
     if (this.props.provider !== "preview") {
       this.props.sendUserActionTelemetry({
         event: "CLICK_BUTTON",
@@ -52,7 +52,7 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
     const { button_url } = this.props.content;
     // If button_url is defined handle it as OPEN_URL action
     const type = this.props.content.button_action || (button_url && "OPEN_URL");
-    this.props.onAction({
+    await this.props.onAction({
       type,
       data: { args: this.props.content.button_action_args || button_url },
     });

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
@@ -60,7 +60,6 @@
       ]
     },
     "button_action_args": {
-      "type": "string",
       "description": "Additional parameters for button action, example which specific menu the button should open"
     },
     "button_label": {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -68,7 +68,6 @@
       ]
     },
     "button_action_args": {
-      "type": "string",
       "description": "Additional parameters for button action, example which specific menu the button should open"
     },
     "button_label": {

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -91,6 +91,19 @@ const MESSAGES = () => [
     },
   },
   {
+    id: "SIMPLE_TEST_BUTTON_ACTION_1",
+    template: "simple_snippet",
+    content: {
+      icon: TEST_ICON,
+      icon_dark_theme: TEST_ICON_BW,
+      button_label: "Open about:config",
+      button_action: "OPEN_ABOUT_PAGE",
+      button_action_args: "config",
+      text: "Testing the OPEN_ABOUT_PAGE action",
+      block_button_text: "Block",
+    },
+  },
+  {
     id: "SIMPLE_WITH_TITLE_TEST_1",
     template: "simple_snippet",
     content: {
@@ -399,6 +412,27 @@ const MESSAGES = () => [
       button_url: "https://www.mozilla.org/en-US/firefox/accounts",
       title: "See if you've been part of an online data breach.",
       text: "Firefox Monitor tells you what hackers already know about you.",
+      block_button_text: "Block",
+    },
+  },
+  {
+    id: "SPECIAL_SNIPPET_MONITOR",
+    template: "simple_below_search_snippet",
+    content: {
+      icon: TEST_ICON,
+      title: "See if you've been part of an online data breach.",
+      text: "Firefox Monitor tells you what hackers already know about you.",
+      button_label: "Get monitor",
+      button_action: "ENABLE_FIREFOX_MONITOR",
+      button_action_args: {
+        url:
+          "https://monitor.firefox.com/oauth/init?utm_source=snippets&utm_campaign=monitor-snippet-test&form_type=email&entrypoint=newtab",
+        flowRequestParams: {
+          entrypoint: "snippets",
+          utm_term: "monitor",
+          form_type: "email",
+        },
+      },
       block_button_text: "Block",
     },
   },

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -1,5 +1,4 @@
 import {
-  helpers,
   FirstRun,
   FLUENT_FILES,
 } from "content-src/asrouter/templates/FirstRun/FirstRun";
@@ -134,41 +133,48 @@ describe("<FirstRun>", () => {
   });
 
   it("should load flow params on mount if fxaEndpoint is defined", () => {
-    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    const stub = sandbox.stub();
     wrapper = mount(
       <FirstRun
         message={message}
         document={fakeDoc}
         dispatch={() => {}}
+        fetchFlowParams={stub}
         fxaEndpoint="https://foo.com"
       />
     );
-    assert.calledOnce(spy);
+    assert.calledOnce(stub);
   });
 
   it("should load flow params onUpdate if fxaEndpoint is not defined on mount and then later defined", () => {
-    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    const stub = sandbox.stub();
     wrapper = mount(
-      <FirstRun message={message} document={fakeDoc} dispatch={() => {}} />
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        fetchFlowParams={stub}
+        dispatch={() => {}}
+      />
     );
-    assert.notCalled(spy);
+    assert.notCalled(stub);
     wrapper.setProps({ fxaEndpoint: "https://foo.com" });
-    assert.calledOnce(spy);
+    assert.calledOnce(stub);
   });
 
   it("should not load flow params again onUpdate if they were already set", () => {
-    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    const stub = sandbox.stub();
     wrapper = mount(
       <FirstRun
         message={message}
         document={fakeDoc}
         dispatch={() => {}}
+        fetchFlowParams={stub}
         fxaEndpoint="https://foo.com"
       />
     );
     wrapper.setProps({ foo: "bar" });
     wrapper.setProps({ foo: "baz" });
-    assert.calledOnce(spy);
+    assert.calledOnce(stub);
   });
 
   it("should load fluent files on mount", () => {


### PR DESCRIPTION
This adds a new user action to ASRouter that allows users to directly authenticate with Firefox Monitor via a URL, similar to how the What's New Page does it.

I have a few questions about the best way to implement this, noted below in comments, before I add tests.