### PR TITLE
(nobug) - Include provider name in React key to allow duplicate messa…

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -606,7 +606,7 @@ export class ASRouterAdminInner extends React.PureComponent {
     }
 
     return (
-      <tr className={itemClassName} key={msg.id}>
+      <tr className={itemClassName} key={`${msg.id}-${msg.provider}`}>
         <td className="message-id">
           <span>
             {msg.id} <br />


### PR DESCRIPTION
…ge ids

Because the `key` attribute needs to be unique, having two messages with the same `key` (2 messages with the same id) confused React not our rendering code as I initially assumed.
I think it should be ok to have 2 messages with the same id because 
1. they are only seen when devtools are enabled
2. they are a copy of the RS message that the user gets and we use this local message in our tests and when working on bugs/features 