### PR TITLE
Bug 1577348 - Use dsimage in dstextpromo; add alt text and rounding to dsimage

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -143,6 +143,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
         const [spoc] = component.data.spocs;
         const {
           image_src,
+          raw_image_src,
           alt_text,
           title,
           url,
@@ -166,6 +167,7 @@ export class _DiscoveryStreamBase extends React.PureComponent {
             <DSTextPromo
               dispatch={this.props.dispatch}
               image={image_src}
+              raw_image_src={raw_image_src}
               alt_text={alt_text || title}
               header={title}
               cta_text={cta}

--- a/content-src/components/DiscoveryStreamComponents/DSImage/DSImage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSImage/DSImage.jsx
@@ -25,8 +25,9 @@ export class DSImage extends React.PureComponent {
       if (entry) {
         if (this.props.optimize) {
           this.setState({
-            containerWidth: entry.boundingClientRect.width,
-            containerHeight: entry.boundingClientRect.height,
+            // Thumbor doesn't handle subpixels and just errors out, so rounding...
+            containerWidth: Math.round(entry.boundingClientRect.width),
+            containerHeight: Math.round(entry.boundingClientRect.height),
           });
         }
 
@@ -94,7 +95,7 @@ export class DSImage extends React.PureComponent {
 
           img = (
             <img
-              alt=""
+              alt={this.props.alt_text}
               crossOrigin="anonymous"
               onError={this.onOptimizedImageError}
               src={source}
@@ -105,7 +106,7 @@ export class DSImage extends React.PureComponent {
       } else if (!this.state.nonOptimizedImageFailed) {
         img = (
           <img
-            alt=""
+            alt={this.props.alt_text}
             crossOrigin="anonymous"
             onError={this.onNonOptimizedImageError}
             src={this.props.source}
@@ -139,4 +140,5 @@ DSImage.defaultProps = {
   rawSource: null, // Unadulterated image URL to filter through Thumbor
   extraClassNames: null, // Additional classnames to append to component
   optimize: true, // Measure parent container to request exact sizes
+  alt_text: null,
 };

--- a/content-src/components/DiscoveryStreamComponents/DSTextPromo/DSTextPromo.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSTextPromo/DSTextPromo.jsx
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { actionCreators as ac } from "common/Actions.jsm";
+import { DSImage } from "../DSImage/DSImage.jsx";
 import { ImpressionStats } from "../../DiscoveryStreamImpressionStats/ImpressionStats";
 import React from "react";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
@@ -44,7 +45,11 @@ export class DSTextPromo extends React.PureComponent {
   render() {
     return (
       <div className="ds-text-promo">
-        <img src={this.props.image} alt={this.props.alt_text} />
+        <DSImage
+          alt_text={this.props.alt_text}
+          source={this.props.image}
+          rawSource={this.props.raw_image_src}
+        />
         <div className="text">
           <h3>
             {`${this.props.header}\u2003`}

--- a/content-src/components/DiscoveryStreamComponents/DSTextPromo/_DSTextPromo.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSTextPromo/_DSTextPromo.scss
@@ -3,11 +3,12 @@
   max-width: 744px;
   margin: 16px auto;
 
-  img {
+  picture {
     width: 40px;
     height: 40px;
     margin: 0 12px 0 0;
     border-radius: 4px;
+    flex-shrink: 0;
   }
 
   .text {


### PR DESCRIPTION
To test:

1. Update `browser.newtabpage.activity-stream.discoverystream.endpoints` with `https://,http://`



2. Update `browser.newtabpage.activity-stream.discoverystream.config` with `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://5ad1b408-b40a-4a49-b6ec-27473d192df0.mock.pstmn.io"}`

expected: Should see a Netflix logo in the TextPromo with actual pixel size of 40x40 (or 80x80 depending on screen density)
