### PR TITLE
Bug 1573930 - FF prefs to control DS

### DIFF
--- a/lib/PrefsFeed.jsm
+++ b/lib/PrefsFeed.jsm
@@ -84,6 +84,33 @@ this.PrefsFeed = class PrefsFeed {
       value: handoffToAwesomebarPrefValue,
     });
 
+    let discoveryStreamEnabled = Services.prefs.getBoolPref(
+      "browser.newtabpage.activity-stream.discoverystream.enabled",
+      false
+    );
+    let discoveryStreamHardcodedBasicLayout = Services.prefs.getBoolPref(
+      "browser.newtabpage.activity-stream.discoverystream.hardcoded-basic-layout",
+      false
+    );
+    let discoveryStreamSpocsEndpoint = Services.prefs.getStringPref(
+      "browser.newtabpage.activity-stream.discoverystream.spocs-endpoint",
+      ""
+    );
+    values["discoverystream.enabled"] = discoveryStreamEnabled;
+    this._prefMap.set("discoverystream.enabled", {
+      value: discoveryStreamEnabled,
+    });
+    values[
+      "discoverystream.hardcoded-basic-layout"
+    ] = discoveryStreamHardcodedBasicLayout;
+    this._prefMap.set("discoverystream.hardcoded-basic-layout", {
+      value: discoveryStreamHardcodedBasicLayout,
+    });
+    values["discoverystream.spocs-endpoint"] = discoveryStreamSpocsEndpoint;
+    this._prefMap.set("discoverystream.spocs-endpoint", {
+      value: discoveryStreamSpocsEndpoint,
+    });
+
     // Set the initial state of all prefs in redux
     this.store.dispatch(
       ac.BroadcastToContent({ type: at.PREFS_INITIAL_VALUES, data: values })

--- a/lib/TopStoriesFeed.jsm
+++ b/lib/TopStoriesFeed.jsm
@@ -54,6 +54,9 @@ const SECTION_ID = "topstories";
 const IMPRESSION_SOURCE = "TOP_STORIES";
 const SPOC_IMPRESSION_TRACKING_PREF =
   "feeds.section.topstories.spoc.impressions";
+const DISCOVERY_STREAM_PREF_ENABLED = "discoverystream.enabled";
+const DISCOVERY_STREAM_PREF_ENABLED_PATH =
+  "browser.newtabpage.activity-stream.discoverystream.enabled";
 const REC_IMPRESSION_TRACKING_PREF = "feeds.section.topstories.rec.impressions";
 const OPTIONS_PREF = "feeds.section.topstories.options";
 const MAX_LIFETIME_CAP = 500; // Guard against misconfiguration on the server
@@ -65,7 +68,10 @@ this.TopStoriesFeed = class TopStoriesFeed {
     // if needed lazy load activity stream top stories feed based on
     // actual user preference when INIT and PREF_CHANGED is invoked
     this.discoveryStreamEnabled =
-      ds && ds.value && JSON.parse(ds.value).enabled;
+      ds &&
+      ds.value &&
+      JSON.parse(ds.value).enabled &&
+      Services.prefs.getBoolPref(DISCOVERY_STREAM_PREF_ENABLED_PATH, false);
     if (!this.discoveryStreamEnabled) {
       this.initializeProperties();
     }
@@ -784,7 +790,9 @@ this.TopStoriesFeed = class TopStoriesFeed {
     }
 
     try {
-      this.discoveryStreamEnabled = JSON.parse(_dsPref).enabled;
+      this.discoveryStreamEnabled =
+        JSON.parse(_dsPref).enabled &&
+        this.store.getState().Prefs.values[DISCOVERY_STREAM_PREF_ENABLED];
     } catch (e) {
       // Load activity stream top stories if fail to determine discovery stream state
       this.discoveryStreamEnabled = false;
@@ -809,6 +817,9 @@ this.TopStoriesFeed = class TopStoriesFeed {
       case at.PREF_CHANGED:
         if (action.data.name === DISCOVERY_STREAM_PREF) {
           this.lazyLoadTopStories(action.data.value);
+        }
+        if (action.data.name === DISCOVERY_STREAM_PREF_ENABLED) {
+          this.lazyLoadTopStories();
         }
         break;
       case at.UNINIT:

--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -5,6 +5,7 @@ support-files =
   head.js
 prefs =
   browser.newtabpage.activity-stream.debug=false
+  browser.newtabpage.activity-stream.discoverystream.enabled=true
   browser.newtabpage.activity-stream.discoverystream.endpoints=data:
   browser.newtabpage.activity-stream.feeds.section.topstories=true
   browser.newtabpage.activity-stream.feeds.section.topstories.options={"provider_name":""}

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -79,6 +79,11 @@ describe("DiscoveryStreamFeed", () => {
     globals = new GlobalOverrider();
     globals.set("gUUIDGenerator", { generateUUID: () => FAKE_UUID });
 
+    sandbox
+      .stub(global.Services.prefs, "getBoolPref")
+      .withArgs("browser.newtabpage.activity-stream.discoverystream.enabled")
+      .returns(true);
+
     // Feed
     feed = new DiscoveryStreamFeed();
     feed.store = createStore(combineReducers(reducers), {
@@ -90,6 +95,7 @@ describe("DiscoveryStreamFeed", () => {
             layout_endpoint: DUMMY_ENDPOINT,
           }),
           [ENDPOINTS_PREF_NAME]: DUMMY_ENDPOINT,
+          "discoverystream.enabled": true,
         },
       },
     });
@@ -311,6 +317,59 @@ describe("DiscoveryStreamFeed", () => {
     });
     it("should use new spocs endpoint if in the config", async () => {
       feed.config.spocs_endpoint = "https://spocs.getpocket.com/spocs2";
+
+      await feed.loadLayout(feed.store.dispatch);
+
+      assert.equal(
+        feed.store.getState().DiscoveryStream.spocs.spocs_endpoint,
+        "https://spocs.getpocket.com/spocs2"
+      );
+    });
+    it("should use local basic layout with hardcoded_layout and FF pref hardcoded_basic_layout", async () => {
+      feed.config.hardcoded_layout = true;
+      feed.store = createStore(combineReducers(reducers), {
+        Prefs: {
+          values: {
+            [CONFIG_PREF_NAME]: JSON.stringify({
+              enabled: false,
+              show_spocs: false,
+              layout_endpoint: DUMMY_ENDPOINT,
+            }),
+            [ENDPOINTS_PREF_NAME]: DUMMY_ENDPOINT,
+            "discoverystream.enabled": true,
+            "discoverystream.hardcoded-basic-layout": true,
+          },
+        },
+      });
+
+      sandbox.stub(feed, "fetchLayout").returns(Promise.resolve(""));
+
+      await feed.loadLayout(feed.store.dispatch);
+
+      assert.notCalled(feed.fetchLayout);
+      assert.equal(
+        feed.store.getState().DiscoveryStream.spocs.spocs_endpoint,
+        "https://spocs.getpocket.com/spocs"
+      );
+      const { layout } = feed.store.getState().DiscoveryStream;
+      assert.equal(layout[0].components[2].properties.items, 3);
+    });
+    it("should use new spocs endpoint if in a FF pref", async () => {
+      feed.store = createStore(combineReducers(reducers), {
+        Prefs: {
+          values: {
+            [CONFIG_PREF_NAME]: JSON.stringify({
+              enabled: false,
+              show_spocs: false,
+              layout_endpoint: DUMMY_ENDPOINT,
+            }),
+            [ENDPOINTS_PREF_NAME]: DUMMY_ENDPOINT,
+            "discoverystream.enabled": true,
+            "discoverystream.spocs-endpoint":
+              "https://spocs.getpocket.com/spocs2",
+          },
+        },
+      });
 
       await feed.loadLayout(feed.store.dispatch);
 

--- a/test/unit/lib/TopStoriesFeed.test.js
+++ b/test/unit/lib/TopStoriesFeed.test.js
@@ -171,9 +171,11 @@ describe("Top Stories Feed", () => {
         Prefs: {
           values: {
             "discoverystream.config": JSON.stringify({ enabled: true }),
+            "discoverystream.enabled": true,
           },
         },
       });
+
       instance.onAction({ type: at.INIT, data: {} });
 
       assert.calledOnce(instance.handleDisabled);
@@ -213,6 +215,14 @@ describe("Top Stories Feed", () => {
       instance.onAction({
         type: at.PREF_CHANGED,
         data: { name: "discoverystream.config", value: {} },
+      });
+      assert.calledOnce(instance.onInit);
+    });
+    it("should fire init on DISCOVERY_STREAM_PREF_ENABLED", () => {
+      sinon.stub(instance, "onInit");
+      instance.onAction({
+        type: at.PREF_CHANGED,
+        data: { name: "discoverystream.enabled", value: true },
       });
       assert.calledOnce(instance.onInit);
     });


### PR DESCRIPTION
To test:

First pref:
1. Set `browser.newtabpage.activity-stream.discoverystream.enabled` to `true`
2. Restart, and ensure new tab shows 7 rows of story cards.
3. Set it to false, restart, and ensure we now see the old AS.

Next pref:
1. Set `browser.newtabpage.activity-stream.discoverystream.hardcoded-basic-layout` to true.
2. Set `browser.newtabpage.activity-stream.discoverystream.enabled` to `true`
3. Restart, ensure you see DS enabled with 3 cards.
4. Set it back to false, and restart, ensure you see the old AS with 3 cards.
5. Attached screen shots for each version of 3 cards to help verify. (DS 3 card experience and AS 3 card experience). Notice the slight difference in the popular topics section under the cards.

DS 3 card experience:
![DS-3-cards](https://user-images.githubusercontent.com/197334/63046574-be675a80-bea0-11e9-97ae-108fd9aaa071.png)

AS 3 card experience:
![AS-3-cards](https://user-images.githubusercontent.com/197334/63046788-287fff80-bea1-11e9-8173-c9dcbe8a824b.png)

Third pref:
1. Ensure you can see sponsored content.
2. Set `browser.newtabpage.activity-stream.discoverystream.enabled` to true.
3. Set `browser.newtabpage.activity-stream.discoverystream.spocs-endpoint` to "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs"
4. Restart and watch the browser toolbox network tab for "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs" and ensure you see sponsored content.
5. Set it to "" or clear it. Restart.
6. On the next load, watch browser toolbox network tab for "https://spocs.getpocket.com/spocs" and ensure you see sponsored content.