### PR TITLE
Bug 1575108 - Update DSCard component to use cta_variant string values

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -10,6 +10,7 @@ import React from "react";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
 import { DSContextFooter } from "../DSContextFooter/DSContextFooter.jsx";
 
+// Default Meta that displays CTA as link if cta_variant in layout is set as "link"
 export const DefaultMeta = ({
   source,
   title,
@@ -18,13 +19,14 @@ export const DefaultMeta = ({
   context_type,
   cta,
   engagement,
+  cta_variant,
 }) => (
   <div className="meta">
     <div className="info-wrap">
       <p className="source clamp">{source}</p>
       <header className="title clamp">{title}</header>
       {excerpt && <p className="excerpt clamp">{excerpt}</p>}
-      {cta && (
+      {cta_variant === "link" && cta && (
         <div role="link" className="cta-link icon icon-arrow" tabIndex="0">
           {cta}
         </div>
@@ -38,7 +40,7 @@ export const DefaultMeta = ({
   </div>
 );
 
-export const VariantMeta = ({
+export const CTAButtonMeta = ({
   source,
   title,
   excerpt,
@@ -147,6 +149,8 @@ export class DSCard extends React.PureComponent {
         <div className="ds-card placeholder" ref={this.setPlaceholderRef} />
       );
     }
+    const isButtonCTA = this.props.cta_variant === "button";
+
     return (
       <div className="ds-card">
         <SafeAnchor
@@ -162,8 +166,8 @@ export class DSCard extends React.PureComponent {
               rawSource={this.props.raw_image_src}
             />
           </div>
-          {this.props.cta_variant && (
-            <VariantMeta
+          {isButtonCTA && (
+            <CTAButtonMeta
               source={this.props.source}
               title={this.props.title}
               excerpt={this.props.excerpt}
@@ -174,7 +178,7 @@ export class DSCard extends React.PureComponent {
               sponsor={this.props.sponsor}
             />
           )}
-          {!this.props.cta_variant && (
+          {!isButtonCTA && (
             <DefaultMeta
               source={this.props.source}
               title={this.props.title}
@@ -183,6 +187,7 @@ export class DSCard extends React.PureComponent {
               engagement={this.props.engagement}
               context_type={this.props.context_type}
               cta={this.props.cta}
+              cta_variant={this.props.cta_variant}
             />
           )}
           <ImpressionStats

--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -166,7 +166,7 @@ export class DSCard extends React.PureComponent {
               rawSource={this.props.raw_image_src}
             />
           </div>
-          {isButtonCTA && (
+          {isButtonCTA ? (
             <CTAButtonMeta
               source={this.props.source}
               title={this.props.title}
@@ -177,8 +177,7 @@ export class DSCard extends React.PureComponent {
               cta={this.props.cta}
               sponsor={this.props.sponsor}
             />
-          )}
-          {!isButtonCTA && (
+          ) : (
             <DefaultMeta
               source={this.props.source}
               title={this.props.title}

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -1341,7 +1341,6 @@ defaultLayoutResp = {
       components: [
         {
           type: "CardGrid",
-          cta_variant: false,
           properties: {
             items: 21,
           },

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -2,7 +2,7 @@ import {
   DSCard,
   DefaultMeta,
   PlaceholderDSCard,
-  VariantMeta,
+  CTAButtonMeta,
 } from "content-src/components/DiscoveryStreamComponents/DSCard/DSCard";
 import {
   DSContextFooter,
@@ -177,48 +177,54 @@ describe("<DSCard>", () => {
       assert.notOk(meta.find(".cta-link").exists());
     });
 
-    it("should render cta-link by default when item has cta", () => {
+    it("should not render cta-link by default when item has cta and cta_variant not link", () => {
       wrapper.setProps({ cta: "test" });
+      const meta = wrapper.find(DefaultMeta);
+      assert.notOk(meta.find(".cta-link").exists());
+    });
+
+    it("should render cta-link by default when item has cta and cta_variant as link", () => {
+      wrapper.setProps({ cta: "test", cta_variant: "link" });
       const meta = wrapper.find(DefaultMeta);
       assert.equal(meta.find(".cta-link").text(), "test");
     });
 
     it("should not render cta-button for non spoc content", () => {
-      wrapper.setProps({ cta: "test", cta_variant: true });
-      const meta = wrapper.find(VariantMeta);
+      wrapper.setProps({ cta: "test", cta_variant: "button" });
+      const meta = wrapper.find(CTAButtonMeta);
       assert.lengthOf(meta.find(".cta-button"), 0);
     });
 
-    it("should render cta-button when item has cta and cta button variant is true and is spoc", () => {
+    it("should render cta-button when item has cta and cta_variant is button and is spoc", () => {
       wrapper.setProps({
         cta: "test",
-        cta_variant: true,
+        cta_variant: "button",
         context: "Sponsored by Foo",
       });
-      const meta = wrapper.find(VariantMeta);
+      const meta = wrapper.find(CTAButtonMeta);
       assert.equal(meta.find(".cta-button").text(), "test");
     });
 
-    it("should not render Sponsored by label in footer for spoc item with cta button variant", () => {
+    it("should not render Sponsored by label in footer for spoc item with cta_variant button", () => {
       wrapper.setProps({
         cta: "test",
         context: "Sponsored by test",
-        cta_variant: true,
+        cta_variant: "button",
       });
 
-      assert.ok(wrapper.find(VariantMeta).exists());
+      assert.ok(wrapper.find(CTAButtonMeta).exists());
       assert.notOk(wrapper.find(DSContextFooter).exists());
     });
 
-    it("should render sponsor text on top for spoc item and cta_variant true", () => {
+    it("should render sponsor text on top for spoc item and cta button variant", () => {
       wrapper.setProps({
         sponsor: "Test",
         context: "Sponsored by test",
-        cta_variant: true,
+        cta_variant: "button",
       });
 
-      assert.ok(wrapper.find(VariantMeta).exists());
-      const meta = wrapper.find(VariantMeta);
+      assert.ok(wrapper.find(CTAButtonMeta).exists());
+      const meta = wrapper.find(CTAButtonMeta);
       assert.equal(meta.find(".source").text(), "Test · Sponsored");
     });
   });


### PR DESCRIPTION
Pre-req:
Direct response promo/spoc with cta property set returned by Adzerk server https://spocs.getpocket.com/spocs

QA steps:
 1. Set browser.newtabpage.activity-stream.discoverystream.endpoints to https://,http://
 2. Set browser.newtabpage.activity-stream.discoverystream.config "hardcode_layout" as false
 3. To test Link CTA variant
Set browser.newtabpage.activity-stream.discoverystream.config layout_endpoint as

https://layout-variants-70.web.readitlater.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=3-col-7-row-cta-link

4. To test Button CTA variant
Set browser.newtabpage.activity-stream.discoverystream.config layout_endpoint as

https://layout-variants-70.web.readitlater.com/v3/newtab/layout?version=1&consumer_key=40249-e88c401e1b1f2242d9e441c4&layout_variant=3-col-7-row-cta-button
