### PR TITLE
(nobug) - Mochitest: messages are rendered in the What's New panel

### DIFF
--- a/test/browser/browser.ini
+++ b/test/browser/browser.ini
@@ -30,3 +30,4 @@ skip-if = (os == "linux") # Test setup only implemented for OSX and Windows
 skip-if = fission
 [browser_asrouter_bookmarkpanel.js]
 [browser_asrouter_toolbarbadge.js]
+[browser_asrouter_whatsnewpanel.js]

--- a/test/browser/browser_asrouter_whatsnewpanel.js
+++ b/test/browser/browser_asrouter_whatsnewpanel.js
@@ -19,33 +19,30 @@ add_task(async function test_messages_rendering() {
 
   await ToolbarPanelHub.enableAppmenuButton();
 
-  const promisePanelOpen = new Promise(resolve =>
-    UITour.showMenu(window, "appMenu", resolve)
-  );
+  const mainView = document.getElementById("appMenu-mainView");
+  UITour.showMenu(window, "appMenu");
+  await BrowserTestUtils.waitForEvent(mainView, "ViewShown");
 
-  await promisePanelOpen;
-
-  Assert.ok(
-    document.getElementById("appMenu-mainView").hidden === false,
-    "Panel is visible"
-  );
+  Assert.equal(mainView.hidden, false, "Panel is visible");
 
   const whatsNewBtn = document.getElementById("appMenu-whatsnew-button");
-
-  Assert.ok(whatsNewBtn.hidden === false, "What's New is present");
+  Assert.equal(whatsNewBtn.hidden, false, "What's New is present");
 
   // Show the What's New Messages
   whatsNewBtn.click();
 
-  await BrowserTestUtils.waitForCondition(
+  const shownMessages = await BrowserTestUtils.waitForCondition(
     () =>
       document.getElementById("PanelUI-whatsNew-message-container") &&
       document.querySelectorAll(
         "#PanelUI-whatsNew-message-container .whatsNew-message"
-      ).length === msgs.length
+      ).length
   );
-
-  info(`${msgs.length} What's New messages rendered.`);
+  Assert.equal(
+    shownMessages,
+    msgs.length,
+    "Expected number of What's New messages rendered."
+  );
 
   UITour.hideMenu(window, "appMenu");
 });

--- a/test/browser/browser_asrouter_whatsnewpanel.js
+++ b/test/browser/browser_asrouter_whatsnewpanel.js
@@ -1,0 +1,51 @@
+const { PanelTestProvider } = ChromeUtils.import(
+  "resource://activity-stream/lib/PanelTestProvider.jsm"
+);
+const { ToolbarPanelHub } = ChromeUtils.import(
+  "resource://activity-stream/lib/ToolbarPanelHub.jsm"
+);
+
+add_task(async function test_messages_rendering() {
+  const msgs = (await PanelTestProvider.getMessages()).filter(
+    ({ template }) => template === "whatsnew_panel_message"
+  );
+
+  Assert.ok(msgs.length, "FxA test message exists");
+
+  Object.defineProperty(ToolbarPanelHub, "messages", {
+    get: () => Promise.resolve(msgs),
+    configurable: true,
+  });
+
+  await ToolbarPanelHub.enableAppmenuButton();
+
+  const promisePanelOpen = new Promise(resolve =>
+    UITour.showMenu(window, "appMenu", resolve)
+  );
+
+  await promisePanelOpen;
+
+  Assert.ok(
+    document.getElementById("appMenu-mainView").hidden === false,
+    "Panel is visible"
+  );
+
+  const whatsNewBtn = document.getElementById("appMenu-whatsnew-button");
+
+  Assert.ok(whatsNewBtn.hidden === false, "What's New is present");
+
+  // Show the What's New Messages
+  whatsNewBtn.click();
+
+  await BrowserTestUtils.waitForCondition(
+    () =>
+      document.getElementById("PanelUI-whatsNew-message-container") &&
+      document.querySelectorAll(
+        "#PanelUI-whatsNew-message-container .whatsNew-message"
+      ).length === msgs.length
+  );
+
+  info(`${msgs.length} What's New messages rendered.`);
+
+  UITour.hideMenu(window, "appMenu");
+});


### PR DESCRIPTION
The test opens the panel, clicks Whats New and checks the correct number of messages are rendered. 