### PR TITLE
Bug 1579966 - Campaign id blocks

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -238,6 +238,7 @@ export class DSCard extends React.PureComponent {
           pocket_id={this.props.pocket_id}
           shim={this.props.shim}
           bookmarkGuid={this.props.bookmarkGuid}
+          campaignId={this.props.campaignId}
         />
       </div>
     );

--- a/content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSLinkMenu/DSLinkMenu.jsx
@@ -76,6 +76,7 @@ export class DSLinkMenu extends React.PureComponent {
               pocket_id: this.props.pocket_id,
               shim: this.props.shim,
               bookmarkGuid: this.props.bookmarkGuid,
+              campaign_id: this.props.campaignId,
             }}
           />
         </ContextMenuButton>

--- a/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Hero/Hero.jsx
@@ -142,6 +142,7 @@ export class Hero extends React.PureComponent {
             pocket_id={heroRec.pocket_id}
             shim={heroRec.shim}
             bookmarkGuid={heroRec.bookmarkGuid}
+            campaignId={heroRec.campaign_id}
           />
         </div>
       );

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -116,6 +116,7 @@ export class ListItem extends React.PureComponent {
             pocket_id={this.props.pocket_id}
             shim={this.props.shim}
             bookmarkGuid={this.props.bookmarkGuid}
+            campaignId={this.props.campaignId}
           />
         )}
       </li>

--- a/content-src/lib/link-menu-options.js
+++ b/content-src/lib/link-menu-options.js
@@ -61,12 +61,20 @@ export const LinkMenuOptions = {
     }),
     userEvent: "OPEN_NEW_WINDOW",
   }),
