### PR TITLE
Bug 1571442 - Search box shouldn't move down with extended Triplets on

### DIFF
--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -415,6 +415,7 @@
 
   .outer-wrapper {
     position: relative;
+    display: block;
 
     .prefs-button {
       button {


### PR DESCRIPTION
To test this:
- Turn discovery stream off
- Collapse all your sections
- Open devtools, trigger EXTENDED_TRIPLETS_1  (or just launch with `--new-profile`)
- Make your window vertically large
- Ensure you don't see a large gap between the triplets and the search