### PR TITLE
Bug 1576680 - Telemetry additions for SPOC Topsites

### DIFF
--- a/content-src/components/TopSites/TopSite.jsx
+++ b/content-src/components/TopSites/TopSite.jsx
@@ -316,6 +316,9 @@ export class TopSite extends React.PureComponent {
       value.card_type = "search";
       value.search_vendor = this.props.link.hostname;
     }
+    if (this.props.link.type === SPOC_TYPE) {
+      value.card_type = "spoc";
+    }
     return { value };
   }
 

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -208,7 +208,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `action` | [Required] Either `activity_stream_event`, `activity_stream_session`, or `activity_stream_performance`. | :one:
 | `addon_version` | [Required] Firefox build ID, i.e. `Services.appinfo.appBuildID`. | :one:
 | `client_id` | [Required] An identifier for this client. | :one:
-| `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search") | :one:
+| `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search", "spoc") | :one:
 | `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon", "wikipedia", "duckduckgo", "bing", etc.). This field only exists when `card_type = "search"` | :one:
 | `date` | [Auto populated by Onyx] The date in YYYY-MM-DD format. | :three:
 | `experiment_id` | [Optional] The unique identifier for a specific experiment. | :one:
@@ -256,7 +256,7 @@ and losing focus. | :one:
 | `pocket` | [Optional] An integer to record the 0-based index when user saves a Pocket tile to Pocket. | :one:
 | `user_prefs` | [Required] The encoded integer of user's preferences. | :one: & :four:
 | `is_preloaded` | [Required] A boolean to signify whether the page is preloaded or not | :one:
-| `icon_type` | [Optional] ("tippytop", "rich_icon", "screenshot_with_icon", "screenshot", "no_image") | :one:
+| `icon_type` | [Optional] ("tippytop", "rich_icon", "screenshot_with_icon", "screenshot", "no_image", "custom_screenshot") | :one:
 | `region` | [Optional] A string maps to pref "browser.search.region", which is essentially the two letter ISO 3166-1 country code populated by the Firefox search service. Note that: 1). it reports "OTHER" for those regions with smaller Firefox user base (less than 10000) so that users cannot be uniquely identified; 2). it reports "UNSET" if this pref is missing; 3). it reports "EMPTY" if the value of this pref is an empty string. | :one:
 | `profile_creation_date` | [Optional] An integer to record the age of the Firefox profile as the total number of days since the UNIX epoch. | :one:
 | `message_id` | [required] A string identifier of the message in Activity Stream Router. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -131,8 +131,8 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "source": "TOP_SITES",
   "action_position": 2,
   "value": {
-    "card_type": ["pinned" | "search"],
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
+    "card_type": ["pinned" | "search" | "spoc"],
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image" | "custom_screenshot"],
     // only exists if its card_type = "search"
     "search_vendor": "google"
   }
@@ -199,7 +199,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "pinned",
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"]
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image" | "custom_screenshot"]
   }
 
   // Basic metadata
@@ -221,8 +221,8 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "source": "TOP_SITES",
   "action_position": 2,
   "value": {
-    "card_type": ["pinned" | "search"],
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"],
+    "card_type": ["pinned" | "search" | "spoc"],
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image" | "custom_screenshot"],
     // only exists if its card_type = "search"
     "search_vendor": "google"
   }
@@ -291,7 +291,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "pinned",
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"]
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image" | "custom_screenshot"]
   }
 
   // Basic metadata
@@ -314,7 +314,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
   "action_position": 2,
   "value": {
     "card_type": "pinned",
-    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image"]
+    "icon_type": ["screenshot_with_icon" | "screenshot" | "tippytop" | "rich_icon" | "no_image" | "custom_screenshot"]
   }
 
   // Basic metadata

--- a/test/schemas/pings.js
+++ b/test/schemas/pings.js
@@ -130,6 +130,7 @@ export const UserEventAction = Joi.object().keys({
           "screenshot_with_icon",
           "screenshot",
           "no_image",
+          "custom_screenshot",
         ]),
         card_type: Joi.valid([
           "bookmark",
@@ -137,6 +138,7 @@ export const UserEventAction = Joi.object().keys({
           "pinned",
           "pocket",
           "search",
+          "spoc",
         ]),
         search_vendor: Joi.valid(["google", "amazon"]),
         has_flow_params: Joi.bool(),

--- a/test/unit/content-src/components/TopSites.test.jsx
+++ b/test/unit/content-src/components/TopSites.test.jsx
@@ -817,6 +817,31 @@ describe("<TopSite>", () => {
       assert.propertyVal(action.data.value, "icon_type", "tippytop");
       assert.propertyVal(action.data.value, "search_vendor", "google");
     });
+    it("should dispatch a UserEventAction with the right data for SPOC top site", () => {
+      const dispatch = sinon.stub();
+      const siteInfo = {
+        iconType: "custom_screenshot",
+        type: "SPOC",
+      };
+      const wrapper = shallow(
+        <TopSite
+          link={Object.assign({}, link, siteInfo)}
+          index={0}
+          dispatch={dispatch}
+        />
+      );
+
+      wrapper.find(TopSiteLink).simulate("click", { preventDefault() {} });
+
+      const [action] = dispatch.firstCall.args;
+      assert.isUserEventAction(action);
+
+      assert.propertyVal(action.data, "event", "CLICK");
+      assert.propertyVal(action.data, "source", "TOP_SITES");
+      assert.propertyVal(action.data, "action_position", 0);
+      assert.propertyVal(action.data.value, "card_type", "spoc");
+      assert.propertyVal(action.data.value, "icon_type", "custom_screenshot");
+    });
     it("should dispatch OPEN_LINK with the right data", () => {
       const dispatch = sinon.stub();
       const wrapper = shallow(


### PR DESCRIPTION
This adds a new card_type `spoc` to identify a SPOC top site. When one clicks or dismisses a SPOC top site, we will include this value into the telemetry ping so that click-through rate and dismissal rate could be calculated accordingly.

Note that the icon type `custom-screenshot` is not a new addition but a document miss when we implemented the custom top site feature, added it back in for the completeness.

This needs a data review.

@punamdahiya Scott is on PTO now, could you take a look at this one?