### PR TITLE
Bug 1570332 - Expose user prefs values to targeting expressions

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -40,6 +40,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [isFxABadgeEnabled](#isfxabadgeenabled)
 * [totalBlockedCount](#totalblockedcount)
 * [recentBookmarks](#recentbookmarks)
+* [userPrefs](#userprefs)
 
 ## Detailed usage
 
@@ -545,4 +546,23 @@ interface Bookmark {
   ...
 }
 declare const recentBookmarks: Array<Bookmark>
+```
+
+### `userPrefs`
+
+Information about user facing prefs configurable from `about:preferences`.
+
+#### Examples
+```java
+userPrefs.cfrFeatures == false
+```
+
+#### Definition
+
+```ts
+declare const userPrefs: {
+  cfrFeatures: boolean;
+  cfrAddons: boolean;
+  snippets: boolean;
+}
 ```

--- a/test/browser/browser_asrouter_targeting.js
+++ b/test/browser/browser_asrouter_targeting.js
@@ -823,6 +823,22 @@ add_task(async function check_hasAccessedFxAPanel() {
   );
 });
 
+add_task(async function check_isFxABadgeEnabled() {
+  is(
+    await ASRouterTargeting.Environment.isFxABadgeEnabled,
+    true,
+    "Default pref value is true"
+  );
+
+  await pushPrefs(["browser.messaging-system.fxatoolbarbadge.enabled", false]);
+
+  is(
+    await ASRouterTargeting.Environment.isFxABadgeEnabled,
+    false,
+    "Value should be false according to pref"
+  );
+});
+
 add_task(async function check_isWhatsNewPanelEnabled() {
   is(
     await ASRouterTargeting.Environment.isWhatsNewPanelEnabled,
@@ -836,6 +852,42 @@ add_task(async function check_isWhatsNewPanelEnabled() {
     await ASRouterTargeting.Environment.isWhatsNewPanelEnabled,
     false,
     "Should update based on pref, e.g., for holdback"
+  );
+});
+
+add_task(async function checkCFRFeaturesUserPref() {
+  await pushPrefs([
+    "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features",
+    false,
+  ]);
+  is(
+    ASRouterTargeting.Environment.userPrefs.cfrFeatures,
+    false,
+    "cfrFeature should be false according to pref"
+  );
+  const message = { id: "foo", targeting: "userPrefs.cfrFeatures == false" };
+  is(
+    await ASRouterTargeting.findMatchingMessage({ messages: [message] }),
+    message,
+    "should select correct item by cfrFeature"
+  );
+});
+
+add_task(async function checkCFRAddonsUserPref() {
+  await pushPrefs([
+    "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons",
+    false,
+  ]);
+  is(
+    ASRouterTargeting.Environment.userPrefs.cfrAddons,
+    false,
+    "cfrFeature should be false according to pref"
+  );
+  const message = { id: "foo", targeting: "userPrefs.cfrAddons == false" };
+  is(
+    await ASRouterTargeting.findMatchingMessage({ messages: [message] }),
+    message,
+    "should select correct item by cfrAddons"
   );
 });
 

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -307,6 +307,7 @@ const TEST_GLOBAL = {
     defineLazyModuleGetters() {},
     defineLazyServiceGetter() {},
     defineLazyServiceGetters() {},
+    defineLazyPreferenceGetter() {},
     generateQI() {
       return {};
     },


### PR DESCRIPTION
I'm exposing the `cfrFeatures` and `cfrAddons` user prefs to be used in targeting expressions. We can then update targeting on required messages to prevent showing them.

I've combined all `defineModuleGetter` calls into 1 `defineLazyModuleGetters` call and converted all preference accesses to use `defineLazyPreferenceGetter`. 
It's not very thorough but I am seeing some small improvements comparing two profiles with/without (compared 3 separate runs and results seems in favor of profile 2 every time).

<img width="457" alt="image" src="https://user-images.githubusercontent.com/810040/63171604-66109400-c02b-11e9-8915-97f2f033b2dd.png">

Profile 1 is without the patch Profile 2 is with.
https://profiler.firefox.com/compare/calltree/?globalTrackOrder=0-1-2&implementation=js&localTrackOrderByPid=88621%20from%20profile%201-0~89339%20from%20profile%202-0~&profiles[]=https%3A%2F%2Fperfht.ml%2F3066ph6&profiles[]=https%3A%2F%2Fperfht.ml%2F306Fkdu&search=targeting&thread=2&v=4