### PR TITLE
Bug 1581209 - enable gzip compression for Structure Ingestion payload

### DIFF
--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -114,6 +114,16 @@ const TEST_GLOBAL = {
       },
     },
     "@mozilla.org/updates/update-checker;1": { createInstance() {} },
+    "@mozilla.org/streamConverters;1": {
+      getService() {
+        return this;
+      },
+    },
+    "@mozilla.org/network/stream-loader;1": {
+      createInstance() {
+        return {};
+      },
+    },
   },
   Ci: {
     nsICryptoHash: {},


### PR DESCRIPTION
Test instructions:

* Flipping `browser.newtabpage.activity-stream.telemetry` and `browser.newtabpage.activity-stream.telemetry.structuredIngestion`
* Open Browser Toolbox from the Tools menu and switch to the `Network` tab
* Open a newtab, and scroll down until you see some Pocket stories, and then close the tab
* Check the `Domain` column, and look for `incoming.telemetry.mozilla.org`
* Click on any entry, make sure the `Requeset headers` from the `Headers` section in the side view contains `"Content-Encoding": gzip`, and the value in the `Params` section is in binary format