### PR TITLE
Bug 1561942 - Messaging System devtools support for What's New panel

### DIFF
--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -1340,6 +1340,11 @@ class _ASRouter {
    */
   routeMessageToTarget(message, target, trigger, force = false) {
     switch (message.template) {
+      case "whatsnew_panel_message":
+        if (force) {
+          ToolbarPanelHub.forceShowMessage(target, message);
+        }
+        break;
       case "cfr_doorhanger":
         if (force) {
           CFRPageActions.forceRecommendation(target, message, this.dispatch);

--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -27,6 +27,7 @@ const APPMENU_BUTTON_ID = "appMenu-whatsnew-button";
 const PANEL_HEADER_SELECTOR = "#PanelUI-whatsNew-title > label";
 
 const BUTTON_STRING_ID = "cfr-whatsnew-button";
+const WHATS_NEW_PANEL_SELECTOR = "PanelUI-whatsNew-message-container";
 
 class _ToolbarPanelHub {
   constructor() {
@@ -534,20 +535,20 @@ class _ToolbarPanelHub {
     );
   }
 
+  /**
+   * @param {object} browser MessageChannel target argument as a response to a user action
+   * @param {object} message Message selected from devtools page
+   */
   forceShowMessage(browser, message) {
     const win = browser.browser.ownerGlobal;
     const doc = browser.browser.ownerDocument;
-    this._showAppmenuButton(win);
-    this.removeMessages(win, "PanelUI-whatsNew-message-container");
-    this.renderMessages(win, doc, "PanelUI-whatsNew-message-container", {
+    this.removeMessages(win, WHATS_NEW_PANEL_SELECTOR);
+    this.renderMessages(win, doc, WHATS_NEW_PANEL_SELECTOR, {
       force: true,
       messages: [message],
     });
     win.PanelUI.panel.addEventListener("popuphidden", event =>
-      this.removeMessages(
-        event.target.ownerGlobal,
-        "PanelUI-whatsNew-message-container"
-      )
+      this.removeMessages(event.target.ownerGlobal, WHATS_NEW_PANEL_SELECTOR)
     );
   }
 }

--- a/test/unit/asrouter/ASRouter.test.js
+++ b/test/unit/asrouter/ASRouter.test.js
@@ -141,6 +141,7 @@ describe("ASRouter", () => {
     FakeToolbarPanelHub = {
       init: sandbox.stub(),
       uninit: sandbox.stub(),
+      forceShowMessage: sandbox.stub(),
     };
     FakeToolbarBadgeHub = {
       init: sandbox.stub(),
@@ -465,10 +466,26 @@ describe("ASRouter", () => {
       sandbox.stub(CFRPageActions, "addRecommendation");
       target = { sendAsyncMessage: sandbox.stub() };
     });
+    it("should route whatsnew_panel_message message to the right hub", () => {
+      Router.routeMessageToTarget(
+        { template: "whatsnew_panel_message" },
+        target,
+        "",
+        true
+      );
+
+      assert.calledOnce(FakeToolbarPanelHub.forceShowMessage);
+      assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
+      assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(CFRPageActions.addRecommendation);
+      assert.notCalled(CFRPageActions.forceRecommendation);
+      assert.notCalled(target.sendAsyncMessage);
+    });
     it("should route toolbar_badge message to the right hub", () => {
       Router.routeMessageToTarget({ template: "toolbar_badge" }, target);
 
       assert.calledOnce(FakeToolbarBadgeHub.registerBadgeNotificationListener);
+      assert.notCalled(FakeToolbarPanelHub.forceShowMessage);
       assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
       assert.notCalled(CFRPageActions.addRecommendation);
       assert.notCalled(CFRPageActions.forceRecommendation);
@@ -483,6 +500,7 @@ describe("ASRouter", () => {
       );
 
       assert.calledOnce(FakeBookmarkPanelHub._forceShowMessage);
+      assert.notCalled(FakeToolbarPanelHub.forceShowMessage);
       assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
       assert.notCalled(CFRPageActions.addRecommendation);
       assert.notCalled(CFRPageActions.forceRecommendation);
@@ -497,6 +515,7 @@ describe("ASRouter", () => {
       );
 
       assert.calledOnce(CFRPageActions.addRecommendation);
+      assert.notCalled(FakeToolbarPanelHub.forceShowMessage);
       assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
       assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
       assert.notCalled(CFRPageActions.forceRecommendation);
@@ -511,6 +530,7 @@ describe("ASRouter", () => {
       );
 
       assert.calledOnce(CFRPageActions.forceRecommendation);
+      assert.notCalled(FakeToolbarPanelHub.forceShowMessage);
       assert.notCalled(CFRPageActions.addRecommendation);
       assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);
       assert.notCalled(FakeToolbarBadgeHub.registerBadgeNotificationListener);
@@ -520,6 +540,7 @@ describe("ASRouter", () => {
       Router.routeMessageToTarget({ template: "snippets" }, target, {}, true);
 
       assert.calledOnce(target.sendAsyncMessage);
+      assert.notCalled(FakeToolbarPanelHub.forceShowMessage);
       assert.notCalled(CFRPageActions.forceRecommendation);
       assert.notCalled(CFRPageActions.addRecommendation);
       assert.notCalled(FakeBookmarkPanelHub._forceShowMessage);


### PR DESCRIPTION
So far the `Show` button in our devtools didn't work for what's new messages.
With this PR clicking show will
* set the panel content to that specific message
* restore the original panel content after the panel is hidden

Works best with the `Disable Pop-up Autohide` feature of the Browser Toolbox but it's not required (clicking show and then opening the panel also works).

No support for multiple messages at once.

## STR

0. Have

Pref name | Prev Value
--- | ---
browser.newtabpage.activity-stream.asrouter.providers.panel_local_testing | {"id":"panel_local_testing", "cohort": "SHOW_TEST"}
browser.newtabpage.activity-stream.asrouter.devtoolsEnabled | true
1. Confirm the panel is visible and populated with messages (might require a restart)

<img width="310" alt="image" src="https://user-images.githubusercontent.com/810040/64721400-f40d5c80-d4bb-11e9-8542-69514812999d.png">
<img width="291" alt="image" src="https://user-images.githubusercontent.com/810040/64721421-fc659780-d4bb-11e9-9fce-32011a3873aa.png">

1. In ASRDevtools (`about:newtab#asrouter`)
2. Select the `panel_local_test` provider
3. Force a message to show by clicking the button
<img width="391" alt="image" src="https://user-images.githubusercontent.com/810040/64721484-1d2ded00-d4bc-11e9-9f10-aadc62c86928.png">

## Expected

1. Opening the panel again only shows that message
<img width="292" alt="image" src="https://user-images.githubusercontent.com/810040/64721606-5ebe9800-d4bc-11e9-9199-ccd9687a61ff.png">
 
2. After closing the panel and opening it again the messages from STR step 1 are restored.