### PR TITLE
Bug 1582061 - What's New links open twice when accessed with 'Space' key

### DIFF
--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -283,7 +283,7 @@ describe("ToolbarPanelHub", () => {
         assert.ok(createdElements.find(el => el.tagName === "p"));
       }
       // Call the click handler to make coverage happy.
-      eventListeners.click();
+      eventListeners.mouseup();
       assert.calledOnce(handleUserActionStub);
     });
     it("should sort based on order field value", async () => {
@@ -405,6 +405,24 @@ describe("ToolbarPanelHub", () => {
 
       assert.notCalled(fakeElementById.addEventListener);
     });
+    it("should attach doCommand cbs that handle user actions", async () => {
+      const messages = (await PanelTestProvider.getMessages()).filter(
+        m => m.template === "whatsnew_panel_message"
+      );
+      getMessagesStub.returns(messages);
+
+      await instance.renderMessages(fakeWindow, fakeDocument, "container-id");
+
+      const buttonEl = createdElements.find(el => el.tagName === "button");
+      const anchorEl = createdElements.find(el => el.tagName === "a");
+
+      assert.notCalled(handleUserActionStub);
+
+      buttonEl.doCommand();
+      anchorEl.doCommand();
+
+      assert.calledTwice(handleUserActionStub);
+    });
     it("should listen for panelhidden and remove the toolbar button", async () => {
       getMessagesStub.returns([]);
 
@@ -473,7 +491,7 @@ describe("ToolbarPanelHub", () => {
         spy.resetHistory();
 
         // Message click event listener cb
-        eventListeners.click();
+        eventListeners.mouseup();
 
         assert.calledOnce(spy);
         assert.calledWithExactly(spy, fakeWindow, "CLICK", messages[0]);
@@ -661,7 +679,7 @@ describe("ToolbarPanelHub", () => {
     it("should open link on click", async () => {
       await fakeInsert();
 
-      eventListeners.click();
+      eventListeners.mouseup();
 
       assert.calledOnce(handleUserActionStub);
       assert.calledWithExactly(handleUserActionStub, {


### PR DESCRIPTION
The current behavior is that [PanelMultiView triggers](https://searchfox.org/mozilla-central/rev/7531325c8660cfa61bf71725f83501028178cbb9/browser/components/customizableui/PanelMultiView.jsm#1830-1837) `doCommand` and dispatches `mousedown` and `click` events on keyboard events to the focused element.
We currently don't do anything for `doCommand` and the navigation happens because of the `click` event that's being dispatched.

The bug is caused because on `Space` events on the link element, we go through the flow described above and additionally another `click` event happens on the [`messageEl`](https://github.com/mozilla/activity-stream/blob/4d9d4cc21856beb4261214aee8420f1adfa3babb/lib/ToolbarPanelHub.jsm#L275). 

I couldn't figure out where this is coming from so instead I switched to a `mouseup` event listener. This will fire when a _real_ user click happens (which I think makes this more straight forward), we now completely ignore the dispatched events by `PanelMultiView` but we do attach an action to the `doCommand` to open the tab.