### PR TITLE
Small bug with pref change, not critical

### DIFF
--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -353,9 +353,15 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       (this.store.getState().Prefs.values[PREF_SPOCS_ENDPOINT] ||
         this.config.spocs_endpoint)
     ) {
-      layout.spocs.url =
-        this.store.getState().Prefs.values[PREF_SPOCS_ENDPOINT] ||
-        this.config.spocs_endpoint;
+      layout = {
+        ...layout,
+        spocs: {
+          ...layout.spocs,
+          url:
+            this.store.getState().Prefs.values[PREF_SPOCS_ENDPOINT] ||
+            this.config.spocs_endpoint,
+        },
+      };
     }
 
     sendUpdate({


### PR DESCRIPTION
To test:

1.    Ensure you can see sponsored content.
2.    Set browser.newtabpage.activity-stream.discoverystream.enabled to true.
3.    Set browser.newtabpage.activity-stream.discoverystream.spocs-endpoint to "https://getpocket.cdn.mozilla.net/v3/firefox/unique-spocs"
4.    Set browser.newtabpage.activity-stream.discoverystream.spocs-endpoint to "" or clear it.
5.    Go to "about:home#devtools-ds" and scroll down until you see "spocs_endpoint https://spocs.getpocket.com/spocs" and ensure you see sponsored content.
