### PR TITLE
Bug 1572441 - Localize Protection panel message

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -395,10 +395,9 @@ const ONBOARDING_MESSAGES = () => [
     id: "PROTECTIONS_PANEL_1",
     template: "protections_panel",
     content: {
-      title: "Browse without being followed",
-      body:
-        "Keep your data to yourself. Firefox protects you from many of the most common trackers that follow what you do online.",
-      link_text: "Learn more",
+      title: { string_id: "cfr-protections-panel-header" },
+      body: { string_id: "cfr-protections-panel-body" },
+      link_text: { string_id: "cfr-protections-panel-link-text" },
       cta_url: `${Services.urlFormatter.formatURLPref(
         "app.support.baseURL"
       )}etp-promotions?as=u&utm_source=inproduct`,

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -378,6 +378,8 @@ class _ToolbarPanelHub {
    */
   async insertProtectionPanelMessage(event) {
     const win = event.target.ownerGlobal;
+    this.maybeInsertFTL(win);
+
     const doc = event.target.ownerDocument;
     const container = doc.getElementById("messaging-system-message-container");
     const infoButton = doc.getElementById("protections-popup-info-button");

--- a/locales-src/asrouter.ftl
+++ b/locales-src/asrouter.ftl
@@ -78,6 +78,12 @@ cfr-doorhanger-bookmark-fxa-close-btn-tooltip =
   .aria-label = Close button
   .title = Close
 
+## Protections panel
+
+cfr-protections-panel-header = Browse without being followed
+cfr-protections-panel-body = Keep your data to yourself. { -brand-short-name } protects you from many of the most common trackers that follow what you do online.
+cfr-protections-panel-link-text = Learn more
+
 ## What's New toolbar button and panel
 
 cfr-whatsnew-button =


### PR DESCRIPTION
r? @k88hudson or @piatra Just adds asrouter.ftl if necessary and convert raw strings to `string_id`s

Before (hardcoded "Firefox"):
![Screen Shot 2019-08-08 at 10 55 02 PM](https://user-images.githubusercontent.com/438537/62757464-43311f00-ba30-11e9-965d-d77228bf5824.png)

After:
![Screen Shot 2019-08-08 at 10 54 07 PM](https://user-images.githubusercontent.com/438537/62757470-488e6980-ba30-11e9-8a48-01ff4a5505a9.png)
