### PR TITLE
Bug 1574946 - Add a Remote Settings provider used for testing messages

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -529,7 +529,7 @@ class _ASRouter {
       });
     } else {
       // Update message providers and fetch new messages on pref change
-      this._loadLocalProviders();
+      this._loadTestProviders();
       this._updateMessageProviders();
       await this.loadMessagesFromAllProviders();
     }
@@ -745,7 +745,7 @@ class _ASRouter {
       handleUserAction: this.handleUserAction,
     });
 
-    this._loadLocalProviders();
+    this._loadTestProviders();
 
     // Instead of setupTrailhead, which adds experiments, just load override pref values
     await this.setFirstRunStateFromPref();
@@ -833,7 +833,7 @@ class _ASRouter {
     }
   }
 
-  _loadLocalProviders() {
+  _loadTestProviders() {
     // If we're in ASR debug mode add the local test providers
     if (ASRouterPreferences.devtoolsEnabled) {
       this._localProviders = {
@@ -841,6 +841,8 @@ class _ASRouter {
         SnippetsTestMessageProvider,
         PanelTestProvider,
       };
+      // Enable remote settings test provider
+      ASRouterPreferences.enableOrDisableProvider("messaging-system", true);
     }
   }
 

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -461,6 +461,19 @@ const PREFS_CONFIG = new Map([
       }),
     },
   ],
+  [
+    "asrouter.providers.messaging-system",
+    {
+      title:
+        "Configuration for CFR Messaging System provider, used in testing only",
+      value: JSON.stringify({
+        id: "messaging-system",
+        enabled: false,
+        type: "remote-settings",
+        bucket: "messaging-system",
+      }),
+    },
+  ],
   // See browser/app/profile/firefox.js for other ASR preferences. They must be defined there to enable roll-outs.
   [
     "discoverystream.config",


### PR DESCRIPTION
The reasoning behind this was to have a remote settings bucket where we could add a multitude of message variations for QA to test.
* It's faster to deploy to RS than to add to a local test provider and wait for exports to reach Nightly
* the [dev kinto](https://github.com/mozilla/activity-stream/blob/b817461ae4380a3ca3bba62b59439540546fc0ff/docs/v2-system-addon/remote_cfr.md) server was insufficient:
  * a bug is sometimes validated a few days later so person working on the bug needs to sync with the person doing QA to ensure there is a message published for test
  * it adds more steps in the QA process (switching to the dev server & disabling signature validation)