### PR TITLE
Test to see if TC builds work after removing `objdir`

### DIFF
--- a/mochitest.sh
+++ b/mochitest.sh
@@ -13,7 +13,7 @@ cd /mozilla-central && hg pull && hg update -C
 cd /activity-stream && npm install . && npm run buildmc
 
 # Build latest m-c with Activity Stream changes
-cd /mozilla-central && ./mach build \
+cd /mozilla-central && rm -rf ./objdir-frontend && ./mach build \
   && ./mach lint browser/components/newtab \
   && ./mach lint -l codespell browser/locales/en-US/browser/newtab \
   && ./mach test browser/components/newtab/test/browser --headless \


### PR DESCRIPTION
I've hit this and seems like TC is having the same issues 
See `dev-platform` email "Watch out for build issues on non-Unicode systems"