### PR TITLE
Bug 1550720 - Expose FxA services associated with profile to targetin…

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -40,7 +40,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [totalBlockedCount](#totalblockedcount)
 * [recentBookmarks](#recentbookmarks)
 * [userPrefs](#userprefs)
-* [listAttachedOAuthClients](#listattachedoauthclients)
+* [attachedFxAOAuthClients](#attachedfxaoauthclients)
 
 ## Detailed usage
 
@@ -557,7 +557,7 @@ declare const userPrefs: {
 }
 ```
 
-### `listAttachedOAuthClients`
+### `attachedFxAOAuthClients`
 
 Information about connected services associated with the FxA Account.
 
@@ -571,5 +571,14 @@ interface OAuthClient {
   lastAccessTime: UnixEpochNumber;
 }
 
-declare const listAttachedOAuthClients: Array<OAuthClient>
+declare const attachedFxAOAuthClients: Array<OAuthClient>
+```
+
+#### Examples
+```javascript
+{
+  id: "7377719276ad44ee",
+  name: "Pocket",
+  lastAccessTime: 1513599164000
+}
 ```

--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -40,6 +40,7 @@ Please note that some targeting attributes require stricter controls on the tele
 * [totalBlockedCount](#totalblockedcount)
 * [recentBookmarks](#recentbookmarks)
 * [userPrefs](#userprefs)
+* [listAttachedOAuthClients](#listattachedoauthclients)
 
 ## Detailed usage
 
@@ -554,4 +555,21 @@ declare const userPrefs: {
   cfrAddons: boolean;
   snippets: boolean;
 }
+```
+
+### `listAttachedOAuthClients`
+
+Information about connected services associated with the FxA Account.
+
+#### Definition
+
+```
+interface OAuthClient {
+  id: string;
+  // FxA service name
+  name: string;
+  lastAccessTime: UnixEpochNumber;
+}
+
+declare const listAttachedOAuthClients: Array<OAuthClient>
 ```

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -21,6 +21,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   AttributionCode: "resource:///modules/AttributionCode.jsm",
   FilterExpressions:
     "resource://gre/modules/components-utils/FilterExpressions.jsm",
+  fxAccounts: "resource://gre/modules/FxAccounts.jsm",
 });
 
 XPCOMUtils.defineLazyPreferenceGetter(
@@ -459,6 +460,9 @@ const TargetingGetters = {
   },
   get totalBlockedCount() {
     return TrackingDBService.sumAllEvents();
+  },
+  get listAttachedOAuthClients() {
+    return this.usesFirefoxSync && fxAccounts.listAttachedOAuthClients();
   },
 };
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -462,7 +462,7 @@ const TargetingGetters = {
     return TrackingDBService.sumAllEvents();
   },
   get listAttachedOAuthClients() {
-    return this.usesFirefoxSync && fxAccounts.listAttachedOAuthClients();
+    return this.usesFirefoxSync ? fxAccounts.listAttachedOAuthClients() : [];
   },
 };
 

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -461,7 +461,7 @@ const TargetingGetters = {
   get totalBlockedCount() {
     return TrackingDBService.sumAllEvents();
   },
-  get listAttachedOAuthClients() {
+  get attachedFxAOAuthClients() {
     return this.usesFirefoxSync ? fxAccounts.listAttachedOAuthClients() : [];
   },
 };


### PR DESCRIPTION
…g expression

Here are some example expressions to validate that the current data format is usable in JEXL.

* Number of times a certain service has been used
    * `listAttachedOAuthClients[.name == "Pocket"]|length`
* Uses a certain service
    * `"Pocket" in listAttachedOAuthClients|mapToProperty("name")`
* Services used in the past week
    * `listAttachedOAuthClients[.lastAccessTime >= (currentDate|date - 3600 * 24 * 7 * 1000)]|mapToProperty("name")`