### PR TITLE
Bug 1575888 - Enable the What's New toolbar badge

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -15,6 +15,7 @@ ChromeUtils.defineModuleGetter(
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
+const ONE_MINUTE = 60 * 1000;
 
 const L10N = new Localization([
   "branding/brand.ftl",
@@ -413,8 +414,7 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      // delay: 5 * 3600 * 1000,
-      delay: 5000,
+      delay: 5 * ONE_MINUTE,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
     },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -14,6 +14,7 @@ ChromeUtils.defineModuleGetter(
   "resource://gre/modules/addons/AddonRepository.jsm"
 );
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
 
 const L10N = new Localization([
   "branding/brand.ftl",
@@ -407,6 +408,29 @@ const ONBOARDING_MESSAGES = () => [
       )}etp-promotions?as=u&utm_source=inproduct`,
     },
     trigger: { id: "protectionsPanelOpen" },
+  },
+  {
+    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
+    template: "toolbar_badge",
+    content: {
+      // delay: 5 * 3600 * 1000,
+      delay: 5000,
+      target: "whats-new-menu-button",
+      action: { id: "show-whatsnew-button" },
+    },
+    priority: 1,
+    trigger: { id: "toolbarBadgeUpdate" },
+    frequency: {
+      // Makes it so that we track impressions for this message while at the
+      // same time it can have unlimited impressions
+      lifetime: Infinity,
+    },
+    // Never saw this message or saw it in the past 4 days or more recent
+    targeting: `isWhatsNewPanelEnabled &&
+      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
+        (!messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'] ||
+      (messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
+        currentDate|date - messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000))`,
   },
 ];
 

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -3,9 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
-const FIREFOX_VERSION = parseInt(Services.appinfo.version.match(/\d+/), 10);
 const TWO_DAYS = 2 * 24 * 3600 * 1000;
 
 const MESSAGES = () => [
@@ -65,29 +62,6 @@ const MESSAGES = () => [
       },
     },
     trigger: { id: "momentsUpdate" },
-  },
-  {
-    id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
-    template: "toolbar_badge",
-    content: {
-      // delay: 5 * 3600 * 1000,
-      delay: 5000,
-      target: "whats-new-menu-button",
-      action: { id: "show-whatsnew-button" },
-    },
-    priority: 1,
-    trigger: { id: "toolbarBadgeUpdate" },
-    frequency: {
-      // Makes it so that we track impressions for this message while at the
-      // same time it can have unlimited impressions
-      lifetime: Infinity,
-    },
-    // Never saw this message or saw it in the past 4 days or more recent
-    targeting: `isWhatsNewPanelEnabled &&
-      (earliestFirefoxVersion && firefoxVersion > earliestFirefoxVersion) &&
-        (!messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'] ||
-      (messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}']|length >= 1 &&
-        currentDate|date - messageImpressions['WHATS_NEW_BADGE_${FIREFOX_VERSION}'][0] <= 4 * 24 * 3600 * 1000))`,
   },
   {
     id: "WHATS_NEW_70_1",

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -7,7 +7,7 @@ describe("PanelTestProvider", () => {
   it("should have a message", () => {
     // Careful: when changing this number make sure that new messages also go
     // through schema verifications.
-    assert.lengthOf(messages, 7);
+    assert.lengthOf(messages, 6);
   });
   it("should be a valid message", () => {
     const fxaMessages = messages.filter(

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -1,6 +1,5 @@
 import { _ToolbarBadgeHub } from "lib/ToolbarBadgeHub.jsm";
 import { GlobalOverrider } from "test/unit/utils";
-import { PanelTestProvider } from "lib/PanelTestProvider.jsm";
 import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
 import { _ToolbarPanelHub } from "lib/ToolbarPanelHub.jsm";
 
@@ -31,10 +30,9 @@ describe("ToolbarBadgeHub", () => {
     fakeAddImpression = sandbox.stub();
     fakeDispatch = sandbox.stub();
     isBrowserPrivateStub = sandbox.stub();
-    const panelTestMsgs = await PanelTestProvider.getMessages();
     const onboardingMsgs = await OnboardingMessageProvider.getUntranslatedMessages();
     fxaMessage = onboardingMsgs.find(({ id }) => id === "FXA_ACCOUNTS_BADGE");
-    whatsnewMessage = panelTestMsgs.find(({ id }) =>
+    whatsnewMessage = onboardingMsgs.find(({ id }) =>
       id.includes("WHATS_NEW_BADGE_")
     );
     fakeElement = {


### PR DESCRIPTION
There's no risk of showing up accidentally because there are no what's new messages yet.