### PR TITLE
Bug 1575063 - Show new topsites image icons immediately on initial "Add Top Site"

### DIFF
--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -177,7 +177,7 @@ export class TopSiteLink extends React.PureComponent {
         backgroundColor: link.backgroundColor,
         backgroundImage: hasScreenshotImage
           ? `url(${this.state.screenshotImage.url})`
-          : "none",
+          : `url(${link.customScreenshotURL})`,
       };
     } else if (tippyTopIcon || faviconSize >= MIN_RICH_FAVICON_SIZE) {
       // styles and class names for top sites with rich icons


### PR DESCRIPTION
Edit: This current fix is a no-go (data leak - see comments below)

Bug:
https://drive.google.com/file/d/1hcMJcs8gfcpEeVThy70RpxAjUuQVBMzc/view?usp=sharing

Fix:
https://drive.google.com/file/d/1lh5O1gonmDo3dq8q6lVtj1CvkAlkk0OC/view?usp=sharing