### PR TITLE
Uplift Bug 1567601 - New "Moments" Page

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -34,6 +34,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [isFxAEnabled](#isFxAEnabled)
 * [xpinstallEnabled](#xpinstallEnabled)
 * [hasPinnedTabs](#haspinnedtabs)
+* [hasAccessedFxAPanel](#hasaccessedfxapanel)
 
 ## Detailed usage
 
@@ -473,4 +474,14 @@ Does the user have any pinned tabs in any windows.
 
 ```ts
 declare const hasPinnedTabs: boolean;
+```
+
+### `hasAccessedFxAPanel`
+
+Boolean pref that gets set the first time the user opens the FxA toolbar panel
+
+#### Definition
+
+```ts
+declare const hasAccessedFxAPanel: boolean;
 ```

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -36,6 +36,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [hasPinnedTabs](#haspinnedtabs)
 * [hasAccessedFxAPanel](#hasaccessedfxapanel)
 * [isWhatsNewPanelEnabled](#iswhatsnewpanelenabled)
+* [earliestFirefoxVersion](#earliestfirefoxversion)
 
 ## Detailed usage
 
@@ -495,4 +496,14 @@ Boolean pref that controls if the What's New panel feature is enabled
 
 ```ts
 declare const isWhatsNewPanelEnabled: boolean;
+```
+
+### `earliestFirefoxVersion`
+
+Integer value of the first Firefox version the profile ran on
+
+#### Definition
+
+```ts
+declare const earliestFirefoxVersion: boolean;
 ```

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -35,6 +35,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [xpinstallEnabled](#xpinstallEnabled)
 * [hasPinnedTabs](#haspinnedtabs)
 * [hasAccessedFxAPanel](#hasaccessedfxapanel)
+* [isWhatsNewPanelEnabled](#iswhatsnewpanelenabled)
 
 ## Detailed usage
 
@@ -484,4 +485,14 @@ Boolean pref that gets set the first time the user opens the FxA toolbar panel
 
 ```ts
 declare const hasAccessedFxAPanel: boolean;
+```
+
+### `isWhatsNewPanelEnabled`
+
+Boolean pref that controls if the What's New panel feature is enabled
+
+#### Definition
+
+```ts
+declare const isWhatsNewPanelEnabled: boolean;
 ```

--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -15,7 +15,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["id"]
+      "required": ["id"],
+      "description": "Optional action to take in addition to showing the notification"
+    },
+    "delay": {
+      "type": "number",
+      "description": "Optional delay in ms after which to show the notification"
     }
   },
   "additionalProperties": false,

--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -1,0 +1,13 @@
+{
+  "title": "ToolbarBadgeMessage",
+  "description": "A template that specifies to which element in the browser toolbar to add a notification.",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["target"]
+}

--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -6,6 +6,16 @@
   "properties": {
     "target": {
       "type": "string"
+    },
+    "action": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["id"]
     }
   },
   "additionalProperties": false,

--- a/content-src/asrouter/templates/OnboardingMessage/UpdateAction.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/UpdateAction.schema.json
@@ -1,0 +1,36 @@
+{
+  "title": "UpdateActionMessage",
+  "description": "A template for messages that execute predetermined actions.",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL data to be used as argument to the action"
+            },
+            "expireDelta": {
+              "type": "number",
+              "description": "Expiration timestamp to be used as argument to the action"
+            }
+          }
+        },
+        "description": "Additional data provided as argument when executing the action"
+      },
+      "additionalProperties": false,
+      "description": "Optional action to take in addition to showing the notification"
+    },
+    "additionalProperties": false,
+    "required": ["id", "action"]
+  },
+  "additionalProperties": false,
+  "required": ["action"]
+}

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -1068,3 +1068,21 @@ This reports an enrollment ping when a user gets enrolled in a Trailhead experim
   }
 }
 ```
+
+## Feature Callouts interaction pings
+
+This reports when a user has seen or clicked a badge/notification in the browser toolbar in a non-PBM window
+
+```
+{
+  "locale": "en-US",
+  "client_id": "9da773d8-4356-f54f-b7cf-6134726bcf3d",
+  "version": "70.0a1",
+  "release_channel": "default",
+  "addon_version": "20190712095934",
+  "action": "cfr_user_event",
+  "source": "CFR",
+  "message_id": "FXA_ACCOUNTS_BADGE",
+  "event": ["CLICK" | "IMPRESSION"],
+}
+```

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -1465,7 +1465,7 @@ class _ASRouter {
     await this._sendMessageToTarget(message, target, trigger);
   }
 
-  handleMessageRequest({ triggerId, template }) {
+  handleMessageRequest({ triggerId, triggerParam, template }) {
     const msgs = this._getUnblockedMessages().filter(m => {
       if (template && m.template !== template) {
         return false;
@@ -1476,7 +1476,11 @@ class _ASRouter {
 
       return true;
     });
-    return this._findMessage(msgs, { id: triggerId });
+
+    return this._findMessage(
+      msgs,
+      triggerId && { id: triggerId, param: triggerParam }
+    );
   }
 
   async setMessageById(id, target, force = true, action = {}) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -783,6 +783,7 @@ class _ASRouter {
     ASRouterPreferences.removeListener(this.onPrefChange);
     ASRouterPreferences.uninit();
     BookmarkPanelHub.uninit();
+    ToolbarBadgeHub.uninit();
 
     // Uninitialise all trigger listeners
     for (const listener of ASRouterTriggerListeners.values()) {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -727,6 +727,7 @@ class _ASRouter {
       handleMessageRequest: this.handleMessageRequest,
       addImpression: this.addImpression,
       blockMessageById: this.blockMessageById,
+      dispatch: this.dispatch,
     });
 
     this._loadLocalProviders();
@@ -1865,6 +1866,7 @@ class _ASRouter {
         await this.addImpression(action.data);
         break;
       case "DOORHANGER_TELEMETRY":
+      case "TOOLBAR_BADGE_TELEMETRY":
         if (this.dispatchToAS) {
           this.dispatchToAS(ac.ASRouterUserEvent(action.data));
         }

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -727,6 +727,7 @@ class _ASRouter {
       handleMessageRequest: this.handleMessageRequest,
       addImpression: this.addImpression,
       blockMessageById: this.blockMessageById,
+      unblockMessageById: this.unblockMessageById,
       dispatch: this.dispatch,
     });
 
@@ -1267,6 +1268,7 @@ class _ASRouter {
         }
         break;
       case "toolbar_badge":
+      case "update_action":
         ToolbarBadgeHub.registerBadgeNotificationListener(message, { force });
         break;
       default:
@@ -1504,6 +1506,17 @@ class _ASRouter {
       this._storage.set("messageBlockList", messageBlockList);
       this._storage.set("messageImpressions", messageImpressions);
       return { messageBlockList, messageImpressions };
+    });
+  }
+
+  unblockMessageById(id) {
+    return this.setState(state => {
+      const messageBlockList = [...state.messageBlockList];
+      const message = state.messages.find(m => m.id === id);
+      const idToUnblock = message && message.campaign ? message.campaign : id;
+      messageBlockList.splice(messageBlockList.indexOf(idToUnblock), 1);
+      this._storage.set("messageBlockList", messageBlockList);
+      return { messageBlockList };
     });
   }
 
@@ -1820,15 +1833,7 @@ class _ASRouter {
         });
         break;
       case "UNBLOCK_MESSAGE_BY_ID":
-        await this.setState(state => {
-          const messageBlockList = [...state.messageBlockList];
-          const message = state.messages.find(m => m.id === action.data.id);
-          const idToUnblock =
-            message && message.campaign ? message.campaign : action.data.id;
-          messageBlockList.splice(messageBlockList.indexOf(idToUnblock), 1);
-          this._storage.set("messageBlockList", messageBlockList);
-          return { messageBlockList };
-        });
+        this.unblockMessageById(action.data.id);
         break;
       case "UNBLOCK_PROVIDER_BY_ID":
         await this.setState(state => {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -744,12 +744,16 @@ class _ASRouter {
       (await this._storage.get("providerImpressions")) || {};
     const previousSessionEnd =
       (await this._storage.get("previousSessionEnd")) || 0;
+    // Infinity so that we default to false (firefoxVersion > previousSessionFirefoxVersion)
+    const previousSessionFirefoxVersion =
+      (await this._storage.get("previousSessionFirefoxVersion")) || Infinity;
     await this.setState({
       messageBlockList,
       providerBlockList,
       messageImpressions,
       providerImpressions,
       previousSessionEnd,
+      previousSessionFirefoxVersion,
     });
     this._updateMessageProviders();
     await this.loadMessagesFromAllProviders();
@@ -769,6 +773,10 @@ class _ASRouter {
 
   uninit() {
     this._storage.set("previousSessionEnd", Date.now());
+    this._storage.set(
+      "previousSessionFirefoxVersion",
+      ASRouterTargeting.Environment.firefoxVersion
+    );
 
     this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
       type: "CLEAR_ALL",
@@ -1028,14 +1036,25 @@ class _ASRouter {
   // Return an object containing targeting parameters used to select messages
   _getMessagesContext() {
     const {
+      messageImpressions,
       previousSessionEnd,
+      previousSessionFirefoxVersion,
       trailheadInterrupt,
       trailheadTriplet,
     } = this.state;
 
     return {
+      get messageImpressions() {
+        return messageImpressions;
+      },
       get previousSessionEnd() {
         return previousSessionEnd;
+      },
+      get previousSessionFirefoxVersion() {
+        // Any comparison with `undefined` will return false
+        return isNaN(previousSessionFirefoxVersion)
+          ? undefined
+          : previousSessionFirefoxVersion;
       },
       get trailheadInterrupt() {
         return trailheadInterrupt;
@@ -1261,7 +1280,7 @@ class _ASRouter {
         }
         break;
       case "toolbar_badge":
-        ToolbarBadgeHub.registerBadgeNotificationListener(message);
+        ToolbarBadgeHub.registerBadgeNotificationListener(message, { force });
         break;
       default:
         target.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -493,6 +493,7 @@ class _ASRouter {
     this._triggerHandler = this._triggerHandler.bind(this);
     this._localProviders = localProviders;
     this.blockMessageById = this.blockMessageById.bind(this);
+    this.unblockMessageById = this.unblockMessageById.bind(this);
     this.onMessage = this.onMessage.bind(this);
     this.handleMessageRequest = this.handleMessageRequest.bind(this);
     this.addImpression = this.addImpression.bind(this);

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -744,16 +744,12 @@ class _ASRouter {
       (await this._storage.get("providerImpressions")) || {};
     const previousSessionEnd =
       (await this._storage.get("previousSessionEnd")) || 0;
-    // Infinity so that we default to false (firefoxVersion > previousSessionFirefoxVersion)
-    const previousSessionFirefoxVersion =
-      (await this._storage.get("previousSessionFirefoxVersion")) || Infinity;
     await this.setState({
       messageBlockList,
       providerBlockList,
       messageImpressions,
       providerImpressions,
       previousSessionEnd,
-      previousSessionFirefoxVersion,
     });
     this._updateMessageProviders();
     await this.loadMessagesFromAllProviders();
@@ -773,10 +769,6 @@ class _ASRouter {
 
   uninit() {
     this._storage.set("previousSessionEnd", Date.now());
-    this._storage.set(
-      "previousSessionFirefoxVersion",
-      ASRouterTargeting.Environment.firefoxVersion
-    );
 
     this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
       type: "CLEAR_ALL",
@@ -1038,7 +1030,6 @@ class _ASRouter {
     const {
       messageImpressions,
       previousSessionEnd,
-      previousSessionFirefoxVersion,
       trailheadInterrupt,
       trailheadTriplet,
     } = this.state;
@@ -1049,12 +1040,6 @@ class _ASRouter {
       },
       get previousSessionEnd() {
         return previousSessionEnd;
-      },
-      get previousSessionFirefoxVersion() {
-        // Any comparison with `undefined` will return false
-        return isNaN(previousSessionFirefoxVersion)
-          ? undefined
-          : previousSessionFirefoxVersion;
       },
       get trailheadInterrupt() {
         return trailheadInterrupt;

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -2,6 +2,9 @@ const { FilterExpressions } = ChromeUtils.import(
   "resource://gre/modules/components-utils/FilterExpressions.jsm"
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const { XPCOMUtils } = ChromeUtils.import(
+  "resource://gre/modules/XPCOMUtils.jsm"
+);
 
 ChromeUtils.defineModuleGetter(
   this,
@@ -42,6 +45,12 @@ ChromeUtils.defineModuleGetter(
   this,
   "AttributionCode",
   "resource:///modules/AttributionCode.jsm"
+);
+XPCOMUtils.defineLazyServiceGetter(
+  this,
+  "UpdateManager",
+  "@mozilla.org/updates/update-manager;1",
+  "nsIUpdateManager"
 );
 
 const FXA_USERNAME_PREF = "services.sync.username";
@@ -399,6 +408,16 @@ const TargetingGetters = {
       "browser.messaging-system.whatsNewPanel.enabled",
       false
     );
+  },
+  get earliestFirefoxVersion() {
+    if (UpdateManager.updateCount) {
+      const earliestFirefoxVersion = UpdateManager.getUpdateAt(
+        UpdateManager.updateCount - 1
+      ).previousAppVersion;
+      return parseInt(earliestFirefoxVersion.match(/\d+/), 10);
+    }
+
+    return null;
   },
 };
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -359,6 +359,12 @@ const TargetingGetters = {
 
     return false;
   },
+  get hasAccessedFxAPanel() {
+    return Services.prefs.getBoolPref(
+      "identity.fxaccounts.toolbar.accessed",
+      true
+    );
+  },
 };
 
 this.ASRouterTargeting = {

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -206,6 +206,35 @@ function sortMessagesByTargeting(messages) {
   });
 }
 
+/**
+ * Sort messages in descending order based on the value of `priority`
+ * Messages with no `priority` are ranked lowest (even after a message with
+ * priority 0).
+ */
+function sortMessagesByPriority(messages) {
+  return messages.sort((a, b) => {
+    if (isNaN(a.priority) && isNaN(b.priority)) {
+      return 0;
+    }
+    if (!isNaN(a.priority) && isNaN(b.priority)) {
+      return -1;
+    }
+    if (isNaN(a.priority) && !isNaN(b.priority)) {
+      return 1;
+    }
+
+    // Descending order; higher priority comes first
+    if (a.priority > b.priority) {
+      return -1;
+    }
+    if (a.priority < b.priority) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
 const TargetingGetters = {
   get locale() {
     return Services.locale.appLocaleAsLangTag;
@@ -365,6 +394,12 @@ const TargetingGetters = {
       true
     );
   },
+  get isWhatsNewPanelEnabled() {
+    return Services.prefs.getBoolPref(
+      "browser.messaging-system.whatsNewPanel.enabled",
+      false
+    );
+  },
 };
 
 this.ASRouterTargeting = {
@@ -471,7 +506,8 @@ this.ASRouterTargeting = {
    */
   async findMatchingMessage({ messages, trigger, context, onError }) {
     const weightSortedMessages = sortMessagesByWeightedRank([...messages]);
-    const sortedMessages = sortMessagesByTargeting(weightSortedMessages);
+    let sortedMessages = sortMessagesByTargeting(weightSortedMessages);
+    sortedMessages = sortMessagesByPriority(sortedMessages);
     const triggerContext = trigger ? trigger.context : {};
     const combinedContext = this.combineContexts(context, triggerContext);
 

--- a/lib/BookmarkPanelHub.jsm
+++ b/lib/BookmarkPanelHub.jsm
@@ -85,7 +85,9 @@ class _BookmarkPanelHub {
     // If we didn't match on a previously cached request then make sure
     // the container is empty
     this._removeContainer(target);
-    const response = await this._handleMessageRequest(this._trigger);
+    const response = await this._handleMessageRequest({
+      triggerId: this._trigger.id,
+    });
 
     return this.onResponse(response, target, win);
   }

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -465,6 +465,16 @@ const ONBOARDING_MESSAGES = async () => [
       "attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",
     trigger: { id: "firstRun" },
   },
+  {
+    id: "FXA_ACCOUNTS_BADGE",
+    template: "toolbar_badge",
+    content: {
+      target: "fxa-toolbar-menu-button",
+    },
+    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
+    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
+    trigger: { id: "toolbarBadgeUpdate" },
+  },
 ];
 
 const OnboardingMessageProvider = {

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -14,6 +14,7 @@ const { AddonRepository } = ChromeUtils.import(
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
+const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
 const L10N = new Localization([
   "branding/brand.ftl",
   "browser/branding/brandings.ftl",
@@ -474,6 +475,27 @@ const ONBOARDING_MESSAGES = async () => [
     // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
     targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
     trigger: { id: "toolbarBadgeUpdate" },
+  },
+  {
+    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
+    template: "toolbar_badge",
+    content: {
+      target: "whats-new-menu-button",
+      action: { id: "show-whatsnew-button" },
+    },
+    priority: 1,
+    trigger: { id: "toolbarBadgeUpdate" },
+    frequency: {
+      // Makes it so that we track impressions for this message while at the
+      // same time it can have unlimited impressions
+      lifetime: Infinity,
+    },
+    // Never saw this message or saw it in the past 4 days or more recent
+    targeting: `isWhatsNewPanelEnabled &&
+      (firefoxVersion > previousSessionFirefoxVersion &&
+        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0) ||
+      (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
+        currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
   },
 ];
 

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -492,8 +492,8 @@ const ONBOARDING_MESSAGES = async () => [
     },
     // Never saw this message or saw it in the past 4 days or more recent
     targeting: `isWhatsNewPanelEnabled &&
-      (firefoxVersion > previousSessionFirefoxVersion &&
-        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0) ||
+      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
+        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
       (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
         currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
   },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -480,6 +480,8 @@ const ONBOARDING_MESSAGES = async () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
+      // delay: 5 * 3600 * 1000,
+      delay: 5000,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
     },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -14,7 +14,6 @@ const { AddonRepository } = ChromeUtils.import(
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
 const L10N = new Localization([
   "branding/brand.ftl",
   "browser/branding/brandings.ftl",
@@ -465,39 +464,6 @@ const ONBOARDING_MESSAGES = async () => [
     targeting:
       "attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",
     trigger: { id: "firstRun" },
-  },
-  {
-    id: "FXA_ACCOUNTS_BADGE",
-    template: "toolbar_badge",
-    content: {
-      target: "fxa-toolbar-menu-button",
-    },
-    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
-    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
-    trigger: { id: "toolbarBadgeUpdate" },
-  },
-  {
-    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
-    template: "toolbar_badge",
-    content: {
-      // delay: 5 * 3600 * 1000,
-      delay: 5000,
-      target: "whats-new-menu-button",
-      action: { id: "show-whatsnew-button" },
-    },
-    priority: 1,
-    trigger: { id: "toolbarBadgeUpdate" },
-    frequency: {
-      // Makes it so that we track impressions for this message while at the
-      // same time it can have unlimited impressions
-      lifetime: Infinity,
-    },
-    // Never saw this message or saw it in the past 4 days or more recent
-    targeting: `isWhatsNewPanelEnabled &&
-      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
-        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
-      (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
-        currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
   },
 ];
 

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -6,6 +6,7 @@
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
+const TWO_DAYS = 2 * 24 * 3600 * 1000;
 
 const MESSAGES = () => [
   {
@@ -59,6 +60,21 @@ const MESSAGES = () => [
     // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
     targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
     trigger: { id: "toolbarBadgeUpdate" },
+  },
+  {
+    id: "WNP_THANK_YOU",
+    template: "update_action",
+    content: {
+      action: {
+        id: "moments-wnp",
+        data: {
+          url:
+            "https://www.mozilla.org/%LOCALE%/etc/firefox/retention/thank-you-a/",
+          expireDelta: TWO_DAYS,
+        },
+      },
+    },
+    trigger: { id: "momentsUpdate" },
   },
   {
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
+
 const MESSAGES = () => [
   {
     id: "SIMPLE_FXA_BOOKMARK_TEST_FLUENT",
@@ -45,6 +49,39 @@ const MESSAGES = () => [
       },
     },
     trigger: { id: "bookmark-panel" },
+  },
+  {
+    id: "FXA_ACCOUNTS_BADGE",
+    template: "toolbar_badge",
+    content: {
+      target: "fxa-toolbar-menu-button",
+    },
+    // Never accessed the FxA panel && doesn't use Firefox sync & has FxA enabled
+    targeting: `!hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true`,
+    trigger: { id: "toolbarBadgeUpdate" },
+  },
+  {
+    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
+    template: "toolbar_badge",
+    content: {
+      // delay: 5 * 3600 * 1000,
+      delay: 5000,
+      target: "whats-new-menu-button",
+      action: { id: "show-whatsnew-button" },
+    },
+    priority: 1,
+    trigger: { id: "toolbarBadgeUpdate" },
+    frequency: {
+      // Makes it so that we track impressions for this message while at the
+      // same time it can have unlimited impressions
+      lifetime: Infinity,
+    },
+    // Never saw this message or saw it in the past 4 days or more recent
+    targeting: `isWhatsNewPanelEnabled &&
+      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
+        messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length == 0 ||
+      (messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
+        currentDate|date - messageImpressions[.id == 'WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000)`,
   },
 ];
 

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -28,7 +28,19 @@ ChromeUtils.defineModuleGetter(
   "PrivateBrowsingUtils",
   "resource://gre/modules/PrivateBrowsingUtils.jsm"
 );
+ChromeUtils.defineModuleGetter(
+  this,
+  "setInterval",
+  "resource://gre/modules/Timer.jsm"
+);
+ChromeUtils.defineModuleGetter(
+  this,
+  "clearInterval",
+  "resource://gre/modules/Timer.jsm"
+);
 
+// Frequency at which to check for new messages
+const SYSTEM_TICK_INTERVAL = 5 * 60 * 1000;
 const notificationsByWindow = new WeakMap();
 
 class _ToolbarBadgeHub {
@@ -38,6 +50,7 @@ class _ToolbarBadgeHub {
     this.state = null;
     this.prefs = {
       WHATSNEW_TOOLBAR_PANEL: "browser.messaging-system.whatsNewPanel.enabled",
+      HOMEPAGE_OVERRIDE_PREF: "browser.startup.homepage_override.once",
     };
     this.removeAllNotifications = this.removeAllNotifications.bind(this);
     this.removeToolbarNotification = this.removeToolbarNotification.bind(this);
@@ -45,6 +58,7 @@ class _ToolbarBadgeHub {
     this.registerBadgeToAllWindows = this.registerBadgeToAllWindows.bind(this);
     this._sendTelemetry = this._sendTelemetry.bind(this);
     this.sendUserEventTelemetry = this.sendUserEventTelemetry.bind(this);
+    this.checkHomepageOverridePref = this.checkHomepageOverridePref.bind(this);
 
     this._handleMessageRequest = null;
     this._addImpression = null;
@@ -54,18 +68,56 @@ class _ToolbarBadgeHub {
 
   async init(
     waitForInitialized,
-    { handleMessageRequest, addImpression, blockMessageById, dispatch }
+    {
+      handleMessageRequest,
+      addImpression,
+      blockMessageById,
+      unblockMessageById,
+      dispatch,
+    }
   ) {
     this._handleMessageRequest = handleMessageRequest;
     this._blockMessageById = blockMessageById;
+    this._unblockMessageById = unblockMessageById;
     this._addImpression = addImpression;
     this._dispatch = dispatch;
-    this.state = {};
     // Need to wait for ASRouter to initialize before trying to fetch messages
     await waitForInitialized;
     this.messageRequest("toolbarBadgeUpdate");
     // Listen for pref changes that could trigger new badges
     Services.prefs.addObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
+    const _intervalId = setInterval(
+      () => this.checkHomepageOverridePref(),
+      SYSTEM_TICK_INTERVAL
+    );
+    this.state = { _intervalId };
+  }
+
+  /**
+   * Pref is set via Remote Settings message. We want to continously
+   * monitor new messages that come in to ensure the one with the
+   * highest priority is set.
+   */
+  checkHomepageOverridePref() {
+    const prefValue = Services.prefs.getStringPref(
+      this.prefs.HOMEPAGE_OVERRIDE_PREF,
+      ""
+    );
+    if (prefValue) {
+      // If the pref is set it means the user has not yet seen this message.
+      // We clear the pref value and re-evaluate all possible messages to ensure
+      // we don't have a higher priority message to show.
+      Services.prefs.clearUserPref(this.prefs.HOMEPAGE_OVERRIDE_PREF);
+      let message_id;
+      try {
+        message_id = JSON.parse(prefValue).message_id;
+      } catch (e) {}
+      if (message_id) {
+        this._unblockMessageById(message_id);
+      }
+    }
+
+    this.messageRequest("momentsUpdate");
   }
 
   observe(aSubject, aTopic, aPrefName) {
@@ -76,11 +128,33 @@ class _ToolbarBadgeHub {
     }
   }
 
-  executeAction({ id }) {
+  executeAction({ id, data, message_id }) {
     switch (id) {
-      case "show-whatsnew-button":
+      case "moments-wnp":
+        const { url, expireDelta } = data;
+        let { expire } = data;
+        if (!expire) {
+          expire = this.getExpirationDate(expireDelta);
+        }
+        Services.prefs.setStringPref(
+          this.prefs.HOMEPAGE_OVERRIDE_PREF,
+          JSON.stringify({ message_id, url, expire })
+        );
+        // Block immediately after taking the action
+        this._blockMessageById(message_id);
         break;
     }
+  }
+
+  /**
+   * If we don't have `expire` defined with the message it could be because
+   * it depends on user dependent parameters. Since the message matched
+   * targeting we calculate `expire` based on the current timestamp and the
+   * `expireDelta` which defines for how long it should be available.
+   * @param expireDelta {number} - Offset in milliseconds from the current date
+   */
+  getExpirationDate(expireDelta) {
+    return Date.now() + expireDelta;
   }
 
   _clearBadgeTimeout() {
@@ -142,7 +216,7 @@ class _ToolbarBadgeHub {
   addToolbarNotification(win, message) {
     const document = win.browser.ownerDocument;
     if (message.content.action) {
-      this.executeAction(message.content.action);
+      this.executeAction({ ...message.content.action, message_id: message.id });
     }
     let toolbarbutton = document.getElementById(message.content.target);
     if (toolbarbutton) {
@@ -187,7 +261,9 @@ class _ToolbarBadgeHub {
       },
       win => {
         const el = notificationsByWindow.get(win);
-        this.removeToolbarNotification(el);
+        if (el) {
+          this.removeToolbarNotification(el);
+        }
         notificationsByWindow.delete(win);
       }
     );
@@ -245,6 +321,7 @@ class _ToolbarBadgeHub {
 
   uninit() {
     this._clearBadgeTimeout();
+    clearInterval(this.state._intervalId);
     this.state = null;
     Services.prefs.removeObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
   }

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+ChromeUtils.defineModuleGetter(
+  this,
+  "EveryWindow",
+  "resource:///modules/EveryWindow.jsm"
+);
+
+const notificationsByWindow = new WeakMap();
+
+class _ToolbarBadgeHub {
+  constructor() {
+    this.id = "toolbar-badge-hub";
+    this.template = "toolbar_badge";
+    this.state = null;
+    this.removeAllNotifications = this.removeAllNotifications.bind(this);
+    this.removeToolbarNotification = this.removeToolbarNotification.bind(this);
+    this.addToolbarNotification = this.addToolbarNotification.bind(this);
+
+    this._handleMessageRequest = null;
+    this._addImpression = null;
+    this._blockMessageById = null;
+  }
+
+  async init(
+    waitForInitialized,
+    { handleMessageRequest, addImpression, blockMessageById }
+  ) {
+    this._handleMessageRequest = handleMessageRequest;
+    this._blockMessageById = blockMessageById;
+    this._addImpression = addImpression;
+    // Need to wait for ASRouter to initialize before trying to fetch messages
+    await waitForInitialized;
+    this.messageRequest("toolbarBadgeUpdate");
+  }
+
+  removeAllNotifications() {
+    // Will call uninit on every window
+    EveryWindow.unregisterCallback(this.id);
+    this._blockMessageById(this.state.notification.id);
+    this.state = null;
+  }
+
+  removeToolbarNotification(toolbarButton) {
+    toolbarButton
+      .querySelector(".toolbarbutton-badge")
+      .removeAttribute("value");
+    toolbarButton.removeAttribute("badged");
+  }
+
+  addToolbarNotification(win, message) {
+    const document = win.browser.ownerDocument;
+    let toolbarbutton = document.getElementById(message.content.target);
+    if (toolbarbutton) {
+      toolbarbutton.setAttribute("badged", true);
+      toolbarbutton
+        .querySelector(".toolbarbutton-badge")
+        .setAttribute("value", "x");
+
+      toolbarbutton.addEventListener("click", this.removeAllNotifications, {
+        once: true,
+      });
+      this.state = { notification: { id: message.id } };
+
+      return toolbarbutton;
+    }
+
+    return null;
+  }
+
+  registerBadgeNotificationListener(message) {
+    this._addImpression(message);
+
+    EveryWindow.registerCallback(
+      this.id,
+      win => {
+        if (notificationsByWindow.has(win)) {
+          // nothing to do
+          return;
+        }
+        const el = this.addToolbarNotification(win, message);
+        notificationsByWindow.set(win, el);
+      },
+      win => {
+        const el = notificationsByWindow.get(win);
+        this.removeToolbarNotification(el);
+        notificationsByWindow.delete(win);
+      }
+    );
+  }
+
+  async messageRequest(triggerId) {
+    const message = await this._handleMessageRequest({
+      triggerId,
+      template: this.template,
+    });
+    if (message) {
+      this.registerBadgeNotificationListener(message);
+    }
+  }
+}
+
+this._ToolbarBadgeHub = _ToolbarBadgeHub;
+
+/**
+ * ToolbarBadgeHub - singleton instance of _ToolbarBadgeHub that can initiate
+ * message requests and render messages.
+ */
+this.ToolbarBadgeHub = new _ToolbarBadgeHub();
+
+const EXPORTED_SYMBOLS = ["ToolbarBadgeHub", "_ToolbarBadgeHub"];

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -98,7 +98,10 @@ class _ToolbarBadgeHub {
   removeToolbarNotification(toolbarButton) {
     toolbarButton
       .querySelector(".toolbarbutton-badge")
-      .removeAttribute("value");
+      .classList.remove("feature-callout");
+    toolbarButton
+      .querySelector(".toolbarbutton-icon")
+      .classList.add("feature-callout");
     toolbarButton.removeAttribute("badged");
   }
 
@@ -112,7 +115,10 @@ class _ToolbarBadgeHub {
       toolbarbutton.setAttribute("badged", true);
       toolbarbutton
         .querySelector(".toolbarbutton-badge")
-        .setAttribute("value", "x");
+        .classList.add("feature-callout");
+      toolbarbutton
+        .querySelector(".toolbarbutton-icon")
+        .classList.add("feature-callout");
 
       // `mousedown` event required because of the `onmousedown` defined on
       // the button that prevents `click` events from firing

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -243,16 +243,16 @@ class _ToolbarBadgeHub {
   }
 
   registerBadgeToAllWindows(message) {
-    // Impression should be added when the badge becomes visible
-    this._addImpression(message);
-    // Send a telemetry ping when adding the notification badge
-    this.sendUserEventTelemetry("IMPRESSION", message);
-
     if (message.template === "update_action") {
       this.executeAction({ ...message.content.action, message_id: message.id });
       // No badge to set only an action to execute
       return;
     }
+
+    // Impression should be added when the badge becomes visible
+    this._addImpression(message);
+    // Send a telemetry ping when adding the notification badge
+    this.sendUserEventTelemetry("IMPRESSION", message);
 
     EveryWindow.registerCallback(
       this.id,

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -46,7 +46,6 @@ const notificationsByWindow = new WeakMap();
 class _ToolbarBadgeHub {
   constructor() {
     this.id = "toolbar-badge-hub";
-    this.template = "toolbar_badge";
     this.state = null;
     this.prefs = {
       WHATSNEW_TOOLBAR_PANEL: "browser.messaging-system.whatsNewPanel.enabled",
@@ -83,7 +82,10 @@ class _ToolbarBadgeHub {
     this._dispatch = dispatch;
     // Need to wait for ASRouter to initialize before trying to fetch messages
     await waitForInitialized;
-    this.messageRequest("toolbarBadgeUpdate");
+    this.messageRequest({
+      triggerId: "toolbarBadgeUpdate",
+      template: "toolbar_badge",
+    });
     // Listen for pref changes that could trigger new badges
     Services.prefs.addObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
     const _intervalId = setInterval(
@@ -117,13 +119,19 @@ class _ToolbarBadgeHub {
       }
     }
 
-    this.messageRequest("momentsUpdate");
+    this.messageRequest({
+      triggerId: "momentsUpdate",
+      template: "update_action",
+    });
   }
 
   observe(aSubject, aTopic, aPrefName) {
     switch (aPrefName) {
       case this.prefs.WHATSNEW_TOOLBAR_PANEL:
-        this.messageRequest("toolbarBadgeUpdate");
+        this.messageRequest({
+          triggerId: "toolbarBadgeUpdate",
+          template: "toolbar_badge",
+        });
         break;
     }
   }
@@ -249,6 +257,12 @@ class _ToolbarBadgeHub {
     // Send a telemetry ping when adding the notification badge
     this.sendUserEventTelemetry("IMPRESSION", message);
 
+    if (message.template === "update_action") {
+      this.executeAction({ ...message.content.action, message_id: message.id });
+      // No badge to set only an action to execute
+      return;
+    }
+
     EveryWindow.registerCallback(
       this.id,
       win => {
@@ -285,10 +299,10 @@ class _ToolbarBadgeHub {
     }
   }
 
-  async messageRequest(triggerId) {
+  async messageRequest({ triggerId, template }) {
     const message = await this._handleMessageRequest({
       triggerId,
-      template: this.template,
+      template,
     });
     if (message) {
       this.registerBadgeNotificationListener(message);

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -96,12 +96,14 @@ class _ToolbarBadgeHub {
   }
 
   removeToolbarNotification(toolbarButton) {
+    // Remove it from the element that displays the badge
     toolbarButton
       .querySelector(".toolbarbutton-badge")
       .classList.remove("feature-callout");
+    // Remove it from the toolbar icon
     toolbarButton
       .querySelector(".toolbarbutton-icon")
-      .classList.add("feature-callout");
+      .classList.remove("feature-callout");
     toolbarButton.removeAttribute("badged");
   }
 
@@ -116,6 +118,8 @@ class _ToolbarBadgeHub {
       toolbarbutton
         .querySelector(".toolbarbutton-badge")
         .classList.add("feature-callout");
+      // This creates the cut-out effect for the icon where the notification
+      // fits in
       toolbarbutton
         .querySelector(".toolbarbutton-icon")
         .classList.add("feature-callout");

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -214,10 +214,6 @@ class _ToolbarBadgeHub {
     toolbarButton
       .querySelector(".toolbarbutton-badge")
       .classList.remove("feature-callout");
-    // Remove it from the toolbar icon
-    toolbarButton
-      .querySelector(".toolbarbutton-icon")
-      .classList.remove("feature-callout");
     toolbarButton.removeAttribute("badged");
   }
 
@@ -231,11 +227,6 @@ class _ToolbarBadgeHub {
       toolbarbutton.setAttribute("badged", true);
       toolbarbutton
         .querySelector(".toolbarbutton-badge")
-        .classList.add("feature-callout");
-      // This creates the cut-out effect for the icon where the notification
-      // fits in
-      toolbarbutton
-        .querySelector(".toolbarbutton-icon")
         .classList.add("feature-callout");
 
       // `mousedown` event required because of the `onmousedown` defined on

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -37,6 +37,13 @@ class _ToolbarBadgeHub {
     this.messageRequest("toolbarBadgeUpdate");
   }
 
+  executeAction({ id }) {
+    switch (id) {
+      case "show-whatsnew-button":
+        break;
+    }
+  }
+
   removeAllNotifications() {
     // Will call uninit on every window
     EveryWindow.unregisterCallback(this.id);
@@ -53,6 +60,9 @@ class _ToolbarBadgeHub {
 
   addToolbarNotification(win, message) {
     const document = win.browser.ownerDocument;
+    if (message.content.action) {
+      this.executeAction(message.content.action);
+    }
     let toolbarbutton = document.getElementById(message.content.target);
     if (toolbarbutton) {
       toolbarbutton.setAttribute("badged", true);
@@ -71,8 +81,14 @@ class _ToolbarBadgeHub {
     return null;
   }
 
-  registerBadgeNotificationListener(message) {
+  registerBadgeNotificationListener(message, options = {}) {
     this._addImpression(message);
+
+    // We need to clear any existing notifications and only show
+    // the one set by devtools
+    if (options.force) {
+      EveryWindow.unregisterCallback(this.id);
+    }
 
     EveryWindow.registerCallback(
       this.id,

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -18,6 +18,16 @@ ChromeUtils.defineModuleGetter(
   "clearTimeout",
   "resource://gre/modules/Timer.jsm"
 );
+ChromeUtils.defineModuleGetter(
+  this,
+  "Services",
+  "resource://gre/modules/Services.jsm"
+);
+ChromeUtils.defineModuleGetter(
+  this,
+  "PrivateBrowsingUtils",
+  "resource://gre/modules/PrivateBrowsingUtils.jsm"
+);
 
 const notificationsByWindow = new WeakMap();
 
@@ -30,19 +40,23 @@ class _ToolbarBadgeHub {
     this.removeToolbarNotification = this.removeToolbarNotification.bind(this);
     this.addToolbarNotification = this.addToolbarNotification.bind(this);
     this.registerBadgeToAllWindows = this.registerBadgeToAllWindows.bind(this);
+    this._sendTelemetry = this._sendTelemetry.bind(this);
+    this.sendUserEventTelemetry = this.sendUserEventTelemetry.bind(this);
 
     this._handleMessageRequest = null;
     this._addImpression = null;
     this._blockMessageById = null;
+    this._dispatch = null;
   }
 
   async init(
     waitForInitialized,
-    { handleMessageRequest, addImpression, blockMessageById }
+    { handleMessageRequest, addImpression, blockMessageById, dispatch }
   ) {
     this._handleMessageRequest = handleMessageRequest;
     this._blockMessageById = blockMessageById;
     this._addImpression = addImpression;
+    this._dispatch = dispatch;
     this.state = {};
     // Need to wait for ASRouter to initialize before trying to fetch messages
     await waitForInitialized;
@@ -85,6 +99,11 @@ class _ToolbarBadgeHub {
         this.removeAllNotifications
       );
       event.target.removeEventListener("click", this.removeAllNotifications);
+      // If we have an event it means the user interacted with the badge
+      // we should send telemetry
+      if (this.state.notification) {
+        this.sendUserEventTelemetry("CLICK", this.state.notification);
+      }
     }
     // Will call uninit on every window
     EveryWindow.unregisterCallback(this.id);
@@ -140,6 +159,8 @@ class _ToolbarBadgeHub {
   registerBadgeToAllWindows(message) {
     // Impression should be added when the badge becomes visible
     this._addImpression(message);
+    // Send a telemetry ping when adding the notification badge
+    this.sendUserEventTelemetry("IMPRESSION", message);
 
     EveryWindow.registerCallback(
       this.id,
@@ -182,6 +203,30 @@ class _ToolbarBadgeHub {
     });
     if (message) {
       this.registerBadgeNotificationListener(message);
+    }
+  }
+
+  _sendTelemetry(ping) {
+    this._dispatch({
+      type: "TOOLBAR_BADGE_TELEMETRY",
+      data: { action: "cfr_user_event", source: "CFR", ...ping },
+    });
+  }
+
+  sendUserEventTelemetry(event, message) {
+    const win = Services.wm.getMostRecentWindow("navigator:browser");
+    // Only send pings for non private browsing windows
+    if (
+      win &&
+      !PrivateBrowsingUtils.isBrowserPrivate(
+        win.ownerGlobal.gBrowser.selectedBrowser
+      )
+    ) {
+      this._sendTelemetry({
+        message_id: message.id,
+        bucket_id: message.id,
+        event,
+      });
     }
   }
 

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -41,7 +41,7 @@ ChromeUtils.defineModuleGetter(
 
 // Frequency at which to check for new messages
 const SYSTEM_TICK_INTERVAL = 5 * 60 * 1000;
-const notificationsByWindow = new WeakMap();
+let notificationsByWindow = new WeakMap();
 
 class _ToolbarBadgeHub {
   constructor() {
@@ -328,6 +328,7 @@ class _ToolbarBadgeHub {
     this._clearBadgeTimeout();
     clearInterval(this.state._intervalId);
     this.state = null;
+    notificationsByWindow = new WeakMap();
     Services.prefs.removeObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
   }
 }

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -36,6 +36,9 @@ class _ToolbarBadgeHub {
     this.id = "toolbar-badge-hub";
     this.template = "toolbar_badge";
     this.state = null;
+    this.prefs = {
+      WHATSNEW_TOOLBAR_PANEL: "browser.messaging-system.whatsNewPanel.enabled",
+    };
     this.removeAllNotifications = this.removeAllNotifications.bind(this);
     this.removeToolbarNotification = this.removeToolbarNotification.bind(this);
     this.addToolbarNotification = this.addToolbarNotification.bind(this);
@@ -61,6 +64,16 @@ class _ToolbarBadgeHub {
     // Need to wait for ASRouter to initialize before trying to fetch messages
     await waitForInitialized;
     this.messageRequest("toolbarBadgeUpdate");
+    // Listen for pref changes that could trigger new badges
+    Services.prefs.addObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
+  }
+
+  observe(aSubject, aTopic, aPrefName) {
+    switch (aPrefName) {
+      case this.prefs.WHATSNEW_TOOLBAR_PANEL:
+        this.messageRequest("toolbarBadgeUpdate");
+        break;
+    }
   }
 
   executeAction({ id }) {
@@ -233,6 +246,7 @@ class _ToolbarBadgeHub {
   uninit() {
     this._clearBadgeTimeout();
     this.state = null;
+    Services.prefs.removeObserver(this.prefs.WHATSNEW_TOOLBAR_PANEL, this);
   }
 }
 

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -823,6 +823,22 @@ add_task(async function check_hasAccessedFxAPanel() {
   );
 });
 
+add_task(async function check_isWhatsNewPanelEnabled() {
+  is(
+    await ASRouterTargeting.Environment.isWhatsNewPanelEnabled,
+    false,
+    "Not enabled yet"
+  );
+
+  await pushPrefs(["browser.messaging-system.whatsNewPanel.enabled", true]);
+
+  is(
+    await ASRouterTargeting.Environment.isWhatsNewPanelEnabled,
+    true,
+    "Should update based on pref"
+  );
+});
+
 add_task(async function checkCFRPinnedTabsTargetting() {
   const now = Date.now();
   const timeMinutesAgo = numMinutes => now - numMinutes * 60 * 1000;

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -807,6 +807,22 @@ add_task(async function check_pinned_tabs() {
   );
 });
 
+add_task(async function check_hasAccessedFxAPanel() {
+  is(
+    await ASRouterTargeting.Environment.hasAccessedFxAPanel,
+    false,
+    "Not accessed yet"
+  );
+
+  await pushPrefs(["identity.fxaccounts.toolbar.accessed", true]);
+
+  is(
+    await ASRouterTargeting.Environment.hasAccessedFxAPanel,
+    true,
+    "Should detect panel access"
+  );
+});
+
 add_task(async function checkCFRPinnedTabsTargetting() {
   const now = Date.now();
   const timeMinutesAgo = numMinutes => now - numMinutes * 60 * 1000;

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -200,6 +200,7 @@ describe("ASRouter", () => {
           addImpression: Router.addImpression,
           blockMessageById: Router.blockMessageById,
           dispatch: Router.dispatch,
+          unblockMessageById: Router.unblockMessageById,
         }
       );
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -66,6 +66,7 @@ describe("ASRouter", () => {
   let dispatchStub;
   let fakeAttributionCode;
   let FakeBookmarkPanelHub;
+  let FakeToolbarBadgeHub;
 
   function createFakeStorage() {
     const getStub = sandbox.stub();
@@ -139,6 +140,10 @@ describe("ASRouter", () => {
       uninit: sandbox.stub(),
       _forceShowMessage: sandbox.stub(),
     };
+    FakeToolbarBadgeHub = {
+      init: sandbox.stub(),
+      registerBadgeNotificationListener: sandbox.stub(),
+    };
     globals.set({
       AttributionCode: fakeAttributionCode,
       // Testing framework doesn't know how to `defineLazyModuleGetter` so we're
@@ -146,6 +151,7 @@ describe("ASRouter", () => {
       SnippetsTestMessageProvider,
       PanelTestProvider,
       BookmarkPanelHub: FakeBookmarkPanelHub,
+      ToolbarBadgeHub: FakeToolbarBadgeHub,
     });
     await createRouterAndInit();
   });
@@ -409,6 +415,75 @@ describe("ASRouter", () => {
         targetStub.sendAsyncMessage.firstCall.args[1].data.evaluationStatus
           .success
       );
+    });
+  });
+
+  describe("#routeMessageToTarget", () => {
+    let target;
+    beforeEach(() => {
+      sandbox.stub(CFRPageActions, "forceRecommendation");
+      sandbox.stub(CFRPageActions, "addRecommendation");
+      target = { sendAsyncMessage: sandbox.stub() };
+    });
+    it("should route toolbar_badge message to the right hub", () => {
+      Router.routeMessageToTarget({ template: "toolbar_badge" }, target);
+
+      assert.calledOnce(FakeToolbarBadgeHub.registerBadgeNotificationListener);
+      assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(CFRPageActions.addRecommendation);
+      assert.notCalled(CFRPageActions.forceRecommendation);
+      assert.notCalled(target.sendAsyncMessage);
+    });
+    it("should route fxa_bookmark_panel message to the right hub force = true", () => {
+      Router.routeMessageToTarget(
+        { template: "fxa_bookmark_panel" },
+        target,
+        {},
+        true
+      );
+
+      assert.calledOnce(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
+      assert.notCalled(CFRPageActions.addRecommendation);
+      assert.notCalled(CFRPageActions.forceRecommendation);
+      assert.notCalled(target.sendAsyncMessage);
+    });
+    it("should route cfr_doorhanger message to the right hub force = false", () => {
+      Router.routeMessageToTarget(
+        { template: "cfr_doorhanger" },
+        target,
+        { param: {} },
+        false
+      );
+
+      assert.calledOnce(CFRPageActions.addRecommendation);
+      assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
+      assert.notCalled(CFRPageActions.forceRecommendation);
+      assert.notCalled(target.sendAsyncMessage);
+    });
+    it("should route cfr_doorhanger message to the right hub force = true", () => {
+      Router.routeMessageToTarget(
+        { template: "cfr_doorhanger" },
+        target,
+        {},
+        true
+      );
+
+      assert.calledOnce(CFRPageActions.forceRecommendation);
+      assert.notCalled(CFRPageActions.addRecommendation);
+      assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
+      assert.notCalled(target.sendAsyncMessage);
+    });
+    it("should route default to sending to content", () => {
+      Router.routeMessageToTarget({ template: "snippets" }, target, {}, true);
+
+      assert.calledOnce(target.sendAsyncMessage);
+      assert.notCalled(CFRPageActions.forceRecommendation);
+      assert.notCalled(CFRPageActions.addRecommendation);
+      assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
     });
   });
 
@@ -691,18 +766,47 @@ describe("ASRouter", () => {
 
   describe("#handleMessageRequest", () => {
     it("should get unblocked messages that match the trigger", async () => {
-      const message = {
+      const message1 = {
         id: "1",
         campaign: "foocampaign",
         trigger: { id: "foo" },
       };
-      await Router.setState({ messages: [message] });
+      const message2 = {
+        id: "2",
+        campaign: "foocampaign",
+        trigger: { id: "bar" },
+      };
+      await Router.setState({ messages: [message2, message1] });
       // Just return the first message provided as arg
       sandbox.stub(Router, "_findMessage").callsFake(messages => messages[0]);
 
-      const result = Router.handleMessageRequest({ id: "foo" });
+      const result = Router.handleMessageRequest({ triggerId: "foo" });
 
-      assert.deepEqual(result, message);
+      assert.deepEqual(result, message1);
+    });
+    it("should get unblocked messages that match trigger and template", async () => {
+      const message1 = {
+        id: "1",
+        campaign: "foocampaign",
+        template: "badge",
+        trigger: { id: "foo" },
+      };
+      const message2 = {
+        id: "2",
+        campaign: "foocampaign",
+        template: "snippet",
+        trigger: { id: "foo" },
+      };
+      await Router.setState({ messages: [message2, message1] });
+      // Just return the first message provided as arg
+      sandbox.stub(Router, "_findMessage").callsFake(messages => messages[0]);
+
+      const result = Router.handleMessageRequest({
+        triggerId: "foo",
+        template: "badge",
+      });
+
+      assert.deepEqual(result, message1);
     });
   });
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -199,6 +199,7 @@ describe("ASRouter", () => {
           handleMessageRequest: Router.handleMessageRequest,
           addImpression: Router.addImpression,
           blockMessageById: Router.blockMessageById,
+          dispatch: Router.dispatch,
         }
       );
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -60,7 +60,6 @@ describe("ASRouter", () => {
   let messageImpressions;
   let providerImpressions;
   let previousSessionEnd;
-  let previousSessionFirefoxVersion;
   let fetchStub;
   let clock;
   let getStringPrefStub;
@@ -87,9 +86,6 @@ describe("ASRouter", () => {
     getStub
       .withArgs("previousSessionEnd")
       .returns(Promise.resolve(previousSessionEnd));
-    getStub
-      .withArgs("previousSessionFirefoxVersion")
-      .returns(Promise.resolve(previousSessionFirefoxVersion));
     return {
       get: getStub,
       set: sandbox.stub().returns(Promise.resolve()),
@@ -116,7 +112,6 @@ describe("ASRouter", () => {
     messageImpressions = {};
     providerImpressions = {};
     previousSessionEnd = 100;
-    previousSessionFirefoxVersion = 69;
     sandbox = sinon.createSandbox();
 
     sandbox.spy(ASRouterPreferences, "init");
@@ -837,13 +832,6 @@ describe("ASRouter", () => {
 
       assert.deepEqual(result, message1);
     });
-    it("should have previousSessionFirefoxVersion in the message context", () => {
-      assert.propertyVal(
-        Router._getMessagesContext(),
-        "previousSessionFirefoxVersion",
-        parseInt(AppConstants.MOZ_APP_VERSION, 10)
-      );
-    });
     it("should have messageImpressions in the message context", () => {
       assert.propertyVal(
         Router._getMessagesContext(),
@@ -934,15 +922,10 @@ describe("ASRouter", () => {
     it("should save previousSessionEnd", () => {
       Router.uninit();
 
-      assert.calledTwice(Router._storage.set);
+      assert.calledOnce(Router._storage.set);
       assert.calledWithExactly(
         Router._storage.set,
         "previousSessionEnd",
-        sinon.match.number
-      );
-      assert.calledWithExactly(
-        Router._storage.set,
-        "previousSessionFirefoxVersion",
         sinon.match.number
       );
     });

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -915,6 +915,30 @@ describe("ASRouter", () => {
       assert.calledOnce(targetStub.sendAsyncMessage);
       assert.equal(Router.state.lastMessageId, null);
     });
+    it("should forward trigger param info", async () => {
+      const trigger = { triggerId: "foo", triggerParam: "bar" };
+      const message1 = {
+        id: "1",
+        campaign: "foocampaign",
+        trigger: { id: "foo" },
+      };
+      const message2 = {
+        id: "2",
+        campaign: "foocampaign",
+        trigger: { id: "bar" },
+      };
+      await Router.setState({ messages: [message2, message1] });
+      // Just return the first message provided as arg
+      const stub = sandbox.stub(Router, "_findMessage");
+
+      Router.handleMessageRequest(trigger);
+
+      assert.calledOnce(stub);
+      assert.calledWithExactly(stub, sinon.match.array, {
+        id: trigger.triggerId,
+        param: trigger.triggerParam,
+      });
+    });
   });
 
   describe("#uninit", () => {

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -142,6 +142,7 @@ describe("ASRouter", () => {
     };
     FakeToolbarBadgeHub = {
       init: sandbox.stub(),
+      uninit: sandbox.stub(),
       registerBadgeNotificationListener: sandbox.stub(),
     };
     globals.set({
@@ -184,6 +185,29 @@ describe("ASRouter", () => {
       await Router.init(channel, createFakeStorage(), dispatchStub);
 
       assert.deepEqual(Router.state.messageBlockList, ["foo"]);
+    });
+    it("should initialize all the hub providers", async () => {
+      // ASRouter init called in `beforeEach` block above
+
+      assert.calledOnce(FakeToolbarBadgeHub.init);
+      assert.calledOnce(FakeBookmarkPanelHub.init);
+
+      assert.calledWithExactly(
+        FakeToolbarBadgeHub.init,
+        Router.waitForInitialized,
+        {
+          handleMessageRequest: Router.handleMessageRequest,
+          addImpression: Router.addImpression,
+          blockMessageById: Router.blockMessageById,
+        }
+      );
+
+      assert.calledWithExactly(
+        FakeBookmarkPanelHub.init,
+        Router.handleMessageRequest,
+        Router.addImpression,
+        Router.dispatch
+      );
     });
     it("should set state.messageImpressions to the messageImpressions object in persistent storage", async () => {
       // Note that messageImpressions are only kept if a message exists in router and has a .frequency property,

--- a/test/unit/asrouter/ASRouterFeed.test.js
+++ b/test/unit/asrouter/ASRouterFeed.test.js
@@ -27,6 +27,7 @@ describe("ASRouterFeed", () => {
     globals.set("ToolbarBadgeHub", FakeToolbarBadgeHub);
 
     Router = new _ASRouter({ providers: [FAKE_LOCAL_PROVIDER] });
+
     storage = {
       get: sandbox.stub().returns(Promise.resolve([])),
       set: sandbox.stub().returns(Promise.resolve()),

--- a/test/unit/asrouter/ASRouterFeed.test.js
+++ b/test/unit/asrouter/ASRouterFeed.test.js
@@ -12,6 +12,7 @@ describe("ASRouterFeed", () => {
   let storage;
   let globals;
   let FakeBookmarkPanelHub;
+  let FakeToolbarBadgeHub;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     globals = new GlobalOverrider();
@@ -19,7 +20,11 @@ describe("ASRouterFeed", () => {
       init: sandbox.stub(),
       uninit: sandbox.stub(),
     };
+    FakeToolbarBadgeHub = {
+      init: sandbox.stub(),
+    };
     globals.set("BookmarkPanelHub", FakeBookmarkPanelHub);
+    globals.set("ToolbarBadgeHub", FakeToolbarBadgeHub);
 
     Router = new _ASRouter({ providers: [FAKE_LOCAL_PROVIDER] });
     storage = {

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -4,7 +4,7 @@ const messages = PanelTestProvider.getMessages();
 
 describe("PanelTestProvider", () => {
   it("should have a message", () => {
-    assert.lengthOf(messages, 2);
+    assert.lengthOf(messages, 4);
   });
   it("should be a valid message", () => {
     assert.jsonSchema(messages[0].content, schema);

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -1,12 +1,28 @@
 import { PanelTestProvider } from "lib/PanelTestProvider.jsm";
 import schema from "content-src/asrouter/schemas/panel/cfr-fxa-bookmark.schema.json";
+import update_schema from "content-src/asrouter/templates/OnboardingMessage/UpdateAction.schema.json";
 const messages = PanelTestProvider.getMessages();
 
 describe("PanelTestProvider", () => {
   it("should have a message", () => {
-    assert.lengthOf(messages, 4);
+    // Careful: when changing this number make sure that new messages also go
+    // through schema verifications.
+    assert.lengthOf(messages, 5);
   });
   it("should be a valid message", () => {
-    assert.jsonSchema(messages[0].content, schema);
+    const fxaMessages = messages.filter(
+      ({ template }) => template === "fxa_bookmark_panel"
+    );
+    for (let message of fxaMessages) {
+      assert.jsonSchema(message.content, schema);
+    }
+  });
+  it("should be a valid message", () => {
+    const updateMessages = messages.filter(
+      ({ template }) => template === "update_action"
+    );
+    for (let message of updateMessages) {
+      assert.jsonSchema(message.content, update_schema);
+    }
   });
 });

--- a/test/unit/asrouter/templates/OnboardingMessage.test.jsx
+++ b/test/unit/asrouter/templates/OnboardingMessage.test.jsx
@@ -1,6 +1,7 @@
 import { GlobalOverrider } from "test/unit/utils";
 import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
 import schema from "content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.schema.json";
+import badgeSchema from "content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json";
 
 const DEFAULT_CONTENT = {
   title: "A title",
@@ -60,6 +61,13 @@ describe("OnboardingMessage", () => {
     messages
       .filter(msg => msg.template in ["onboarding", "return_to_amo_overlay"])
       .forEach(msg => assert.jsonSchema(msg.content, schema));
+  });
+  it("should validate all badge template messages", async () => {
+    const messages = await OnboardingMessageProvider.getUntranslatedMessages();
+
+    messages
+      .filter(msg => msg.template === "toolbar_badge")
+      .forEach(msg => assert.jsonSchema(msg.content, badgeSchema));
   });
   it("should decode the content field (double decoding)", async () => {
     const fakeContent = "foo%2540bar.org";

--- a/test/unit/lib/BookmarkPanelHub.test.js
+++ b/test/unit/lib/BookmarkPanelHub.test.js
@@ -138,7 +138,9 @@ describe("BookmarkPanelHub", () => {
       await instance.messageRequest(fakeTarget, {});
 
       assert.calledOnce(fakeHandleMessageRequest);
-      assert.calledWithExactly(fakeHandleMessageRequest, instance._trigger);
+      assert.calledWithExactly(fakeHandleMessageRequest, {
+        triggerId: instance._trigger.id,
+      });
     });
     it("should call onResponse", async () => {
       fakeHandleMessageRequest.resolves(fakeMessage);

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -1,6 +1,6 @@
 import { _ToolbarBadgeHub } from "lib/ToolbarBadgeHub.jsm";
 import { GlobalOverrider } from "test/unit/utils";
-import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
+import { PanelTestProvider } from "lib/PanelTestProvider.jsm";
 
 describe("ToolbarBadgeHub", () => {
   let sandbox;
@@ -18,7 +18,7 @@ describe("ToolbarBadgeHub", () => {
     sandbox = sinon.createSandbox();
     instance = new _ToolbarBadgeHub();
     fakeAddImpression = sandbox.stub();
-    const msgs = await OnboardingMessageProvider.getUntranslatedMessages();
+    const msgs = await PanelTestProvider.getMessages();
     fxaMessage = msgs.find(({ id }) => id === "FXA_ACCOUNTS_BADGE");
     whatsnewMessage = msgs.find(({ id }) => id.includes("WHATS_NEW_BADGE_"));
     fakeElement = {

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -386,7 +386,7 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(fakeElement.removeAttribute);
       assert.calledWithExactly(fakeElement.removeAttribute, "badged");
-      assert.calledTwice(fakeElement.classList.remove);
+      assert.calledOnce(fakeElement.classList.remove);
       assert.calledWithExactly(fakeElement.classList.remove, "feature-callout");
     });
   });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -22,6 +22,10 @@ describe("ToolbarBadgeHub", () => {
     fxaMessage = msgs.find(({ id }) => id === "FXA_ACCOUNTS_BADGE");
     whatsnewMessage = msgs.find(({ id }) => id.includes("WHATS_NEW_BADGE_"));
     fakeElement = {
+      classList: {
+        add: sandbox.stub(),
+        remove: sandbox.stub(),
+      },
       setAttribute: sandbox.stub(),
       removeAttribute: sandbox.stub(),
       querySelector: sandbox.stub(),
@@ -127,9 +131,9 @@ describe("ToolbarBadgeHub", () => {
     it("should show a notification", () => {
       instance.addToolbarNotification(target, fxaMessage);
 
-      assert.calledTwice(fakeElement.setAttribute);
+      assert.calledOnce(fakeElement.setAttribute);
       assert.calledWithExactly(fakeElement.setAttribute, "badged", true);
-      assert.calledWithExactly(fakeElement.setAttribute, "value", "x");
+      assert.calledWithExactly(fakeElement.classList.add, "feature-callout");
     });
     it("should attach a cb on the notification", () => {
       instance.addToolbarNotification(target, fxaMessage);
@@ -223,8 +227,9 @@ describe("ToolbarBadgeHub", () => {
     it("should remove the notification", () => {
       instance.removeToolbarNotification(fakeElement);
 
-      assert.calledTwice(fakeElement.removeAttribute);
+      assert.calledOnce(fakeElement.removeAttribute);
       assert.calledWithExactly(fakeElement.removeAttribute, "badged");
+      assert.calledWithExactly(fakeElement.classList.remove, "feature-callout");
     });
   });
   describe("removeAllNotifications", () => {

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -1,0 +1,206 @@
+import { _ToolbarBadgeHub } from "lib/ToolbarBadgeHub.jsm";
+import { GlobalOverrider } from "test/unit/utils";
+import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
+
+describe("BookmarkPanelHub", () => {
+  let sandbox;
+  let instance;
+  let fakeAddImpression;
+  let fxaMessage;
+  let fakeElement;
+  let globals;
+  let everyWindowStub;
+  beforeEach(async () => {
+    globals = new GlobalOverrider();
+    sandbox = sinon.createSandbox();
+    instance = new _ToolbarBadgeHub();
+    fakeAddImpression = sandbox.stub();
+    [
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      fxaMessage,
+    ] = await OnboardingMessageProvider.getUntranslatedMessages();
+    fakeElement = {
+      setAttribute: sandbox.stub(),
+      removeAttribute: sandbox.stub(),
+      querySelector: sandbox.stub(),
+      addEventListener: sandbox.stub(),
+    };
+    // Share the same element when selecting child nodes
+    fakeElement.querySelector.returns(fakeElement);
+    everyWindowStub = {
+      registerCallback: sandbox.stub(),
+      unregisterCallback: sandbox.stub(),
+    };
+    globals.set("EveryWindow", everyWindowStub);
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  it("should create an instance", () => {
+    assert.ok(instance);
+  });
+  describe("#init", () => {
+    it("should make a messageRequest on init", async () => {
+      sandbox.stub(instance, "messageRequest");
+      const waitForInitialized = sandbox.stub().resolves();
+
+      await instance.init(waitForInitialized, {});
+      assert.calledOnce(instance.messageRequest);
+      assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+    });
+  });
+  describe("messageRequest", () => {
+    let handleMessageRequestStub;
+    beforeEach(() => {
+      handleMessageRequestStub = sandbox.stub().returns(fxaMessage);
+      sandbox
+        .stub(instance, "_handleMessageRequest")
+        .value(handleMessageRequestStub);
+      sandbox.stub(instance, "registerBadgeNotificationListener");
+    });
+    it("should fetch a message with the provided trigger and template", async () => {
+      await instance.messageRequest("trigger");
+
+      assert.calledOnce(handleMessageRequestStub);
+      assert.calledWithExactly(handleMessageRequestStub, {
+        triggerId: "trigger",
+        template: instance.template,
+      });
+    });
+    it("should call addToolbarNotification with browser window and message", async () => {
+      await instance.messageRequest("trigger");
+
+      assert.calledOnce(instance.registerBadgeNotificationListener);
+      assert.calledWithExactly(
+        instance.registerBadgeNotificationListener,
+        fxaMessage
+      );
+    });
+    it("shouldn't do anything if no message is provided", () => {
+      handleMessageRequestStub.returns(null);
+      instance.messageRequest("trigger");
+
+      assert.notCalled(instance.registerBadgeNotificationListener);
+    });
+  });
+  describe("addToolbarNotification", () => {
+    let target;
+    let fakeDocument;
+    beforeEach(() => {
+      fakeDocument = { getElementById: sandbox.stub().returns(fakeElement) };
+      target = { browser: { ownerDocument: fakeDocument } };
+    });
+    it("shouldn't do anything if target element is not found", () => {
+      fakeDocument.getElementById.returns(null);
+      instance.addToolbarNotification(target, fxaMessage);
+
+      assert.notCalled(fakeElement.setAttribute);
+    });
+    it("should target the element specified in the message", () => {
+      instance.addToolbarNotification(target, fxaMessage);
+
+      assert.calledOnce(fakeDocument.getElementById);
+      assert.calledWithExactly(
+        fakeDocument.getElementById,
+        fxaMessage.content.target
+      );
+    });
+    it("should show a notification", () => {
+      instance.addToolbarNotification(target, fxaMessage);
+
+      assert.calledTwice(fakeElement.setAttribute);
+      assert.calledWithExactly(fakeElement.setAttribute, "badged", true);
+      assert.calledWithExactly(fakeElement.setAttribute, "value", "x");
+    });
+    it("should attach a cb on the notification", () => {
+      instance.addToolbarNotification(target, fxaMessage);
+
+      assert.calledOnce(fakeElement.addEventListener);
+      assert.calledWithExactly(
+        fakeElement.addEventListener,
+        "click",
+        instance.removeAllNotifications,
+        { once: true }
+      );
+    });
+  });
+  describe("registerBadgeNotificationListener", () => {
+    beforeEach(() => {
+      sandbox.stub(instance, "_addImpression").value(fakeAddImpression);
+      sandbox.stub(instance, "addToolbarNotification").returns(fakeElement);
+      sandbox.stub(instance, "removeToolbarNotification");
+    });
+    it("should add an impression for the message", () => {
+      instance.registerBadgeNotificationListener(fxaMessage);
+
+      assert.calledOnce(instance._addImpression);
+      assert.calledWithExactly(instance._addImpression, fxaMessage);
+    });
+    it("should register a callback that adds/removes the notification", () => {
+      instance.registerBadgeNotificationListener(fxaMessage);
+
+      assert.calledOnce(everyWindowStub.registerCallback);
+      assert.calledWithExactly(
+        everyWindowStub.registerCallback,
+        instance.id,
+        sinon.match.func,
+        sinon.match.func
+      );
+
+      const [
+        ,
+        initFn,
+        uninitFn,
+      ] = everyWindowStub.registerCallback.firstCall.args;
+
+      initFn(window);
+      // Test that it doesn't try to add a second notification
+      initFn(window);
+
+      assert.calledOnce(instance.addToolbarNotification);
+      assert.calledWithExactly(
+        instance.addToolbarNotification,
+        window,
+        fxaMessage
+      );
+
+      uninitFn(window);
+
+      assert.calledOnce(instance.removeToolbarNotification);
+      assert.calledWithExactly(instance.removeToolbarNotification, fakeElement);
+    });
+  });
+  describe("removeToolbarNotification", () => {
+    it("should remove the notification", () => {
+      instance.removeToolbarNotification(fakeElement);
+
+      assert.calledTwice(fakeElement.removeAttribute);
+      assert.calledWithExactly(fakeElement.removeAttribute, "badged");
+    });
+  });
+  describe("removeAllNotifications", () => {
+    let blockMessageByIdStub;
+    beforeEach(() => {
+      blockMessageByIdStub = sandbox.stub();
+      sandbox.stub(instance, "_blockMessageById").value(blockMessageByIdStub);
+      instance.state = { notification: { id: fxaMessage.id } };
+    });
+    it("should call to block the message", () => {
+      instance.removeAllNotifications();
+
+      assert.calledOnce(blockMessageByIdStub);
+      assert.calledWithExactly(blockMessageByIdStub, fxaMessage.id);
+    });
+    it("should remove the window listener", () => {
+      instance.removeAllNotifications();
+
+      assert.calledOnce(everyWindowStub.unregisterCallback);
+      assert.calledWithExactly(everyWindowStub.unregisterCallback, instance.id);
+    });
+  });
+});

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -96,7 +96,10 @@ describe("ToolbarBadgeHub", () => {
 
       await instance.init(waitForInitialized, {});
       assert.calledOnce(instance.messageRequest);
-      assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+      assert.calledWithExactly(instance.messageRequest, {
+        template: "toolbar_badge",
+        triggerId: "toolbarBadgeUpdate",
+      });
     });
     it("should add a pref observer", async () => {
       await instance.init(sandbox.stub().resolves(), {});
@@ -162,12 +165,15 @@ describe("ToolbarBadgeHub", () => {
       sandbox.stub(instance, "registerBadgeNotificationListener");
     });
     it("should fetch a message with the provided trigger and template", async () => {
-      await instance.messageRequest("trigger");
+      await instance.messageRequest({
+        triggerId: "trigger",
+        template: "template",
+      });
 
       assert.calledOnce(handleMessageRequestStub);
       assert.calledWithExactly(handleMessageRequestStub, {
         triggerId: "trigger",
-        template: instance.template,
+        template: "template",
       });
     });
     it("should call addToolbarNotification with browser window and message", async () => {
@@ -309,6 +315,15 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(everyWindowStub.unregisterCallback);
       assert.calledWithExactly(everyWindowStub.unregisterCallback, instance.id);
+    });
+    it("should only call executeAction for 'update_action' messages", () => {
+      const stub = sandbox.stub(instance, "executeAction");
+      const updateActionMsg = { ...fxaMessage, template: "update_action" };
+
+      instance.registerBadgeNotificationListener(updateActionMsg);
+
+      assert.notCalled(everyWindowStub.registerCallback);
+      assert.calledOnce(stub);
     });
   });
   describe("executeAction", () => {
@@ -547,7 +562,10 @@ describe("ToolbarBadgeHub", () => {
       instance.observe("", "", instance.prefs.WHATSNEW_TOOLBAR_PANEL);
 
       assert.calledOnce(instance.messageRequest);
-      assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+      assert.calledWithExactly(instance.messageRequest, {
+        template: "toolbar_badge",
+        triggerId: "toolbarBadgeUpdate",
+      });
     });
     it("should not react to other pref changes", () => {
       sandbox.stub(instance, "messageRequest");
@@ -599,7 +617,10 @@ describe("ToolbarBadgeHub", () => {
 
       assert.notCalled(unblockMessageByIdStub);
       assert.calledOnce(messageRequestStub);
-      assert.calledWithExactly(messageRequestStub, "momentsUpdate");
+      assert.calledWithExactly(messageRequestStub, {
+        template: "update_action",
+        triggerId: "momentsUpdate",
+      });
     });
   });
 });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -15,8 +15,12 @@ describe("ToolbarBadgeHub", () => {
   let everyWindowStub;
   let clearTimeoutStub;
   let setTimeoutStub;
+  let setIntervalStub;
   let addObserverStub;
   let removeObserverStub;
+  let getStringPrefStub;
+  let clearUserPrefStub;
+  let setStringPrefStub;
   beforeEach(async () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
@@ -45,6 +49,7 @@ describe("ToolbarBadgeHub", () => {
     };
     clearTimeoutStub = sandbox.stub();
     setTimeoutStub = sandbox.stub();
+    setIntervalStub = sandbox.stub();
     const fakeWindow = {
       ownerGlobal: {
         gBrowser: {
@@ -54,11 +59,15 @@ describe("ToolbarBadgeHub", () => {
     };
     addObserverStub = sandbox.stub();
     removeObserverStub = sandbox.stub();
+    getStringPrefStub = sandbox.stub();
+    clearUserPrefStub = sandbox.stub();
+    setStringPrefStub = sandbox.stub();
     globals.set({
       EveryWindow: everyWindowStub,
       PrivateBrowsingUtils: { isBrowserPrivate: isBrowserPrivateStub },
       setTimeout: setTimeoutStub,
       clearTimeout: clearTimeoutStub,
+      setInterval: setIntervalStub,
       Services: {
         wm: {
           getMostRecentWindow: () => fakeWindow,
@@ -66,6 +75,9 @@ describe("ToolbarBadgeHub", () => {
         prefs: {
           addObserver: addObserverStub,
           removeObserver: removeObserverStub,
+          getStringPref: getStringPrefStub,
+          clearUserPref: clearUserPrefStub,
+          setStringPref: setStringPrefStub,
         },
       },
     });
@@ -96,13 +108,31 @@ describe("ToolbarBadgeHub", () => {
         instance
       );
     });
+    it("should setInterval for `checkHomepageOverridePref`", async () => {
+      await instance.init(sandbox.stub().resolves(), {});
+      sandbox.stub(instance, "checkHomepageOverridePref");
+
+      assert.calledOnce(setIntervalStub);
+      assert.calledWithExactly(
+        setIntervalStub,
+        sinon.match.func,
+        5 * 60 * 1000
+      );
+
+      assert.notCalled(instance.checkHomepageOverridePref);
+      const [cb] = setIntervalStub.firstCall.args;
+
+      cb();
+
+      assert.calledOnce(instance.checkHomepageOverridePref);
+    });
   });
   describe("#uninit", () => {
     beforeEach(async () => {
-      instance.init(sandbox.stub().resolves(), {});
+      await instance.init(sandbox.stub().resolves(), {});
     });
-    it("should clear any setTimeout cbs", () => {
-      instance.init(sandbox.stub().resolves(), {});
+    it("should clear any setTimeout cbs", async () => {
+      await instance.init(sandbox.stub().resolves(), {});
 
       instance.state.showBadgeTimeoutId = 2;
 
@@ -205,15 +235,15 @@ describe("ToolbarBadgeHub", () => {
       instance.addToolbarNotification(target, whatsnewMessage);
 
       assert.calledOnce(instance.executeAction);
-      assert.calledWithExactly(
-        instance.executeAction,
-        whatsnewMessage.content.action
-      );
+      assert.calledWithExactly(instance.executeAction, {
+        ...whatsnewMessage.content.action,
+        message_id: whatsnewMessage.id,
+      });
     });
   });
   describe("registerBadgeNotificationListener", () => {
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), {
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
         addImpression: fakeAddImpression,
         dispatch: fakeDispatch,
       });
@@ -282,8 +312,57 @@ describe("ToolbarBadgeHub", () => {
     });
   });
   describe("executeAction", () => {
-    it("should call ToolbarPanelHub.enableToolbarButton", () => {
-      instance.executeAction({ id: "show-whatsnew-button" });
+    let blockMessageByIdStub;
+    beforeEach(async () => {
+      blockMessageByIdStub = sandbox.stub();
+      await instance.init(sandbox.stub().resolves(), {
+        blockMessageById: blockMessageByIdStub,
+      });
+    });
+    it("should set HOMEPAGE_OVERRIDE_PREF on `moments-wnp` action", () => {
+      instance.executeAction({
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expire: 1,
+        },
+        message_id: "bar",
+      });
+
+      assert.calledOnce(setStringPrefStub);
+      assert.calledWithExactly(
+        setStringPrefStub,
+        instance.prefs.HOMEPAGE_OVERRIDE_PREF,
+        JSON.stringify({ message_id: "bar", url: "foo.com", expire: 1 })
+      );
+    });
+    it("should block after taking the action", () => {
+      instance.executeAction({
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expire: 1,
+        },
+        message_id: "bar",
+      });
+
+      assert.calledOnce(blockMessageByIdStub);
+      assert.calledWithExactly(blockMessageByIdStub, "bar");
+    });
+    it("should compute expire based on expireDelta", () => {
+      sandbox.spy(instance, "getExpirationDate");
+
+      instance.executeAction({
+        id: "moments-wnp",
+        data: {
+          url: "foo.com",
+          expireDelta: 10,
+        },
+        message_id: "bar",
+      });
+
+      assert.calledOnce(instance.getExpirationDate);
+      assert.calledWithExactly(instance.getExpirationDate, 10);
     });
   });
   describe("removeToolbarNotification", () => {
@@ -299,8 +378,10 @@ describe("ToolbarBadgeHub", () => {
   describe("removeAllNotifications", () => {
     let blockMessageByIdStub;
     let fakeEvent;
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), { dispatch: fakeDispatch });
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
+        dispatch: fakeDispatch,
+      });
       blockMessageByIdStub = sandbox.stub();
       sandbox.stub(instance, "_blockMessageById").value(blockMessageByIdStub);
       instance.state = { notification: { id: fxaMessage.id } };
@@ -396,8 +477,8 @@ describe("ToolbarBadgeHub", () => {
   });
   describe("message with delay", () => {
     let msg_with_delay;
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), {
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
         addImpression: fakeAddImpression,
       });
       msg_with_delay = {
@@ -436,8 +517,10 @@ describe("ToolbarBadgeHub", () => {
     });
   });
   describe("#sendUserEventTelemetry", () => {
-    beforeEach(() => {
-      instance.init(sandbox.stub().resolves(), { dispatch: fakeDispatch });
+    beforeEach(async () => {
+      await instance.init(sandbox.stub().resolves(), {
+        dispatch: fakeDispatch,
+      });
     });
     it("should check for private window and not send", () => {
       isBrowserPrivateStub.returns(true);
@@ -472,6 +555,51 @@ describe("ToolbarBadgeHub", () => {
       instance.observe("", "", "foo");
 
       assert.notCalled(instance.messageRequest);
+    });
+  });
+  describe("#checkHomepageOverridePref", () => {
+    let messageRequestStub;
+    let unblockMessageByIdStub;
+    beforeEach(async () => {
+      unblockMessageByIdStub = sandbox.stub();
+      await instance.init(sandbox.stub().resolves(), {
+        unblockMessageById: unblockMessageByIdStub,
+      });
+      messageRequestStub = sandbox.stub(instance, "messageRequest");
+    });
+    it("should reset HOMEPAGE_OVERRIDE_PREF if set", () => {
+      getStringPrefStub.returns(true);
+
+      instance.checkHomepageOverridePref();
+
+      assert.calledOnce(getStringPrefStub);
+      assert.calledWithExactly(
+        getStringPrefStub,
+        instance.prefs.HOMEPAGE_OVERRIDE_PREF,
+        ""
+      );
+      assert.calledOnce(clearUserPrefStub);
+      assert.calledWithExactly(
+        clearUserPrefStub,
+        instance.prefs.HOMEPAGE_OVERRIDE_PREF
+      );
+    });
+    it("should unblock the message set in the pref", () => {
+      getStringPrefStub.returns(JSON.stringify({ message_id: "foo" }));
+
+      instance.checkHomepageOverridePref();
+
+      assert.calledOnce(unblockMessageByIdStub);
+      assert.calledWithExactly(unblockMessageByIdStub, "foo");
+    });
+    it("should catch parse errors", () => {
+      getStringPrefStub.returns({});
+
+      instance.checkHomepageOverridePref();
+
+      assert.notCalled(unblockMessageByIdStub);
+      assert.calledOnce(messageRequestStub);
+      assert.calledWithExactly(messageRequestStub, "momentsUpdate");
     });
   });
 });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -15,6 +15,8 @@ describe("ToolbarBadgeHub", () => {
   let everyWindowStub;
   let clearTimeoutStub;
   let setTimeoutStub;
+  let addObserverStub;
+  let removeObserverStub;
   beforeEach(async () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
@@ -43,12 +45,6 @@ describe("ToolbarBadgeHub", () => {
     };
     clearTimeoutStub = sandbox.stub();
     setTimeoutStub = sandbox.stub();
-    globals.set("EveryWindow", everyWindowStub);
-    globals.set("setTimeout", setTimeoutStub);
-    globals.set("clearTimeout", clearTimeoutStub);
-    globals.set("PrivateBrowsingUtils", {
-      isBrowserPrivate: isBrowserPrivateStub,
-    });
     const fakeWindow = {
       ownerGlobal: {
         gBrowser: {
@@ -56,9 +52,21 @@ describe("ToolbarBadgeHub", () => {
         },
       },
     };
-    globals.set("Services", {
-      wm: {
-        getMostRecentWindow: () => fakeWindow,
+    addObserverStub = sandbox.stub();
+    removeObserverStub = sandbox.stub();
+    globals.set({
+      EveryWindow: everyWindowStub,
+      PrivateBrowsingUtils: { isBrowserPrivate: isBrowserPrivateStub },
+      setTimeout: setTimeoutStub,
+      clearTimeout: clearTimeoutStub,
+      Services: {
+        wm: {
+          getMostRecentWindow: () => fakeWindow,
+        },
+        prefs: {
+          addObserver: addObserverStub,
+          removeObserver: removeObserverStub,
+        },
       },
     });
   });
@@ -78,8 +86,21 @@ describe("ToolbarBadgeHub", () => {
       assert.calledOnce(instance.messageRequest);
       assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
     });
+    it("should add a pref observer", async () => {
+      await instance.init(sandbox.stub().resolves(), {});
+
+      assert.calledOnce(addObserverStub);
+      assert.calledWithExactly(
+        addObserverStub,
+        instance.prefs.WHATSNEW_TOOLBAR_PANEL,
+        instance
+      );
+    });
   });
   describe("#uninit", () => {
+    beforeEach(async () => {
+      instance.init(sandbox.stub().resolves(), {});
+    });
     it("should clear any setTimeout cbs", () => {
       instance.init(sandbox.stub().resolves(), {});
 
@@ -89,6 +110,16 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(clearTimeoutStub);
       assert.calledWithExactly(clearTimeoutStub, 2);
+    });
+    it("should remove the pref observer", () => {
+      instance.uninit();
+
+      assert.calledOnce(removeObserverStub);
+      assert.calledWithExactly(
+        removeObserverStub,
+        instance.prefs.WHATSNEW_TOOLBAR_PANEL,
+        instance
+      );
     });
   });
   describe("messageRequest", () => {
@@ -424,6 +455,23 @@ describe("ToolbarBadgeHub", () => {
       const [ping] = instance._dispatch.firstCall.args;
       assert.propertyVal(ping, "type", "TOOLBAR_BADGE_TELEMETRY");
       assert.propertyVal(ping.data, "event", "CLICK");
+    });
+  });
+  describe("#observe", () => {
+    it("should make a message request when the whats new pref is changed", () => {
+      sandbox.stub(instance, "messageRequest");
+
+      instance.observe("", "", instance.prefs.WHATSNEW_TOOLBAR_PANEL);
+
+      assert.calledOnce(instance.messageRequest);
+      assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+    });
+    it("should not react to other pref changes", () => {
+      sandbox.stub(instance, "messageRequest");
+
+      instance.observe("", "", "foo");
+
+      assert.notCalled(instance.messageRequest);
     });
   });
 });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -2,7 +2,7 @@ import { _ToolbarBadgeHub } from "lib/ToolbarBadgeHub.jsm";
 import { GlobalOverrider } from "test/unit/utils";
 import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
 
-describe("BookmarkPanelHub", () => {
+describe("ToolbarBadgeHub", () => {
   let sandbox;
   let instance;
   let fakeAddImpression;
@@ -11,6 +11,8 @@ describe("BookmarkPanelHub", () => {
   let fakeElement;
   let globals;
   let everyWindowStub;
+  let clearTimeoutStub;
+  let setTimeoutStub;
   beforeEach(async () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
@@ -31,10 +33,15 @@ describe("BookmarkPanelHub", () => {
       registerCallback: sandbox.stub(),
       unregisterCallback: sandbox.stub(),
     };
+    clearTimeoutStub = sandbox.stub();
+    setTimeoutStub = sandbox.stub();
     globals.set("EveryWindow", everyWindowStub);
+    globals.set("setTimeout", setTimeoutStub);
+    globals.set("clearTimeout", clearTimeoutStub);
   });
   afterEach(() => {
     sandbox.restore();
+    globals.restore();
   });
   it("should create an instance", () => {
     assert.ok(instance);
@@ -47,6 +54,18 @@ describe("BookmarkPanelHub", () => {
       await instance.init(waitForInitialized, {});
       assert.calledOnce(instance.messageRequest);
       assert.calledWithExactly(instance.messageRequest, "toolbarBadgeUpdate");
+    });
+  });
+  describe("#uninit", () => {
+    it("should clear any setTimeout cbs", () => {
+      instance.init(sandbox.stub().resolves(), {});
+
+      instance.state.showBadgeTimeoutId = 2;
+
+      instance.uninit();
+
+      assert.calledOnce(clearTimeoutStub);
+      assert.calledWithExactly(clearTimeoutStub, 2);
     });
   });
   describe("messageRequest", () => {
@@ -115,12 +134,16 @@ describe("BookmarkPanelHub", () => {
     it("should attach a cb on the notification", () => {
       instance.addToolbarNotification(target, fxaMessage);
 
-      assert.calledOnce(fakeElement.addEventListener);
+      assert.calledTwice(fakeElement.addEventListener);
+      assert.calledWithExactly(
+        fakeElement.addEventListener,
+        "mousedown",
+        instance.removeAllNotifications
+      );
       assert.calledWithExactly(
         fakeElement.addEventListener,
         "click",
-        instance.removeAllNotifications,
-        { once: true }
+        instance.removeAllNotifications
       );
     });
     it("should execute actions if they exist", () => {
@@ -136,9 +159,14 @@ describe("BookmarkPanelHub", () => {
   });
   describe("registerBadgeNotificationListener", () => {
     beforeEach(() => {
-      sandbox.stub(instance, "_addImpression").value(fakeAddImpression);
+      instance.init(sandbox.stub().resolves(), {
+        addImpression: fakeAddImpression,
+      });
       sandbox.stub(instance, "addToolbarNotification").returns(fakeElement);
       sandbox.stub(instance, "removeToolbarNotification");
+    });
+    afterEach(() => {
+      instance.uninit();
     });
     it("should add an impression for the message", () => {
       instance.registerBadgeNotificationListener(fxaMessage);
@@ -201,10 +229,12 @@ describe("BookmarkPanelHub", () => {
   });
   describe("removeAllNotifications", () => {
     let blockMessageByIdStub;
+    let fakeEvent;
     beforeEach(() => {
       blockMessageByIdStub = sandbox.stub();
       sandbox.stub(instance, "_blockMessageById").value(blockMessageByIdStub);
       instance.state = { notification: { id: fxaMessage.id } };
+      fakeEvent = { target: { removeEventListener: sandbox.stub() } };
     });
     it("should call to block the message", () => {
       instance.removeAllNotifications();
@@ -217,6 +247,110 @@ describe("BookmarkPanelHub", () => {
 
       assert.calledOnce(everyWindowStub.unregisterCallback);
       assert.calledWithExactly(everyWindowStub.unregisterCallback, instance.id);
+    });
+    it("should ignore right mouse button (mousedown event)", () => {
+      fakeEvent.type = "mousedown";
+      fakeEvent.button = 1; // not left click
+
+      instance.removeAllNotifications(fakeEvent);
+
+      assert.notCalled(fakeEvent.target.removeEventListener);
+      assert.notCalled(everyWindowStub.unregisterCallback);
+    });
+    it("should ignore right mouse button (click event)", () => {
+      fakeEvent.type = "click";
+      fakeEvent.button = 1; // not left click
+
+      instance.removeAllNotifications(fakeEvent);
+
+      assert.notCalled(fakeEvent.target.removeEventListener);
+      assert.notCalled(everyWindowStub.unregisterCallback);
+    });
+    it("should ignore keypresses that are not meant to focus the target", () => {
+      fakeEvent.type = "keypress";
+      fakeEvent.key = "\t"; // not enter
+
+      instance.removeAllNotifications(fakeEvent);
+
+      assert.notCalled(fakeEvent.target.removeEventListener);
+      assert.notCalled(everyWindowStub.unregisterCallback);
+    });
+    it("should remove the event listeners after succesfully focusing the element", () => {
+      fakeEvent.type = "click";
+      fakeEvent.button = 0;
+
+      instance.removeAllNotifications(fakeEvent);
+
+      assert.calledTwice(fakeEvent.target.removeEventListener);
+      assert.calledWithExactly(
+        fakeEvent.target.removeEventListener,
+        "mousedown",
+        instance.removeAllNotifications
+      );
+      assert.calledWithExactly(
+        fakeEvent.target.removeEventListener,
+        "click",
+        instance.removeAllNotifications
+      );
+    });
+    it("should remove the event listeners after succesfully focusing the element", () => {
+      fakeEvent.type = "keypress";
+      fakeEvent.key = "Enter";
+
+      instance.removeAllNotifications(fakeEvent);
+
+      assert.calledTwice(fakeEvent.target.removeEventListener);
+      assert.calledWithExactly(
+        fakeEvent.target.removeEventListener,
+        "mousedown",
+        instance.removeAllNotifications
+      );
+      assert.calledWithExactly(
+        fakeEvent.target.removeEventListener,
+        "click",
+        instance.removeAllNotifications
+      );
+    });
+  });
+  describe("message with delay", () => {
+    let msg_with_delay;
+    beforeEach(() => {
+      instance.init(sandbox.stub().resolves(), {
+        addImpression: fakeAddImpression,
+      });
+      msg_with_delay = {
+        ...fxaMessage,
+        content: {
+          ...fxaMessage.content,
+          delay: 500,
+        },
+      };
+      sandbox.stub(instance, "registerBadgeToAllWindows");
+    });
+    afterEach(() => {
+      instance.uninit();
+    });
+    it("should register a cb to fire after msg.content.delay ms", () => {
+      instance.registerBadgeNotificationListener(msg_with_delay);
+
+      assert.calledOnce(setTimeoutStub);
+      assert.calledWithExactly(
+        setTimeoutStub,
+        sinon.match.func,
+        msg_with_delay.content.delay
+      );
+
+      const [cb] = setTimeoutStub.firstCall.args;
+
+      assert.notCalled(instance.registerBadgeToAllWindows);
+
+      cb();
+
+      assert.calledOnce(instance.registerBadgeToAllWindows);
+      assert.calledWithExactly(
+        instance.registerBadgeToAllWindows,
+        msg_with_delay
+      );
     });
   });
 });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -6,6 +6,8 @@ describe("ToolbarBadgeHub", () => {
   let sandbox;
   let instance;
   let fakeAddImpression;
+  let fakeDispatch;
+  let isBrowserPrivateStub;
   let fxaMessage;
   let whatsnewMessage;
   let fakeElement;
@@ -18,6 +20,8 @@ describe("ToolbarBadgeHub", () => {
     sandbox = sinon.createSandbox();
     instance = new _ToolbarBadgeHub();
     fakeAddImpression = sandbox.stub();
+    fakeDispatch = sandbox.stub();
+    isBrowserPrivateStub = sandbox.stub();
     const msgs = await PanelTestProvider.getMessages();
     fxaMessage = msgs.find(({ id }) => id === "FXA_ACCOUNTS_BADGE");
     whatsnewMessage = msgs.find(({ id }) => id.includes("WHATS_NEW_BADGE_"));
@@ -42,6 +46,21 @@ describe("ToolbarBadgeHub", () => {
     globals.set("EveryWindow", everyWindowStub);
     globals.set("setTimeout", setTimeoutStub);
     globals.set("clearTimeout", clearTimeoutStub);
+    globals.set("PrivateBrowsingUtils", {
+      isBrowserPrivate: isBrowserPrivateStub,
+    });
+    const fakeWindow = {
+      ownerGlobal: {
+        gBrowser: {
+          selectedBrowser: "browser",
+        },
+      },
+    };
+    globals.set("Services", {
+      wm: {
+        getMostRecentWindow: () => fakeWindow,
+      },
+    });
   });
   afterEach(() => {
     sandbox.restore();
@@ -165,6 +184,7 @@ describe("ToolbarBadgeHub", () => {
     beforeEach(() => {
       instance.init(sandbox.stub().resolves(), {
         addImpression: fakeAddImpression,
+        dispatch: fakeDispatch,
       });
       sandbox.stub(instance, "addToolbarNotification").returns(fakeElement);
       sandbox.stub(instance, "removeToolbarNotification");
@@ -211,6 +231,18 @@ describe("ToolbarBadgeHub", () => {
       assert.calledOnce(instance.removeToolbarNotification);
       assert.calledWithExactly(instance.removeToolbarNotification, fakeElement);
     });
+    it("should send an impression", async () => {
+      sandbox.stub(instance, "sendUserEventTelemetry");
+
+      instance.registerBadgeNotificationListener(fxaMessage);
+
+      assert.calledOnce(instance.sendUserEventTelemetry);
+      assert.calledWithExactly(
+        instance.sendUserEventTelemetry,
+        "IMPRESSION",
+        fxaMessage
+      );
+    });
     it("should unregister notifications when forcing a badge via devtools", () => {
       instance.registerBadgeNotificationListener(fxaMessage, { force: true });
 
@@ -237,6 +269,7 @@ describe("ToolbarBadgeHub", () => {
     let blockMessageByIdStub;
     let fakeEvent;
     beforeEach(() => {
+      instance.init(sandbox.stub().resolves(), { dispatch: fakeDispatch });
       blockMessageByIdStub = sandbox.stub();
       sandbox.stub(instance, "_blockMessageById").value(blockMessageByIdStub);
       instance.state = { notification: { id: fxaMessage.id } };
@@ -299,6 +332,18 @@ describe("ToolbarBadgeHub", () => {
         instance.removeAllNotifications
       );
     });
+    it("should send telemetry", () => {
+      fakeEvent.type = "click";
+      fakeEvent.button = 0;
+      sandbox.stub(instance, "sendUserEventTelemetry");
+
+      instance.removeAllNotifications(fakeEvent);
+
+      assert.calledOnce(instance.sendUserEventTelemetry);
+      assert.calledWithExactly(instance.sendUserEventTelemetry, "CLICK", {
+        id: "FXA_ACCOUNTS_BADGE",
+      });
+    });
     it("should remove the event listeners after succesfully focusing the element", () => {
       fakeEvent.type = "keypress";
       fakeEvent.key = "Enter";
@@ -357,6 +402,28 @@ describe("ToolbarBadgeHub", () => {
         instance.registerBadgeToAllWindows,
         msg_with_delay
       );
+    });
+  });
+  describe("#sendUserEventTelemetry", () => {
+    beforeEach(() => {
+      instance.init(sandbox.stub().resolves(), { dispatch: fakeDispatch });
+    });
+    it("should check for private window and not send", () => {
+      isBrowserPrivateStub.returns(true);
+
+      instance.sendUserEventTelemetry("CLICK", { id: fxaMessage });
+
+      assert.notCalled(instance._dispatch);
+    });
+    it("should check for private window and send", () => {
+      isBrowserPrivateStub.returns(false);
+
+      instance.sendUserEventTelemetry("CLICK", { id: fxaMessage });
+
+      assert.calledOnce(fakeDispatch);
+      const [ping] = instance._dispatch.firstCall.args;
+      assert.propertyVal(ping, "type", "TOOLBAR_BADGE_TELEMETRY");
+      assert.propertyVal(ping.data, "event", "CLICK");
     });
   });
 });

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -229,6 +229,7 @@ describe("ToolbarBadgeHub", () => {
 
       assert.calledOnce(fakeElement.removeAttribute);
       assert.calledWithExactly(fakeElement.removeAttribute, "badged");
+      assert.calledTwice(fakeElement.classList.remove);
       assert.calledWithExactly(fakeElement.classList.remove, "feature-callout");
     });
   });

--- a/test/unit/ping-centre/PingCentre.test.js
+++ b/test/unit/ping-centre/PingCentre.test.js
@@ -340,6 +340,7 @@ describe("PingCentre", () => {
           locale: FAKE_LOCALE,
           topic: "activity-stream",
           client_id: FAKE_TELEMETRY_ID,
+          version: "69.0a1",
           release_channel: FAKE_UPDATE_CHANNEL,
         },
         fakePingJSON
@@ -363,6 +364,7 @@ describe("PingCentre", () => {
         {
           locale: FAKE_LOCALE,
           client_id: FAKE_TELEMETRY_ID,
+          version: "69.0a1",
           release_channel: FAKE_UPDATE_CHANNEL,
         },
         fakePingJSON
@@ -424,6 +426,7 @@ describe("PingCentre", () => {
           locale: FAKE_LOCALE,
           topic: "activity-stream",
           client_id: FAKE_TELEMETRY_ID,
+          version: "69.0a1",
           release_channel: FAKE_UPDATE_CHANNEL,
         },
         fakePingJSON
@@ -524,6 +527,7 @@ describe("PingCentre", () => {
         {
           locale: FAKE_LOCALE,
           client_id: FAKE_TELEMETRY_ID,
+          version: "69.0a1",
           release_channel: FAKE_UPDATE_CHANNEL,
         },
         fakePingJSON

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -42,7 +42,7 @@ const TEST_GLOBAL = {
       return Promise.resolve({ addons: [], fullData: false });
     },
   },
-  AppConstants: { MOZILLA_OFFICIAL: true },
+  AppConstants: { MOZILLA_OFFICIAL: true, MOZ_APP_VERSION: "69.0a1" },
   UpdateUtils: { getUpdateChannel() {} },
   BrowserWindowTracker: { getTopWindow() {} },
   ChromeUtils: {
@@ -288,7 +288,7 @@ const TEST_GLOBAL = {
       getEnumerator: () => [],
     },
     ww: { registerNotification() {}, unregisterNotification() {} },
-    appinfo: { appBuildID: "20180710100040" },
+    appinfo: { appBuildID: "20180710100040", version: "69.0a1" },
   },
   XPCOMUtils: {
     defineLazyGetter(object, name, f) {

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -282,7 +282,11 @@ const TEST_GLOBAL = {
       createNullPrincipal() {},
       getSystemPrincipal() {},
     },
-    wm: { getMostRecentWindow: () => window, getEnumerator: () => [] },
+    wm: {
+      getMostRecentWindow: () => window,
+      getMostRecentBrowserWindow: () => window,
+      getEnumerator: () => [],
+    },
     ww: { registerNotification() {}, unregisterNotification() {} },
     appinfo: { appBuildID: "20180710100040" },
   },


### PR DESCRIPTION
This uplifts 10 Badge bugs:
https://bugzilla.mozilla.org/buglist.cgi?f1=blocked&o1=allwords&v1=1560987&resolution=FIXED
Excluding:
- Bug 1561547 - Use Messaging System to badge the FxA accounts toolbar button
- Bug 1563733 - Use Messaging System to badge the What's New toolbar button

Including: 2 (nobug)
```
27b79564 Bug 1561536 - Add new message schema and template type for feature callouts (#5133)
d8570e05 Bug 1561540 - CFR messages should have a priority field that allows sorting (#5156)
7c9f5603 Bug 1564898 - Use UpdateManager to get the earliest Firefox version used (#5165)
6ebba35b Bug 1564811 - Badge actions can define a timeout delay after which the action is executed (#5170)
90b5eea2 (nobug) Move the What's New and Badge test messages to PanelTestProvider.jsm (#5171)
23e918ca Port 1561537 - Add badge/feature-callout style that matches the design spec r=r1cky
28bf2f0d (nobug) - Restore the default icon style after removing the badge (#5180)
ffcb9a2a Bug 1561554 - Add telemetry events for notification badges (#5176)
4fcf6451 Bug 1566372 - Listen for pref changes as a way to trigger notifications (#5191)
993d0446 Bug 1571818 - handleMessageRequest method does not consider trigger params (#5226)
c42d699c Port 1570935 - Remove clip-path property for causing performance regression r=k88hudson
e125087c Port 1533846 - Clear WeakMap entries for Messaging System notifications r=k88hudson
```

And 3 moments bugs:
https://bugzilla.mozilla.org/buglist.cgi?f1=blocked&o1=allwords&v1=1567601&keywords=github-merged
```
84abc9de Bug 1569020 - Add a new badge action for setting homepage_override pref (#5207)
f4878d99 Bug 1571846 - Moments pref reset issue (#5223)
2febea0f Bug 1573953 - Don't add impressions for moments page pref check (#5256)
```

Each of the 15 commits should be passing `npm test`

To test this, you'll need to at least apply to mozilla-beta:
Bug 1568692 - Show a page like what's new on startup once but not dependent on major version bump
https://phabricator.services.mozilla.com/D41837

Several commits needed conflict resolution for not having ToolbarPanelHub and `Bug 1571818 - handleMessageRequest method does not consider trigger params` had conflicts also from not yet uplifting extended triplets.

Forced showing `WNP_THANK_YOU` from devtools verified `browser.startup.homepage_override.once;{"message_id":"WNP_THANK_YOU","url":"https://www.mozilla.org/%LOCALE%/etc/firefox/retention/thank-you-a/","expire":1565904001843}` and restarted:
![Screen Shot 2019-08-13 at 1 58 22 PM](https://user-images.githubusercontent.com/438537/62978185-88a96f80-bdd5-11e9-8dca-5f1f58543d6b.png)
