### PR TITLE
Bug 1577655 - Dismiss wrapper design tweaks

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSDismiss/DSDismiss.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSDismiss/DSDismiss.jsx
@@ -69,10 +69,9 @@ export class DSDismiss extends React.PureComponent {
           onClick={this.onDismissClick}
           onMouseEnter={this.onHover}
           onMouseLeave={this.offHover}
+          aria-label="dismiss"
         >
-          <span className="icon icon-dismiss">
-            <span className="sr-only">Dismiss</span>
-          </span>
+          <span className="icon icon-dismiss" />
         </button>
       </div>
     );

--- a/content-src/components/DiscoveryStreamComponents/DSDismiss/DSDismiss.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSDismiss/DSDismiss.jsx
@@ -70,7 +70,9 @@ export class DSDismiss extends React.PureComponent {
           onMouseEnter={this.onHover}
           onMouseLeave={this.offHover}
         >
-          <span className="icon icon-dismiss" />
+          <span className="icon icon-dismiss">
+            <span className="sr-only">Dismiss</span>
+          </span>
         </button>
       </div>
     );

--- a/content-src/components/DiscoveryStreamComponents/DSDismiss/_DSDismiss.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSDismiss/_DSDismiss.scss
@@ -3,11 +3,15 @@
   overflow: hidden;
   border-radius: 8px;
   transition-delay: 100ms;
-  transition-duration: 100ms;
+  transition-duration: 200ms;
   transition-property: background;
 
   &.hovering {
-    background: var(--newtab-element-hover-color);
+    @include dark-theme-only {
+      background: $grey-90-30;
+    }
+
+    background: $grey-90-10;
   }
 
   &:hover {
@@ -17,6 +21,10 @@
   }
 
   .ds-dismiss-button {
+    @include dark-theme-only {
+      background: $grey-90-30;
+    }
+
     border: 0;
     cursor: pointer;
     height: 32px;
@@ -29,10 +37,31 @@
     right: 0;
     top: 0;
     border-radius: 50%;
-    margin: 16px 24px 0 0;
-    transition-duration: 200ms;
-    transition-property: opacity;
-    opacity: 0;
-    background: var(--newtab-element-active-color);
+    margin: 18px 18px 0 0;
+    background: $grey-90-10;
+
+    &:hover {
+      @include dark-theme-only {
+        background: $grey-90-50;
+      }
+
+      background: $grey-90-20;
+    }
+
+    &:active {
+      @include dark-theme-only {
+        background: $grey-90-70;
+      }
+
+      background: $grey-90-30;
+    }
+
+    &:focus {
+      @include dark-theme-only {
+        box-shadow: 0 0 0 2px $grey-80, 0 0 0 5px $blue-50-50;
+      }
+
+      box-shadow: 0 0 0 2px $white, 0 0 0 5px $blue-50-50;
+    }
   }
 }

--- a/content-src/components/DiscoveryStreamComponents/DSTextPromo/_DSTextPromo.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSTextPromo/_DSTextPromo.scss
@@ -16,8 +16,11 @@
     width: 40px;
     height: 40px;
     margin: 4px 12px 0 0;
-    border-radius: 4px;
     flex-shrink: 0;
+
+    img {
+      border-radius: 4px;
+    }
   }
 
   .text {

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -48,19 +48,3 @@
   border-radius: 4px;
   outline: none;
 }
-
-@mixin sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px; // Fix for https://github.com/twbs/bootstrap/issues/25686
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.sr-only {
-  @include sr-only;
-}

--- a/content-src/styles/_mixins.scss
+++ b/content-src/styles/_mixins.scss
@@ -48,3 +48,19 @@
   border-radius: 4px;
   outline: none;
 }
+
+@mixin sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px; // Fix for https://github.com/twbs/bootstrap/issues/25686
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sr-only {
+  @include sr-only;
+}


### PR DESCRIPTION
To test:

1. Update `browser.newtabpage.activity-stream.discoverystream.endpoints` with `https://,http://`

2. Update `browser.newtabpage.activity-stream.discoverystream.config` with `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://5ad1b408-b40a-4a49-b6ec-27473d192df0.mock.pstmn.io/layout-1577654"} `

3. Verify requested changes [per ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1577655)