### PR TITLE
Bug 1569700 - CFR: recommend firefox send for PDFs

### DIFF
--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -269,6 +269,7 @@ this.ASRouterTriggerListeners = new Map([
       _initialized: false,
       _triggerHandler: null,
       _hosts: null,
+      _matchPatternSet: null,
 
       /*
        * If the listener is already initialised, `init` will replace the trigger
@@ -296,6 +297,19 @@ this.ASRouterTriggerListeners = new Map([
           this._initialized = true;
         }
         this._triggerHandler = triggerHandler;
+        if (patterns) {
+          if (this._matchPatternSet) {
+            this._matchPatternSet = new MatchPatternSet(
+              new Set([...this._matchPatternSet.patterns, ...patterns]),
+              MATCH_PATTERN_OPTIONS
+            );
+          } else {
+            this._matchPatternSet = new MatchPatternSet(
+              patterns,
+              MATCH_PATTERN_OPTIONS
+            );
+          }
+        }
         if (this._hosts) {
           hosts.forEach(h => this._hosts.add(h));
         } else {
@@ -323,7 +337,7 @@ this.ASRouterTriggerListeners = new Map([
         if (aWebProgress.isTopLevel && !isSameDocument) {
           const match = checkURLMatch(
             aLocationURI,
-            { hosts: this._hosts },
+            { hosts: this._hosts, matchPatternSet: this._matchPatternSet },
             aRequest
           );
           if (match) {

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -182,6 +182,60 @@ const MESSAGES = () => [
       id: "openBookmarkedURL",
     },
   },
+  {
+    id: "PDF_URL_FFX_SEND",
+    template: "cfr_doorhanger",
+    content: {
+      layout: "icon_and_message",
+      category: "cfrFeatures",
+      notification_text: { string_id: "cfr-doorhanger-extension-notification" },
+      heading_text: { string_id: "cfr-doorhanger-firefox-send-header" },
+      info_icon: {
+        label: { string_id: "cfr-doorhanger-extension-sumo-link" },
+        sumo_path: "https://example.com",
+      },
+      text: { string_id: "cfr-doorhanger-firefox-send-body" },
+      icon: "chrome://branding/content/icon64.png",
+      buttons: {
+        primary: {
+          label: { string_id: "cfr-doorhanger-firefox-send-ok-button" },
+          action: {
+            type: "OPEN_URL",
+            data: {
+              args:
+                "https://send.firefox.com/login/?utm_source=activity-stream&entrypoint=activity-stream-cfr-pdf",
+              where: "tabshifted",
+            },
+          },
+        },
+        secondary: [
+          {
+            label: { string_id: "cfr-doorhanger-extension-cancel-button" },
+            action: { type: "CANCEL" },
+          },
+          {
+            label: {
+              string_id: "cfr-doorhanger-extension-never-show-recommendation",
+            },
+          },
+          {
+            label: {
+              string_id: "cfr-doorhanger-extension-manage-settings-button",
+            },
+            action: {
+              type: "OPEN_PREFERENCES_PAGE",
+              data: { category: "general-cfrfeatures" },
+            },
+          },
+        ],
+      },
+    },
+    targeting: "true",
+    trigger: {
+      id: "openURL",
+      patterns: ["*://*/*.pdf"],
+    },
+  },
 ];
 
 const PanelTestProvider = {

--- a/test/unit/asrouter/PanelTestProvider.test.js
+++ b/test/unit/asrouter/PanelTestProvider.test.js
@@ -8,7 +8,7 @@ describe("PanelTestProvider", () => {
   it("should have a message", () => {
     // Careful: when changing this number make sure that new messages also go
     // through schema verifications.
-    assert.lengthOf(messages, 8);
+    assert.lengthOf(messages, 9);
   });
   it("should be a valid message", () => {
     const fxaMessages = messages.filter(


### PR DESCRIPTION
I added support to `openURL` trigger for [`MatchPattern`s](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) and landed a testable CFR that recommends Firefox Send.