### PR TITLE
Bug 1559185 - Use existing default prefs for dynamic prefs too

### DIFF
--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -271,6 +271,18 @@ describe("ActivityStream", () => {
 
       assert.isTrue(PREFS_CONFIG.get("feeds.section.topstories").value);
     });
+    it("should not change default even with expected geo and locale", () => {
+      as._defaultPrefs.set("feeds.section.topstories", false);
+      sandbox.stub(global.Services.prefs, "getStringPref").returns("US");
+      sandbox
+        .stub(global.Services.locale, "appLocaleAsLangTag")
+        .get(() => "en-US");
+
+      as._updateDynamicPrefs();
+      clock.tick(1);
+
+      assert.isFalse(PREFS_CONFIG.get("feeds.section.topstories").value);
+    });
   });
   describe("telemetry reporting on init failure", () => {
     it("should send a ping on init error", () => {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -77,6 +77,9 @@ export class FakensIPrefBranch {
       if ("initHook" in args) {
         args.initHook.call(this);
       }
+      if (args.defaultBranch) {
+        this.prefs = {};
+      }
     }
     this._prefBranch = {};
     this.observers = {};


### PR DESCRIPTION
r?@ScottDowne or @k88hudson Similar to #4531 except handle dynamic prefs to reuse existing defaults while still allowing a temporary default (for dummy geo).

You can test with the existing `firefox.js` to dynamically set on geo change for a new profile. Then also test with an explicit `false` pref (as well as `true`).