### PR TITLE
Bug 1577345 - Intersection observer prop update bug

### DIFF
--- a/content-src/components/DiscoveryStreamImpressionStats/ImpressionStats.jsx
+++ b/content-src/components/DiscoveryStreamImpressionStats/ImpressionStats.jsx
@@ -193,12 +193,6 @@ export class ImpressionStats extends React.PureComponent {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.rows.length && this.props.rows !== prevProps.rows) {
-      this.setImpressionObserverOrAddListener();
-    }
-  }
-
   componentWillUnmount() {
     if (this._handleIntersect && this.impressionObserver) {
       this.impressionObserver.unobserve(this.refs.impression);

--- a/content-src/components/DiscoveryStreamImpressionStats/ImpressionStats.jsx
+++ b/content-src/components/DiscoveryStreamImpressionStats/ImpressionStats.jsx
@@ -23,8 +23,9 @@ export const INTERSECTION_RATIO = 0.5;
  * only when the component is visible on the page.
  *
  * Note:
- *   * This wrapper could be used either at the individual card level,
- *     or by the card container components
+ *   * This wrapper used to be used either at the individual card level,
+ *     or by the card container components.
+ *     It is now only used for individual card level.
  *   * Each impression will be sent only once as soon as the desired
  *     visibility is detected
  *   * Batching is not yet implemented, hence it might send multiple

--- a/test/unit/content-src/components/DiscoveryStreamComponents/ImpressionStats.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/ImpressionStats.test.jsx
@@ -153,9 +153,7 @@ describe("<ImpressionStats>", () => {
     const dispatch = sinon.spy();
     const props = {
       dispatch,
-      IntersectionObserver: buildIntersectionObserver(
-        ZeroIntersectEntries
-      ),
+      IntersectionObserver: buildIntersectionObserver(ZeroIntersectEntries),
     };
     const wrapper = renderImpressionStats(props);
 

--- a/test/unit/content-src/components/DiscoveryStreamComponents/ImpressionStats.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/ImpressionStats.test.jsx
@@ -154,8 +154,7 @@ describe("<ImpressionStats>", () => {
     const props = {
       dispatch,
       IntersectionObserver: buildIntersectionObserver(
-        ZeroIntersectEntries,
-        false
+        ZeroIntersectEntries
       ),
     };
     const wrapper = renderImpressionStats(props);
@@ -173,15 +172,7 @@ describe("<ImpressionStats>", () => {
     ]);
 
     dispatch.resetHistory();
-
-    // Simulating the full intersection change with a row change
-    wrapper.setProps({
-      ...props,
-      ...{ rows: [{ id: 1, pos: 0 }, { id: 2, pos: 1 }, { id: 3, pos: 2 }] },
-      ...{
-        IntersectionObserver: buildIntersectionObserver(FullIntersectEntries),
-      },
-    });
+    wrapper.instance().impressionObserver.callback(FullIntersectEntries);
 
     // For the impression
     assert.calledOnce(dispatch);
@@ -193,25 +184,6 @@ describe("<ImpressionStats>", () => {
       { id: 2, pos: 1 },
       { id: 3, pos: 2 },
     ]);
-  });
-  it("should send a loaded content and an impression if props are updated and props.rows are different", () => {
-    const props = { dispatch: sinon.spy() };
-    const wrapper = renderImpressionStats(props);
-    props.dispatch.resetHistory();
-
-    // New rows
-    wrapper.setProps({ ...DEFAULT_PROPS, ...{ rows: [{ id: 4, pos: 3 }] } });
-
-    assert.calledTwice(props.dispatch);
-  });
-  it("should not send any ping if props are updated but IDs are the same", () => {
-    const props = { dispatch: sinon.spy() };
-    const wrapper = renderImpressionStats(props);
-    props.dispatch.resetHistory();
-
-    wrapper.setProps(DEFAULT_PROPS);
-
-    assert.notCalled(props.dispatch);
   });
   it("should remove visibility change listener when the wrapper is removed", () => {
     const props = {


### PR DESCRIPTION
To test:

1. Update `browser.newtabpage.activity-stream.discoverystream.endpoints` with `https://,http://`



2. Update `browser.newtabpage.activity-stream.discoverystream.config` with `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://5ad1b408-b40a-4a49-b6ec-27473d192df0.mock.pstmn.io"}`

3. Open a new tab, should see a sponsored topsite.
4. Open the console.
5. Dismiss the sponsored topsite.

expected. no errors in the console.