### PR TITLE
Bug 1561370 - Land strings and images for Firefox 70 What's New messages

### DIFF
--- a/locales-src/asrouter.ftl
+++ b/locales-src/asrouter.ftl
@@ -92,6 +92,42 @@ cfr-whatsnew-button =
 
 cfr-whatsnew-panel-header = What’s New
 
+cfr-whatsnew-release-notes-link-text = Read the release notes
+
+cfr-whatsnew-fx70-title = { -brand-short-name } now fights harder for your privacy
+cfr-whatsnew-fx70-body =
+   The latest update enhances the Tracking Protection feature and makes it
+   easier than ever to create secure passwords for every site.
+
+cfr-whatsnew-tracking-protect-title = Protect yourself from trackers
+cfr-whatsnew-tracking-protect-body =
+   { -brand-short-name } blocks many common social and cross-site trackers that
+   follow what you do online.
+cfr-whatsnew-tracking-protect-link-text = View your protection report
+
+# This string is displayed before a large numeral that indicates the total
+# number of tracking elements blocked. Don’t add $blockedCount to your
+# localization, because it would result in the number showing twice.
+cfr-whatsnew-tracking-blocked-title =
+  { $blockedCount ->
+    [one] Tracker blocked
+   *[other] Trackers blocked
+  }
+cfr-whatsnew-tracking-blocked-subtitle =
+   Since { DATETIME($earliestDate, month: "long", year: "numeric") }
+cfr-whatsnew-tracking-blocked-link-text = View Protection Report
+
+cfr-whatsnew-lockwise-backup-title = Back up your passwords
+cfr-whatsnew-lockwise-backup-body =
+   Now generate secure passwords you can access anywhere you sign in.
+cfr-whatsnew-lockwise-backup-link-text = Turn on backups
+
+cfr-whatsnew-lockwise-take-title = Take your passwords with you
+cfr-whatsnew-lockwise-take-body =
+   The { -lockwise-brand-short-name } mobile app lets you securely access your
+   backed up passwords from anywhere.
+cfr-whatsnew-lockwise-take-link-text = Get the app
+
 ## Bookmark Sync
 
 cfr-doorhanger-sync-bookmarks-header = Get this bookmark on your phone


### PR DESCRIPTION
This is still WIP but probably good enough to get a first pass making sure we've got the desired strings. This is on top of #5267 to rename the ftl message ids for the blocked related items.

Theoretically https://docs.google.com/presentation/d/17BCPTuDWVSnLcLuFx-HFa4ESCpIH8A-Ss9V7F2m8rFQ/edit#slide=id.g5e3431b199_0_0 and https://docs.google.com/presentation/d/17BCPTuDWVSnLcLuFx-HFa4ESCpIH8A-Ss9V7F2m8rFQ/edit#slide=id.g5e44344997_3_0 are "finalized" but sounds like usage of "Protection Report" has some questions.

From those 2 pages, there's:
1) firefox 70 hero
2) protection report 
  a. for >= 100 blocked items
  b. fewer than 100 blocked items
3) lockwise
  a. password sync not on
  b. password sync on
4) firefox 70 release notes