### PR TITLE
Uplift Bug 1569303 - Extended First Run Triplets

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,7 @@ module.exports = {
 
     "react/jsx-boolean-value": [2, "always"],
     "react/jsx-key": 2,
-    "react/jsx-no-bind": 0,
+    "react/jsx-no-bind": 2,
     "react/jsx-no-comment-textnodes": 2,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-target-blank": 2,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
       // These files use fluent-dom to insert content
       "files": [
         "content-src/asrouter/templates/OnboardingMessage/**",
+        "content-src/asrouter/templates/FirstRun/**",
         "content-src/asrouter/templates/Trailhead/**",
         "content-src/asrouter/templates/StartupOverlay/StartupOverlay.jsx",
         "content-src/components/TopSites/**",
@@ -76,7 +77,7 @@ module.exports = {
 
     "react/jsx-boolean-value": [2, "always"],
     "react/jsx-key": 2,
-    "react/jsx-no-bind": 2,
+    "react/jsx-no-bind": 0,
     "react/jsx-no-comment-textnodes": 2,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-target-blank": 2,

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -116,7 +116,7 @@ export class ASRouterUISurface extends React.PureComponent {
     this.onUserAction = this.onUserAction.bind(this);
     this.fetchFlowParams = this.fetchFlowParams.bind(this);
 
-    this.state = { message: {} };
+    this.state = { message: {}, interruptCleared: false };
     if (props.document) {
       this.headerPortal = props.document.getElementById(
         "header-asrouter-container"
@@ -238,6 +238,9 @@ export class ASRouterUISurface extends React.PureComponent {
     switch (action.type) {
       case "SET_MESSAGE":
         this.setState({ message: action.data });
+        break;
+      case "CLEAR_INTERRUPT":
+        this.setState({ interruptCleared: true });
         break;
       case "CLEAR_MESSAGE":
         this.clearMessage(action.data.id);
@@ -373,6 +376,7 @@ export class ASRouterUISurface extends React.PureComponent {
         >
           <FirstRun
             document={this.props.document}
+            interruptCleared={this.state.interruptCleared}
             message={message}
             sendUserActionTelemetry={this.sendUserActionTelemetry}
             executeAction={ASRouterUtils.executeAction}

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -377,7 +377,7 @@ export class ASRouterUISurface extends React.PureComponent {
             sendUserActionTelemetry={this.sendUserActionTelemetry}
             executeAction={ASRouterUtils.executeAction}
             dispatch={this.props.dispatch}
-            onBlock={this.onBlockById(this.state.message.id)}
+            onBlockById={ASRouterUtils.blockById}
             onDismiss={this.onDismissById(this.state.message.id)}
             fxaEndpoint={this.props.fxaEndpoint}
             fetchFlowParams={this.fetchFlowParams}

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -114,6 +114,8 @@ export class ASRouterUISurface extends React.PureComponent {
     this.sendImpression = this.sendImpression.bind(this);
     this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
     this.onUserAction = this.onUserAction.bind(this);
+    this.fetchFlowParams = this.fetchFlowParams.bind(this);
+
     this.state = { message: {} };
     if (props.document) {
       this.headerPortal = props.document.getElementById(
@@ -157,7 +159,7 @@ export class ASRouterUISurface extends React.PureComponent {
         );
       }
     } catch (error) {
-      console.error(error);
+      console.error(error); // eslint-disable-line no-console
       dispatch(
         ac.OnlyToMain({
           type: at.TELEMETRY_UNDESIRED_EVENT,
@@ -378,6 +380,7 @@ export class ASRouterUISurface extends React.PureComponent {
             onBlock={this.onBlockById(this.state.message.id)}
             onDismiss={this.onDismissById(this.state.message.id)}
             fxaEndpoint={this.props.fxaEndpoint}
+            fetchFlowParams={this.fetchFlowParams}
           />
         </ImpressionsWrapper>
       );

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -12,17 +12,19 @@ import { generateBundles } from "./rich-text-strings";
 import { ImpressionsWrapper } from "./components/ImpressionsWrapper/ImpressionsWrapper";
 import { LocalizationProvider } from "fluent-react";
 import { NEWTAB_DARK_THEME } from "content-src/lib/constants";
-import { OnboardingMessage } from "./templates/OnboardingMessage/OnboardingMessage";
 import React from "react";
 import ReactDOM from "react-dom";
-import { ReturnToAMO } from "./templates/ReturnToAMO/ReturnToAMO";
 import { SnippetsTemplates } from "./templates/template-manifest";
-import { StartupOverlay } from "./templates/StartupOverlay/StartupOverlay";
-import { Trailhead } from "./templates/Trailhead/Trailhead";
+import { FirstRun } from "./templates/FirstRun/FirstRun";
 
 const INCOMING_MESSAGE_NAME = "ASRouter:parent-to-child";
 const OUTGOING_MESSAGE_NAME = "ASRouter:child-to-parent";
-const TEMPLATES_ABOVE_PAGE = ["trailhead"];
+const TEMPLATES_ABOVE_PAGE = [
+  "trailhead",
+  "fxa_overlay",
+  "return_to_amo_overlay",
+];
+const FIRST_RUN_TEMPLATES = TEMPLATES_ABOVE_PAGE;
 const TEMPLATES_BELOW_SEARCH = ["simple_below_search_snippet"];
 
 export const ASRouterUtils = {
@@ -49,9 +51,6 @@ export const ASRouterUtils = {
   },
   dismissById(id) {
     ASRouterUtils.sendMessage({ type: "DISMISS_MESSAGE_BY_ID", data: { id } });
-  },
-  dismissBundle(bundle) {
-    ASRouterUtils.sendMessage({ type: "DISMISS_BUNDLE", data: { bundle } });
   },
   executeAction(button_action) {
     ASRouterUtils.sendMessage({
@@ -114,7 +113,7 @@ export class ASRouterUISurface extends React.PureComponent {
     this.sendImpression = this.sendImpression.bind(this);
     this.sendUserActionTelemetry = this.sendUserActionTelemetry.bind(this);
     this.onUserAction = this.onUserAction.bind(this);
-    this.state = { message: {}, bundle: {} };
+    this.state = { message: {} };
     if (props.document) {
       this.headerPortal = props.document.getElementById(
         "header-asrouter-container"
@@ -169,14 +168,10 @@ export class ASRouterUISurface extends React.PureComponent {
   }
 
   sendUserActionTelemetry(extraProps = {}) {
-    const { message, bundle } = this.state;
-    if (!message && !extraProps.message_id) {
-      throw new Error(`You must provide a message_id for bundled messages`);
-    }
-    // snippets_user_event, onboarding_user_event
-    const eventType = `${message.provider || bundle.provider}_user_event`;
+    const { message } = this.state;
+    const eventType = `${message.provider}_user_event`;
     ASRouterUtils.sendTelemetry({
-      message_id: message.id || extraProps.message_id,
+      message_id: message.id,
       source: extraProps.id,
       action: eventType,
       ...extraProps,
@@ -228,26 +223,6 @@ export class ASRouterUISurface extends React.PureComponent {
     return () => ASRouterUtils.dismissById(id);
   }
 
-  dismissBundle(bundle) {
-    return () => {
-      ASRouterUtils.dismissBundle(bundle);
-      this.sendUserActionTelemetry({
-        event: "DISMISS",
-        id: "onboarding-cards",
-        message_id: bundle.map(m => m.id).join(","),
-        // Passing the action because some bundles (Trailhead) don't have a provider set
-        action: "onboarding_user_event",
-      });
-    };
-  }
-
-  triggerOnboarding() {
-    ASRouterUtils.sendMessage({
-      type: "TRIGGER",
-      data: { trigger: { id: "showOnboarding" } },
-    });
-  }
-
   clearMessage(id) {
     if (id === this.state.message.id) {
       this.setState({ message: {} });
@@ -261,9 +236,6 @@ export class ASRouterUISurface extends React.PureComponent {
       case "SET_MESSAGE":
         this.setState({ message: action.data });
         break;
-      case "SET_BUNDLED_MESSAGES":
-        this.setState({ bundle: action.data });
-        break;
       case "CLEAR_MESSAGE":
         this.clearMessage(action.data.id);
         break;
@@ -272,13 +244,8 @@ export class ASRouterUISurface extends React.PureComponent {
           this.setState({ message: {} });
         }
         break;
-      case "CLEAR_BUNDLE":
-        if (this.state.bundle.bundle) {
-          this.setState({ bundle: {} });
-        }
-        break;
       case "CLEAR_ALL":
-        this.setState({ message: {}, bundle: {} });
+        this.setState({ message: {} });
         break;
       case "AS_ROUTER_TARGETING_UPDATE":
         action.data.forEach(id => this.clearMessage(id));
@@ -345,15 +312,11 @@ export class ASRouterUISurface extends React.PureComponent {
   }
 
   renderSnippets() {
-    if (
-      this.state.bundle.template === "onboarding" ||
-      this.state.message.template === "fxa_overlay" ||
-      this.state.message.template === "return_to_amo_overlay" ||
-      this.state.message.template === "trailhead"
-    ) {
+    const { message } = this.state;
+    if (!SnippetsTemplates[message.template]) {
       return null;
     }
-    const SnippetComponent = SnippetsTemplates[this.state.message.template];
+    const SnippetComponent = SnippetsTemplates[message.template];
     const { content } = this.state.message;
 
     return (
@@ -380,70 +343,6 @@ export class ASRouterUISurface extends React.PureComponent {
     );
   }
 
-  renderOnboarding() {
-    if (this.state.bundle.template === "onboarding") {
-      return (
-        <OnboardingMessage
-          {...this.state.bundle}
-          UISurface="NEWTAB_OVERLAY"
-          onAction={ASRouterUtils.executeAction}
-          onDismissBundle={this.dismissBundle(this.state.bundle.bundle)}
-          sendUserActionTelemetry={this.sendUserActionTelemetry}
-        />
-      );
-    }
-    return null;
-  }
-
-  renderFirstRunOverlay() {
-    const { message } = this.state;
-    if (message.template === "fxa_overlay") {
-      global.document.body.classList.add("fxa");
-      return (
-        <StartupOverlay
-          onReady={this.triggerOnboarding}
-          onBlock={this.onDismissById(message.id)}
-          dispatch={this.props.dispatch}
-        />
-      );
-    } else if (message.template === "return_to_amo_overlay") {
-      global.document.body.classList.add("amo");
-      return (
-        <LocalizationProvider
-          bundles={generateBundles({ amo_html: message.content.text })}
-        >
-          <ReturnToAMO
-            {...message}
-            UISurface="NEWTAB_OVERLAY"
-            onReady={this.triggerOnboarding}
-            onBlock={this.onDismissById(message.id)}
-            onAction={ASRouterUtils.executeAction}
-            sendUserActionTelemetry={this.sendUserActionTelemetry}
-          />
-        </LocalizationProvider>
-      );
-    }
-    return null;
-  }
-
-  renderTrailhead() {
-    const { message } = this.state;
-    if (message.template === "trailhead") {
-      return (
-        <Trailhead
-          document={this.props.document}
-          message={message}
-          onAction={ASRouterUtils.executeAction}
-          onDismissBundle={this.dismissBundle(this.state.message.bundle)}
-          sendUserActionTelemetry={this.sendUserActionTelemetry}
-          dispatch={this.props.dispatch}
-          fxaEndpoint={this.props.fxaEndpoint}
-        />
-      );
-    }
-    return null;
-  }
-
   renderPreviewBanner() {
     if (this.state.message.provider !== "preview") {
       return null;
@@ -457,9 +356,27 @@ export class ASRouterUISurface extends React.PureComponent {
     );
   }
 
+  renderFirstRun() {
+    const { message } = this.state;
+    if (FIRST_RUN_TEMPLATES.includes(message.template)) {
+      return (
+        <FirstRun
+          document={this.props.document}
+          message={message}
+          sendUserActionTelemetry={this.sendUserActionTelemetry}
+          executeAction={ASRouterUtils.executeAction}
+          dispatch={this.props.dispatch}
+          onDismiss={this.onDismissById(this.state.message.id)}
+          fxaEndpoint={this.props.fxaEndpoint}
+        />
+      );
+    }
+    return null;
+  }
+
   render() {
-    const { message, bundle } = this.state;
-    if (!message.id && !bundle.template) {
+    const { message } = this.state;
+    if (!message.id) {
       return null;
     }
     const shouldRenderBelowSearch = TEMPLATES_BELOW_SEARCH.includes(
@@ -480,9 +397,7 @@ export class ASRouterUISurface extends React.PureComponent {
       ReactDOM.createPortal(
         <>
           {this.renderPreviewBanner()}
-          {this.renderTrailhead()}
-          {this.renderFirstRunOverlay()}
-          {this.renderOnboarding()}
+          {this.renderFirstRun()}
           {this.renderSnippets()}
         </>,
         shouldRenderInHeader ? this.headerPortal : this.footerPortal

--- a/content-src/asrouter/asrouter-content.jsx
+++ b/content-src/asrouter/asrouter-content.jsx
@@ -23,6 +23,7 @@ const TEMPLATES_ABOVE_PAGE = [
   "trailhead",
   "fxa_overlay",
   "return_to_amo_overlay",
+  "extended_triplets",
 ];
 const FIRST_RUN_TEMPLATES = TEMPLATES_ABOVE_PAGE;
 const TEMPLATES_BELOW_SEARCH = ["simple_below_search_snippet"];
@@ -275,7 +276,7 @@ export class ASRouterUISurface extends React.PureComponent {
       });
     } else {
       ASRouterUtils.sendMessage({
-        type: "SNIPPETS_REQUEST",
+        type: "NEWTAB_MESSAGE_REQUEST",
         data: { endpoint },
       });
     }
@@ -360,15 +361,25 @@ export class ASRouterUISurface extends React.PureComponent {
     const { message } = this.state;
     if (FIRST_RUN_TEMPLATES.includes(message.template)) {
       return (
-        <FirstRun
+        <ImpressionsWrapper
+          id="FIRST_RUN"
+          message={this.state.message}
+          sendImpression={this.sendImpression}
+          shouldSendImpressionOnUpdate={shouldSendImpressionOnUpdate}
+          // This helps with testing
           document={this.props.document}
-          message={message}
-          sendUserActionTelemetry={this.sendUserActionTelemetry}
-          executeAction={ASRouterUtils.executeAction}
-          dispatch={this.props.dispatch}
-          onDismiss={this.onDismissById(this.state.message.id)}
-          fxaEndpoint={this.props.fxaEndpoint}
-        />
+        >
+          <FirstRun
+            document={this.props.document}
+            message={message}
+            sendUserActionTelemetry={this.sendUserActionTelemetry}
+            executeAction={ASRouterUtils.executeAction}
+            dispatch={this.props.dispatch}
+            onBlock={this.onBlockById(this.state.message.id)}
+            onDismiss={this.onDismissById(this.state.message.id)}
+            fxaEndpoint={this.props.fxaEndpoint}
+          />
+        </ImpressionsWrapper>
       );
     }
     return null;

--- a/content-src/asrouter/templates/FirstRun/FirstRun.jsx
+++ b/content-src/asrouter/templates/FirstRun/FirstRun.jsx
@@ -18,8 +18,9 @@ export const FLUENT_FILES = [
 ];
 
 export const helpers = {
-  selectInterruptAndTriplets(message = {}) {
-    const hasInterrupt = Boolean(message.content);
+  selectInterruptAndTriplets(message = {}, interruptCleared) {
+    const hasInterrupt =
+      interruptCleared === true ? false : Boolean(message.content);
     const hasTriplets = Boolean(message.bundle && message.bundle.length);
     const UTMTerm = message.utm_term || "";
     return {
@@ -71,18 +72,22 @@ export class FirstRun extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { message } = props;
-    if (message && message.id !== state.prevMessageId) {
+    const { message, interruptCleared } = props;
+    if (
+      interruptCleared !== state.prevInterruptCleared ||
+      (message && message.id !== state.prevMessageId)
+    ) {
       const {
         hasTriplets,
         hasInterrupt,
         interrupt,
         triplets,
         UTMTerm,
-      } = helpers.selectInterruptAndTriplets(message);
+      } = helpers.selectInterruptAndTriplets(message, interruptCleared);
 
       return {
         prevMessageId: message.id,
+        prevInterruptCleared: interruptCleared,
 
         hasInterrupt,
         hasTriplets,

--- a/content-src/asrouter/templates/FirstRun/FirstRun.jsx
+++ b/content-src/asrouter/templates/FirstRun/FirstRun.jsx
@@ -171,6 +171,10 @@ export class FirstRun extends React.PureComponent {
 
   closeTriplets() {
     this.setState({ isTripletsContainerVisible: false });
+    // TODO: Needs to block ALL extended triplets as well
+    if (this.props.message.template === "extended_triplets") {
+      this.props.onBlock();
+    }
   }
 
   render() {

--- a/content-src/asrouter/templates/FirstRun/FirstRun.jsx
+++ b/content-src/asrouter/templates/FirstRun/FirstRun.jsx
@@ -175,6 +175,7 @@ export class FirstRun extends React.PureComponent {
             onNextScene={this.closeInterrupt}
             UTMTerm={UTMTerm}
             sendUserActionTelemetry={sendUserActionTelemetry}
+            executeAction={executeAction}
             dispatch={dispatch}
             flowParams={flowParams}
             onDismiss={this.closeInterrupt}

--- a/content-src/asrouter/templates/FirstRun/FirstRun.jsx
+++ b/content-src/asrouter/templates/FirstRun/FirstRun.jsx
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { Interrupt } from "./Interrupt";
+import { Triplets } from "./Triplets";
+import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
+import { addUtmParams } from "./addUtmParams";
+
+export const FLUENT_FILES = [
+  "branding/brand.ftl",
+  "browser/branding/brandings.ftl",
+  "browser/branding/sync-brand.ftl",
+  "browser/newtab/onboarding.ftl",
+];
+
+export const helpers = {
+  selectInterruptAndTriplets(message = {}) {
+    const hasInterrupt = Boolean(message.content);
+    const hasTriplets = Boolean(message.bundle && message.bundle.length);
+    const UTMTerm = message.utm_term || "";
+    return {
+      hasTriplets,
+      hasInterrupt,
+      interrupt: hasInterrupt ? message : null,
+      triplets: hasTriplets ? message.bundle : null,
+      UTMTerm,
+    };
+  },
+
+  addFluent(document) {
+    FLUENT_FILES.forEach(file => {
+      const link = document.head.appendChild(document.createElement("link"));
+      link.href = file;
+      link.rel = "localization";
+    });
+  },
+
+  async fetchFlowParams({ fxaEndpoint, UTMTerm, dispatch, setFlowParams }) {
+    try {
+      const url = new URL(
+        `${fxaEndpoint}/metrics-flow?entrypoint=activity-stream-firstrun&form_type=email`
+      );
+      addUtmParams(url, UTMTerm);
+      const response = await fetch(url, { credentials: "omit" });
+      if (response.status === 200) {
+        const { deviceId, flowId, flowBeginTime } = await response.json();
+        setFlowParams({ deviceId, flowId, flowBeginTime });
+      } else {
+        dispatch(
+          ac.OnlyToMain({
+            type: at.TELEMETRY_UNDESIRED_EVENT,
+            data: {
+              event: "FXA_METRICS_FETCH_ERROR",
+              value: response.status,
+            },
+          })
+        );
+      }
+    } catch (error) {
+      dispatch(
+        ac.OnlyToMain({
+          type: at.TELEMETRY_UNDESIRED_EVENT,
+          data: { event: "FXA_METRICS_ERROR" },
+        })
+      );
+    }
+  },
+};
+
+const { useEffect, useState } = React;
+export const FirstRun = props => {
+  const {
+    message,
+    sendUserActionTelemetry,
+    fxaEndpoint,
+    dispatch,
+    executeAction,
+    document,
+  } = props;
+
+  const {
+    hasTriplets,
+    hasInterrupt,
+    interrupt,
+    triplets,
+    UTMTerm,
+  } = helpers.selectInterruptAndTriplets(message);
+
+  const [addedFluent, setAddedFluent] = useState(false);
+  useEffect(() => {
+    helpers.addFluent(document);
+    // We need to remove hide-main since we should show it underneath everything that has rendered
+    props.document.body.classList.remove("hide-main");
+    setAddedFluent(true);
+  }, []);
+
+  const [state, setState] = useState({
+    isInterruptVisible: false,
+    isTripletsContainerVisible: false,
+    isTripletsContentVisible: false,
+  });
+
+  useEffect(() => {
+    setState({
+      isInterruptVisible: hasInterrupt,
+      isTripletsContainerVisible: hasTriplets,
+      isTripletsContentVisible: false,
+    });
+    if (!hasInterrupt) {
+      props.document.body.classList.remove("welcome");
+    }
+  }, [interrupt, triplets, hasInterrupt, hasTriplets]);
+
+  const [flowParams, setFlowParams] = useState();
+  useEffect(() => {
+    if (fxaEndpoint && UTMTerm) {
+      helpers.fetchFlowParams({
+        fxaEndpoint,
+        UTMTerm,
+        dispatch,
+        setFlowParams,
+      });
+    }
+  }, [fxaEndpoint, UTMTerm, dispatch]);
+
+  const {
+    isInterruptVisible,
+    isTripletsContainerVisible,
+    isTripletsContentVisible,
+  } = state;
+
+  const closeInterrupt = () => {
+    setState(prevState => ({
+      isInterruptVisible: false,
+      isTripletsContainerVisible: prevState.hasTriplets,
+      isTripletsContentVisible: prevState.hasTriplets,
+    }));
+  };
+
+  const closeTriplets = () => setState({ isTripletsContainerVisible: false });
+
+  const dismissAndGoNext = () => {
+    // onDismiss();
+    closeInterrupt();
+  };
+
+  // Don't render before we add strings;
+  if (!addedFluent) return null;
+
+  return (
+    <>
+      {isInterruptVisible ? (
+        <Interrupt
+          document={props.document}
+          message={interrupt}
+          onNextScene={closeInterrupt}
+          UTMTerm={UTMTerm}
+          sendUserActionTelemetry={sendUserActionTelemetry}
+          dispatch={dispatch}
+          flowParams={flowParams}
+          onDismiss={dismissAndGoNext}
+          fxaEndpoint={fxaEndpoint}
+        />
+      ) : null}
+      {hasTriplets ? (
+        <Triplets
+          document={props.document}
+          cards={triplets}
+          showCardPanel={isTripletsContainerVisible}
+          showContent={isTripletsContentVisible}
+          hideContainer={closeTriplets}
+          sendUserActionTelemetry={sendUserActionTelemetry}
+          UTMTerm={`${UTMTerm}-card`}
+          flowParams={flowParams}
+          onAction={executeAction}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/content-src/asrouter/templates/FirstRun/FirstRun.jsx
+++ b/content-src/asrouter/templates/FirstRun/FirstRun.jsx
@@ -7,6 +7,9 @@ import { Interrupt } from "./Interrupt";
 import { Triplets } from "./Triplets";
 import { BASE_PARAMS } from "./addUtmParams";
 
+// Note: should match the transition time on .trailheadCards in _Trailhead.scss
+const TRANSITION_LENGTH = 500;
+
 export const FLUENT_FILES = [
   "branding/brand.ftl",
   "browser/branding/brandings.ftl",
@@ -140,10 +143,11 @@ export class FirstRun extends React.PureComponent {
 
   closeTriplets() {
     this.setState({ isTripletsContainerVisible: false });
-    // TODO: Needs to block ALL extended triplets as well
-    if (this.props.message.template === "extended_triplets") {
-      this.props.onBlock();
-    }
+
+    // Closing triplets should prevent any future extended triplets from showing up
+    setTimeout(() => {
+      this.props.onBlockById("EXTENDED_TRIPLETS_1");
+    }, TRANSITION_LENGTH);
   }
 
   render() {

--- a/content-src/asrouter/templates/FirstRun/Interrupt.jsx
+++ b/content-src/asrouter/templates/FirstRun/Interrupt.jsx
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { Trailhead } from "../Trailhead/Trailhead";
+import { ReturnToAMO } from "../ReturnToAMO/ReturnToAMO";
+import { StartupOverlay } from "../StartupOverlay/StartupOverlay";
+import { LocalizationProvider } from "fluent-react";
+import { generateBundles } from "../../rich-text-strings";
+
+export class Interrupt extends React.PureComponent {
+  render() {
+    const {
+      onDismiss,
+      onNextScene,
+      message,
+      sendUserActionTelemetry,
+      executeAction,
+      dispatch,
+      fxaEndpoint,
+      UTMTerm,
+      flowParams,
+    } = this.props;
+
+    switch (message.template) {
+      case "return_to_amo_overlay":
+        return (
+          <LocalizationProvider
+            bundles={generateBundles({ amo_html: message.content.text })}
+          >
+            <ReturnToAMO
+              {...message}
+              UISurface="NEWTAB_OVERLAY"
+              onBlock={onDismiss}
+              onAction={executeAction}
+              sendUserActionTelemetry={sendUserActionTelemetry}
+            />
+          </LocalizationProvider>
+        );
+      case "fxa_overlay":
+        return (
+          <StartupOverlay
+            onBlock={onDismiss}
+            dispatch={dispatch}
+            fxa_endpoint={fxaEndpoint}
+          />
+        );
+      case "trailhead":
+        return (
+          <Trailhead
+            document={this.props.document}
+            message={message}
+            onNextScene={onNextScene}
+            onAction={executeAction}
+            sendUserActionTelemetry={sendUserActionTelemetry}
+            dispatch={dispatch}
+            fxaEndpoint={fxaEndpoint}
+            UTMTerm={UTMTerm}
+            flowParams={flowParams}
+          />
+        );
+      default:
+        throw new Error(`${message.template} is not a valid FirstRun message`);
+    }
+  }
+}

--- a/content-src/asrouter/templates/FirstRun/Triplets.jsx
+++ b/content-src/asrouter/templates/FirstRun/Triplets.jsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { OnboardingCard } from "../../templates/OnboardingMessage/OnboardingMessage";
+import { addUtmParams } from "./addUtmParams";
+
+export class Triplets extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onCardAction = this.onCardAction.bind(this);
+    this.onHideContainer = this.onHideContainer.bind(this);
+  }
+
+  componentWillMount() {
+    global.document.body.classList.add("inline-onboarding");
+  }
+
+  componentWillUnmount() {
+    this.props.document.body.classList.remove("inline-onboarding");
+  }
+
+  onCardAction(action) {
+    let actionUpdates = {};
+    const { flowParams, UTMTerm } = this.props;
+
+    if (action.type === "OPEN_URL") {
+      let url = new URL(action.data.args);
+      addUtmParams(url, UTMTerm);
+
+      if (action.addFlowParams) {
+        url.searchParams.append("device_id", flowParams.deviceId);
+        url.searchParams.append("flow_id", flowParams.flowId);
+        url.searchParams.append("flow_begin_time", flowParams.flowBeginTime);
+      }
+
+      actionUpdates = { data: { ...action.data, args: url.toString() } };
+    }
+
+    this.props.onAction({ ...action, ...actionUpdates });
+  }
+
+  onHideContainer() {
+    const { sendUserActionTelemetry, cards, hideContainer } = this.props;
+    hideContainer();
+    sendUserActionTelemetry({
+      event: "DISMISS",
+      id: "onboarding-cards",
+      message_id: cards.map(m => m.id).join(","),
+      action: "onboarding_user_event",
+    });
+  }
+
+  render() {
+    const {
+      cards,
+      showCardPanel,
+      showContent,
+      sendUserActionTelemetry,
+    } = this.props;
+    return (
+      <div
+        className={`trailheadCards ${showCardPanel ? "expanded" : "collapsed"}`}
+      >
+        <div className="trailheadCardsInner" aria-hidden={!showContent}>
+          <h1 data-l10n-id="onboarding-welcome-header" />
+          <div className={`trailheadCardGrid${showContent ? " show" : ""}`}>
+            {cards.map(card => (
+              <OnboardingCard
+                key={card.id}
+                className="trailheadCard"
+                sendUserActionTelemetry={sendUserActionTelemetry}
+                onAction={this.onCardAction}
+                UISurface="TRAILHEAD"
+                {...card}
+              />
+            ))}
+          </div>
+          {showCardPanel && (
+            <button
+              className="icon icon-dismiss"
+              onClick={this.onHideContainer}
+              data-l10n-id="onboarding-cards-dismiss"
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/content-src/asrouter/templates/FirstRun/addUtmParams.js
+++ b/content-src/asrouter/templates/FirstRun/addUtmParams.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const BASE_PARAMS = {
+export const BASE_PARAMS = {
   utm_source: "activity-stream",
   utm_campaign: "firstrun",
   utm_medium: "referral",

--- a/content-src/asrouter/templates/FirstRun/addUtmParams.js
+++ b/content-src/asrouter/templates/FirstRun/addUtmParams.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const BASE_PARAMS = {
+  utm_source: "activity-stream",
+  utm_campaign: "firstrun",
+  utm_medium: "referral",
+};
+
+/**
+ * Takes in a url as a string or URL object and returns a URL object with the
+ * utm_* parameters added to it. If a URL object is passed in, the paraemeters
+ * are added to it (the return value can be ignored in that case as it's the
+ * same object).
+ */
+export function addUtmParams(url, utmTerm) {
+  let returnUrl = url;
+  if (typeof returnUrl === "string") {
+    returnUrl = new URL(url);
+  }
+  Object.keys(BASE_PARAMS).forEach(key => {
+    returnUrl.searchParams.append(key, BASE_PARAMS[key]);
+  });
+  returnUrl.searchParams.append("utm_term", utmTerm);
+  return returnUrl;
+}

--- a/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
+++ b/content-src/asrouter/templates/OnboardingMessage/OnboardingMessage.jsx
@@ -1,11 +1,8 @@
-import { ModalOverlay } from "../../components/ModalOverlay/ModalOverlay";
-import React from "react";
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const FLUENT_FILES = [
-  "branding/brand.ftl",
-  "browser/branding/sync-brand.ftl",
-  "browser/newtab/onboarding.ftl",
-];
+import React from "react";
 
 export class OnboardingCard extends React.PureComponent {
   constructor(props) {
@@ -50,36 +47,6 @@ export class OnboardingCard extends React.PureComponent {
           </span>
         </div>
       </div>
-    );
-  }
-}
-
-export class OnboardingMessage extends React.PureComponent {
-  componentWillMount() {
-    FLUENT_FILES.forEach(file => {
-      const link = document.head.appendChild(document.createElement("link"));
-      link.href = file;
-      link.rel = "localization";
-    });
-  }
-
-  render() {
-    const { props } = this;
-    const { button_label, header } = props.extraTemplateStrings;
-    return (
-      <ModalOverlay {...props} button_label={button_label} title={header}>
-        <div className="onboardingMessageContainer">
-          {props.bundle.map(message => (
-            <OnboardingCard
-              key={message.id}
-              sendUserActionTelemetry={props.sendUserActionTelemetry}
-              onAction={props.onAction}
-              UISurface={props.UISurface}
-              {...message}
-            />
-          ))}
-        </div>
-      </ModalOverlay>
     );
   }
 }

--- a/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
+++ b/content-src/asrouter/templates/OnboardingMessage/_OnboardingMessage.scss
@@ -1,20 +1,3 @@
-.onboardingMessageContainer {
-  display: grid;
-  grid-column-gap: 21px;
-  grid-template-columns: auto auto auto;
-  padding-left: 30px;
-  padding-right: 30px;
-  min-height: 500px;
-
-  // at 850px, the cards go from vertical layout to horizontal layout
-  @media(max-width: 850px) {
-    grid-template-columns: none;
-    grid-template-rows: auto auto auto;
-    padding-left: 110px;
-    padding-right: 110px;
-  }
-}
-
 .onboardingMessage {
   height: 340px;
   text-align: center;

--- a/content-src/asrouter/templates/ReturnToAMO/ReturnToAMO.jsx
+++ b/content-src/asrouter/templates/ReturnToAMO/ReturnToAMO.jsx
@@ -11,8 +11,11 @@ export class ReturnToAMO extends React.PureComponent {
     this.onBlockButton = this.onBlockButton.bind(this);
   }
 
+  componentWillMount() {
+    global.document.body.classList.add("amo");
+  }
+
   componentDidMount() {
-    this.props.onReady();
     this.props.sendUserActionTelemetry({
       event: "IMPRESSION",
       id: this.props.UISurface,

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -1,14 +1,11 @@
-import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
-import { ModalOverlayWrapper } from "../../components/ModalOverlay/ModalOverlay";
-import { OnboardingCard } from "../OnboardingMessage/OnboardingMessage";
-import React from "react";
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const FLUENT_FILES = [
-  "branding/brand.ftl",
-  "browser/branding/brandings.ftl",
-  "browser/branding/sync-brand.ftl",
-  "browser/newtab/onboarding.ftl",
-];
+import { actionCreators as ac } from "common/Actions.jsm";
+import { ModalOverlayWrapper } from "../../components/ModalOverlay/ModalOverlay";
+import { addUtmParams } from "../FirstRun/addUtmParams";
+import React from "react";
 
 // From resource://devtools/client/shared/focus.js
 const FOCUSABLE_SELECTOR = [
@@ -25,104 +22,30 @@ export class Trailhead extends React.PureComponent {
   constructor(props) {
     super(props);
     this.closeModal = this.closeModal.bind(this);
-    this.hideCardPanel = this.hideCardPanel.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
     this.onStartBlur = this.onStartBlur.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.onInputInvalid = this.onInputInvalid.bind(this);
-    this.onCardAction = this.onCardAction.bind(this);
 
     this.state = {
       emailInput: "",
-      isModalOpen: true,
-      showCardPanel: true,
-      showCards: false,
-      // The params below are for FxA metrics
-      deviceId: "",
-      flowId: "",
-      flowBeginTime: 0,
     };
-    this.fxaMetricsInitialized = false;
   }
 
   get dialog() {
     return this.props.document.getElementById("trailheadDialog");
   }
 
-  async componentWillMount() {
-    FLUENT_FILES.forEach(file => {
-      const link = document.head.appendChild(document.createElement("link"));
-      link.href = file;
-      link.rel = "localization";
-    });
-
-    await this.componentWillUpdate(this.props);
-  }
-
-  // Get the fxa data if we don't have it yet from mount or update
-  async componentWillUpdate(props) {
-    if (props.fxaEndpoint && !this.fxaMetricsInitialized) {
-      try {
-        this.fxaMetricsInitialized = true;
-        const url = new URL(
-          `${
-            props.fxaEndpoint
-          }/metrics-flow?entrypoint=activity-stream-firstrun&form_type=email`
-        );
-        this.addUtmParams(url);
-        const response = await fetch(url, { credentials: "omit" });
-        if (response.status === 200) {
-          const { deviceId, flowId, flowBeginTime } = await response.json();
-          this.setState({ deviceId, flowId, flowBeginTime });
-        } else {
-          props.dispatch(
-            ac.OnlyToMain({
-              type: at.TELEMETRY_UNDESIRED_EVENT,
-              data: {
-                event: "FXA_METRICS_FETCH_ERROR",
-                value: response.status,
-              },
-            })
-          );
-        }
-      } catch (error) {
-        props.dispatch(
-          ac.OnlyToMain({
-            type: at.TELEMETRY_UNDESIRED_EVENT,
-            data: { event: "FXA_METRICS_ERROR" },
-          })
-        );
-      }
-    }
-  }
-
   componentDidMount() {
-    // We need to remove hide-main since we should show it underneath everything that has rendered
-    this.props.document.body.classList.remove("hide-main");
-
-    // Add inline-onboarding class to disable fixed search header and fixed positioned settings icon
-    this.props.document.body.classList.add("inline-onboarding");
-
-    // The rest of the page is "hidden" when the modal is open
-    if (this.props.message.content) {
-      this.props.document
-        .getElementById("root")
-        .setAttribute("aria-hidden", "true");
-
-      // Start with focus in the email input box
-      this.dialog.querySelector("input[name=email]").focus();
-    } else {
-      // No modal overlay, let the user scroll and deal them some cards.
-      this.props.document.body.classList.remove("welcome");
-
-      if (this.props.message.includeBundle || this.props.message.cards) {
-        this.revealCards();
-      }
+    // The rest of the page is "hidden" to screen readers when the modal is open
+    this.props.document
+      .getElementById("root")
+      .setAttribute("aria-hidden", "true");
+    // Start with focus in the email input box
+    const input = this.dialog.querySelector("input[name=email]");
+    if (input) {
+      input.focus();
     }
-  }
-
-  componentWillUnmount() {
-    this.props.document.body.classList.remove("inline-onboarding");
   }
 
   onInputChange(e) {
@@ -168,8 +91,7 @@ export class Trailhead extends React.PureComponent {
     global.removeEventListener("visibilitychange", this.closeModal);
     this.props.document.body.classList.remove("welcome");
     this.props.document.getElementById("root").removeAttribute("aria-hidden");
-    this.setState({ isModalOpen: false });
-    this.revealCards();
+    this.props.onNextScene();
 
     // If closeModal() was triggered by a visibilitychange event, the user actually
     // submitted the email form so we don't send a SKIPPED_SIGNIN ping.
@@ -187,7 +109,7 @@ export class Trailhead extends React.PureComponent {
    * Report to telemetry additional information about the form submission.
    */
   _getFormInfo() {
-    const value = { has_flow_params: this.state.flowId.length > 0 };
+    const value = { has_flow_params: this.props.flowParams.flowId.length > 0 };
     return { value };
   }
 
@@ -199,234 +121,141 @@ export class Trailhead extends React.PureComponent {
     e.target.focus();
   }
 
-  hideCardPanel() {
-    this.setState({ showCardPanel: false });
-    this.props.onDismissBundle();
-  }
-
-  revealCards() {
-    this.setState({ showCards: true });
-  }
-
-  /**
-   * Takes in a url as a string or URL object and returns a URL object with the
-   * utm_* parameters added to it. If a URL object is passed in, the paraemeters
-   * are added to it (the return value can be ignored in that case as it's the
-   * same object).
-   */
-  addUtmParams(url, isCard = false) {
-    let returnUrl = url;
-    if (typeof returnUrl === "string") {
-      returnUrl = new URL(url);
-    }
-    returnUrl.searchParams.append("utm_source", "activity-stream");
-    returnUrl.searchParams.append("utm_campaign", "firstrun");
-    returnUrl.searchParams.append("utm_medium", "referral");
-    returnUrl.searchParams.append(
-      "utm_term",
-      `${this.props.message.utm_term}${isCard ? "-card" : ""}`
-    );
-    return returnUrl;
-  }
-
-  onCardAction(action) {
-    let actionUpdates = {};
-
-    if (action.type === "OPEN_URL") {
-      let url = new URL(action.data.args);
-      this.addUtmParams(url, true);
-
-      if (action.addFlowParams) {
-        url.searchParams.append("device_id", this.state.deviceId);
-        url.searchParams.append("flow_id", this.state.flowId);
-        url.searchParams.append("flow_begin_time", this.state.flowBeginTime);
-      }
-
-      actionUpdates = { data: { ...action.data, args: url } };
-    }
-
-    this.props.onAction({ ...action, ...actionUpdates });
-  }
-
   render() {
     const { props } = this;
-    const { bundle: cards, content, utm_term } = props.message;
+    const { UTMTerm } = props;
+    const { content } = props.message;
     const innerClassName = ["trailhead", content && content.className]
       .filter(v => v)
       .join(" ");
 
     return (
-      <>
-        {this.state.isModalOpen && content ? (
-          <ModalOverlayWrapper
-            innerClassName={innerClassName}
-            onClose={this.closeModal}
-            id="trailheadDialog"
-            headerId="trailheadHeader"
-          >
-            <div className="trailheadInner">
-              <div className="trailheadContent">
-                <h1
-                  data-l10n-id={content.title.string_id}
-                  id="trailheadHeader"
-                />
-                {content.subtitle && (
-                  <p data-l10n-id={content.subtitle.string_id} />
-                )}
-                <ul className="trailheadBenefits">
-                  {content.benefits.map(item => (
-                    <li key={item.id} className={item.id}>
-                      <h3 data-l10n-id={item.title.string_id} />
-                      <p data-l10n-id={item.text.string_id} />
-                    </li>
-                  ))}
-                </ul>
-                <a
-                  className="trailheadLearn"
-                  data-l10n-id={content.learn.text.string_id}
-                  href={this.addUtmParams(content.learn.url)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              </div>
-              <div
-                role="group"
-                aria-labelledby="joinFormHeader"
-                aria-describedby="joinFormBody"
-                className="trailheadForm"
-              >
-                <h3
-                  id="joinFormHeader"
-                  data-l10n-id={content.form.title.string_id}
-                />
-                <p
-                  id="joinFormBody"
-                  data-l10n-id={content.form.text.string_id}
-                />
-                <form
-                  method="get"
-                  action={this.props.fxaEndpoint}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onSubmit={this.onSubmit}
-                >
-                  <input name="service" type="hidden" value="sync" />
-                  <input name="action" type="hidden" value="email" />
-                  <input name="context" type="hidden" value="fx_desktop_v3" />
-                  <input
-                    name="entrypoint"
-                    type="hidden"
-                    value="activity-stream-firstrun"
-                  />
-                  <input
-                    name="utm_source"
-                    type="hidden"
-                    value="activity-stream"
-                  />
-                  <input name="utm_campaign" type="hidden" value="firstrun" />
-                  <input name="utm_term" type="hidden" value={utm_term} />
-                  <input
-                    name="device_id"
-                    type="hidden"
-                    value={this.state.deviceId}
-                  />
-                  <input
-                    name="flow_id"
-                    type="hidden"
-                    value={this.state.flowId}
-                  />
-                  <input
-                    name="flow_begin_time"
-                    type="hidden"
-                    value={this.state.flowBeginTime}
-                  />
-                  <input name="style" type="hidden" value="trailhead" />
-                  <p
-                    data-l10n-id="onboarding-join-form-email-error"
-                    className="error"
-                  />
-                  <input
-                    data-l10n-id={content.form.email.string_id}
-                    name="email"
-                    type="email"
-                    onInvalid={this.onInputInvalid}
-                    onChange={this.onInputChange}
-                  />
-                  <p
-                    className="trailheadTerms"
-                    data-l10n-id="onboarding-join-form-legal"
-                  >
-                    <a
-                      data-l10n-name="terms"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={this.addUtmParams(
-                        "https://accounts.firefox.com/legal/terms"
-                      )}
-                    />
-                    <a
-                      data-l10n-name="privacy"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={this.addUtmParams(
-                        "https://accounts.firefox.com/legal/privacy"
-                      )}
-                    />
-                  </p>
-                  <button
-                    data-l10n-id={content.form.button.string_id}
-                    type="submit"
-                  />
-                </form>
-              </div>
-            </div>
-
-            <button
-              className="trailheadStart"
-              data-l10n-id={content.skipButton.string_id}
-              onBlur={this.onStartBlur}
-              onClick={this.closeModal}
+      <ModalOverlayWrapper
+        innerClassName={innerClassName}
+        onClose={this.closeModal}
+        id="trailheadDialog"
+        headerId="trailheadHeader"
+      >
+        <div className="trailheadInner">
+          <div className="trailheadContent">
+            <h1 data-l10n-id={content.title.string_id} id="trailheadHeader" />
+            {content.subtitle && (
+              <p data-l10n-id={content.subtitle.string_id} />
+            )}
+            <ul className="trailheadBenefits">
+              {content.benefits.map(item => (
+                <li key={item.id} className={item.id}>
+                  <h3 data-l10n-id={item.title.string_id} />
+                  <p data-l10n-id={item.text.string_id} />
+                </li>
+              ))}
+            </ul>
+            <a
+              className="trailheadLearn"
+              data-l10n-id={content.learn.text.string_id}
+              href={addUtmParams(content.learn.url, UTMTerm)}
+              target="_blank"
+              rel="noopener noreferrer"
             />
-          </ModalOverlayWrapper>
-        ) : null}
-        {cards && cards.length ? (
-          <div
-            className={`trailheadCards ${
-              this.state.showCardPanel ? "expanded" : "collapsed"
-            }`}
-          >
-            <div
-              className="trailheadCardsInner"
-              aria-hidden={!this.state.showCards}
-            >
-              <h1 data-l10n-id="onboarding-welcome-header" />
-              <div
-                className={`trailheadCardGrid${
-                  this.state.showCards ? " show" : ""
-                }`}
-              >
-                {cards.map(card => (
-                  <OnboardingCard
-                    key={card.id}
-                    className="trailheadCard"
-                    sendUserActionTelemetry={props.sendUserActionTelemetry}
-                    onAction={this.onCardAction}
-                    UISurface="TRAILHEAD"
-                    {...card}
-                  />
-                ))}
-              </div>
-              {this.state.showCardPanel && (
-                <button
-                  className="icon icon-dismiss"
-                  onClick={this.hideCardPanel}
-                  data-l10n-id="onboarding-cards-dismiss"
-                />
-              )}
-            </div>
           </div>
-        ) : null}
-      </>
+          <div
+            role="group"
+            aria-labelledby="joinFormHeader"
+            aria-describedby="joinFormBody"
+            className="trailheadForm"
+          >
+            <h3
+              id="joinFormHeader"
+              data-l10n-id={content.form.title.string_id}
+            />
+            <p id="joinFormBody" data-l10n-id={content.form.text.string_id} />
+            <form
+              method="get"
+              action={this.props.fxaEndpoint}
+              target="_blank"
+              rel="noopener noreferrer"
+              onSubmit={this.onSubmit}
+            >
+              <input name="service" type="hidden" value="sync" />
+              <input name="action" type="hidden" value="email" />
+              <input name="context" type="hidden" value="fx_desktop_v3" />
+              <input
+                name="entrypoint"
+                type="hidden"
+                value="activity-stream-firstrun"
+              />
+              <input name="utm_source" type="hidden" value="activity-stream" />
+              <input name="utm_campaign" type="hidden" value="firstrun" />
+              <input name="utm_term" type="hidden" value={UTMTerm} />
+              <input
+                name="device_id"
+                type="hidden"
+                value={this.props.flowParams.deviceId}
+              />
+              <input
+                name="flow_id"
+                type="hidden"
+                value={this.props.flowParams.flowId}
+              />
+              <input
+                name="flow_begin_time"
+                type="hidden"
+                value={this.props.flowParams.flowBeginTime}
+              />
+              <input name="style" type="hidden" value="trailhead" />
+              <p
+                data-l10n-id="onboarding-join-form-email-error"
+                className="error"
+              />
+              <input
+                data-l10n-id={content.form.email.string_id}
+                name="email"
+                type="email"
+                onInvalid={this.onInputInvalid}
+                onChange={this.onInputChange}
+              />
+              <p
+                className="trailheadTerms"
+                data-l10n-id="onboarding-join-form-legal"
+              >
+                <a
+                  data-l10n-name="terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={addUtmParams(
+                    "https://accounts.firefox.com/legal/terms",
+                    UTMTerm
+                  )}
+                />
+                <a
+                  data-l10n-name="privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={addUtmParams(
+                    "https://accounts.firefox.com/legal/privacy",
+                    UTMTerm
+                  )}
+                />
+              </p>
+              <button
+                data-l10n-id={content.form.button.string_id}
+                type="submit"
+              />
+            </form>
+          </div>
+        </div>
+
+        <button
+          className="trailheadStart"
+          data-l10n-id={content.skipButton.string_id}
+          onBlur={this.onStartBlur}
+          onClick={this.closeModal}
+        />
+      </ModalOverlayWrapper>
     );
   }
 }
+
+Trailhead.defaultProps = {
+  flowParams: { deviceId: "", flowId: "", flowBeginTime: "" },
+};

--- a/content-src/asrouter/templates/Trailhead/Trailhead.jsx
+++ b/content-src/asrouter/templates/Trailhead/Trailhead.jsx
@@ -37,6 +37,9 @@ export class Trailhead extends React.PureComponent {
   }
 
   componentDidMount() {
+    // We need to remove hide-main since we should show it underneath everything that has rendered
+    this.props.document.body.classList.remove("hide-main");
+
     // The rest of the page is "hidden" to screen readers when the modal is open
     this.props.document
       .getElementById("root")

--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -265,8 +265,13 @@
   background: var(--trailhead-cards-background-color);
   overflow: hidden;
   text-align: center;
+  // Note: should match TRANSITION_LENGTH in FirstRun.jsx
   transition: max-height 0.5s $photon-easing;
 
+  // This is needed for the transition to work, but will cut off content at the smallest breakpoint
+  @media (min-width: $break-point-medium) {
+    max-height: 1000px;
+  }
 
   &.collapsed {
     max-height: 0;

--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -414,6 +414,7 @@
 
   .outer-wrapper {
     position: relative;
+    display: block;
 
     .prefs-button {
       button {

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -955,6 +955,20 @@ CFR impression ping has two forms, in which the message_id could be of different
 }
 ```
 
+#### Onboarding impression
+```js
+{
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "action": "onboarding_user_event",
+  "impression_id": "n/a",
+  "source": "FIRST_RUN",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "message_id": "EXTENDED_TRIPLETS_1",
+  "event": "IMPRESSION"
+}
+```
+
 ### User interaction pings
 
 This reports the user's interaction with Activity Stream Router.

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -93,6 +93,11 @@ const TRAILHEAD_CONFIG = {
   },
   LOCALES: ["en-US", "en-GB", "en-CA", "de", "de-DE", "fr", "fr-FR"],
   EXPERIMENT_RATIOS: [["", 0], ["interrupts", 1], ["triplets", 3]],
+  // Per bug 1571817, for those who meet the targeting criteria of extended
+  // triplets, 99% users (control group) will see the extended triplets, and
+  // the rest 1% (holdback group) won't.
+  EXPERIMENT_RATIOS_FOR_EXTENDED_TRIPLETS: [["control", 99], ["holdback", 1]],
+  EXTENDED_TRIPLETS_EXPERIMENT_PREF: "trailhead.extendedTriplets.experiment",
 };
 
 const INCOMING_MESSAGE_NAME = "ASRouter:child-to-parent";
@@ -489,6 +494,8 @@ class _ASRouter {
       trailheadTriplet: "",
       messages: [],
       errors: [],
+      extendedTripletsInitialized: false,
+      showExtendedTriplets: true,
     };
     this._triggerHandler = this._triggerHandler.bind(this);
     this._localProviders = localProviders;
@@ -980,6 +987,40 @@ class _ASRouter {
       type: at.TRAILHEAD_ENROLL_EVENT,
       data,
     });
+  }
+
+  async setupExtendedTriplets() {
+    // Don't re-initialize
+    if (this.state.extendedTripletsInitialized) {
+      return;
+    }
+
+    let branch = Services.prefs.getStringPref(
+      TRAILHEAD_CONFIG.EXTENDED_TRIPLETS_EXPERIMENT_PREF,
+      ""
+    );
+    if (!branch) {
+      const { userId } = ClientEnvironment;
+      branch = await chooseBranch(
+        `${userId}-extended-triplets-experiment`,
+        TRAILHEAD_CONFIG.EXPERIMENT_RATIOS_FOR_EXTENDED_TRIPLETS
+      );
+      Services.prefs.setStringPref(
+        TRAILHEAD_CONFIG.EXTENDED_TRIPLETS_EXPERIMENT_PREF,
+        branch
+      );
+    }
+
+    // In order for ping centre to pick this up, it MUST contain a substring activity-stream
+    const experimentName = `activity-stream-extended-triplets`;
+    TelemetryEnvironment.setExperimentActive(experimentName, branch);
+
+    const state = { extendedTripletsInitialized: true };
+    // Disable the extended triplets for the "holdback" group.
+    if (branch === "holdback") {
+      state.showExtendedTriplets = false;
+    }
+    await this.setState(state);
   }
 
   async setupTrailhead() {
@@ -1790,11 +1831,24 @@ class _ASRouter {
       }));
     } else {
       // On new tab, send cards if they match; othwerise send a snippet
-      message =
-        (await this.handleMessageRequest({
-          provider: "onboarding",
-          template: "extended_triplets",
-        })) || (await this.handleMessageRequest({ provider: "snippets" }));
+      message = await this.handleMessageRequest({
+        provider: "onboarding",
+        template: "extended_triplets",
+      });
+
+      // Set up the experiment for extended triplets. It's done here because we
+      // only want to enroll users (for both control and holdback) if they meet
+      // the targeting criteria.
+      if (message) {
+        await this.setupExtendedTriplets();
+      }
+
+      // If no extended triplets message was returned, or the holdback experiment
+      // is active, show snippets instead
+      if (!message || !this.state.showExtendedTriplets) {
+        message = await this.handleMessageRequest({ provider: "snippets" });
+      }
+
       await this.setState({ lastMessageId: message ? message.id : null });
     }
 

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -896,18 +896,25 @@ class _ASRouter {
     let interrupt;
     let triplet;
 
-    // Use control Trailhead Branch (for cards) if we are showing RTAMO.
-    if (await this._hasAddonAttributionData()) {
-      return { experiment, interrupt: "control", triplet: "" };
-    }
-
-    // If a value is set in TRAILHEAD_OVERRIDE_PREF, it will be returned and no experiment will be set.
     const overrideValue = Services.prefs.getStringPref(
       TRAILHEAD_CONFIG.OVERRIDE_PREF,
       ""
     );
     if (overrideValue) {
       [interrupt, triplet] = overrideValue.split("-");
+    }
+
+    // Use control Trailhead Branch (for cards) if we are showing RTAMO.
+    if (await this._hasAddonAttributionData()) {
+      return {
+        experiment,
+        interrupt: "control",
+        triplet: triplet || "privacy",
+      };
+    }
+
+    // If a value is set in TRAILHEAD_OVERRIDE_PREF, it will be returned and no experiment will be set.
+    if (overrideValue) {
       return { experiment, interrupt, triplet: triplet || "" };
     }
 
@@ -973,6 +980,7 @@ class _ASRouter {
       interrupt,
       triplet,
     } = await this._generateTrailheadBranches();
+
     await this.setState({
       trailheadInitialized: true,
       trailheadInterrupt: interrupt,
@@ -1824,11 +1832,6 @@ class _ASRouter {
         this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
           type: "CLEAR_PROVIDER",
           data: { id: action.data.id },
-        });
-        break;
-      case "DISMISS_BUNDLE":
-        this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
-          type: "CLEAR_BUNDLE",
         });
         break;
       case "BLOCK_BUNDLE":

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -1611,10 +1611,8 @@ class _ASRouter {
         "webextension-install-notify"
       );
       this.messageChannel.sendAsyncMessage(OUTGOING_MESSAGE_NAME, {
-        type: "CLEAR_MESSAGE",
-        data: { id: "RETURN_TO_AMO_1" },
+        type: "CLEAR_INTERRUPT",
       });
-      this.blockMessageById("RETURN_TO_AMO_1");
     };
     Services.obs.addObserver(addonInstallObs, "webextension-install-notify");
   }

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -734,8 +734,8 @@ class _ASRouter {
 
     this._loadLocalProviders();
 
-    // We need to check whether to set up telemetry for trailhead
-    await this.setupTrailhead();
+    // Instead of setupTrailhead, which adds experiments, just load override pref values
+    await this.setFirstRunStateFromPref();
 
     const messageBlockList =
       (await this._storage.get("messageBlockList")) || [];
@@ -884,6 +884,25 @@ class _ASRouter {
     } catch (e) {
       return false;
     }
+  }
+
+  async setFirstRunStateFromPref() {
+    let interrupt;
+    let triplet;
+
+    const overrideValue = Services.prefs.getStringPref(
+      TRAILHEAD_CONFIG.OVERRIDE_PREF,
+      ""
+    );
+
+    if (overrideValue) {
+      [interrupt, triplet] = overrideValue.split("-");
+    }
+
+    await this.setState({
+      trailheadInterrupt: interrupt,
+      trailheadTriplet: triplet,
+    });
   }
 
   /**
@@ -1448,33 +1467,11 @@ class _ASRouter {
     return impressions;
   }
 
-  async sendNextMessage(target, trigger) {
-    const msgs = this._getUnblockedMessages();
-    let message = null;
-    const previewMsgs = this.state.messages.filter(
-      item => item.provider === "preview"
-    );
-    // Always send preview messages when available
-    if (previewMsgs.length) {
-      [message] = previewMsgs;
-    } else {
-      message = await this._findMessage(msgs, trigger);
-    }
-
-    if (previewMsgs.length) {
-      // We don't want to cache preview messages, remove them after we selected the message to show
-      await this.setState(state => ({
-        lastMessageId: message.id,
-        messages: state.messages.filter(m => m.id !== message.id),
-      }));
-    } else {
-      await this.setState({ lastMessageId: message ? message.id : null });
-    }
-    await this._sendMessageToTarget(message, target, trigger);
-  }
-
-  handleMessageRequest({ triggerId, triggerParam, template }) {
+  handleMessageRequest({ triggerId, triggerParam, provider, template }) {
     const msgs = this._getUnblockedMessages().filter(m => {
+      if (provider && m.provider !== provider) {
+        return false;
+      }
       if (template && m.template !== template) {
         return false;
       }
@@ -1770,6 +1767,63 @@ class _ASRouter {
     this.onMessage({ data: action, target });
   }
 
+  async sendNewTabMessage(target, options = {}) {
+    const { endpoint } = options;
+    let message;
+
+    // Load preview endpoint for snippets if one is sent
+    if (endpoint) {
+      await this._addPreviewEndpoint(endpoint.url, target.portID);
+    }
+
+    // Load all messages
+    await this.loadMessagesFromAllProviders();
+
+    if (endpoint) {
+      message = await this.handleMessageRequest({ provider: "preview" });
+      // We don't want to cache preview messages, remove them after we selected the message to show
+      await this.setState(state => ({
+        lastMessageId: message ? message.id : null,
+        messages: message
+          ? state.messages.filter(m => m.id !== message.id)
+          : state.messages,
+      }));
+    } else {
+      // On new tab, send cards if they match; othwerise send a snippet
+      message =
+        (await this.handleMessageRequest({
+          provider: "onboarding",
+          template: "extended_triplets",
+        })) || (await this.handleMessageRequest({ provider: "snippets" }));
+      await this.setState({ lastMessageId: message ? message.id : null });
+    }
+
+    await this._sendMessageToTarget(message, target);
+  }
+
+  async sendTriggerMessage(target, trigger) {
+    await this.loadMessagesFromAllProviders();
+
+    if (trigger.id === "firstRun") {
+      // On about welcome, set up trailhead experiments
+      if (!this.state.trailheadInitialized) {
+        Services.prefs.setBoolPref(
+          TRAILHEAD_CONFIG.DID_SEE_ABOUT_WELCOME_PREF,
+          true
+        );
+        await this.setupTrailhead();
+      }
+    }
+
+    const message = await this.handleMessageRequest({
+      triggerId: trigger.id,
+      triggerParam: trigger.param,
+    });
+
+    await this.setState({ lastMessageId: message ? message.id : null });
+    await this._sendMessageToTarget(message, target, trigger);
+  }
+
   /* eslint-disable complexity */
   async onMessage({ data: action, target }) {
     switch (action.type) {
@@ -1778,37 +1832,16 @@ class _ASRouter {
           await this.handleUserAction({ data: action.data, target });
         }
         break;
-      case "SNIPPETS_REQUEST":
-      case "TRIGGER":
-        // Wait for our initial message loading to be done before responding to any UI requests
+      case "NEWTAB_MESSAGE_REQUEST":
         await this.waitForInitialized;
-        if (action.data && action.data.endpoint) {
-          await this._addPreviewEndpoint(
-            action.data.endpoint.url,
-            target.portID
-          );
-        }
-
-        // Special experiment intialization for trailhead
-        if (
-          action.data &&
-          action.data.trigger &&
-          action.data.trigger.id === "firstRun"
-        ) {
-          Services.prefs.setBoolPref(
-            TRAILHEAD_CONFIG.DID_SEE_ABOUT_WELCOME_PREF,
-            true
-          );
-          await this.setupTrailhead();
-        }
-
-        // Check if any updates are needed first
-        await this.loadMessagesFromAllProviders();
-        await this.sendNextMessage(
-          target,
-          (action.data && action.data.trigger) || {}
-        );
+        await this.sendNewTabMessage(target, action.data);
         break;
+      case "TRIGGER":
+        await this.waitForInitialized;
+        await this.sendTriggerMessage(
+          target,
+          action.data && action.data.trigger
+        );
       case "BLOCK_MESSAGE_BY_ID":
         await this.blockMessageById(action.data.id);
         // Block the message but don't dismiss it in case the action taken has

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -101,6 +101,7 @@ const ONBOARDING_MESSAGES = () => [
   {
     id: "EXTENDED_TRIPLETS_1",
     template: "extended_triplets",
+    campaign: "firstrun_triplets",
     targeting:
       "trailheadTriplet && ((currentDate|date - profileAgeCreated) / 86400000) < 7",
     includeBundle: {

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -3,9 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 /* globals Localization */
-const { FxAccountsConfig } = ChromeUtils.import(
-  "resource://gre/modules/FxAccountsConfig.jsm"
-);
 const { AttributionCode } = ChromeUtils.import(
   "resource:///modules/AttributionCode.jsm"
 );
@@ -21,114 +18,7 @@ const L10N = new Localization([
   "browser/newtab/onboarding.ftl",
 ]);
 
-const ONBOARDING_MESSAGES = async () => [
-  {
-    id: "ONBOARDING_1",
-    template: "onboarding",
-    bundled: 3,
-    order: 2,
-    content: {
-      title: { string_id: "onboarding-private-browsing-title" },
-      text: { string_id: "onboarding-private-browsing-text" },
-      icon: "privatebrowsing",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: { type: "OPEN_PRIVATE_BROWSER_WINDOW" },
-      },
-    },
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_2",
-    template: "onboarding",
-    bundled: 3,
-    order: 3,
-    content: {
-      title: { string_id: "onboarding-screenshots-title" },
-      text: { string_id: "onboarding-screenshots-text" },
-      icon: "screenshots",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: {
-          type: "OPEN_URL",
-          data: {
-            args: "https://screenshots.firefox.com/#tour",
-            where: "tabshifted",
-          },
-        },
-      },
-    },
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_3",
-    template: "onboarding",
-    bundled: 3,
-    order: 1,
-    content: {
-      title: { string_id: "onboarding-addons-title" },
-      text: { string_id: "onboarding-addons-text" },
-      icon: "addons",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: {
-          type: "OPEN_ABOUT_PAGE",
-          data: { args: "addons" },
-        },
-      },
-    },
-    targeting:
-      "trailheadInterrupt == 'control' && attributionData.campaign != 'non-fx-button' && attributionData.source != 'addons.mozilla.org'",
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_4",
-    template: "onboarding",
-    bundled: 3,
-    order: 1,
-    content: {
-      title: { string_id: "onboarding-ghostery-title" },
-      text: { string_id: "onboarding-ghostery-text" },
-      icon: "gift",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-try-now" },
-        action: {
-          type: "OPEN_URL",
-          data: {
-            args: "https://addons.mozilla.org/en-US/firefox/addon/ghostery/",
-            where: "tabshifted",
-          },
-        },
-      },
-    },
-    targeting:
-      "trailheadInterrupt == 'control' && providerCohorts.onboarding == 'ghostery'",
-    trigger: { id: "showOnboarding" },
-  },
-  {
-    id: "ONBOARDING_5",
-    template: "onboarding",
-    bundled: 3,
-    order: 4,
-    content: {
-      title: { string_id: "onboarding-fxa-title" },
-      text: { string_id: "onboarding-fxa-text" },
-      icon: "sync",
-      primary_button: {
-        label: { string_id: "onboarding-button-label-get-started" },
-        action: {
-          type: "OPEN_URL",
-          data: {
-            args: await FxAccountsConfig.promiseEmailFirstURI("onboarding"),
-            where: "tabshifted",
-          },
-        },
-      },
-    },
-    targeting:
-      "trailheadInterrupt == 'control' && attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",
-    trigger: { id: "showOnboarding" },
-  },
+const ONBOARDING_MESSAGES = () => [
   {
     id: "TRAILHEAD_1",
     template: "trailhead",
@@ -436,7 +326,13 @@ const ONBOARDING_MESSAGES = async () => [
   {
     id: "FXA_1",
     template: "fxa_overlay",
+    content: {},
     trigger: { id: "firstRun" },
+    includeBundle: {
+      length: 3,
+      template: "onboarding",
+      trigger: { id: "showOnboarding" },
+    },
   },
   {
     id: "RETURN_TO_AMO_1",
@@ -460,6 +356,11 @@ const ONBOARDING_MESSAGES = async () => [
       secondary_button: {
         label: { string_id: "return-to-amo-get-started-button" },
       },
+    },
+    includeBundle: {
+      length: 3,
+      template: "onboarding",
+      trigger: { id: "showOnboarding" },
     },
     targeting:
       "attributionData.campaign == 'non-fx-button' && attributionData.source == 'addons.mozilla.org'",

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -99,6 +99,19 @@ const ONBOARDING_MESSAGES = () => [
     trigger: { id: "firstRun" },
   },
   {
+    id: "EXTENDED_TRIPLETS_1",
+    template: "extended_triplets",
+    targeting:
+      "trailheadTriplet && ((currentDate|date - profileAgeCreated) / 86400000) < 7",
+    includeBundle: {
+      length: 3,
+      template: "onboarding",
+      trigger: { id: "showOnboarding" },
+    },
+    frequency: { lifetime: 20 },
+    utm_term: "trailhead-cards",
+  },
+  {
     id: "TRAILHEAD_CARD_1",
     template: "onboarding",
     bundled: 3,

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -145,7 +145,7 @@ const ONBOARDING_MESSAGES = () => [
     id: "TRAILHEAD_CARD_2",
     template: "onboarding",
     bundled: 3,
-    order: 2,
+    order: 1,
     content: {
       title: { string_id: "onboarding-data-sync-title" },
       text: { string_id: "onboarding-data-sync-text2" },
@@ -170,7 +170,7 @@ const ONBOARDING_MESSAGES = () => [
     id: "TRAILHEAD_CARD_3",
     template: "onboarding",
     bundled: 3,
-    order: 3,
+    order: 2,
     content: {
       title: { string_id: "onboarding-firefox-monitor-title" },
       text: { string_id: "onboarding-firefox-monitor-text" },
@@ -227,7 +227,7 @@ const ONBOARDING_MESSAGES = () => [
     id: "TRAILHEAD_CARD_6",
     template: "onboarding",
     bundled: 3,
-    order: 1,
+    order: 3,
     content: {
       title: { string_id: "onboarding-mobile-phone-title" },
       text: { string_id: "onboarding-mobile-phone-text" },

--- a/test/browser/browser_aboutwelcome.js
+++ b/test/browser/browser_aboutwelcome.js
@@ -85,9 +85,9 @@ add_task(async function test_trailhead_branches() {
     // Expected selectors:
     [
       ".trailhead.syncCohort",
-      "button[data-l10n-id=onboarding-mobile-phone-button]",
       "button[data-l10n-id=onboarding-data-sync-button2]",
       "button[data-l10n-id=onboarding-firefox-monitor-button]",
+      "button[data-l10n-id=onboarding-mobile-phone-button]",
     ]
   );
 

--- a/test/browser/browser_onboarding_rtamo.js
+++ b/test/browser/browser_onboarding_rtamo.js
@@ -83,9 +83,6 @@ add_task(async () => {
       ".ReturnToAMOContainer",
       ".ReturnToAMOAddonContents",
       ".ReturnToAMOIcon",
-      // Regular onboarding cards
-      ".onboardingMessageContainer",
-      ".onboardingMessage",
     ]) {
       ok(content.document.querySelector(selector), `Should render ${selector}`);
     }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1876,7 +1876,6 @@ describe("ASRouter", () => {
       it("should add/remove observers for `webextension-install-notify`", async () => {
         sandbox.spy(global.Services.obs, "addObserver");
         sandbox.spy(global.Services.obs, "removeObserver");
-        sandbox.spy(Router, "blockMessageById");
 
         sandbox.stub(MessageLoaderUtils, "installAddonFromURL").resolves(null);
         const msg = fakeExecuteUserAction({
@@ -1894,8 +1893,6 @@ describe("ASRouter", () => {
 
         assert.calledOnce(global.Services.obs.removeObserver);
         assert.calledOnce(channel.sendAsyncMessage);
-        assert.calledOnce(Router.blockMessageById);
-        assert.calledWithExactly(Router.blockMessageById, "RETURN_TO_AMO_1");
       });
     });
 

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1179,6 +1179,81 @@ describe("ASRouter", () => {
 
         assert.lengthOf(Router.state.providers.filter(p => p.url === url), 0);
       });
+      it("should handle onboarding message provider", async () => {
+        const handleMessageRequestStub = sandbox.stub(
+          Router,
+          "handleMessageRequest"
+        );
+        handleMessageRequestStub
+          .withArgs({
+            provider: "onboarding",
+            template: "extended_triplets",
+          })
+          .resolves({ id: "foo" });
+        const spy = sandbox.spy(Router, "setupExtendedTriplets");
+        const msg = fakeAsyncMessage({
+          type: "NEWTAB_MESSAGE_REQUEST",
+          data: {},
+        });
+        await Router.onMessage(msg);
+
+        assert.calledOnce(spy);
+      });
+      it("should fallback to snippets if one was assigned to the holdback experiment", async () => {
+        sandbox.stub(global.Sampling, "ratioSample").resolves(1); // 1 = holdback branch
+        const handleMessageRequestStub = sandbox.stub(
+          Router,
+          "handleMessageRequest"
+        );
+        handleMessageRequestStub
+          .withArgs({
+            provider: "onboarding",
+            template: "extended_triplets",
+          })
+          .resolves({ id: "foo" });
+        const msg = fakeAsyncMessage({
+          type: "NEWTAB_MESSAGE_REQUEST",
+          data: {},
+        });
+        await Router.onMessage(msg);
+
+        assert.calledTwice(handleMessageRequestStub);
+        assert.calledWithExactly(handleMessageRequestStub, {
+          provider: "onboarding",
+          template: "extended_triplets",
+        });
+        assert.calledWithExactly(handleMessageRequestStub, {
+          provider: "snippets",
+        });
+      });
+      it("should fallback to snippets if onboarding message provider returned none", async () => {
+        const handleMessageRequestStub = sandbox.stub(
+          Router,
+          "handleMessageRequest"
+        );
+        handleMessageRequestStub
+          .withArgs({
+            provider: "onboarding",
+            template: "extended_triplets",
+          })
+          .resolves(null);
+        const spy = sandbox.spy(Router, "setupExtendedTriplets");
+        const msg = fakeAsyncMessage({
+          type: "NEWTAB_MESSAGE_REQUEST",
+          data: {},
+        });
+        await Router.onMessage(msg);
+
+        assert.notCalled(spy);
+        assert.calledTwice(handleMessageRequestStub);
+        assert.calledWithExactly(handleMessageRequestStub, {
+          provider: "onboarding",
+          template: "extended_triplets",
+        });
+        assert.calledWithExactly(handleMessageRequestStub, {
+          provider: "snippets",
+        });
+      });
     });
 
     describe("#onMessage: BLOCK_MESSAGE_BY_ID", () => {
@@ -2831,6 +2906,75 @@ describe("ASRouter", () => {
           interrupt: "join",
           triplet: "supercharge",
         });
+      });
+    });
+
+    describe(".setupExtendedTriplets", () => {
+      let setStringPrefStub;
+      let setExperimentActiveStub;
+
+      beforeEach(() => {
+        setStringPrefStub = sandbox.stub(
+          global.Services.prefs,
+          "setStringPref"
+        );
+        setExperimentActiveStub = sandbox.stub(
+          global.TelemetryEnvironment,
+          "setExperimentActive"
+        );
+      });
+
+      it("should generates a control branch configuration and update Router.state", async () => {
+        sandbox.stub(global.Sampling, "ratioSample").resolves(0); // 0 = control branch
+
+        await Router.setupExtendedTriplets();
+
+        assert.propertyVal(Router.state, "extendedTripletsInitialized", true);
+        assert.propertyVal(Router.state, "showExtendedTriplets", true);
+        assert.calledWith(
+          setStringPrefStub,
+          TRAILHEAD_CONFIG.EXTENDED_TRIPLETS_EXPERIMENT_PREF,
+          "control"
+        );
+        assert.calledWith(
+          setExperimentActiveStub,
+          "activity-stream-extended-triplets",
+          "control"
+        );
+      });
+      it("should generates a test branch configuration and update Router.state", async () => {
+        sandbox.stub(global.Sampling, "ratioSample").resolves(1); // 1 = holdback branch
+
+        await Router.setupExtendedTriplets();
+
+        assert.propertyVal(Router.state, "extendedTripletsInitialized", true);
+        assert.propertyVal(Router.state, "showExtendedTriplets", false);
+        assert.calledWith(
+          setStringPrefStub,
+          TRAILHEAD_CONFIG.EXTENDED_TRIPLETS_EXPERIMENT_PREF,
+          "holdback"
+        );
+        assert.calledWith(
+          setExperimentActiveStub,
+          "activity-stream-extended-triplets",
+          "holdback"
+        );
+      });
+      it("should reuse the existing branch if it's already defined", async () => {
+        getStringPrefStub.returns("control");
+
+        await Router.setupExtendedTriplets();
+
+        assert.notCalled(setStringPrefStub);
+      });
+      it("should only run once", async () => {
+        sandbox.spy(Router, "setState");
+
+        await Router.setupExtendedTriplets();
+        await Router.setupExtendedTriplets();
+        await Router.setupExtendedTriplets();
+
+        assert.calledOnce(Router.setState);
       });
     });
   });

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -33,9 +33,6 @@ const FAKE_PROVIDERS = [
   FAKE_REMOTE_PROVIDER,
   FAKE_REMOTE_SETTINGS_PROVIDER,
 ];
-const ALL_MESSAGE_IDS = [...FAKE_LOCAL_MESSAGES, ...FAKE_REMOTE_MESSAGES].map(
-  message => message.id
-);
 const FAKE_BUNDLE = [FAKE_LOCAL_MESSAGES[1], FAKE_LOCAL_MESSAGES[2]];
 const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 const FAKE_RESPONSE_HEADERS = { get() {} };
@@ -791,6 +788,54 @@ describe("ASRouter", () => {
   });
 
   describe("#handleMessageRequest", () => {
+    it("should not return a blocked message", async () => {
+      // Block all messages except the first
+      await Router.setState(() => ({
+        messages: [
+          { id: "foo", provider: "snippets" },
+          { id: "bar", provider: "snippets" },
+        ],
+        messageBlockList: ["foo"],
+      }));
+      const result = await Router.handleMessageRequest({
+        provider: "snippets",
+      });
+      assert.equal(result.id, "bar");
+    });
+    it("should not return a message from a blocked campaign", async () => {
+      // Block all messages except the first
+      await Router.setState(() => ({
+        messages: [
+          { id: "foo", provider: "snippets", campaign: "foocampaign" },
+          { id: "bar", provider: "snippets" },
+        ],
+        messageBlockList: ["foocampaign"],
+      }));
+
+      const result = await Router.handleMessageRequest({
+        provider: "snippets",
+      });
+
+      assert.equal(result.id, "bar");
+    });
+    it("should not return a message from a blocked provider", async () => {
+      // There are only two providers; block the FAKE_LOCAL_PROVIDER, leaving
+      // only FAKE_REMOTE_PROVIDER unblocked, which provides only one message
+      await Router.setState(() => ({
+        providerBlockList: ["snippets"],
+      }));
+
+      await Router.setState(() => ({
+        messages: [{ id: "foo", provider: "snippets" }],
+        messageBlockList: ["foocampaign"],
+      }));
+
+      const result = await Router.handleMessageRequest({
+        provider: "snippets",
+      });
+
+      assert.isNull(result);
+    });
     it("should get unblocked messages that match the trigger", async () => {
       const message1 = {
         id: "1",
@@ -834,86 +879,12 @@ describe("ASRouter", () => {
 
       assert.deepEqual(result, message1);
     });
-    it("should get unblocked messages that match trigger and template", async () => {
-      const message1 = {
-        id: "1",
-        campaign: "foocampaign",
-        template: "badge",
-        trigger: { id: "foo" },
-      };
-      const message2 = {
-        id: "2",
-        campaign: "foocampaign",
-        template: "snippet",
-        trigger: { id: "foo" },
-      };
-      await Router.setState({ messages: [message2, message1] });
-      // Just return the first message provided as arg
-      sandbox.stub(Router, "_findMessage").callsFake(messages => messages[0]);
-
-      const result = Router.handleMessageRequest({
-        triggerId: "foo",
-        template: "badge",
-      });
-
-      assert.deepEqual(result, message1);
-    });
     it("should have messageImpressions in the message context", () => {
       assert.propertyVal(
         Router._getMessagesContext(),
         "messageImpressions",
         Router.state.messageImpressions
       );
-    });
-  });
-
-  describe("blocking", () => {
-    it("should not return a blocked message", async () => {
-      // Block all messages except the first
-      await Router.setState(() => ({
-        messageBlockList: ALL_MESSAGE_IDS.slice(1),
-      }));
-      const targetStub = { sendAsyncMessage: sandbox.stub() };
-
-      await Router.sendNextMessage(targetStub);
-
-      assert.calledOnce(targetStub.sendAsyncMessage);
-      assert.equal(Router.state.lastMessageId, ALL_MESSAGE_IDS[0]);
-    });
-    it("should not return a message from a blocked campaign", async () => {
-      // Block all messages except the first
-      await Router.setState(() => ({
-        messages: [{ id: "foo", campaign: "foocampaign" }, { id: "bar" }],
-        messageBlockList: ["foocampaign"],
-      }));
-      const targetStub = { sendAsyncMessage: sandbox.stub() };
-
-      await Router.sendNextMessage(targetStub);
-
-      assert.calledOnce(targetStub.sendAsyncMessage);
-      assert.equal(Router.state.lastMessageId, "bar");
-    });
-    it("should not return a message from a blocked provider", async () => {
-      // There are only two providers; block the FAKE_LOCAL_PROVIDER, leaving
-      // only FAKE_REMOTE_PROVIDER unblocked, which provides only one message
-      await Router.setState(() => ({
-        providerBlockList: [FAKE_LOCAL_PROVIDER.id],
-      }));
-      const targetStub = { sendAsyncMessage: sandbox.stub() };
-
-      await Router.sendNextMessage(targetStub);
-
-      assert.calledOnce(targetStub.sendAsyncMessage);
-      assert.equal(Router.state.lastMessageId, FAKE_REMOTE_MESSAGES[0].id);
-    });
-    it("should not return a message if all messages are blocked", async () => {
-      await Router.setState(() => ({ messageBlockList: ALL_MESSAGE_IDS }));
-      const targetStub = { sendAsyncMessage: sandbox.stub() };
-
-      await Router.sendNextMessage(targetStub);
-
-      assert.calledOnce(targetStub.sendAsyncMessage);
-      assert.equal(Router.state.lastMessageId, null);
     });
     it("should forward trigger param info", async () => {
       const trigger = { triggerId: "foo", triggerParam: "bar" };
@@ -982,24 +953,23 @@ describe("ASRouter", () => {
   });
 
   describe("onMessage", () => {
-    describe("#onMessage: SNIPPETS_REQUEST", () => {
+    describe("#onMessage: NEWTAB_MESSAGE_REQUEST", () => {
       it("should set state.lastMessageId to a message id", async () => {
-        await Router.onMessage(fakeAsyncMessage({ type: "SNIPPETS_REQUEST" }));
+        await Router.setState({
+          messages: [{ id: "foo", provider: "snippets" }],
+        });
+        await Router.onMessage(
+          fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" })
+        );
 
-        assert.include(ALL_MESSAGE_IDS, Router.state.lastMessageId);
+        assert.equal(Router.state.lastMessageId, "foo");
       });
       it("should send a message back to the to the target", async () => {
         // force the only message to be a regular message so getRandomItemFromArray picks it
         await Router.setState({
-          messages: [
-            {
-              id: "foo",
-              template: "simple_template",
-              content: { title: "Foo", body: "Foo123" },
-            },
-          ],
+          messages: [{ id: "foo", provider: "snippets" }],
         });
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
         await Router.onMessage(msg);
         const [currentMessage] = Router.state.messages.filter(
           message => message.id === Router.state.lastMessageId
@@ -1017,13 +987,14 @@ describe("ASRouter", () => {
           messages: [
             {
               id: "foo1",
+              provider: "snippets",
               template: "simple_template",
               bundled: 1,
               content: { title: "Foo1", body: "Foo123-1" },
             },
           ],
         });
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
         await Router.onMessage(msg);
         const [currentMessage] = Router.state.messages.filter(
           message => message.id === Router.state.lastMessageId
@@ -1046,6 +1017,7 @@ describe("ASRouter", () => {
         sandbox.stub(Router, "_findProvider").returns(null);
         const firstMessage = {
           id: "foo2",
+          provider: "snippets",
           template: "simple_template",
           bundled: 2,
           order: 1,
@@ -1053,13 +1025,14 @@ describe("ASRouter", () => {
         };
         const secondMessage = {
           id: "foo1",
+          provider: "snippets",
           template: "simple_template",
           bundled: 2,
           order: 2,
           content: { title: "Foo1", body: "Foo123-1" },
         };
         await Router.setState({ messages: [secondMessage, firstMessage] });
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
         await Router.onMessage(msg);
         assert.calledWith(
           msg.target.sendAsyncMessage,
@@ -1122,13 +1095,14 @@ describe("ASRouter", () => {
           messages: [
             {
               id: "foo1",
+              provider: "snippets",
               template: "simple_template",
               bundled: 2,
               content: { title: "Foo1", body: "Foo123-1" },
             },
           ],
         });
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
         await Router.onMessage(msg);
         assert.calledWith(
           msg.target.sendAsyncMessage,
@@ -1138,7 +1112,7 @@ describe("ASRouter", () => {
       });
       it("should send a CLEAR_ALL message if no messages are available", async () => {
         await Router.setState({ messages: [] });
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
         await Router.onMessage(msg);
 
         assert.calledWith(
@@ -1147,10 +1121,10 @@ describe("ASRouter", () => {
           { type: "CLEAR_ALL" }
         );
       });
-      it("should make a request to the provided endpoint on SNIPPETS_REQUEST", async () => {
+      it("should make a request to the provided endpoint on NEWTAB_MESSAGE_REQUEST", async () => {
         const url = "https://snippets-admin.mozilla.org/foo";
         const msg = fakeAsyncMessage({
-          type: "SNIPPETS_REQUEST",
+          type: "NEWTAB_MESSAGE_REQUEST",
           data: { endpoint: { url } },
         });
         await Router.onMessage(msg);
@@ -1172,7 +1146,7 @@ describe("ASRouter", () => {
       it("should dispatch SNIPPETS_PREVIEW_MODE when adding a preview endpoint", async () => {
         const url = "https://snippets-admin.mozilla.org/foo";
         const msg = fakeAsyncMessage({
-          type: "SNIPPETS_REQUEST",
+          type: "NEWTAB_MESSAGE_REQUEST",
           data: { endpoint: { url } },
         });
         await Router.onMessage(msg);
@@ -1188,7 +1162,7 @@ describe("ASRouter", () => {
       it("should not add a url that is not from a whitelisted host", async () => {
         const url = "https://mozilla.org";
         const msg = fakeAsyncMessage({
-          type: "SNIPPETS_REQUEST",
+          type: "NEWTAB_MESSAGE_REQUEST",
           data: { endpoint: { url } },
         });
         await Router.onMessage(msg);
@@ -1198,7 +1172,7 @@ describe("ASRouter", () => {
       it("should reject bad urls", async () => {
         const url = "foo";
         const msg = fakeAsyncMessage({
-          type: "SNIPPETS_REQUEST",
+          type: "NEWTAB_MESSAGE_REQUEST",
           data: { endpoint: { url } },
         });
         await Router.onMessage(msg);
@@ -1418,25 +1392,26 @@ describe("ASRouter", () => {
       });
     });
 
-    describe("#onMessage: SNIPPETS_REQUEST", () => {
-      it("should call sendNextMessage on SNIPPETS_REQUEST", async () => {
-        sandbox.stub(Router, "sendNextMessage").resolves();
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+    describe("#onMessage: NEWTAB_MESSAGE_REQUEST", () => {
+      it("should call sendNewTabMessage on NEWTAB_MESSAGE_REQUEST", async () => {
+        sandbox.stub(Router, "sendNewTabMessage").resolves();
+        const data = { endpoint: "foo" };
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST", data });
 
         await Router.onMessage(msg);
 
-        assert.calledOnce(Router.sendNextMessage);
+        assert.calledOnce(Router.sendNewTabMessage);
         assert.calledWithExactly(
-          Router.sendNextMessage,
+          Router.sendNewTabMessage,
           sinon.match.instanceOf(FakeRemotePageManager),
-          {}
+          data
         );
       });
       it("should return the preview message if that's available and remove it from Router.state", async () => {
         const expectedObj = { provider: "preview" };
         Router.setState({ messages: [expectedObj] });
 
-        await Router.sendNextMessage(channel);
+        await Router.sendNewTabMessage(channel, { endpoint: "foo.com" });
 
         assert.calledWith(
           channel.sendAsyncMessage,
@@ -1510,11 +1485,11 @@ describe("ASRouter", () => {
         );
       });
       it("should get the bundle and send the message if the message has a bundle", async () => {
-        sandbox.stub(Router, "sendNextMessage").resolves();
-        const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+        sandbox.stub(Router, "sendNewTabMessage").resolves();
+        const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
         msg.bundled = 2; // force this message to want to be bundled
         await Router.onMessage(msg);
-        assert.calledOnce(Router.sendNextMessage);
+        assert.calledOnce(Router.sendNewTabMessage);
       });
     });
 
@@ -1530,6 +1505,7 @@ describe("ASRouter", () => {
         assert.calledOnce(Router._findMessage);
         assert.deepEqual(Router._findMessage.firstCall.args[1], {
           id: "firstRun",
+          param: undefined,
         });
       });
       it("consider the trigger when picking a message", async () => {
@@ -2533,9 +2509,9 @@ describe("ASRouter", () => {
         .stub(global.FilterExpressions, "eval")
         .returns(Promise.reject(new Error("fake error")));
       await Router.setState({
-        messages: [{ id: "foo", targeting: "foo2.[[(" }],
+        messages: [{ id: "foo", provider: "snippets", targeting: "foo2.[[(" }],
       });
-      const msg = fakeAsyncMessage({ type: "SNIPPETS_REQUEST" });
+      const msg = fakeAsyncMessage({ type: "NEWTAB_MESSAGE_REQUEST" });
       dispatchStub.reset();
 
       await Router.onMessage(msg);
@@ -2548,7 +2524,19 @@ describe("ASRouter", () => {
   });
 
   describe("trailhead", () => {
-    it("should call .setupTrailhead on init", async () => {
+    it("should call .setFirstRunStateFromPref and initialize trailhead branches on init", async () => {
+      sandbox.spy(Router, "setFirstRunStateFromPref");
+      getStringPrefStub
+        .withArgs(TRAILHEAD_CONFIG.OVERRIDE_PREF)
+        .returns("join-supercharge");
+
+      await Router.init(channel, createFakeStorage(), dispatchStub);
+
+      assert.calledOnce(Router.setFirstRunStateFromPref);
+      assert.equal(Router.state.trailheadInterrupt, "join");
+      assert.equal(Router.state.trailheadTriplet, "supercharge");
+    });
+    it.skip("should call .setupTrailhead on init", async () => {
       sandbox.spy(Router, "setupTrailhead");
       sandbox
         .stub(Router, "_generateTrailheadBranches")
@@ -2563,7 +2551,7 @@ describe("ASRouter", () => {
       assert.calledOnce(Router.setupTrailhead);
       assert.propertyVal(Router.state, "trailheadInitialized", true);
     });
-    it("should call .setupTrailhead on init but return early if the DID_SEE_ABOUT_WELCOME_PREF is false", async () => {
+    it.skip("should call .setupTrailhead on init but return early if the DID_SEE_ABOUT_WELCOME_PREF is false", async () => {
       sandbox.spy(Router, "setupTrailhead");
       sandbox.spy(Router, "_generateTrailheadBranches");
       sandbox
@@ -2577,7 +2565,7 @@ describe("ASRouter", () => {
       assert.notCalled(Router._generateTrailheadBranches);
       assert.propertyVal(Router.state, "trailheadInitialized", false);
     });
-    it("should call .setupTrailhead and set the DID_SEE_ABOUT_WELCOME_PREF on a firstRun TRIGGER message", async () => {
+    it("should call .setupTrailhead and set the DID_SEE_ABOUT_WELCOME_PREF on a firstRun message", async () => {
       sandbox.spy(Router, "setupTrailhead");
       const msg = fakeAsyncMessage({
         type: "TRIGGER",

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -1284,23 +1284,6 @@ describe("ASRouter", () => {
       });
     });
 
-    describe("#onMessage: DISMISS_BUNDLE", () => {
-      it("should add all the ids in the bundle to the messageBlockList and send a CLEAR_BUNDLE message", async () => {
-        await Router.setState({ lastMessageId: "foo" });
-        const msg = fakeAsyncMessage({
-          type: "DISMISS_BUNDLE",
-          data: { bundle: FAKE_BUNDLE },
-        });
-        await Router.onMessage(msg);
-
-        assert.calledWith(
-          channel.sendAsyncMessage,
-          PARENT_TO_CHILD_MESSAGE_NAME,
-          { type: "CLEAR_BUNDLE" }
-        );
-      });
-    });
-
     describe("#onMessage: UNBLOCK_MESSAGE_BY_ID", () => {
       it("should remove the id from the messageBlockList", async () => {
         await Router.onMessage(

--- a/test/unit/asrouter/asrouter-content.test.jsx
+++ b/test/unit/asrouter/asrouter-content.test.jsx
@@ -21,21 +21,6 @@ const FAKE_BELOW_SEARCH_SNIPPET = FAKE_LOCAL_MESSAGES.find(
 );
 
 FAKE_MESSAGE = Object.assign({}, FAKE_MESSAGE, { provider: "fakeprovider" });
-const FAKE_BUNDLED_MESSAGE = {
-  bundle: [
-    {
-      id: "foo",
-      template: "onboarding",
-      content: {
-        title: "Foo",
-        primary_button: { label: "Bar" },
-        text: "Foo123",
-      },
-    },
-  ],
-  extraTemplateStrings: {},
-  template: "onboarding",
-};
 
 describe("ASRouterUtils", () => {
   let global;
@@ -85,6 +70,11 @@ describe("ASRouterUISurface", () => {
       location: { href: "" },
       _listeners: new Set(),
       _visibilityState: "hidden",
+      head: {
+        appendChild(el) {
+          return el;
+        },
+      },
       get visibilityState() {
         return this._visibilityState;
       },
@@ -105,7 +95,15 @@ describe("ASRouterUISurface", () => {
         return document.createElement("body");
       },
       getElementById(id) {
-        return id === "header-asrouter-container" ? headerPortal : footerPortal;
+        switch (id) {
+          case "header-asrouter-container":
+            return headerPortal;
+          default:
+            return footerPortal;
+        }
+      },
+      createElement(tag) {
+        return document.createElement(tag);
       },
     };
     globalO = new GlobalOverrider();
@@ -152,11 +150,6 @@ describe("ASRouterUISurface", () => {
     );
   });
 
-  it("should render the component if a bundle of messages is defined", () => {
-    wrapper.setState({ bundle: FAKE_BUNDLED_MESSAGE });
-    assert.isTrue(wrapper.exists());
-  });
-
   it("should render a preview banner if message provider is preview", () => {
     wrapper.setState({ message: { ...FAKE_MESSAGE, provider: "preview" } });
     assert.isTrue(wrapper.find(".snippets-preview-banner").exists());
@@ -180,10 +173,13 @@ describe("ASRouterUISurface", () => {
   });
 
   it("should render a trailhead message in the header portal", async () => {
+    // wrapper = shallow(<ASRouterUISurface document={fakeDocument} />);
     const message = (await OnboardingMessageProvider.getUntranslatedMessages()).find(
       msg => msg.template === "trailhead"
     );
+
     wrapper.setState({ message });
+
     assert.isTrue(headerPortal.childElementCount > 0);
     assert.equal(footerPortal.childElementCount, 0);
   });
@@ -376,19 +372,6 @@ describe("ASRouterUISurface", () => {
         `${FAKE_MESSAGE.provider}_user_event`
       );
       assert.propertyVal(payload, "source", "NEWTAB_FOOTER_BAR");
-    });
-
-    it("should call .sendTelemetry with the right message data when a bundle is dismissed", () => {
-      wrapper.instance().dismissBundle([{ id: 1 }, { id: 2 }, { id: 3 }])();
-
-      assert.calledOnce(ASRouterUtils.sendTelemetry);
-      assert.calledWith(ASRouterUtils.sendTelemetry, {
-        action: "onboarding_user_event",
-        event: "DISMISS",
-        id: "onboarding-cards",
-        message_id: "1,2,3",
-        source: "onboarding-cards",
-      });
     });
   });
 

--- a/test/unit/asrouter/constants.js
+++ b/test/unit/asrouter/constants.js
@@ -4,12 +4,14 @@ export const PARENT_TO_CHILD_MESSAGE_NAME = "ASRouter:parent-to-child";
 export const FAKE_LOCAL_MESSAGES = [
   {
     id: "foo",
+    provider: "snippets",
     template: "simple_snippet",
     content: { title: "Foo", body: "Foo123" },
   },
   {
     id: "foo1",
     template: "simple_snippet",
+    provider: "snippets",
     bundled: 2,
     order: 1,
     content: { title: "Foo1", body: "Foo123-1" },
@@ -17,6 +19,7 @@ export const FAKE_LOCAL_MESSAGES = [
   {
     id: "foo2",
     template: "simple_snippet",
+    provider: "snippets",
     bundled: 2,
     order: 2,
     content: { title: "Foo2", body: "Foo123-2" },
@@ -29,16 +32,19 @@ export const FAKE_LOCAL_MESSAGES = [
   { id: "baz", content: { title: "Foo", body: "Foo123" } },
   {
     id: "newsletter",
+    provider: "snippets",
     template: "newsletter_snippet",
     content: { title: "Foo", body: "Foo123" },
   },
   {
     id: "fxa",
+    provider: "snippets",
     template: "fxa_signup_snippet",
     content: { title: "Foo", body: "Foo123" },
   },
   {
     id: "belowsearch",
+    provider: "snippets",
     template: "simple_below_search_snippet",
     content: { text: "Foo" },
   },

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -1,5 +1,4 @@
 import {
-  helpers,
   FirstRun,
   FLUENT_FILES,
 } from "content-src/asrouter/templates/FirstRun/FirstRun";
@@ -134,41 +133,48 @@ describe("<FirstRun>", () => {
   });
 
   it("should load flow params on mount if fxaEndpoint is defined", () => {
-    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    const stub = sandbox.stub();
     wrapper = mount(
       <FirstRun
         message={message}
         document={fakeDoc}
         dispatch={() => {}}
+        fetchFlowParams={stub}
         fxaEndpoint="https://foo.com"
       />
     );
-    assert.calledOnce(spy);
+    assert.calledOnce(stub);
   });
 
   it("should load flow params onUpdate if fxaEndpoint is not defined on mount and then later defined", () => {
-    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    const stub = sandbox.stub();
     wrapper = mount(
-      <FirstRun message={message} document={fakeDoc} dispatch={() => {}} />
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        fetchFlowParams={stub}
+        dispatch={() => {}}
+      />
     );
-    assert.notCalled(spy);
+    assert.notCalled(stub);
     wrapper.setProps({ fxaEndpoint: "https://foo.com" });
-    assert.calledOnce(spy);
+    assert.calledOnce(stub);
   });
 
   it("should not load flow params again onUpdate if they were already set", () => {
-    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    const stub = sandbox.stub();
     wrapper = mount(
       <FirstRun
         message={message}
         document={fakeDoc}
         dispatch={() => {}}
+        fetchFlowParams={stub}
         fxaEndpoint="https://foo.com"
       />
     );
     wrapper.setProps({ foo: "bar" });
     wrapper.setProps({ foo: "baz" });
-    assert.calledOnce(spy);
+    assert.calledOnce(stub);
   });
 
   it("should load fluent files on mount", () => {

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -213,6 +213,13 @@ describe("<FirstRun>", () => {
     );
   });
 
+  it("should hide the interrupt when props.interruptCleared changes to true", () => {
+    assert.lengthOf(wrapper.find(Interrupt), 1, "Interrupt shown");
+    wrapper.setProps({ interruptCleared: true });
+
+    assert.lengthOf(wrapper.find(Interrupt), 0, "Interrupt hidden");
+  });
+
   it("should hide triplets when closeTriplets is called and block extended triplets after 500ms", () => {
     // Simulate calling next scene
     wrapper

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -1,0 +1,210 @@
+import {
+  helpers,
+  FirstRun,
+  FLUENT_FILES,
+} from "content-src/asrouter/templates/FirstRun/FirstRun";
+import { Interrupt } from "content-src/asrouter/templates/FirstRun/Interrupt";
+import { Triplets } from "content-src/asrouter/templates/FirstRun/Triplets";
+import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
+import { mount } from "enzyme";
+import React from "react";
+
+const FAKE_TRIPLETS = [
+  {
+    id: "CARD_1",
+    content: {
+      title: { string_id: "onboarding-private-browsing-title" },
+      text: { string_id: "onboarding-private-browsing-text" },
+      icon: "icon",
+      primary_button: {
+        label: { string_id: "onboarding-button-label-try-now" },
+        action: {
+          type: "OPEN_URL",
+          data: { args: "https://example.com/" },
+        },
+      },
+    },
+  },
+];
+
+const FAKE_FLOW_PARAMS = {
+  deviceId: "foo",
+  flowId: "abc1",
+  flowBeginTime: 1234,
+};
+
+async function getTestMessage(id) {
+  const message = (await OnboardingMessageProvider.getUntranslatedMessages()).find(
+    msg => msg.id === id
+  );
+  return { ...message, bundle: FAKE_TRIPLETS };
+}
+
+describe("<FirstRun>", () => {
+  let wrapper;
+  let message;
+  let fakeDoc;
+  let sandbox;
+
+  async function setup() {
+    sandbox = sinon.createSandbox();
+    message = await getTestMessage("TRAILHEAD_1");
+    fakeDoc = {
+      body: document.createElement("body"),
+      head: document.createElement("head"),
+      createElement: type => document.createElement(type),
+      getElementById: () => document.createElement("div"),
+      activeElement: document.createElement("div"),
+    };
+
+    sandbox
+      .stub(global, "fetch")
+      .withArgs("http://fake.com/endpoint")
+      .resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_FLOW_PARAMS),
+      });
+
+    wrapper = mount(
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        dispatch={() => {}}
+        sendUserActionTelemetry={() => {}}
+      />
+    );
+  }
+
+  beforeEach(setup);
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render", () => {
+    assert.ok(wrapper);
+  });
+  describe("with both interrupt and triplets", () => {
+    it("should render interrupt and triplets", () => {
+      assert.lengthOf(wrapper.find(Interrupt), 1, "<Interrupt>");
+      assert.lengthOf(wrapper.find(Triplets), 1, "<Triplets>");
+    });
+    it("should show the card panel and hide the content on the Triplets", () => {
+      // This is so the container shows up in the background but we can fade in the content when intterupt is closed.
+      const tripletsProps = wrapper.find(Triplets).props();
+      assert.propertyVal(tripletsProps, "showCardPanel", true);
+      assert.propertyVal(tripletsProps, "showContent", false);
+    });
+    it("should set the UTM term to trailhead-join (for the traihead-join message)", () => {
+      const iProps = wrapper.find(Interrupt).props();
+      const tProps = wrapper.find(Triplets).props();
+      assert.propertyVal(iProps, "UTMTerm", "trailhead-join");
+      assert.propertyVal(tProps, "UTMTerm", "trailhead-join-card");
+    });
+  });
+
+  describe("with an interrupt but no triplets", () => {
+    beforeEach(() => {
+      message.bundle = []; // Empty triplets
+      wrapper = mount(<FirstRun message={message} document={fakeDoc} />);
+    });
+    it("should render interrupt but no triplets", () => {
+      assert.lengthOf(wrapper.find(Interrupt), 1, "<Interrupt>");
+      assert.lengthOf(wrapper.find(Triplets), 0, "<Triplets>");
+    });
+  });
+
+  describe("with triplets but no interrupt", () => {
+    it("should render interrupt but no triplets", () => {
+      delete message.content; // Empty interrupt
+      wrapper = mount(<FirstRun message={message} document={fakeDoc} />);
+
+      assert.lengthOf(wrapper.find(Interrupt), 0, "<Interrupt>");
+      assert.lengthOf(wrapper.find(Triplets), 1, "<Triplets>");
+    });
+  });
+
+  describe("with no triplets or interrupt", () => {
+    it("should render empty", () => {
+      message = { type: "FOO_123" };
+      wrapper = mount(<FirstRun message={message} document={fakeDoc} />);
+
+      assert.isTrue(wrapper.isEmptyRender());
+    });
+  });
+
+  it("should load flow params on mount if fxaEndpoint is defined", () => {
+    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    wrapper = mount(
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        dispatch={() => {}}
+        fxaEndpoint="https://foo.com"
+      />
+    );
+    assert.calledOnce(spy);
+  });
+
+  it("should load flow params onUpdate if fxaEndpoint is not defined on mount and then later defined", () => {
+    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    wrapper = mount(
+      <FirstRun message={message} document={fakeDoc} dispatch={() => {}} />
+    );
+    assert.notCalled(spy);
+    wrapper.setProps({ fxaEndpoint: "https://foo.com" });
+    assert.calledOnce(spy);
+  });
+
+  it("should not load flow params again onUpdate if they were already set", () => {
+    const spy = sandbox.spy(helpers, "fetchFlowParams");
+    wrapper = mount(
+      <FirstRun
+        message={message}
+        document={fakeDoc}
+        dispatch={() => {}}
+        fxaEndpoint="https://foo.com"
+      />
+    );
+    wrapper.setProps({ foo: "bar" });
+    wrapper.setProps({ foo: "baz" });
+    assert.calledOnce(spy);
+  });
+
+  it("should load fluent files on mount", () => {
+    assert.lengthOf(fakeDoc.head.querySelectorAll("link"), FLUENT_FILES.length);
+  });
+
+  it("should hide the interrupt and show the triplets when onNextScene is called", () => {
+    // Simulate calling next scene
+    wrapper
+      .find(Interrupt)
+      .find(".trailheadStart")
+      .simulate("click");
+
+    assert.lengthOf(wrapper.find(Interrupt), 0, "Interrupt hidden");
+    assert.isTrue(
+      wrapper
+        .find(Triplets)
+        .find(".trailheadCardGrid")
+        .hasClass("show"),
+      "Show triplet content"
+    );
+  });
+
+  it("should hide triplets when closeTriplets is called", () => {
+    // Simulate calling next scene
+    wrapper
+      .find(Triplets)
+      .find(".icon-dismiss")
+      .simulate("click");
+
+    assert.isFalse(
+      wrapper
+        .find(Triplets)
+        .find(".trailheadCardGrid")
+        .hasClass("show"),
+      "Show triplet content"
+    );
+  });
+});

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -132,6 +132,16 @@ describe("<FirstRun>", () => {
     });
   });
 
+  it("should pass along executeAction appropriately", () => {
+    const stub = sandbox.stub();
+    wrapper = mount(
+      <FirstRun message={message} document={fakeDoc} executeAction={stub} />
+    );
+
+    assert.propertyVal(wrapper.find(Interrupt).props(), "executeAction", stub);
+    assert.propertyVal(wrapper.find(Triplets).props(), "onAction", stub);
+  });
+
   it("should load flow params on mount if fxaEndpoint is defined", () => {
     const stub = sandbox.stub();
     wrapper = mount(

--- a/test/unit/asrouter/templates/FirstRun.test.jsx
+++ b/test/unit/asrouter/templates/FirstRun.test.jsx
@@ -44,9 +44,12 @@ describe("<FirstRun>", () => {
   let message;
   let fakeDoc;
   let sandbox;
+  let clock;
+  let onBlockByIdStub;
 
   async function setup() {
     sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
     message = await getTestMessage("TRAILHEAD_1");
     fakeDoc = {
       body: document.createElement("body"),
@@ -55,6 +58,7 @@ describe("<FirstRun>", () => {
       getElementById: () => document.createElement("div"),
       activeElement: document.createElement("div"),
     };
+    onBlockByIdStub = sandbox.stub();
 
     sandbox
       .stub(global, "fetch")
@@ -71,6 +75,7 @@ describe("<FirstRun>", () => {
         document={fakeDoc}
         dispatch={() => {}}
         sendUserActionTelemetry={() => {}}
+        onBlockById={onBlockByIdStub}
       />
     );
   }
@@ -208,7 +213,7 @@ describe("<FirstRun>", () => {
     );
   });
 
-  it("should hide triplets when closeTriplets is called", () => {
+  it("should hide triplets when closeTriplets is called and block extended triplets after 500ms", () => {
     // Simulate calling next scene
     wrapper
       .find(Triplets)
@@ -222,5 +227,9 @@ describe("<FirstRun>", () => {
         .hasClass("show"),
       "Show triplet content"
     );
+
+    assert.notCalled(onBlockByIdStub);
+    clock.tick(500);
+    assert.calledWith(onBlockByIdStub, "EXTENDED_TRIPLETS_1");
   });
 });

--- a/test/unit/asrouter/templates/Interrupt.test.jsx
+++ b/test/unit/asrouter/templates/Interrupt.test.jsx
@@ -1,0 +1,37 @@
+import { Interrupt } from "content-src/asrouter/templates/FirstRun/Interrupt";
+import { ReturnToAMO } from "content-src/asrouter/templates/ReturnToAMO/ReturnToAMO";
+import { StartupOverlay } from "content-src/asrouter/templates/StartupOverlay/StartupOverlay";
+import { Trailhead } from "content-src/asrouter/templates//Trailhead/Trailhead";
+import { shallow } from "enzyme";
+import React from "react";
+
+describe("<Interrupt>", () => {
+  let wrapper;
+  it("should render Return TO AMO when the message has a template of return_to_amo_overlay", () => {
+    wrapper = shallow(
+      <Interrupt
+        message={{ id: "FOO", content: {}, template: "return_to_amo_overlay" }}
+      />
+    );
+    assert.lengthOf(wrapper.find(ReturnToAMO), 1);
+  });
+  it("should render Trailhead when the message has a template of trailhead", () => {
+    wrapper = shallow(
+      <Interrupt message={{ id: "FOO", content: {}, template: "trailhead" }} />
+    );
+    assert.lengthOf(wrapper.find(Trailhead), 1);
+  });
+  it("should render StartupOverlay when the message has a template of fxa_overlay", () => {
+    wrapper = shallow(
+      <Interrupt message={{ id: "FOO", template: "fxa_overlay" }} />
+    );
+    assert.lengthOf(wrapper.find(StartupOverlay), 1);
+  });
+  it("should throw an error if another type of message is dispatched", () => {
+    assert.throws(() => {
+      wrapper = shallow(
+        <Interrupt message={{ id: "FOO", template: "something" }} />
+      );
+    });
+  });
+});

--- a/test/unit/asrouter/templates/Trailhead.test.jsx
+++ b/test/unit/asrouter/templates/Trailhead.test.jsx
@@ -4,7 +4,7 @@ import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
 import React from "react";
 import { Trailhead } from "content-src/asrouter/templates/Trailhead/Trailhead";
 
-const CARDS = [
+export const CARDS = [
   {
     content: {
       title: { string_id: "onboarding-private-browsing-title" },
@@ -27,11 +27,13 @@ describe("<Trailhead>", () => {
   let dispatch;
   let onAction;
   let sandbox;
+  let onNextScene;
 
   beforeEach(async () => {
     sandbox = sinon.sandbox.create();
     dispatch = sandbox.stub();
     onAction = sandbox.stub();
+    onNextScene = sandbox.stub();
     sandbox.stub(global, "fetch").resolves({
       ok: true,
       status: 200,
@@ -59,10 +61,12 @@ describe("<Trailhead>", () => {
     wrapper = mount(
       <Trailhead
         message={message}
+        UTMTerm={message.utm_term}
         fxaEndpoint="https://accounts.firefox.com/endpoint"
         dispatch={dispatch}
         onAction={onAction}
         document={fakeDocument}
+        onNextScene={onNextScene}
       />
     );
   });
@@ -71,10 +75,12 @@ describe("<Trailhead>", () => {
     sandbox.restore();
   });
 
-  it("should emit UserEvent SKIPPED_SIGNIN when you click the start browsing button", () => {
+  it("should emit UserEvent SKIPPED_SIGNIN and call nextScene when you click the start browsing button", () => {
     let skipButton = wrapper.find(".trailheadStart");
     assert.ok(skipButton.exists());
     skipButton.simulate("click");
+
+    assert.calledOnce(onNextScene);
 
     assert.calledOnce(dispatch);
     assert.isUserEventAction(dispatch.firstCall.args[0]);
@@ -116,37 +122,6 @@ describe("<Trailhead>", () => {
         event: at.SUBMIT_EMAIL,
         value: { has_flow_params: false },
       })
-    );
-  });
-
-  it("should add utm_* query params to card actions", () => {
-    let { action } = CARDS[0].content.primary_button;
-    wrapper.instance().onCardAction(action);
-    assert.calledOnce(onAction);
-    const url = onAction.firstCall.args[0].data.args;
-    assert.equal(
-      url,
-      "https://example.com/?utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card"
-    );
-  });
-
-  it("should add flow parameters to card action urls if addFlowParams is true", () => {
-    let action = {
-      type: "OPEN_URL",
-      addFlowParams: true,
-      data: { args: "https://example.com/path?foo=bar" },
-    };
-    wrapper.setState({
-      deviceId: "abc",
-      flowId: "123",
-      flowBeginTime: 456,
-    });
-    wrapper.instance().onCardAction(action);
-    assert.calledOnce(onAction);
-    const url = onAction.firstCall.args[0].data.args;
-    assert.equal(
-      url,
-      "https://example.com/path?foo=bar&utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card&device_id=abc&flow_id=123&flow_begin_time=456"
     );
   });
 

--- a/test/unit/asrouter/templates/Triplets.test.jsx
+++ b/test/unit/asrouter/templates/Triplets.test.jsx
@@ -1,0 +1,96 @@
+import { mount } from "enzyme";
+import { Triplets } from "content-src/asrouter/templates/FirstRun/Triplets";
+import { OnboardingCard } from "content-src/asrouter/templates/OnboardingMessage/OnboardingMessage";
+import React from "react";
+
+const CARDS = [
+  {
+    id: "CARD_1",
+    content: {
+      title: { string_id: "onboarding-private-browsing-title" },
+      text: { string_id: "onboarding-private-browsing-text" },
+      icon: "icon",
+      primary_button: {
+        label: { string_id: "onboarding-button-label-try-now" },
+        action: {
+          type: "OPEN_URL",
+          data: { args: "https://example.com/" },
+        },
+      },
+    },
+  },
+];
+
+describe("<Triplets>", () => {
+  let wrapper;
+  let sandbox;
+  let sendTelemetryStub;
+  let onAction;
+  let onHide;
+
+  async function setup() {
+    sandbox = sinon.createSandbox();
+    sendTelemetryStub = sandbox.stub();
+    onAction = sandbox.stub();
+    onHide = sandbox.stub();
+
+    wrapper = mount(
+      <Triplets
+        cards={CARDS}
+        showCardPanel={true}
+        showContent={true}
+        hideContainer={onHide}
+        onAction={onAction}
+        UTMTerm="trailhead-join-card"
+        sendUserActionTelemetry={sendTelemetryStub}
+      />
+    );
+  }
+
+  beforeEach(setup);
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should add an expanded class to container if props.showCardPanel is true", () => {
+    wrapper.setProps({ showCardPanel: true });
+    assert.isTrue(
+      wrapper.find(".trailheadCards").hasClass("expanded"),
+      "has .expanded)"
+    );
+  });
+  it("should add a collapsed class to container if props.showCardPanel is true", () => {
+    wrapper.setProps({ showCardPanel: false });
+    assert.isFalse(
+      wrapper.find(".trailheadCards").hasClass("expanded"),
+      "has .expanded)"
+    );
+  });
+  it("should send telemetry and call props.hideContainer when the dismiss button is clicked", () => {
+    wrapper.find("button.icon-dismiss").simulate("click");
+    assert.calledOnce(onHide);
+    assert.calledWith(sendTelemetryStub, {
+      event: "DISMISS",
+      message_id: CARDS[0].id,
+      id: "onboarding-cards",
+      action: "onboarding_user_event",
+    });
+  });
+  it("should add utm_* query params to card actions and send the right ping when a card button is clicked", () => {
+    wrapper
+      .find(OnboardingCard)
+      .find("button.onboardingButton")
+      .simulate("click");
+    assert.calledOnce(onAction);
+    const url = onAction.firstCall.args[0].data.args;
+    assert.equal(
+      url,
+      "https://example.com/?utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral&utm_term=trailhead-join-card"
+    );
+    assert.calledWith(sendTelemetryStub, {
+      event: "CLICK_BUTTON",
+      message_id: CARDS[0].id,
+      id: "TRAILHEAD",
+    });
+  });
+});

--- a/test/unit/content-src/components/ReturnToAMO.test.jsx
+++ b/test/unit/content-src/components/ReturnToAMO.test.jsx
@@ -66,10 +66,6 @@ describe("<ReturnToAMO>", () => {
       sendUserActionTelemetryStub.reset();
     });
 
-    it("should call onReady on componentDidMount", () => {
-      assert.calledOnce(onReady);
-    });
-
     it("should send telemetry on block", () => {
       wrapper.instance().onBlockButton();
 

--- a/test/unit/content-src/components/StartupOverlay.test.jsx
+++ b/test/unit/content-src/components/StartupOverlay.test.jsx
@@ -1,44 +1,40 @@
 import { actionCreators as ac, actionTypes as at } from "common/Actions.jsm";
 import { mount } from "enzyme";
 import React from "react";
-import { _StartupOverlay as StartupOverlay } from "content-src/asrouter/templates/StartupOverlay/StartupOverlay";
+import { StartupOverlay } from "content-src/asrouter/templates/StartupOverlay/StartupOverlay";
 
 describe("<StartupOverlay>", () => {
   let wrapper;
   let dispatch;
-  let onReady;
   let onBlock;
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     dispatch = sandbox.stub();
-    onReady = sandbox.stub();
     onBlock = sandbox.stub();
 
-    wrapper = mount(
-      <StartupOverlay onBlock={onBlock} onReady={onReady} dispatch={dispatch} />
-    );
+    wrapper = mount(<StartupOverlay onBlock={onBlock} dispatch={dispatch} />);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it("should not render if state.show is false", () => {
-    wrapper.setState({ overlayRemoved: true });
-    assert.isTrue(wrapper.isEmptyRender());
-  });
-
-  it("should call prop.onReady after mount + timeout", async () => {
+  it("should add show class after mount and timeout", async () => {
     const clock = sandbox.useFakeTimers();
-    wrapper = mount(
-      <StartupOverlay onBlock={onBlock} onReady={onReady} dispatch={dispatch} />
+    wrapper = mount(<StartupOverlay onBlock={onBlock} dispatch={dispatch} />);
+    assert.isFalse(
+      wrapper.find(".overlay-wrapper").hasClass("show"),
+      ".overlay-wrapper does not have .show class"
     );
-    wrapper.setState({ overlayRemoved: false });
 
     clock.tick(10);
+    wrapper.update();
 
-    assert.calledOnce(onReady);
+    assert.isTrue(
+      wrapper.find(".overlay-wrapper").hasClass("show"),
+      ".overlay-wrapper has .show class"
+    );
   });
 
   it("should emit UserEvent SKIPPED_SIGNIN when you click the skip button", () => {

--- a/test/unit/content-src/components/addUtmParams.test.js
+++ b/test/unit/content-src/components/addUtmParams.test.js
@@ -1,0 +1,18 @@
+import { addUtmParams } from "content-src/asrouter/templates/FirstRun/addUtmParams";
+
+describe("addUtmParams", () => {
+  it("should convert a string URL", () => {
+    const result = addUtmParams("https://foo.com", "foo");
+    assert.equal(result.hostname, "foo.com");
+  });
+  it("should add all base params", () => {
+    assert.match(
+      addUtmParams(new URL("https://foo.com"), "foo").toString(),
+      /utm_source=activity-stream&utm_campaign=firstrun&utm_medium=referral/
+    );
+  });
+  it("should add utm_term", () => {
+    const params = addUtmParams(new URL("https://foo.com"), "foo").searchParams;
+    assert.equal(params.get("utm_term"), "foo", "utm_term");
+  });
+});


### PR DESCRIPTION
This is on top of a dummy `beta-wip` branch that merges `beta-monitor` #5244 (for "1570026 part 1") and `beta-moments` #5250 (for triggerParams).

This uplifts 9 Extended bugs:
https://bugzilla.mozilla.org/buglist.cgi?f1=blocked&o1=allwords&v1=1569303&resolution=FIXED
```
fe05904e Bug 1560065 - Refactor first run to separate Interrupts and Triplets
cdd41d99 Bug 1560065 - Converted hooks to class component due to failing tests
d40f56fd Bug 1568909 - Show triplets for extended period after first run
82187f91 Bug 1570026 - Part 2. Refactor FirstRun to use generic fetchFlowParams
2fa2908c Bug 1571817 - Hold back rollout test for Extended Triplets (#5233)
469c7ee7 Bug 1572378 - Unable to install extension from RTAMO overlay (#5234)
00243975 Bug 1570754 - Add delay to clearing triplets and always block extended
0e377da0 Port 1570481 - Update and reorder set of first run cards r=Mardak
7af1293f Bug 1571442 - Search box shouldn't move down with extended Triplets on
d9e0fa13 Bug 1573209 - Installing addon from ReturntoAMO shouldnt hide triplets (#5248)
```

Notably, we need to uplift a firefox.js change from bug 1570481 to change default triplets.

The first commit doesn't pass `npm test` for same reason it didn't pass originally (hooks).

Otherwise very few conflicts other than already-uplifted 993d044 resolving by skipping `returnAll` and adding params.

Manually set `trailhead.firstrun.branches` to `join-supercharge` and opened new tab:
![Screen Shot 2019-08-13 at 5 36 17 PM](https://user-images.githubusercontent.com/438537/62986592-26f6fe80-bdf1-11e9-9474-3c743bae9c87.png)