### PR TITLE
Bug 1572841 - Avoid loading JSMs eagerly in Discovery Stream

### DIFF
--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -6,30 +6,38 @@
 const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
-const { NewTabUtils } = ChromeUtils.import(
+ChromeUtils.defineModuleGetter(
+  this,
+  "NewTabUtils",
   "resource://gre/modules/NewTabUtils.jsm"
 );
 const { setTimeout, clearTimeout } = ChromeUtils.import(
   "resource://gre/modules/Timer.jsm"
 );
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.defineModuleGetter(
+  this,
+  "Services",
+  "resource://gre/modules/Services.jsm"
+);
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 ChromeUtils.defineModuleGetter(
   this,
   "perfService",
   "resource://activity-stream/common/PerfService.jsm"
 );
-const { UserDomainAffinityProvider } = ChromeUtils.import(
+ChromeUtils.defineModuleGetter(
+  this,
+  "UserDomainAffinityProvider",
   "resource://activity-stream/lib/UserDomainAffinityProvider.jsm"
 );
-
 const { actionTypes: at, actionCreators: ac } = ChromeUtils.import(
   "resource://activity-stream/common/Actions.jsm"
 );
-const { PersistentCache } = ChromeUtils.import(
+ChromeUtils.defineModuleGetter(
+  this,
+  "PersistentCache",
   "resource://activity-stream/lib/PersistentCache.jsm"
 );
-
 XPCOMUtils.defineLazyServiceGetters(this, {
   gUUIDGenerator: ["@mozilla.org/uuid-generator;1", "nsIUUIDGenerator"],
 });


### PR DESCRIPTION
To test, this is mostly a tiny refactor, so regression testing is probably the best bet, things should work as they always did.