### PR TITLE
Uplift Bug 1569300 - Special Monitor Snippet

### DIFF
--- a/common/Actions.jsm
+++ b/common/Actions.jsm
@@ -157,6 +157,7 @@ for (const type of [
   "OPEN_PREFERENCES_PAGE",
   "SHOW_FIREFOX_ACCOUNTS",
   "PIN_CURRENT_TAB",
+  "ENABLE_FIREFOX_MONITOR",
 ]) {
   ASRouterActions[type] = type;
 }

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -393,7 +393,9 @@ export class ASRouterUISurface extends React.PureComponent {
 
     return shouldRenderBelowSearch ? (
       // Render special below search snippets in place;
-      <div className="below-search-snippet">{this.renderSnippets()}</div>
+      <div className="below-search-snippet-wrapper">
+        {this.renderSnippets()}
+      </div>
     ) : (
       // For onboarding, regular snippets etc. we should render
       // everything in our footer container.

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -1,4 +1,12 @@
-import { actionCreators as ac } from "common/Actions.jsm";
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  actionCreators as ac,
+  actionTypes as at,
+  ASRouterActions as ra,
+} from "common/Actions.jsm";
 import { OUTGOING_MESSAGE_NAME as AS_GENERAL_OUTGOING_MESSAGE_NAME } from "content-src/lib/init-store";
 import { generateBundles } from "./rich-text-strings";
 import { ImpressionsWrapper } from "./components/ImpressionsWrapper/ImpressionsWrapper";
@@ -105,6 +113,7 @@ export class ASRouterUISurface extends React.PureComponent {
     this.sendClick = this.sendClick.bind(this);
     this.sendImpression = this.sendImpression.bind(this);
     this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
+    this.onUserAction = this.onUserAction.bind(this);
     this.state = { message: {}, bundle: {} };
     if (props.document) {
       this.headerPortal = props.document.getElementById(
@@ -114,6 +123,49 @@ export class ASRouterUISurface extends React.PureComponent {
         "footer-asrouter-container"
       );
     }
+  }
+
+  async fetchFlowParams(params = {}) {
+    let result = {};
+    const { fxaEndpoint, dispatch } = this.props;
+    if (!fxaEndpoint) {
+      const err =
+        "Tried to fetch flow params before fxaEndpoint pref was ready";
+      console.error(err); // eslint-disable-line no-console
+    }
+
+    try {
+      const urlObj = new URL(fxaEndpoint);
+      urlObj.pathname = "metrics-flow";
+      Object.keys(params).forEach(key => {
+        urlObj.searchParams.append(key, params[key]);
+      });
+      const response = await fetch(urlObj.toString(), { credentials: "omit" });
+      if (response.status === 200) {
+        const { deviceId, flowId, flowBeginTime } = await response.json();
+        result = { deviceId, flowId, flowBeginTime };
+      } else {
+        console.error("Non-200 response", response); // eslint-disable-line no-console
+        dispatch(
+          ac.OnlyToMain({
+            type: at.TELEMETRY_UNDESIRED_EVENT,
+            data: {
+              event: "FXA_METRICS_FETCH_ERROR",
+              value: response.status,
+            },
+          })
+        );
+      }
+    } catch (error) {
+      console.error(error);
+      dispatch(
+        ac.OnlyToMain({
+          type: at.TELEMETRY_UNDESIRED_EVENT,
+          data: { event: "FXA_METRICS_ERROR" },
+        })
+      );
+    }
+    return result;
   }
 
   sendUserActionTelemetry(extraProps = {}) {
@@ -266,6 +318,32 @@ export class ASRouterUISurface extends React.PureComponent {
     ASRouterUtils.removeListener(this.onMessageFromParent);
   }
 
+  async getMonitorUrl({ url, flowRequestParams = {} }) {
+    const flowValues = await this.fetchFlowParams(flowRequestParams);
+
+    // Note that flowParams are actually added dynamically on the page
+    const urlObj = new URL(url);
+    ["deviceId", "flowId", "flowBeginTime"].forEach(key => {
+      if (key in flowValues) {
+        urlObj.searchParams.append(key, flowValues[key]);
+      }
+    });
+
+    return urlObj.toString();
+  }
+
+  async onUserAction(action) {
+    switch (action.type) {
+      // This needs to be handled locally because its
+      case ra.ENABLE_FIREFOX_MONITOR:
+        const url = await this.getMonitorUrl(action.data.args);
+        ASRouterUtils.executeAction({ type: ra.OPEN_URL, data: { args: url } });
+        break;
+      default:
+        ASRouterUtils.executeAction(action);
+    }
+  }
+
   renderSnippets() {
     if (
       this.state.bundle.template === "onboarding" ||
@@ -293,7 +371,7 @@ export class ASRouterUISurface extends React.PureComponent {
             UISurface="NEWTAB_FOOTER_BAR"
             onBlock={this.onBlockById(this.state.message.id)}
             onDismiss={this.onDismissById(this.state.message.id)}
-            onAction={ASRouterUtils.executeAction}
+            onAction={this.onUserAction}
             sendClick={this.sendClick}
             sendUserActionTelemetry={this.sendUserActionTelemetry}
           />

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "../../components/Button/Button";
 import { RichText } from "../../components/RichText/RichText";
 import { safeURI } from "../../template-utils";
 import { SnippetBase } from "../../components/SnippetBase/SnippetBase";
@@ -8,6 +9,11 @@ const DEFAULT_ICON_PATH = "chrome://branding/content/icon64.png";
 const ICON_ALT_TEXT = "";
 
 export class SimpleBelowSearchSnippet extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onButtonClick = this.onButtonClick.bind(this);
+  }
+
   renderText() {
     const { props } = this;
     return (
@@ -21,38 +27,103 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
     );
   }
 
+  renderTitle() {
+    const { title } = this.props.content;
+    return title ? (
+      <h3
+        className={`title ${this._shouldRenderButton() ? "title-inline" : ""}`}
+      >
+        {title}
+      </h3>
+    ) : null;
+  }
+
+  onButtonClick() {
+    if (this.props.provider !== "preview") {
+      this.props.sendUserActionTelemetry({
+        event: "CLICK_BUTTON",
+        id: this.props.UISurface,
+      });
+    }
+    const { button_url } = this.props.content;
+    // If button_url is defined handle it as OPEN_URL action
+    const type = this.props.content.button_action || (button_url && "OPEN_URL");
+    this.props.onAction({
+      type,
+      data: { args: this.props.content.button_action_args || button_url },
+    });
+    if (!this.props.content.do_not_autoblock) {
+      this.props.onBlock();
+    }
+  }
+
+  _shouldRenderButton() {
+    return (
+      this.props.content.button_action ||
+      this.props.onButtonClick ||
+      this.props.content.button_url
+    );
+  }
+
+  renderButton() {
+    const { props } = this;
+    if (!this._shouldRenderButton()) {
+      return null;
+    }
+
+    return (
+      <Button
+        onClick={props.onButtonClick || this.onButtonClick}
+        color={props.content.button_color}
+        backgroundColor={props.content.button_background_color}
+      >
+        {props.content.button_label}
+      </Button>
+    );
+  }
+
   render() {
     const { props } = this;
     let className = "SimpleBelowSearchSnippet";
+    let containerName = "below-search-snippet";
 
     if (props.className) {
       className += ` ${props.className}`;
     }
+    if (this._shouldRenderButton()) {
+      className += " withButton";
+      containerName += " withButton";
+    }
 
     return (
-      <SnippetBase
-        {...props}
-        className={className}
-        textStyle={this.props.textStyle}
-      >
-        <img
-          src={safeURI(props.content.icon) || DEFAULT_ICON_PATH}
-          className="icon icon-light-theme"
-          alt={props.content.icon_alt_text || ICON_ALT_TEXT}
-        />
-        <img
-          src={
-            safeURI(props.content.icon_dark_theme || props.content.icon) ||
-            DEFAULT_ICON_PATH
-          }
-          className="icon icon-dark-theme"
-          alt={props.content.icon_alt_text || ICON_ALT_TEXT}
-        />
-        <div>
-          <p className="body">{this.renderText()}</p>
-          {this.props.extraContent}
+      <div className={containerName}>
+        <div className="snippet-hover-wrapper">
+          <SnippetBase
+            {...props}
+            className={className}
+            textStyle={this.props.textStyle}
+          >
+            <img
+              src={safeURI(props.content.icon) || DEFAULT_ICON_PATH}
+              className="icon icon-light-theme"
+              alt={props.content.icon_alt_text || ICON_ALT_TEXT}
+            />
+            <img
+              src={
+                safeURI(props.content.icon_dark_theme || props.content.icon) ||
+                DEFAULT_ICON_PATH
+              }
+              className="icon icon-dark-theme"
+              alt={props.content.icon_alt_text || ICON_ALT_TEXT}
+            />
+            <div className="textContainer">
+              {this.renderTitle()} <p className="body">{this.renderText()}</p>
+              {this.props.extraContent}
+            </div>
+            {<div className="buttonContainer">{this.renderButton()}</div>}
+          </SnippetBase>
         </div>
-      </SnippetBase>
+      </div>
     );
   }
 }

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
@@ -16,7 +16,7 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
 
   renderText() {
     const { props } = this;
-    return (
+    return props.content.text ? (
       <RichText
         text={props.content.text}
         customElements={this.props.customElements}
@@ -24,16 +24,15 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
         links={props.content.links}
         sendClick={props.sendClick}
       />
-    );
+    ) : null;
   }
 
   renderTitle() {
     const { title } = this.props.content;
     return title ? (
-      <h3
-        className={`title ${this._shouldRenderButton() ? "title-inline" : ""}`}
-      >
+      <h3 className={"title title-inline"}>
         {title}
+        <br />
       </h3>
     ) : null;
   }
@@ -117,7 +116,8 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
               alt={props.content.icon_alt_text || ICON_ALT_TEXT}
             />
             <div className="textContainer">
-              {this.renderTitle()} <p className="body">{this.renderText()}</p>
+              {this.renderTitle()}
+              <p className="body">{this.renderText()}</p>
               {this.props.extraContent}
             </div>
             {<div className="buttonContainer">{this.renderButton()}</div>}

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.jsx
@@ -38,7 +38,7 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
     ) : null;
   }
 
-  onButtonClick() {
+  async onButtonClick() {
     if (this.props.provider !== "preview") {
       this.props.sendUserActionTelemetry({
         event: "CLICK_BUTTON",
@@ -48,7 +48,7 @@ export class SimpleBelowSearchSnippet extends React.PureComponent {
     const { button_url } = this.props.content;
     // If button_url is defined handle it as OPEN_URL action
     const type = this.props.content.button_action || (button_url && "OPEN_URL");
-    this.props.onAction({
+    await this.props.onAction({
       type,
       data: { args: this.props.content.button_action_args || button_url },
     });

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
@@ -60,7 +60,6 @@
       ]
     },
     "button_action_args": {
-      "type": "string",
       "description": "Additional parameters for button action, example which specific menu the button should open"
     },
     "button_label": {

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/SimpleBelowSearchSnippet.schema.json
@@ -1,9 +1,13 @@
 {
   "title": "SimpleBelowSearchSnippet",
-  "description": "A simple template with just an icon and rich text. It gets inserted below the Activity Stream search box.",
+  "description": "A simple template with an icon, rich text and an optional button. It gets inserted below the Activity Stream search box.",
   "version": "1.2.0",
   "type": "object",
   "definitions": {
+    "plainText": {
+      "description": "Plain text (no HTML allowed)",
+      "type": "string"
+    },
     "richText": {
       "description": "Text with HTML subset allowed: i, b, u, strong, em, br",
       "type": "string"
@@ -15,6 +19,12 @@
     }
   },
   "properties": {
+    "title": {
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Snippet title displayed before snippet text"}
+      ]
+    },
     "text": {
       "allOf": [
         {"$ref": "#/definitions/richText"},
@@ -38,6 +48,34 @@
       "type": "string",
       "description": "Tooltip text used for dismiss button.",
       "default": "Remove this"
+    },
+    "button_action": {
+      "type": "string",
+      "description": "The type of action the button should trigger."
+    },
+    "button_url": {
+      "allOf": [
+        {"$ref": "#/definitions/link_url"},
+        {"description": "A url, button_label links to this"}
+      ]
+    },
+    "button_action_args": {
+      "type": "string",
+      "description": "Additional parameters for button action, example which specific menu the button should open"
+    },
+    "button_label": {
+      "allOf": [
+        {"$ref": "#/definitions/plainText"},
+        {"description": "Text for a button next to main snippet text that links to button_url. Requires button_url."}
+      ]
+    },
+    "button_color": {
+      "type": "string",
+      "description": "The text color of the button. Valid CSS color."
+    },
+    "button_background_color": {
+      "type": "string",
+      "description": "The background color of the button. Valid CSS color."
     },
     "do_not_autoblock": {
       "type": "boolean",
@@ -64,5 +102,10 @@
   },
   "additionalProperties": false,
   "required": ["text"],
-  "dependencies": {}
+  "dependencies": {
+    "button_action": ["button_label"],
+    "button_url": ["button_label"],
+    "button_color": ["button_label"],
+    "button_background_color": ["button_label"]
+  }
 }

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
@@ -5,14 +5,24 @@
   &.withButton {
     padding: 0 25px;
     margin: auto;
+    min-height: 60px;
     background-color: transparent;
 
     // Add more padding if discovery stream is enabled.
     .ds-outer-wrapper-breakpoint-override & {
       padding: 0 50px;
+
+      @media (max-width: 865px) {
+
+        .buttonContainer {
+          margin: auto;
+        }
+      }
     }
 
     .snippet-hover-wrapper {
+      min-height: 60px;
+      border-radius: 4px;
 
       &:hover {
         background-color: var(--newtab-element-hover-color);
@@ -23,6 +33,10 @@
           // larger inset if discovery stream is enabled.
           .ds-outer-wrapper-breakpoint-override & {
             inset-inline-end: -8%;
+
+            @media (max-width: 865px) {
+              inset-inline-end: 2%;
+            }
           }
         }
       }
@@ -35,7 +49,6 @@
   border: 0;
   box-shadow: none;
   position: relative;
-  line-height: 40px;
   margin: auto;
   z-index: auto;
 
@@ -45,6 +58,7 @@
 
   &.active {
     background-color: var(--newtab-element-hover-color);
+    border-radius: 4px;
   }
 
   .innerWrapper {
@@ -59,7 +73,8 @@
 
     @mixin full-width-styles {
       align-items: flex-start;
-      background-color: inherit;
+      background-color: transparent;
+      border-radius: 4px;
       box-shadow: none;
       flex-direction: row;
       padding: 0;
@@ -89,17 +104,31 @@
     display: block;
     inset-inline-end: 20px;
     opacity: 1;
-    top: 24px;
+    top: 50%;
+  }
+
+  .title {
+    font-size: inherit;
+    margin: 0;
+  }
+
+  .title-inline {
+    display: inline;
+  }
+
+  .textContainer {
+    margin: 10px;
+    margin-inline-start: 0;
   }
 
   .icon {
+    margin-top: 8px;
+    margin-inline-start: 12px;
     height: 32px;
-    margin-top: 15px;
     width: 32px;
 
     @mixin full-width-styles {
       height: 24px;
-      margin-top: 10px;
       width: 24px;
     }
 
@@ -116,6 +145,7 @@
   &.withButton {
     line-height: 20px;
     margin-bottom: 10px;
+    min-height: 60px;
     background-color: transparent;
 
     .blockButton {
@@ -123,6 +153,7 @@
       inset-inline-end: -15%;
       opacity: 1;
       margin: auto;
+      top: unset;
 
       @media (max-width: 1120px) {
         inset-inline-end: 2%;
@@ -135,39 +166,31 @@
       .ds-outer-wrapper-breakpoint-override & {
         inset-inline-end: -10%;
         margin: auto;
+
+        @media (max-width: 865px) {
+          inset-inline-end: 2%;
+        }
       }
-    }
-
-    .textContainer {
-      margin: 10px;
-    }
-
-    .title {
-      font-size: inherit;
-      margin: 0;
-    }
-
-    .title-inline {
-      display: inline;
     }
 
     .icon {
       width: 42px;
       height: 42px;
       flex-shrink: 0;
-
-      @media (max-width: 865px) {
-        display: none;
-      }
+      margin: auto 0;
+      margin-inline-end: 10px;
     }
 
     .buttonContainer {
       margin: auto;
+      margin-inline-end: 0;
     }
   }
 
   .body {
     display: inline;
+    position: sticky;
+    transform: translateY(-50%);
     margin: 8px 0 0;
 
     @media (min-width: $break-point-medium) {

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
@@ -1,13 +1,46 @@
+
+.below-search-snippet {
+  margin: 0 auto 16px;
+
+  &.withButton {
+    padding: 0 25px;
+    margin: auto;
+
+    // Add more padding if discovery stream is enabled.
+    .ds-outer-wrapper-breakpoint-override & {
+      padding: 0 50px;
+    }
+
+    .snippet-hover-wrapper {
+
+      &:hover {
+        background-color: var(--newtab-element-hover-color);
+
+        .blockButton {
+          display: block;
+        }
+      }
+    }
+  }
+}
+
 .SimpleBelowSearchSnippet {
-  background-color: inherit;
+  background-color: transparent;
   border: 0;
   box-shadow: none;
   position: relative;
+  line-height: 40px;
+  width: 736px;
+  margin: auto;
   z-index: auto;
+
+  &.active {
+    background-color: var(--newtab-element-hover-color);
+  }
 
   .innerWrapper {
     align-items: center;
-    background-color: var(--newtab-card-background-color);
+    background-color: transparent;
     border-radius: 4px;
     box-shadow: var(--newtab-card-shadow);
     flex-direction: column;
@@ -21,7 +54,6 @@
       box-shadow: none;
       flex-direction: row;
       padding: 0;
-      padding-inline-end: 36px;
       text-align: inherit;
     }
 
@@ -35,15 +67,9 @@
     }
   }
 
-  &.active {
-    .innerWrapper {
-      background-color: var(--newtab-element-hover-color);
-    }
-  }
-
   .blockButton {
     display: block;
-    inset-inline-end: 15px;
+    inset-inline-end: 20px;
     opacity: 1;
     top: 24px;
   }
@@ -51,6 +77,7 @@
   .icon {
     height: 32px;
     margin-inline-start: 12px;
+    margin-top: 15px;
     width: 32px;
 
     @mixin full-width-styles {
@@ -69,7 +96,44 @@
     }
   }
 
+  &.withButton {
+    line-height: 20px;
+    margin-bottom: 10px;
+
+    .blockButton {
+      display: none;
+      inset-inline-end: -80px;
+      opacity: 1;
+      margin: auto;
+    }
+
+    .textContainer {
+      margin: 10px;
+    }
+
+    .title {
+      font-size: inherit;
+      margin: 0;
+    }
+
+    .title-inline {
+      display: inline;
+    }
+
+    .icon {
+      width: 42px;
+      height: 42px;
+      margin-inline-end: 12px;
+      flex-shrink: 0;
+    }
+
+    .buttonContainer {
+      margin: auto;
+    }
+  }
+
   .body {
+    display: inline;
     margin: 8px 0 0;
 
     @media (min-width: $break-point-medium) {

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
@@ -5,6 +5,7 @@
   &.withButton {
     padding: 0 25px;
     margin: auto;
+    background-color: transparent;
 
     // Add more padding if discovery stream is enabled.
     .ds-outer-wrapper-breakpoint-override & {
@@ -99,6 +100,7 @@
   &.withButton {
     line-height: 20px;
     margin-bottom: 10px;
+    background-color: transparent;
 
     .blockButton {
       display: none;

--- a/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
+++ b/content-src/asrouter/templates/SimpleBelowSearchSnippet/_SimpleBelowSearchSnippet.scss
@@ -19,6 +19,11 @@
 
         .blockButton {
           display: block;
+
+          // larger inset if discovery stream is enabled.
+          .ds-outer-wrapper-breakpoint-override & {
+            inset-inline-end: -8%;
+          }
         }
       }
     }
@@ -31,9 +36,12 @@
   box-shadow: none;
   position: relative;
   line-height: 40px;
-  width: 736px;
   margin: auto;
   z-index: auto;
+
+  @media (min-width: $break-point-large) {
+    width: 736px;
+  }
 
   &.active {
     background-color: var(--newtab-element-hover-color);
@@ -62,9 +70,18 @@
       @include full-width-styles;
     }
 
+    @media (max-width: 1120px) {
+      margin: 0 60px;
+    }
+
+    @media (max-width: 865px) {
+      margin: 0 60px 0 0;
+    }
+
     // Disable breakpoints for now if discovery stream is enabled.
     .ds-outer-wrapper-breakpoint-override & {
       @include full-width-styles;
+      margin: auto;
     }
   }
 
@@ -77,7 +94,6 @@
 
   .icon {
     height: 32px;
-    margin-inline-start: 12px;
     margin-top: 15px;
     width: 32px;
 
@@ -104,9 +120,22 @@
 
     .blockButton {
       display: none;
-      inset-inline-end: -80px;
+      inset-inline-end: -15%;
       opacity: 1;
       margin: auto;
+
+      @media (max-width: 1120px) {
+        inset-inline-end: 2%;
+      }
+
+      @media (max-width: 865px) {
+        margin-top: 10px;
+      }
+
+      .ds-outer-wrapper-breakpoint-override & {
+        inset-inline-end: -10%;
+        margin: auto;
+      }
     }
 
     .textContainer {
@@ -125,8 +154,11 @@
     .icon {
       width: 42px;
       height: 42px;
-      margin-inline-end: 12px;
       flex-shrink: 0;
+
+      @media (max-width: 865px) {
+        display: none;
+      }
     }
 
     .buttonContainer {

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.jsx
@@ -171,36 +171,38 @@ export class SimpleSnippet extends React.PureComponent {
     }
 
     return (
-      <SnippetBase
-        {...props}
-        className={className}
-        textStyle={this.props.textStyle}
-      >
-        {sectionHeader}
-        <ConditionalWrapper
-          condition={sectionHeader}
-          wrap={this.wrapSnippetContent}
+      <div className="snippet-hover-wrapper">
+        <SnippetBase
+          {...props}
+          className={className}
+          textStyle={this.props.textStyle}
         >
-          <img
-            src={safeURI(props.content.icon) || DEFAULT_ICON_PATH}
-            className="icon icon-light-theme"
-            alt={props.content.icon_alt_text || ICON_ALT_TEXT}
-          />
-          <img
-            src={
-              safeURI(props.content.icon_dark_theme || props.content.icon) ||
-              DEFAULT_ICON_PATH
-            }
-            className="icon icon-dark-theme"
-            alt={props.content.icon_alt_text || ICON_ALT_TEXT}
-          />
-          <div>
-            {this.renderTitle()} <p className="body">{this.renderText()}</p>
-            {this.props.extraContent}
-          </div>
-          {<div>{this.renderButton()}</div>}
-        </ConditionalWrapper>
-      </SnippetBase>
+          {sectionHeader}
+          <ConditionalWrapper
+            condition={sectionHeader}
+            wrap={this.wrapSnippetContent}
+          >
+            <img
+              src={safeURI(props.content.icon) || DEFAULT_ICON_PATH}
+              className="icon icon-light-theme"
+              alt={props.content.icon_alt_text || ICON_ALT_TEXT}
+            />
+            <img
+              src={
+                safeURI(props.content.icon_dark_theme || props.content.icon) ||
+                DEFAULT_ICON_PATH
+              }
+              className="icon icon-dark-theme"
+              alt={props.content.icon_alt_text || ICON_ALT_TEXT}
+            />
+            <div>
+              {this.renderTitle()} <p className="body">{this.renderText()}</p>
+              {this.props.extraContent}
+            </div>
+            {<div>{this.renderButton()}</div>}
+          </ConditionalWrapper>
+        </SnippetBase>
+      </div>
     );
   }
 }

--- a/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
+++ b/content-src/asrouter/templates/SimpleSnippet/SimpleSnippet.schema.json
@@ -68,7 +68,6 @@
       ]
     },
     "button_action_args": {
-      "type": "string",
       "description": "Additional parameters for button action, example which specific menu the button should open"
     },
     "button_label": {

--- a/content-src/components/Base/_Base.scss
+++ b/content-src/components/Base/_Base.scss
@@ -15,10 +15,21 @@
   }
 }
 
-main,
-.below-search-snippet.withButton {
+main {
   margin: auto;
   width: $wrapper-default-width;
+  // Offset the snippets container so things at the bottom of the page are still
+  // visible when snippets are visible. Adjust for other spacing.
+  padding-bottom: $snippets-container-height - $section-spacing - $base-gutter;
+
+  section {
+    margin-bottom: $section-spacing;
+    position: relative;
+  }
+
+  .hide-main & {
+    visibility: hidden;
+  }
 
   @media (min-width: $break-point-medium) {
     width: $wrapper-max-width-medium;
@@ -34,19 +45,9 @@ main,
 
 }
 
-main {
-  // Offset the snippets container so things at the bottom of the page are still
-  // visible when snippets are visible. Adjust for other spacing.
-  padding-bottom: $snippets-container-height - $section-spacing - $base-gutter;
-
-  section {
-    margin-bottom: $section-spacing;
-    position: relative;
-  }
-
-  .hide-main & {
-    visibility: hidden;
-  }
+.below-search-snippet.withButton {
+  margin: auto;
+  width: 100%;
 }
 
 .ds-outer-wrapper-search-alignment {

--- a/content-src/components/Base/_Base.scss
+++ b/content-src/components/Base/_Base.scss
@@ -15,11 +15,9 @@
   }
 }
 
-main {
+main,
+.below-search-snippet.withButton {
   margin: auto;
-  // Offset the snippets container so things at the bottom of the page are still
-  // visible when snippets are visible. Adjust for other spacing.
-  padding-bottom: $snippets-container-height - $section-spacing - $base-gutter;
   width: $wrapper-default-width;
 
   @media (min-width: $break-point-medium) {
@@ -34,6 +32,13 @@ main {
     width: $wrapper-max-width-widest;
   }
 
+}
+
+main {
+  // Offset the snippets container so things at the bottom of the page are still
+  // visible when snippets are visible. Adjust for other spacing.
+  padding-bottom: $snippets-container-height - $section-spacing - $base-gutter;
+
   section {
     margin-bottom: $section-spacing;
     position: relative;
@@ -42,7 +47,6 @@ main {
   .hide-main & {
     visibility: hidden;
   }
-
 }
 
 .ds-outer-wrapper-search-alignment {

--- a/content-src/components/Search/_Search.scss
+++ b/content-src/components/Search/_Search.scss
@@ -131,25 +131,7 @@ $glyph-forward: url('chrome://browser/skin/forward.svg');
   }
 }
 
-.below-search-snippet {
-  margin: 0 auto 16px;
-  width: $searchbar-width-small;
-
-  @media (min-width: $break-point-medium) {
-    width: $searchbar-width-medium;
-  }
-
-  @media (min-width: $break-point-large) {
-    width: $searchbar-width-large;
-  }
-
-  // Disable breakpoints for now if discovery stream is enabled.
-  .ds-outer-wrapper-breakpoint-override & {
-    width: $searchbar-width-large;
-  }
-}
-
-.non-collapsible-section + .below-search-snippet {
+.non-collapsible-section + .below-search-snippet-wrapper {
   // If search is enabled, we need to invade its large bottom padding.
   margin-top: -48px;
 }
@@ -159,12 +141,12 @@ $glyph-forward: url('chrome://browser/skin/forward.svg');
     padding: 0 0 30px;
   }
 
-  .non-collapsible-section + .below-search-snippet {
+  .non-collapsible-section + .below-search-snippet-wrapper {
     // In shorter windows, search doesn't have such a large padding.
     margin-top: -14px;
   }
 
-  .below-search-snippet {
+  .below-search-snippet-wrapper {
     min-height: 0;
   }
 }

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -403,6 +403,21 @@ const MESSAGES = () => [
     },
   },
   {
+    id: "SIMPLE_BELOW_SEARCH_TEST_TITLE",
+    template: "simple_below_search_snippet",
+    content: {
+      icon: TEST_ICON,
+      icon_dark_theme: TEST_ICON_BW,
+      title: "See if you've been part of an online data breach.",
+      text:
+        "Securely store passwords, bookmarks, and more with a Firefox Account. <syncLink>Sign up</syncLink>",
+      links: {
+        syncLink: { url: "https://www.mozilla.org/en-US/firefox/accounts" },
+      },
+      block_button_text: "Block",
+    },
+  },
+  {
     id: "SPECIAL_SNIPPET_BUTTON_1",
     template: "simple_below_search_snippet",
     content: {
@@ -411,6 +426,32 @@ const MESSAGES = () => [
       button_label: "Find Out Now",
       button_url: "https://www.mozilla.org/en-US/firefox/accounts",
       title: "See if you've been part of an online data breach.",
+      text: "Firefox Monitor tells you what hackers already know about you.",
+      block_button_text: "Block",
+    },
+  },
+  {
+    id: "SPECIAL_SNIPPET_LONG_CONTENT",
+    template: "simple_below_search_snippet",
+    content: {
+      icon: TEST_ICON,
+      icon_dark_theme: TEST_ICON_BW,
+      button_label: "Find Out Now",
+      button_url: "https://www.mozilla.org/en-US/firefox/accounts",
+      title: "See if you've been part of an online data breach.",
+      text:
+        "Firefox Monitor tells you what hackers already know about you. Here's some extra text to make the content really long.",
+      block_button_text: "Block",
+    },
+  },
+  {
+    id: "SPECIAL_SNIPPET_NO_TITLE",
+    template: "simple_below_search_snippet",
+    content: {
+      icon: TEST_ICON,
+      icon_dark_theme: TEST_ICON_BW,
+      button_label: "Find Out Now",
+      button_url: "https://www.mozilla.org/en-US/firefox/accounts",
       text: "Firefox Monitor tells you what hackers already know about you.",
       block_button_text: "Block",
     },

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -91,6 +91,19 @@ const MESSAGES = () => [
     },
   },
   {
+    id: "SIMPLE_TEST_BUTTON_ACTION_1",
+    template: "simple_snippet",
+    content: {
+      icon: TEST_ICON,
+      icon_dark_theme: TEST_ICON_BW,
+      button_label: "Open about:config",
+      button_action: "OPEN_ABOUT_PAGE",
+      button_action_args: "config",
+      text: "Testing the OPEN_ABOUT_PAGE action",
+      block_button_text: "Block",
+    },
+  },
+  {
     id: "SIMPLE_WITH_TITLE_TEST_1",
     template: "simple_snippet",
     content: {
@@ -399,6 +412,27 @@ const MESSAGES = () => [
       button_url: "https://www.mozilla.org/en-US/firefox/accounts",
       title: "See if you've been part of an online data breach.",
       text: "Firefox Monitor tells you what hackers already know about you.",
+      block_button_text: "Block",
+    },
+  },
+  {
+    id: "SPECIAL_SNIPPET_MONITOR",
+    template: "simple_below_search_snippet",
+    content: {
+      icon: TEST_ICON,
+      title: "See if you've been part of an online data breach.",
+      text: "Firefox Monitor tells you what hackers already know about you.",
+      button_label: "Get monitor",
+      button_action: "ENABLE_FIREFOX_MONITOR",
+      button_action_args: {
+        url:
+          "https://monitor.firefox.com/oauth/init?utm_source=snippets&utm_campaign=monitor-snippet-test&form_type=email&entrypoint=newtab",
+        flowRequestParams: {
+          entrypoint: "snippets",
+          utm_term: "monitor",
+          form_type: "email",
+        },
+      },
       block_button_text: "Block",
     },
   },

--- a/lib/SnippetsTestMessageProvider.jsm
+++ b/lib/SnippetsTestMessageProvider.jsm
@@ -389,6 +389,19 @@ const MESSAGES = () => [
       block_button_text: "Block",
     },
   },
+  {
+    id: "SPECIAL_SNIPPET_BUTTON_1",
+    template: "simple_below_search_snippet",
+    content: {
+      icon: TEST_ICON,
+      icon_dark_theme: TEST_ICON_BW,
+      button_label: "Find Out Now",
+      button_url: "https://www.mozilla.org/en-US/firefox/accounts",
+      title: "See if you've been part of an online data breach.",
+      text: "Firefox Monitor tells you what hackers already know about you.",
+      block_button_text: "Block",
+    },
+  },
 ];
 
 const SnippetsTestMessageProvider = {

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -9,6 +9,7 @@ import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
 import React from "react";
 import { mount } from "enzyme";
 import { Trailhead } from "../../../content-src/asrouter/templates/Trailhead/Trailhead";
+import { actionCreators as ac } from "common/Actions.jsm";
 
 let [FAKE_MESSAGE] = FAKE_LOCAL_MESSAGES;
 const FAKE_NEWSLETTER_SNIPPET = FAKE_LOCAL_MESSAGES.find(
@@ -63,17 +64,23 @@ describe("ASRouterUtils", () => {
 
 describe("ASRouterUISurface", () => {
   let wrapper;
-  let global;
+  let globalO;
   let sandbox;
   let headerPortal;
   let footerPortal;
   let fakeDocument;
+  let fetchStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     headerPortal = document.createElement("div");
     footerPortal = document.createElement("div");
     sandbox.stub(footerPortal, "querySelector").returns(footerPortal);
+    fetchStub = sandbox.stub(global, "fetch").resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
     fakeDocument = {
       location: { href: "" },
       _listeners: new Set(),
@@ -101,8 +108,8 @@ describe("ASRouterUISurface", () => {
         return id === "header-asrouter-container" ? headerPortal : footerPortal;
       },
     };
-    global = new GlobalOverrider();
-    global.set({
+    globalO = new GlobalOverrider();
+    globalO.set({
       RPMAddMessageListener: sandbox.stub(),
       RPMRemoveMessageListener: sandbox.stub(),
       RPMSendAsyncMessage: sandbox.stub(),
@@ -115,7 +122,7 @@ describe("ASRouterUISurface", () => {
 
   afterEach(() => {
     sandbox.restore();
-    global.restore();
+    globalO.restore();
   });
 
   it("should render the component if a message id is defined", () => {
@@ -381,6 +388,146 @@ describe("ASRouterUISurface", () => {
         id: "onboarding-cards",
         message_id: "1,2,3",
         source: "onboarding-cards",
+      });
+    });
+  });
+
+  describe(".fetchFlowParams", () => {
+    let dispatchStub;
+    const assertCalledWithURL = url =>
+      assert.calledWith(fetchStub, new URL(url).toString(), {
+        credentials: "omit",
+      });
+    beforeEach(() => {
+      dispatchStub = sandbox.stub();
+      wrapper = mount(
+        <ASRouterUISurface
+          dispatch={dispatchStub}
+          fxaEndpoint="https://accounts.firefox.com"
+        />
+      );
+    });
+    it("should use the base url returned from the endpoint pref", async () => {
+      wrapper = mount(
+        <ASRouterUISurface
+          dispatch={dispatchStub}
+          fxaEndpoint="https://foo.com"
+        />
+      );
+      await wrapper.instance().fetchFlowParams();
+
+      assertCalledWithURL("https://foo.com/metrics-flow");
+    });
+    it("should add given search params to the URL", async () => {
+      const params = { foo: "1", bar: "2" };
+
+      await wrapper.instance().fetchFlowParams(params);
+
+      assertCalledWithURL(
+        "https://accounts.firefox.com/metrics-flow?foo=1&bar=2"
+      );
+    });
+    it("should return flowId, flowBeginTime, deviceId on a 200 response", async () => {
+      const flowInfo = { flowId: "foo", flowBeginTime: 123, deviceId: "bar" };
+      fetchStub.withArgs("https://accounts.firefox.com/metrics-flow").resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(flowInfo),
+      });
+
+      const result = await wrapper.instance().fetchFlowParams();
+      assert.deepEqual(result, flowInfo);
+    });
+    it("should return {} and dispatch a TELEMETRY_UNDESIRED_EVENT on a non-200 response", async () => {
+      fetchStub.withArgs("https://accounts.firefox.com/metrics-flow").resolves({
+        ok: false,
+        status: 400,
+        statusText: "Client error",
+        url: "https://accounts.firefox.com/metrics-flow",
+      });
+
+      const result = await wrapper.instance().fetchFlowParams();
+      assert.deepEqual(result, {});
+      assert.calledWith(
+        dispatchStub,
+        ac.OnlyToMain({
+          type: "TELEMETRY_UNDESIRED_EVENT",
+          data: {
+            event: "FXA_METRICS_FETCH_ERROR",
+            value: 400,
+          },
+        })
+      );
+    });
+    it("should return {} and dispatch a TELEMETRY_UNDESIRED_EVENT on a parsing erorr", async () => {
+      fetchStub.withArgs("https://accounts.firefox.com/metrics-flow").resolves({
+        ok: false,
+        status: 200,
+        // No json to parse, throws an error
+      });
+
+      const result = await wrapper.instance().fetchFlowParams();
+      assert.deepEqual(result, {});
+      assert.calledWith(
+        dispatchStub,
+        ac.OnlyToMain({
+          type: "TELEMETRY_UNDESIRED_EVENT",
+          data: { event: "FXA_METRICS_ERROR" },
+        })
+      );
+    });
+
+    describe(".onUserAction", () => {
+      it("if the action.type is ENABLE_FIREFOX_MONITOR, it should generate the right monitor URL given some flowParams", async () => {
+        const flowInfo = { flowId: "foo", flowBeginTime: 123, deviceId: "bar" };
+        fetchStub
+          .withArgs(
+            "https://accounts.firefox.com/metrics-flow?utm_term=avocado"
+          )
+          .resolves({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(flowInfo),
+          });
+
+        sandbox.spy(ASRouterUtils, "executeAction");
+
+        const msg = {
+          type: "ENABLE_FIREFOX_MONITOR",
+          data: {
+            args: {
+              url: "https://monitor.firefox.com?foo=bar",
+              flowRequestParams: {
+                utm_term: "avocado",
+              },
+            },
+          },
+        };
+
+        await wrapper.instance().onUserAction(msg);
+
+        assertCalledWithURL(
+          "https://accounts.firefox.com/metrics-flow?utm_term=avocado"
+        );
+        assert.calledWith(ASRouterUtils.executeAction, {
+          type: "OPEN_URL",
+          data: {
+            args: new URL(
+              "https://monitor.firefox.com?foo=bar&deviceId=bar&flowId=foo&flowBeginTime=123"
+            ).toString(),
+          },
+        });
+      });
+      it("if the action.type is not ENABLE_FIREFOX_MONITOR, it should just call ASRouterUtils.executeAction", async () => {
+        const msg = {
+          type: "FOO",
+          data: {
+            args: "bar",
+          },
+        };
+        sandbox.spy(ASRouterUtils, "executeAction");
+        await wrapper.instance().onUserAction(msg);
+        assert.calledWith(ASRouterUtils.executeAction, msg);
       });
     });
   });


### PR DESCRIPTION
This uplifts 5 bugs:
https://bugzilla.mozilla.org/buglist.cgi?keywords=github-merged&o1=allwords&v1=1569300&f1=blocked
```
5118b78c Bug 1569597 - Updated schema & template, added test snippet with corr… (#5208)
5ea99ba1 Bug 1571435 - Overrode the .active class for snippets with buttons, to prevent a double highlight. (#5224)
70b63230 Bug 1571441 - Fixed snippet width and block button position on smaller screens (#5227)
9e70a342 Bug 1570026 - Part 1. Add Monitor action for snippets
46821636 Bug 1572463 - Fixes for the Special Monitor Snippet (#5235)
```

Needed to resolve conflicts in https://github.com/mozilla/activity-stream/commit/083792d8cff311fd2b9c2a6c8779baec8d5b6a5b for not uplifting https://github.com/mozilla/activity-stream/commit/fe05904ed881d799a6e53d8fbe36976e33fe127c in this set. This also has the lint warning for console but will get fixed when uplifting the fetch flow refactor.

Forced showing `SPECIAL_SNIPPET_MONITOR` from devtools:
![Screen Shot 2019-08-12 at 12 26 32 PM](https://user-images.githubusercontent.com/438537/62892397-064d7c80-bcfd-11e9-9e8a-ffdc7d8eaa9c.png)


Clicking the button resulted in:
`
Navigated to https://monitor.firefox.com/oauth/init?utm_source=snippets&utm_campaign=monitor-snippet-test&form_type=email&entrypoint=newtab&deviceId=ea72b48cb3814ee59a598ecf11c9ef68&flowId=4b31ac045145f31c63f9bb8bf6bd0937b25934c57fe5df067fbddac6c9daea89&flowBeginTime=1565638029372
`