+  // This blocks the url for regular stories,
+  // but also sends a message to DiscoveryStream with campaign_id.
+  // If DiscoveryStream sees this message for a campaign_id
+  // it also blocks it on the campaign_id.
   BlockUrl: (site, index, eventSource) => ({
     id: "newtab-menu-dismiss",
     icon: "dismiss",
     action: ac.AlsoToMain({
       type: at.BLOCK_URL,
-      data: { url: site.open_url || site.url, pocket_id: site.pocket_id },
+      data: {
+        url: site.open_url || site.url,
+        pocket_id: site.pocket_id,
+        ...(site.campaign_id ? { campaign_id: site.campaign_id } : {}),
+      },
     }),
     impression: ac.ImpressionStats({
       source: eventSource,

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -468,6 +468,14 @@ const PREFS_CONFIG = new Map([
   ],
   // See browser/app/profile/firefox.js for other ASR preferences. They must be defined there to enable roll-outs.
   [
+    "discoverystream.campaign.blocks",
+    {
+      title: "Track campaign blocks",
+      skipBroadcast: true,
+      value: "{}",
+    },
+  ],
+  [
     "discoverystream.config",
     {
       title: "Configuration for the new pocket new tab",

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -62,6 +62,7 @@ const PREF_TOPSTORIES = "feeds.section.topstories";
 const PREF_SPOCS_CLEAR_ENDPOINT = "discoverystream.endpointSpocsClear";
 const PREF_SHOW_SPONSORED = "showSponsored";
 const PREF_SPOC_IMPRESSIONS = "discoverystream.spoc.impressions";
+const PREF_CAMPAIGN_BLOCKS = "discoverystream.campaign.blocks";
 const PREF_REC_IMPRESSIONS = "discoverystream.rec.impressions";
 
 let defaultLayoutResp;
@@ -773,8 +774,11 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   filterBlocked(data) {
     const filtered = [];
     if (data && data.length) {
+      let campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS, []);
       const filteredItems = data.filter(item => {
-        const blocked = NewTabUtils.blockedLinks.isBlocked({ url: item.url });
+        const blocked =
+          NewTabUtils.blockedLinks.isBlocked({ url: item.url }) ||
+          campaigns.includes(item.campaign_id);
         if (blocked) {
           filtered.push(item);
         }
@@ -838,7 +842,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   //                   `filterItems` as the frequency capped items.
   frequencyCapSpocs(spocs) {
     if (spocs && spocs.length) {
-      const impressions = this.readImpressionsPref(PREF_SPOC_IMPRESSIONS);
+      const impressions = this.readDataPref(PREF_SPOC_IMPRESSIONS);
       const caps = [];
       const result = spocs.filter(s => {
         const isBelow = this.isBelowFrequencyCap(impressions, s);
@@ -1009,7 +1013,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
       recsExpireTime * 1000 || DEFAULT_RECS_EXPIRE_TIME,
       DEFAULT_RECS_EXPIRE_TIME
     );
-    const impressions = this.readImpressionsPref(PREF_REC_IMPRESSIONS);
+    const impressions = this.readDataPref(PREF_REC_IMPRESSIONS);
     const expired = [];
     const active = [];
     for (const item of recommendations) {
@@ -1122,7 +1126,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   }
 
   async reset() {
-    this.resetImpressionPrefs();
+    this.resetDataPrefs();
     await this.resetCache();
     if (this.loaded) {
       Services.obs.removeObserver(this, "idle-daily");
@@ -1137,9 +1141,10 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     await this.cache.set("affinities", {});
   }
 
-  resetImpressionPrefs() {
-    this.writeImpressionsPref(PREF_SPOC_IMPRESSIONS, {});
-    this.writeImpressionsPref(PREF_REC_IMPRESSIONS, {});
+  resetDataPrefs() {
+    this.writeDataPref(PREF_SPOC_IMPRESSIONS, {});
+    this.writeDataPref(PREF_REC_IMPRESSIONS, {});
+    this.writeDataPref(PREF_CAMPAIGN_BLOCKS, []);
   }
 
   resetState() {
@@ -1164,20 +1169,28 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   }
 
   recordCampaignImpression(campaignId) {
-    let impressions = this.readImpressionsPref(PREF_SPOC_IMPRESSIONS);
+    let impressions = this.readDataPref(PREF_SPOC_IMPRESSIONS);
 
     const timeStamps = impressions[campaignId] || [];
     timeStamps.push(Date.now());
     impressions = { ...impressions, [campaignId]: timeStamps };
 
-    this.writeImpressionsPref(PREF_SPOC_IMPRESSIONS, impressions);
+    this.writeDataPref(PREF_SPOC_IMPRESSIONS, impressions);
   }
 
   recordTopRecImpressions(recId) {
-    let impressions = this.readImpressionsPref(PREF_REC_IMPRESSIONS);
+    let impressions = this.readDataPref(PREF_REC_IMPRESSIONS);
     if (!impressions[recId]) {
       impressions = { ...impressions, [recId]: Date.now() };
-      this.writeImpressionsPref(PREF_REC_IMPRESSIONS, impressions);
+      this.writeDataPref(PREF_REC_IMPRESSIONS, impressions);
+    }
+  }
+
+  recordBlockCampaignId(campaignId) {
+    const campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS, []);
+    if (!campaigns.includes(campaignId)) {
+      campaigns.push(campaignId);
+      this.writeDataPref(PREF_CAMPAIGN_BLOCKS, campaigns);
     }
   }
 
@@ -1214,17 +1227,17 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     );
   }
 
-  writeImpressionsPref(pref, impressions) {
+  writeDataPref(pref, impressions) {
     this.store.dispatch(ac.SetPref(pref, JSON.stringify(impressions)));
   }
 
-  readImpressionsPref(pref) {
+  readDataPref(pref, defaultVal = {}) {
     const prefVal = this.store.getState().Prefs.values[pref];
-    return prefVal ? JSON.parse(prefVal) : {};
+    return prefVal ? JSON.parse(prefVal) : defaultVal;
   }
 
   cleanUpImpressionPref(isExpired, pref) {
-    const impressions = this.readImpressionsPref(pref);
+    const impressions = this.readDataPref(pref);
     let changed = false;
 
     Object.keys(impressions).forEach(id => {
@@ -1235,7 +1248,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     });
 
     if (changed) {
-      this.writeImpressionsPref(pref, impressions);
+      this.writeDataPref(pref, impressions);
     }
   }
 
@@ -1331,6 +1344,9 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
           }
         }
         break;
+      // This is fired from the browser, it has no concept of spocs, campaign or pocket.
+      // We match the blocked url with our available spoc urls to see if there is a match.
+      // I suspect we *could* instead do this in BLOCK_URL but I'm not sure.
       case at.PLACES_LINK_BLOCKED:
         if (this.showSpocs) {
           const spocsState = this.store.getState().DiscoveryStream.spocs;
@@ -1346,6 +1362,8 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
             this._sendSpocsFill({ blocked_by_user: filtered }, false);
 
             // If we're blocking a spoc, we want a slightly different treatment for open tabs.
+            // AlsoToPreloaded updates the source data and preloaded tabs with a new spoc.
+            // BroadcastToContent updates open tabs with a non spoc instead of a new spoc.
             this.store.dispatch(
               ac.AlsoToPreloaded({
                 type: at.DISCOVERY_STREAM_LINK_BLOCKED,
@@ -1372,6 +1390,16 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
         // When this feed is shutting down:
         this.uninitPrefs();
         break;
+      case at.BLOCK_URL: {
+        // If we block a story that also has a campaign_id
+        // we want to record that as blocked too.
+        // This is because a single campaign might have slightly different urls.
+        const { campaign_id } = action.data;
+        if (campaign_id) {
+          this.recordBlockCampaignId(campaign_id);
+        }
+        break;
+      }
       case at.PREF_CHANGED:
         switch (action.data.name) {
           case PREF_CONFIG:

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -1188,7 +1188,6 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
 
   recordBlockCampaignId(campaignId) {
     const campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS);
-    // This is a number, not a string. TODO
     if (!campaigns[campaignId]) {
       campaigns[campaignId] = 1;
       this.writeDataPref(PREF_CAMPAIGN_BLOCKS, campaigns);

--- a/lib/DiscoveryStreamFeed.jsm
+++ b/lib/DiscoveryStreamFeed.jsm
@@ -774,11 +774,11 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   filterBlocked(data) {
     const filtered = [];
     if (data && data.length) {
-      let campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS, []);
+      let campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS);
       const filteredItems = data.filter(item => {
         const blocked =
           NewTabUtils.blockedLinks.isBlocked({ url: item.url }) ||
-          campaigns.includes(item.campaign_id);
+          campaigns[item.campaign_id];
         if (blocked) {
           filtered.push(item);
         }
@@ -1144,7 +1144,7 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   resetDataPrefs() {
     this.writeDataPref(PREF_SPOC_IMPRESSIONS, {});
     this.writeDataPref(PREF_REC_IMPRESSIONS, {});
-    this.writeDataPref(PREF_CAMPAIGN_BLOCKS, []);
+    this.writeDataPref(PREF_CAMPAIGN_BLOCKS, {});
   }
 
   resetState() {
@@ -1187,9 +1187,10 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
   }
 
   recordBlockCampaignId(campaignId) {
-    const campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS, []);
-    if (!campaigns.includes(campaignId)) {
-      campaigns.push(campaignId);
+    const campaigns = this.readDataPref(PREF_CAMPAIGN_BLOCKS);
+    // This is a number, not a string. TODO
+    if (!campaigns[campaignId]) {
+      campaigns[campaignId] = 1;
       this.writeDataPref(PREF_CAMPAIGN_BLOCKS, campaigns);
     }
   }
@@ -1231,9 +1232,9 @@ this.DiscoveryStreamFeed = class DiscoveryStreamFeed {
     this.store.dispatch(ac.SetPref(pref, JSON.stringify(impressions)));
   }
 
-  readDataPref(pref, defaultVal = {}) {
+  readDataPref(pref) {
     const prefVal = this.store.getState().Prefs.values[pref];
-    return prefVal ? JSON.parse(prefVal) : defaultVal;
+    return prefVal ? JSON.parse(prefVal) : {};
   }
 
   cleanUpImpressionPref(isExpired, pref) {

--- a/lib/PlacesFeed.jsm
+++ b/lib/PlacesFeed.jsm
@@ -255,6 +255,9 @@ class PlacesFeed {
   /**
    * observe - An observer for the LINK_BLOCKED_EVENT.
    *           Called when a link is blocked.
+   *           Links can be blocked outside of newtab,
+   *           which is why we need to listen to this
+   *           on such a generic level.
    *
    * @param  {null} subject
    * @param  {str} topic   The name of the event

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSDismiss.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSDismiss.test.jsx
@@ -2,7 +2,7 @@ import { DSDismiss } from "content-src/components/DiscoveryStreamComponents/DSDi
 import React from "react";
 import { shallow } from "enzyme";
 
-describe("<DSTextPromo>", () => {
+describe("<DSDismiss>", () => {
   const fakeSpoc = {
     url: "https://foo.com",
     guid: "1234",

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -1235,6 +1235,21 @@ describe("DiscoveryStreamFeed", () => {
     });
   });
 
+  describe("#recordBlockCampaignId", () => {
+    it("should call writeDataPref with new campaign id added", () => {
+      sandbox.stub(feed, "readDataPref").returns(["1234"]);
+      sandbox.stub(feed, "writeDataPref").returns();
+
+      feed.recordBlockCampaignId("5678");
+
+      assert.calledOnce(feed.readDataPref);
+      assert.calledWith(feed.writeDataPref, "discoverystream.campaign.blocks", [
+        "1234",
+        "5678",
+      ]);
+    });
+  });
+
   describe("#cleanUpCampaignImpressionPref", () => {
     it("should remove campaign-3 because it is no longer being used", async () => {
       const fakeSpocs = {
@@ -1612,6 +1627,21 @@ describe("DiscoveryStreamFeed", () => {
         feed.store.dispatch.thirdCall.args[0].type,
         "DISCOVERY_STREAM_SPOC_BLOCKED"
       );
+    });
+  });
+
+  describe("#onAction: BLOCK_URL", () => {
+    it("should call recordBlockCampaignId whith BLOCK_URL", async () => {
+      sandbox.stub(feed, "recordBlockCampaignId").returns();
+
+      await feed.onAction({
+        type: at.BLOCK_URL,
+        data: {
+          campaign_id: "1234",
+        },
+      });
+
+      assert.calledWith(feed.recordBlockCampaignId, "1234");
     });
   });
 

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -892,7 +892,7 @@ describe("DiscoveryStreamFeed", () => {
         first: Date.now() - recsExpireTime * 1000,
         third: Date.now(),
       };
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
 
       const result = feed.rotate(
         feedResponse.recommendations,
@@ -1107,7 +1107,7 @@ describe("DiscoveryStreamFeed", () => {
       const fakeImpressions = {
         seen: [Date.now() - 1],
       };
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
 
       const { data: result, filtered } = feed.frequencyCapSpocs(fakeSpocs);
 
@@ -1224,16 +1224,14 @@ describe("DiscoveryStreamFeed", () => {
 
   describe("#recordCampaignImpression", () => {
     it("should return false if time based cap is hit", () => {
-      sandbox.stub(feed, "readImpressionsPref").returns({});
-      sandbox.stub(feed, "writeImpressionsPref").returns();
+      sandbox.stub(feed, "readDataPref").returns({});
+      sandbox.stub(feed, "writeDataPref").returns();
 
       feed.recordCampaignImpression("seen");
 
-      assert.calledWith(
-        feed.writeImpressionsPref,
-        SPOC_IMPRESSION_TRACKING_PREF,
-        { seen: [0] }
-      );
+      assert.calledWith(feed.writeDataPref, SPOC_IMPRESSION_TRACKING_PREF, {
+        seen: [0],
+      });
     });
   });
 
@@ -1267,39 +1265,35 @@ describe("DiscoveryStreamFeed", () => {
         "campaign-2": [Date.now() - 1],
         "campaign-3": [Date.now() - 1],
       };
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
-      sandbox.stub(feed, "writeImpressionsPref").returns();
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
+      sandbox.stub(feed, "writeDataPref").returns();
 
       feed.cleanUpCampaignImpressionPref(fakeSpocs);
 
-      assert.calledWith(
-        feed.writeImpressionsPref,
-        SPOC_IMPRESSION_TRACKING_PREF,
-        { "campaign-2": [-1] }
-      );
+      assert.calledWith(feed.writeDataPref, SPOC_IMPRESSION_TRACKING_PREF, {
+        "campaign-2": [-1],
+      });
     });
   });
 
   describe("#recordTopRecImpressions", () => {
     it("should add a rec id to the rec impression pref", () => {
-      sandbox.stub(feed, "readImpressionsPref").returns({});
-      sandbox.stub(feed, "writeImpressionsPref");
+      sandbox.stub(feed, "readDataPref").returns({});
+      sandbox.stub(feed, "writeDataPref");
 
       feed.recordTopRecImpressions("rec");
 
-      assert.calledWith(
-        feed.writeImpressionsPref,
-        REC_IMPRESSION_TRACKING_PREF,
-        { rec: 0 }
-      );
+      assert.calledWith(feed.writeDataPref, REC_IMPRESSION_TRACKING_PREF, {
+        rec: 0,
+      });
     });
     it("should not add an impression if it already exists", () => {
-      sandbox.stub(feed, "readImpressionsPref").returns({ rec: 4 });
-      sandbox.stub(feed, "writeImpressionsPref");
+      sandbox.stub(feed, "readDataPref").returns({ rec: 4 });
+      sandbox.stub(feed, "writeDataPref");
 
       feed.recordTopRecImpressions("rec");
 
-      assert.notCalled(feed.writeImpressionsPref);
+      assert.notCalled(feed.writeDataPref);
     });
   });
 
@@ -1336,20 +1330,19 @@ describe("DiscoveryStreamFeed", () => {
         rec3: Date.now() - 1,
         rec5: Date.now() - 1,
       };
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
-      sandbox.stub(feed, "writeImpressionsPref").returns();
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
+      sandbox.stub(feed, "writeDataPref").returns();
 
       feed.cleanUpTopRecImpressionPref(newFeeds);
 
-      assert.calledWith(
-        feed.writeImpressionsPref,
-        REC_IMPRESSION_TRACKING_PREF,
-        { rec2: -1, rec3: -1 }
-      );
+      assert.calledWith(feed.writeDataPref, REC_IMPRESSION_TRACKING_PREF, {
+        rec2: -1,
+        rec3: -1,
+      });
     });
   });
 
-  describe("#writeImpressionsPref", () => {
+  describe("#writeDataPref", () => {
     it("should call Services.prefs.setStringPref", () => {
       sandbox.spy(feed.store, "dispatch");
       const fakeImpressions = {
@@ -1357,7 +1350,7 @@ describe("DiscoveryStreamFeed", () => {
         bar: [Date.now() - 1],
       };
 
-      feed.writeImpressionsPref(SPOC_IMPRESSION_TRACKING_PREF, fakeImpressions);
+      feed.writeDataPref(SPOC_IMPRESSION_TRACKING_PREF, fakeImpressions);
 
       assert.calledWithMatch(feed.store.dispatch, {
         data: {
@@ -1369,7 +1362,7 @@ describe("DiscoveryStreamFeed", () => {
     });
   });
 
-  describe("#readImpressionsPref", () => {
+  describe("#readDataPref", () => {
     it("should return what's in Services.prefs.getStringPref", () => {
       const fakeImpressions = {
         foo: [Date.now() - 1],
@@ -1377,7 +1370,7 @@ describe("DiscoveryStreamFeed", () => {
       };
       setPref(SPOC_IMPRESSION_TRACKING_PREF, fakeImpressions);
 
-      const result = feed.readImpressionsPref(SPOC_IMPRESSION_TRACKING_PREF);
+      const result = feed.readDataPref(SPOC_IMPRESSION_TRACKING_PREF);
 
       assert.deepEqual(result, fakeImpressions);
     });
@@ -1463,7 +1456,7 @@ describe("DiscoveryStreamFeed", () => {
       ];
 
       sandbox.stub(feed, "recordCampaignImpression").returns();
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
       sandbox.spy(feed.store, "dispatch");
 
       await feed.onAction({
@@ -1484,7 +1477,7 @@ describe("DiscoveryStreamFeed", () => {
       Object.defineProperty(feed, "showSpocs", { get: () => true });
       const fakeImpressions = {};
       sandbox.stub(feed, "recordCampaignImpression").returns();
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
       sandbox.spy(feed.store, "dispatch");
 
       await feed.onAction({
@@ -1499,7 +1492,7 @@ describe("DiscoveryStreamFeed", () => {
       Object.defineProperty(feed, "showSpocs", { get: () => true });
       const fakeImpressions = {};
       sandbox.stub(feed, "recordCampaignImpression").returns();
-      sandbox.stub(feed, "readImpressionsPref").returns(fakeImpressions);
+      sandbox.stub(feed, "readDataPref").returns(fakeImpressions);
       sandbox.spy(feed.store, "dispatch");
       sandbox.spy(feed, "frequencyCapSpocs");
 
@@ -1725,7 +1718,7 @@ describe("DiscoveryStreamFeed", () => {
       assert.calledOnce(feed.resetCache);
     });
     it("should dispatch DISCOVERY_STREAM_LAYOUT_RESET from DISCOVERY_STREAM_CONFIG_CHANGE", async () => {
-      sandbox.stub(feed, "resetImpressionPrefs");
+      sandbox.stub(feed, "resetDataPrefs");
       sandbox.stub(feed, "resetCache").resolves();
       sandbox.stub(feed, "enable").resolves();
       setPref(CONFIG_PREF_NAME, { enabled: true });

--- a/test/unit/lib/DiscoveryStreamFeed.test.js
+++ b/test/unit/lib/DiscoveryStreamFeed.test.js
@@ -1237,16 +1237,16 @@ describe("DiscoveryStreamFeed", () => {
 
   describe("#recordBlockCampaignId", () => {
     it("should call writeDataPref with new campaign id added", () => {
-      sandbox.stub(feed, "readDataPref").returns(["1234"]);
+      sandbox.stub(feed, "readDataPref").returns({ "1234": 1 });
       sandbox.stub(feed, "writeDataPref").returns();
 
       feed.recordBlockCampaignId("5678");
 
       assert.calledOnce(feed.readDataPref);
-      assert.calledWith(feed.writeDataPref, "discoverystream.campaign.blocks", [
-        "1234",
-        "5678",
-      ]);
+      assert.calledWith(feed.writeDataPref, "discoverystream.campaign.blocks", {
+        "1234": 1,
+        "5678": 1,
+      });
     });
   });
 


### PR DESCRIPTION
To test:
1. Ensure `browser.newtabpage.activity-stream.discoverystream.enabled` is true.
2. Ensure `browser.newtabpage.activity-stream.discoverystream.config` is enabled along with spocs, example: `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":true,"personalized":false,"layout_endpoint":"https://getpocket.cdn.mozilla.net/v3/newtab/layout?version=1&consumer_key=$apiKey&layout_variant=basic"}`
3. Ensure `browser.newtabpage.activity-stream.discoverystream.endpoints` is set to `http,https` to allow the custom spoc url used for testing.
4. Set `browser.newtabpage.activity-stream.discoverystream.spocs-endpoint` to `https://e5e8374d-fffa-4a77-a604-31603852b6fd.mock.pstmn.io/t-1579966`
5. Open a new tab.
6. Dismiss the first spoc.
7. check that the pref `browser.newtabpage.activity-stream.discoverystream.campaign.blocks` now holds the value `[1234]`
8. Restart the browser.
9. open a new tab.
expected: Should not see another spoc.
What this means is, when you set the spocs endpoint in step 1, you actually got 2 spocs, with different urls and the same campaign id. When you dismissed it, it blocked that url and campaign id. You don't see the spoc right away not because of my patch, but because it was already deduped. By restarting you ensure it's actually blocked.