### PR TITLE
Bug 1579480 - newtab DS cards not removing idle callback

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -141,7 +141,7 @@ export class DSCard extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.idleCallbackId = window.requestIdleCallback(
+    this.idleCallbackId = this.props.windowObj.requestIdleCallback(
       this.onIdleCallback.bind(this)
     );
     if (this.placholderElement) {
@@ -154,6 +154,9 @@ export class DSCard extends React.PureComponent {
     // Remove observer on unmount
     if (this.observer && this.placholderElement) {
       this.observer.unobserve(this.placholderElement);
+    }
+    if (this.idleCallbackId) {
+      this.props.windowObj.cancelIdleCallback(this.idleCallbackId);
     }
   }
 
@@ -234,4 +237,9 @@ export class DSCard extends React.PureComponent {
     );
   }
 }
+
+DSCard.defaultProps = {
+  windowObj: window, // Added to support unit tests
+};
+
 export const PlaceholderDSCard = props => <DSCard placeholder={true} />;

--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -76,7 +76,7 @@ export class DSCard extends React.PureComponent {
 
     this.onLinkClick = this.onLinkClick.bind(this);
     this.setPlaceholderRef = element => {
-      this.placholderElement = element;
+      this.placeholderElement = element;
     };
 
     this.state = {
@@ -117,8 +117,8 @@ export class DSCard extends React.PureComponent {
       const entry = entries.find(e => e.isIntersecting);
 
       if (entry) {
-        if (this.placholderElement) {
-          this.observer.unobserve(this.placholderElement);
+        if (this.placeholderElement) {
+          this.observer.unobserve(this.placeholderElement);
         }
 
         // Stop observing since element has been seen
@@ -131,8 +131,8 @@ export class DSCard extends React.PureComponent {
 
   onIdleCallback() {
     if (!this.state.isSeen) {
-      if (this.observer && this.placholderElement) {
-        this.observer.unobserve(this.placholderElement);
+      if (this.observer && this.placeholderElement) {
+        this.observer.unobserve(this.placeholderElement);
       }
       this.setState({
         isSeen: true,
@@ -144,16 +144,16 @@ export class DSCard extends React.PureComponent {
     this.idleCallbackId = this.props.windowObj.requestIdleCallback(
       this.onIdleCallback.bind(this)
     );
-    if (this.placholderElement) {
+    if (this.placeholderElement) {
       this.observer = new IntersectionObserver(this.onSeen.bind(this));
-      this.observer.observe(this.placholderElement);
+      this.observer.observe(this.placeholderElement);
     }
   }
 
   componentWillUnmount() {
     // Remove observer on unmount
-    if (this.observer && this.placholderElement) {
-      this.observer.unobserve(this.placholderElement);
+    if (this.observer && this.placeholderElement) {
+      this.observer.unobserve(this.placeholderElement);
     }
     if (this.idleCallbackId) {
       this.props.windowObj.cancelIdleCallback(this.idleCallbackId);

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -240,7 +240,7 @@ describe("<DSCard>", () => {
       wrapper.instance().observer = {
         unobserve: sandbox.stub(),
       };
-      wrapper.instance().placholderElement = "element";
+      wrapper.instance().placeholderElement = "element";
 
       wrapper.instance().onSeen([
         {
@@ -258,7 +258,7 @@ describe("<DSCard>", () => {
 
     it("should setup proper placholder ref for isSeen", () => {
       wrapper.instance().setPlaceholderRef("element");
-      assert.equal(wrapper.instance().placholderElement, "element");
+      assert.equal(wrapper.instance().placeholderElement, "element");
     });
 
     it("should setup observer on componentDidMount", () => {

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -266,6 +266,24 @@ describe("<DSCard>", () => {
       assert.isTrue(!!wrapper.instance().observer);
     });
   });
+  describe("DSCard with Idle Callback", () => {
+    let windowStub = {
+      requestIdleCallback: sinon.stub().returns(1),
+      cancelIdleCallback: sinon.stub(),
+    };
+    beforeEach(() => {
+      wrapper = shallow(<DSCard windowObj={windowStub} />);
+    });
+
+    it("should call requestIdleCallback on componentDidMount", () => {
+      assert.calledOnce(windowStub.requestIdleCallback);
+    });
+
+    it("should call cancelIdleCallback on componentWillUnmount", () => {
+      wrapper.instance().componentWillUnmount();
+      assert.calledOnce(windowStub.cancelIdleCallback);
+    });
+  });
 });
 
 describe("<PlaceholderDSCard> component", () => {


### PR DESCRIPTION
Hard to test, in general making sure all rows of cards appear is probably good enough for regression testing.

1. Set `browser.newtabpage.activity-stream.discoverystream.enabled` to true
2. Load a new tab.
3. wait a few seconds.
4. Scroll from top to bottom
Expected: cards should be already loaded as you scroll, or fade in.
Not Expected: If you see no cards at all, or if cards don't fade in/are not already loaded.

To test the actual bug, I've only reproduced it a few times.

1. Set `browser.newtabpage.activity-stream.discoverystream.enabled` to true
2. Open the page's console.
3. toggle `browser.newtabpage.activity-stream.discoverystream.enabled` a few times.
Expected: no console errors.
Not expected: console error for "Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method"

But for the second set of steps, it's hard to reproduce and possibly not a worry if you don't see the error without the patch.