### PR TITLE
Bug 1575797 - After downloading a file, 'Top Sites' and 'Highlights' empty: 'Oops, something went wrong loading this content. Refresh page to try again.'

### DIFF
--- a/lib/DownloadsManager.jsm
+++ b/lib/DownloadsManager.jsm
@@ -45,7 +45,7 @@ this.DownloadsManager = class DownloadsManager {
         DownloadsViewUI.getSizeWithUnits(download) ||
         DownloadsCommon.strings.sizeUnknown,
       referrer: download.source.referrerInfo
-        ? download.source.referrerInfo.originalReferrer
+        ? download.source.referrerInfo.originalReferrer.spec
         : null,
       date_added: download.endTime,
     };


### PR DESCRIPTION
r? @punamdahiya or @ScottDowne or @ncloudioj Save the referrer as a string and not a nsIURI.