### PR TITLE
Bug 1571846 - Moments pref reset issue

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -494,6 +494,7 @@ class _ASRouter {
     this._triggerHandler = this._triggerHandler.bind(this);
     this._localProviders = localProviders;
     this.blockMessageById = this.blockMessageById.bind(this);
+    this.unblockMessageById = this.unblockMessageById.bind(this);
     this.onMessage = this.onMessage.bind(this);
     this.handleMessageRequest = this.handleMessageRequest.bind(this);
     this.addImpression = this.addImpression.bind(this);

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -56,7 +56,6 @@ const notificationsByWindow = new WeakMap();
 class _ToolbarBadgeHub {
   constructor() {
     this.id = "toolbar-badge-hub";
-    this.template = "toolbar_badge";
     this.state = null;
     this.prefs = {
       WHATSNEW_TOOLBAR_PANEL: "browser.messaging-system.whatsNewPanel.enabled",
@@ -93,7 +92,10 @@ class _ToolbarBadgeHub {
     this._dispatch = dispatch;
     // Need to wait for ASRouter to initialize before trying to fetch messages
     await waitForInitialized;
-    this.messageRequest("toolbarBadgeUpdate");
+    this.messageRequest({
+      triggerId: "toolbarBadgeUpdate",
+      template: "toolbar_badge",
+    });
     // Listen for pref changes that could trigger new badges
     Services.prefs.addObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
     const _intervalId = setInterval(
@@ -127,13 +129,19 @@ class _ToolbarBadgeHub {
       }
     }
 
-    this.messageRequest("momentsUpdate");
+    this.messageRequest({
+      triggerId: "momentsUpdate",
+      template: "update_action",
+    });
   }
 
   observe(aSubject, aTopic, aPrefName) {
     switch (aPrefName) {
       case this.prefs.WHATSNEW_TOOLBAR_PANEL:
-        this.messageRequest("toolbarBadgeUpdate");
+        this.messageRequest({
+          triggerId: "toolbarBadgeUpdate",
+          template: "toolbar_badge",
+        });
         break;
     }
   }
@@ -263,6 +271,12 @@ class _ToolbarBadgeHub {
     // Send a telemetry ping when adding the notification badge
     this.sendUserEventTelemetry("IMPRESSION", message);
 
+    if (message.template === "update_action") {
+      this.executeAction({ ...message.content.action, message_id: message.id });
+      // No badge to set only an action to execute
+      return;
+    }
+
     EveryWindow.registerCallback(
       this.id,
       win => {
@@ -299,10 +313,10 @@ class _ToolbarBadgeHub {
     }
   }
 
-  async messageRequest(triggerId) {
+  async messageRequest({ triggerId, template }) {
     const message = await this._handleMessageRequest({
       triggerId,
-      template: this.template,
+      template,
     });
     if (message) {
       this.registerBadgeNotificationListener(message);

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -101,7 +101,10 @@ describe("ToolbarBadgeHub", () => {
 
       await instance.init(waitForInitialized, {});
       assert.calledOnce(instance.messageRequest);
-      assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+      assert.calledWithExactly(instance.messageRequest, {
+        template: "toolbar_badge",
+        triggerId: "toolbarBadgeUpdate",
+      });
     });
     it("should add a pref observer", async () => {
       await instance.init(sandbox.stub().resolves(), {});
@@ -167,12 +170,15 @@ describe("ToolbarBadgeHub", () => {
       sandbox.stub(instance, "registerBadgeNotificationListener");
     });
     it("should fetch a message with the provided trigger and template", async () => {
-      await instance.messageRequest("trigger");
+      await instance.messageRequest({
+        triggerId: "trigger",
+        template: "template",
+      });
 
       assert.calledOnce(handleMessageRequestStub);
       assert.calledWithExactly(handleMessageRequestStub, {
         triggerId: "trigger",
-        template: instance.template,
+        template: "template",
       });
     });
     it("should call addToolbarNotification with browser window and message", async () => {
@@ -322,6 +328,15 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(everyWindowStub.unregisterCallback);
       assert.calledWithExactly(everyWindowStub.unregisterCallback, instance.id);
+    });
+    it("should only call executeAction for 'update_action' messages", () => {
+      const stub = sandbox.stub(instance, "executeAction");
+      const updateActionMsg = { ...msg_no_delay, template: "update_action" };
+
+      instance.registerBadgeNotificationListener(updateActionMsg);
+
+      assert.notCalled(everyWindowStub.registerCallback);
+      assert.calledOnce(stub);
     });
   });
   describe("executeAction", () => {
@@ -580,7 +595,10 @@ describe("ToolbarBadgeHub", () => {
       instance.observe("", "", instance.prefs.WHATSNEW_TOOLBAR_PANEL);
 
       assert.calledOnce(instance.messageRequest);
-      assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+      assert.calledWithExactly(instance.messageRequest, {
+        template: "toolbar_badge",
+        triggerId: "toolbarBadgeUpdate",
+      });
     });
     it("should not react to other pref changes", () => {
       sandbox.stub(instance, "messageRequest");
@@ -632,7 +650,10 @@ describe("ToolbarBadgeHub", () => {
 
       assert.notCalled(unblockMessageByIdStub);
       assert.calledOnce(messageRequestStub);
-      assert.calledWithExactly(messageRequestStub, "momentsUpdate");
+      assert.calledWithExactly(messageRequestStub, {
+        template: "update_action",
+        triggerId: "momentsUpdate",
+      });
     });
   });
 });


### PR DESCRIPTION
There were two separate issues preventing the `reset & recheck` behavior:
  * `unblockMessageById` was not bound to `ASRouter` so unblocking the message failed. The pref would not get set back again.
  * because `update_action` messages don't show an actual badge the cleanup process would never happen. The map that holds the window reference was always populated and would skip the message a second time around

- [x] Follow up with tests