### PR TITLE
Bug 1575820 - Show extended triplets on new tab after sync login

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -514,11 +514,13 @@ class _ASRouter {
     if (TARGETING_PREFERENCES.includes(prefName)) {
       // Notify all tabs of messages that have become invalid after pref change
       const invalidMessages = [];
+      const context = this._getMessagesContext();
+
       for (const msg of this._getUnblockedMessages()) {
         if (!msg.targeting) {
           continue;
         }
-        const isMatch = await ASRouterTargeting.isMatch(msg.targeting);
+        const isMatch = await ASRouterTargeting.isMatch(msg.targeting, context);
         if (!isMatch) {
           invalidMessages.push(msg.id);
         }


### PR DESCRIPTION
Issue here is logging into sync causes services.sync.username pref to change which triggers [onPrefChange](https://github.com/mozilla/activity-stream/blob/master/lib/ASRouter.jsm#L523) adding Extended Triplets message  to list of invalid messages. 

Invalid messages gets cleared by [AS_ROUTER_TARGETING_UPDATE handler](https://github.com/mozilla/activity-stream/blob/master/content-src/asrouter/asrouter-content.jsx#L257)

Fix in patch assumes we want to show extended triplets if its visible while sync pref change.  