### PR TITLE
(nobug) - Run test for webextension topSites that uses redux state

### DIFF
--- a/mochitest.sh
+++ b/mochitest.sh
@@ -23,6 +23,7 @@ cd /mozilla-central && ./mach build \
     browser/base/content/test/static/browser_parsable_css.js \
     browser/base/content/test/tabs/browser_new_tab_in_privileged_process_pref.js \
     browser/components/enterprisepolicies/tests/browser/browser_policy_set_homepage.js \
+    browser/components/extensions/test/browser/browser_ext_topSites.js \
     browser/components/preferences/in-content/tests/browser_hometab_restore_defaults.js \
     browser/components/preferences/in-content/tests/browser_newtab_menu.js \
     browser/components/preferences/in-content/tests/browser_search_subdialogs_within_preferences_1.js \


### PR DESCRIPTION
r?@punamdahiya or @ScottDowne This was added in https://bugzilla.mozilla.org/show_bug.cgi?id=1568617