### PR TITLE
Bug 1582005 - Add bucket_id as a required field

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/WhatsNewMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/WhatsNewMessage.schema.json
@@ -28,6 +28,10 @@
       "description": "Different message layouts",
      "enum": ["tracking-protections"]
     },
+    "bucket_id": {
+      "type": "string",
+      "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+    },
     "published_date": {
       "type": "integer",
       "description": "The date/time (number of milliseconds elapsed since January 1, 1970 00:00:00 UTC) the message was published."
@@ -76,5 +80,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["published_date", "title", "body", "cta_url"]
+  "required": ["published_date", "title", "body", "cta_url", "bucket_id"]
 }

--- a/lib/PanelTestProvider.jsm
+++ b/lib/PanelTestProvider.jsm
@@ -68,6 +68,7 @@ const MESSAGES = () => [
     template: "whatsnew_panel_message",
     order: 3,
     content: {
+      bucket_id: "WHATS_NEW_70_1",
       published_date: 1560969794394,
       title: "Protection Is Our Focus",
       icon_url:
@@ -86,6 +87,7 @@ const MESSAGES = () => [
     template: "whatsnew_panel_message",
     order: 1,
     content: {
+      bucket_id: "WHATS_NEW_70_1",
       published_date: 1560969794394,
       title: "Another thing new in Firefox 70",
       body:
@@ -102,6 +104,7 @@ const MESSAGES = () => [
     template: "whatsnew_panel_message",
     order: 1,
     content: {
+      bucket_id: "WHATS_NEW_69_1",
       published_date: 1557346235089,
       title: "Something new in Firefox 69",
       body:
@@ -118,6 +121,7 @@ const MESSAGES = () => [
     template: "whatsnew_panel_message",
     order: 2,
     content: {
+      bucket_id: "WHATS_NEW_70_3",
       published_date: 1560969794394,
       layout: "tracking-protections",
       title: { string_id: "cfr-whatsnew-tracking-blocked-title" },


### PR DESCRIPTION
I think a reason this was skipped is because it wasn't part of the schema.