### PR TITLE
Bug 1575889 - Fixing a bit about how we flip the pref from AS to DS

### DIFF
--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -1263,13 +1263,41 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       case at.PREF_CHANGED:
         switch (action.data.name) {
           case PREF_CONFIG:
-          case PREF_ENABLED:
-          case PREF_HARDCODED_BASIC_LAYOUT:
-          case PREF_SPOCS_ENDPOINT:
             // Clear the cached config and broadcast the newly computed value
             this._prefCache.config = null;
             this.store.dispatch(
               ac.BroadcastToContent({
+                type: at.DISCOVERY_STREAM_CONFIG_CHANGE,
+                data: this.config,
+              })
+            );
+            break;
+          case PREF_ENABLED:
+            // Clear the cached config and broadcast the newly computed value
+            this._prefCache.config = null;
+            // If we're turning this from off to on, we should not update open tabs.
+            if (action.data.value) {
+              this.store.dispatch(
+                ac.AlsoToPreloaded({
+                  type: at.DISCOVERY_STREAM_CONFIG_CHANGE,
+                  data: this.config,
+                })
+              );
+            } else {
+              this.store.dispatch(
+                ac.BroadcastToContent({
+                  type: at.DISCOVERY_STREAM_CONFIG_CHANGE,
+                  data: this.config,
+                })
+              );
+            }
+            break;
+          case PREF_SPOCS_ENDPOINT:
+          case PREF_HARDCODED_BASIC_LAYOUT:
+            // Clear the cached config and broadcast the newly computed value
+            this._prefCache.config = null;
+            this.store.dispatch(
+              ac.AlsoToPreloaded({
                 type: at.DISCOVERY_STREAM_CONFIG_CHANGE,
                 data: this.config,
               })

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -1689,7 +1689,7 @@ describe("DiscoveryStreamFeed", () => {
         layout_endpoint: "foo",
       });
     });
-    it("should fire loadSpocs is showSponsored pref changes", async () => {
+    it("should fire loadSpocs if showSponsored pref changes", async () => {
       sandbox.stub(feed, "loadSpocs").returns(Promise.resolve());
 
       await feed.onAction({
@@ -1718,6 +1718,106 @@ describe("DiscoveryStreamFeed", () => {
       });
 
       assert.calledOnce(feed.clearSpocs);
+    });
+    it("should fire BroadcastToContent for config changes", async () => {
+      sandbox.spy(feed.store, "dispatch");
+
+      await feed.onAction({
+        type: at.PREF_CHANGED,
+        data: { name: CONFIG_PREF_NAME },
+      });
+
+      assert.calledWith(
+        feed.store.dispatch,
+        ac.BroadcastToContent({
+          data: {
+            enabled: false,
+            layout_endpoint: "https://getpocket.cdn.mozilla.net/dummy",
+            show_spocs: false,
+          },
+          type: "DISCOVERY_STREAM_CONFIG_CHANGE",
+        })
+      );
+    });
+    it("should fire BroadcastToContent for enabled false", async () => {
+      sandbox.spy(feed.store, "dispatch");
+
+      await feed.onAction({
+        type: at.PREF_CHANGED,
+        data: { name: "discoverystream.enabled", value: false },
+      });
+
+      assert.calledWith(
+        feed.store.dispatch,
+        ac.BroadcastToContent({
+          data: {
+            enabled: false,
+            layout_endpoint: "https://getpocket.cdn.mozilla.net/dummy",
+            show_spocs: false,
+          },
+          type: "DISCOVERY_STREAM_CONFIG_CHANGE",
+        })
+      );
+    });
+    it("should fire AlsoToPreloaded for enabled true", async () => {
+      sandbox.spy(feed.store, "dispatch");
+
+      await feed.onAction({
+        type: at.PREF_CHANGED,
+        data: { name: "discoverystream.enabled", value: true },
+      });
+
+      assert.calledWith(
+        feed.store.dispatch,
+        ac.AlsoToPreloaded({
+          data: {
+            enabled: false,
+            layout_endpoint: "https://getpocket.cdn.mozilla.net/dummy",
+            show_spocs: false,
+          },
+          type: "DISCOVERY_STREAM_CONFIG_CHANGE",
+        })
+      );
+    });
+    it("should fire AlsoToPreloaded for hardcoded basic layout", async () => {
+      sandbox.spy(feed.store, "dispatch");
+
+      await feed.onAction({
+        type: at.PREF_CHANGED,
+        data: { name: "discoverystream.hardcoded-basic-layout" },
+      });
+
+      assert.calledWith(
+        feed.store.dispatch,
+        ac.AlsoToPreloaded({
+          data: {
+            enabled: false,
+            layout_endpoint: "https://getpocket.cdn.mozilla.net/dummy",
+            show_spocs: false,
+          },
+          type: "DISCOVERY_STREAM_CONFIG_CHANGE",
+        })
+      );
+    });
+    it("should fire AlsoToPreloaded for spocs endpoint changes", async () => {
+      sandbox.spy(feed.store, "dispatch");
+
+      await feed.onAction({
+        type: at.PREF_CHANGED,
+        data: { name: "discoverystream.spocs-endpoint" },
+      });
+
+      assert.calledWith(
+        feed.store.dispatch,
+        ac.AlsoToPreloaded({
+          data: {
+            enabled: false,
+            layout_endpoint: "https://getpocket.cdn.mozilla.net/dummy",
+            show_spocs: false,
+          },
+          type: "DISCOVERY_STREAM_CONFIG_CHANGE",
+        })
+      );
     });
   });
 


### PR DESCRIPTION
To test:

1. Set `browser.newtabpage.activity-stream.discoverystream.enabled` to `false`
2. Open a new tab, keep it open.
3. Flip `browser.newtabpage.activity-stream.discoverystream.enabled` from `false` to `true`
4. Look at the tab you opened, expected, it shouldn't have changed.
5. Open a new tab
6. expected, it should be different