### PR TITLE
Bug 1578236 - Add back the CFR message after navigating between tabs …

### DIFF
--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -698,7 +698,12 @@ const CFRPageActions = {
     }
     if (RecommendationMap.has(browser)) {
       const recommendation = RecommendationMap.get(browser);
-      if (isHostMatch(browser, recommendation.host)) {
+      if (
+        isHostMatch(browser, recommendation.host) ||
+        // If there is no host associated we assume we're back on a tab
+        // that had a CFR message so we should show it again
+        !recommendation.host
+      ) {
         // The browser has a recommendation specified with this host, so show
         // the page action
         pageAction.showAddressBarNotifier(recommendation);

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -801,7 +801,7 @@ describe("CFRPageActions", () => {
         );
       });
       it("should show the pageAction if a recommendation exists and it doesn't have a host defined", () => {
-        const recNoHost = { ...savedRec, host: null };
+        const recNoHost = { ...savedRec, host: undefined };
         CFRPageActions.RecommendationMap.set(fakeBrowser, recNoHost);
         CFRPageActions.updatePageActions(fakeBrowser);
         assert.calledOnce(PageAction.prototype.showAddressBarNotifier);

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -800,6 +800,16 @@ describe("CFRPageActions", () => {
           savedRec
         );
       });
+      it("should show the pageAction if a recommendation exists and it doesn't have a host defined", () => {
+        const recNoHost = { ...savedRec, host: null };
+        CFRPageActions.RecommendationMap.set(fakeBrowser, recNoHost);
+        CFRPageActions.updatePageActions(fakeBrowser);
+        assert.calledOnce(PageAction.prototype.showAddressBarNotifier);
+        assert.calledWith(
+          PageAction.prototype.showAddressBarNotifier,
+          recNoHost
+        );
+      });
       it("should hideAddressBarNotifier the pageAction and delete the recommendation if the recommendation exists but the host doesn't match", () => {
         const someOtherFakeHost = "subdomain.mozilla.com";
         fakeBrowser.documentURI.host = someOtherFakeHost;


### PR DESCRIPTION
…when a host is not defined

Issue was that upon coming back to a tab with the SAVE_LOGIN CFR, `showAddressNotifier` would not get called because the recommendation doesn't have a host defined.

Initially I also considered adding a "fallback" host when calling `addRecommendation` to be whatever website the browser was on when the message appeared. I don't think this would be a good solution because we might want to keep showing messages that don't have a host defined even when navigating to a different tab (the recommendation isn't tied to a particular website instead it advertieses a ffx feature).

TODO
- [x] backports
- [x] tests

I need to do some backports first before I can add tests.