### PR TITLE
Bug 1573204 - Adding an extra line to pocket stories

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
+++ b/content-src/components/DiscoveryStreamComponents/CardGrid/_CardGrid.scss
@@ -68,7 +68,7 @@ $col4-header-font-size: 14;
       }
 
       .excerpt {
-        @include limit-visibile-lines(3, 24, 15);
+        @include limit-visibile-lines(4, 24, 15);
       }
     }
 

--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -104,7 +104,7 @@ $excerpt-line-height: 20;
     .excerpt {
       // show only 3 lines of copy
       @include limit-visibile-lines(
-        3,
+        4,
         $excerpt-line-height,
         $excerpt-font-size
       );


### PR DESCRIPTION
To test:

1. Open a new tab
2. Ensure we see pocket stories with at max 4 lines of text.
3. Ensure cards in a single row are all the same height, based on the height of the tallest card.