### PR TITLE
Bug 1576510 - Use aria-labelledby to add additional description information to badged toolbar buttons

### DIFF
--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -22,8 +22,9 @@
       "type": "number",
       "description": "Optional delay in ms after which to show the notification"
     },
-    "aria-label": {
+    "badgeDescription": {
       "type": "object",
+      "description": "This is used in combination with the badged button to offer a text based alternative to the visual badging. Example 'New Feature: What's New'",
       "properties": {
         "string_id": {
           "type": "string",

--- a/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
+++ b/content-src/asrouter/templates/OnboardingMessage/ToolbarBadgeMessage.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "ToolbarBadgeMessage",
   "description": "A template that specifies to which element in the browser toolbar to add a notification.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "object",
   "properties": {
     "target": {
@@ -21,6 +21,16 @@
     "delay": {
       "type": "number",
       "description": "Optional delay in ms after which to show the notification"
+    },
+    "aria-label": {
+      "type": "object",
+      "properties": {
+        "string_id": {
+          "type": "string",
+          "description": "Fluent string id"
+        }
+      },
+      "required": ["string_id"]
     }
   },
   "additionalProperties": false,

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -458,7 +458,7 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      delay: 5 * ONE_MINUTE,
+      delay: 5,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
       "aria-label": { string_id: "cfr-badge-reader-label-newfeature" },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -458,7 +458,7 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      delay: 5 * ONE_MINUTE,
+      delay: 5,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
     },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -461,6 +461,7 @@ const ONBOARDING_MESSAGES = () => [
       delay: 5,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
+      "aria-label": { string_id: "cfr-badge-reader-label-newfeature" },
     },
     priority: 1,
     trigger: { id: "toolbarBadgeUpdate" },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -458,7 +458,7 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      delay: 5,
+      delay: 5 * ONE_MINUTE,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
       badgeDescription: { string_id: "cfr-badge-reader-label-newfeature" },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -458,7 +458,7 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      delay: 5,
+      delay: 5 * ONE_MINUTE,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
       "aria-label": { string_id: "cfr-badge-reader-label-newfeature" },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -458,7 +458,7 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      delay: 5 * ONE_MINUTE,
+      delay: 5,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
       badgeDescription: { string_id: "cfr-badge-reader-label-newfeature" },

--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -458,10 +458,10 @@ const ONBOARDING_MESSAGES = () => [
     id: `WHATS_NEW_BADGE_${FIREFOX_VERSION}`,
     template: "toolbar_badge",
     content: {
-      delay: 5,
+      delay: 5 * ONE_MINUTE,
       target: "whats-new-menu-button",
       action: { id: "show-whatsnew-button" },
-      "aria-label": { string_id: "cfr-badge-reader-label-newfeature" },
+      badgeDescription: { string_id: "cfr-badge-reader-label-newfeature" },
     },
     priority: 1,
     trigger: { id: "toolbarBadgeUpdate" },

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -3,56 +3,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-ChromeUtils.defineModuleGetter(
-  this,
-  "EveryWindow",
-  "resource:///modules/EveryWindow.jsm"
+const { XPCOMUtils } = ChromeUtils.import(
+  "resource://gre/modules/XPCOMUtils.jsm"
 );
-ChromeUtils.defineModuleGetter(
-  this,
-  "ToolbarPanelHub",
-  "resource://activity-stream/lib/ToolbarPanelHub.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "Services",
-  "resource://gre/modules/Services.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "setTimeout",
-  "resource://gre/modules/Timer.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "clearTimeout",
-  "resource://gre/modules/Timer.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "Services",
-  "resource://gre/modules/Services.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "PrivateBrowsingUtils",
-  "resource://gre/modules/PrivateBrowsingUtils.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "setInterval",
-  "resource://gre/modules/Timer.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "clearInterval",
-  "resource://gre/modules/Timer.jsm"
-);
-ChromeUtils.defineModuleGetter(
-  this,
-  "requestIdleCallback",
-  "resource://gre/modules/Timer.jsm"
-);
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+  EveryWindow: "resource:///modules/EveryWindow.jsm",
+  ToolbarPanelHub: "resource://activity-stream/lib/ToolbarPanelHub.jsm",
+  Services: "resource://gre/modules/Services.jsm",
+  PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.jsm",
+});
+
+const {
+  setInterval,
+  clearInterval,
+  requestIdleCallback,
+  setTimeout,
+  clearTimeout,
+} = ChromeUtils.import("resource://gre/modules/Timer.jsm");
 
 // Frequency at which to check for new messages
 const SYSTEM_TICK_INTERVAL = 5 * 60 * 1000;

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -233,12 +233,16 @@ class _ToolbarBadgeHub {
     toolbarButton
       .querySelector(".toolbarbutton-badge")
       .classList.remove("feature-callout");
-    // Remove id used for for aria-label badge description
-    toolbarButton
-      .querySelector("toolbarbutton-notification-description")
-      .removeAttribute("id");
-    toolbarButton.removeAttribute("aria-labelledby");
     toolbarButton.removeAttribute("badged");
+    // Remove id used for for aria-label badge description
+    const notificationDescription = toolbarButton.querySelector(
+      "#toolbarbutton-notification-description"
+    );
+    if (notificationDescription) {
+      notificationDescription.remove();
+      toolbarButton.removeAttribute("aria-labelledby");
+      toolbarButton.removeAttribute("aria-describedby");
+    }
   }
 
   addToolbarNotification(win, message) {
@@ -258,17 +262,28 @@ class _ToolbarBadgeHub {
       if (message.content["aria-label"]) {
         toolbarbutton.setAttribute(
           "aria-labelledby",
+          `toolbarbutton-notification-description ${message.content.target}`
+        );
+        // Because tooltiptext is different to the label, it gets duplicated as
+        // the description. Setting `describedby` to the same value as
+        // `labelledby` will be detected by the a11y code and the description
+        // will be removed.
+        toolbarbutton.setAttribute(
+          "aria-describedby",
+          `toolbarbutton-notification-description ${message.content.target}`
+        );
+        const descriptionEl = document.createElement("span");
+        descriptionEl.setAttribute(
+          "id",
           "toolbarbutton-notification-description"
         );
-        toolbarbutton
-          .querySelector(".toolbarbutton-text")
-          .setAttribute("id", "toolbarbutton-notification-description");
+        descriptionEl.setAttribute("hidden", true);
         document.l10n.setAttributes(
-          toolbarbutton.querySelector(".toolbarbutton-text"),
+          descriptionEl,
           message.content["aria-label"].string_id
         );
+        toolbarbutton.appendChild(descriptionEl);
       }
-
       // `mousedown` event required because of the `onmousedown` defined on
       // the button that prevents `click` events from firing
       toolbarbutton.addEventListener("mousedown", this.removeAllNotifications);

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -259,7 +259,7 @@ class _ToolbarBadgeHub {
       // we add this content to the hidden `toolbarbutton-text` node.
       // We then use `aria-labelledby` to link this description to the button
       // that received the notification badge.
-      if (message.content["aria-label"]) {
+      if (message.content.badgeDescription) {
         toolbarbutton.setAttribute(
           "aria-labelledby",
           `toolbarbutton-notification-description ${message.content.target}`
@@ -280,7 +280,7 @@ class _ToolbarBadgeHub {
         descriptionEl.setAttribute("hidden", true);
         document.l10n.setAttributes(
           descriptionEl,
-          message.content["aria-label"].string_id
+          message.content.badgeDescription.string_id
         );
         toolbarbutton.appendChild(descriptionEl);
       }

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -233,6 +233,11 @@ class _ToolbarBadgeHub {
     toolbarButton
       .querySelector(".toolbarbutton-badge")
       .classList.remove("feature-callout");
+    // Remove id used for for aria-label badge description
+    toolbarButton
+      .querySelector("toolbarbutton-notification-description")
+      .removeAttribute("id");
+    toolbarButton.removeAttribute("aria-labelledby");
     toolbarButton.removeAttribute("badged");
   }
 
@@ -243,13 +248,26 @@ class _ToolbarBadgeHub {
     }
     let toolbarbutton = document.getElementById(message.content.target);
     if (toolbarbutton) {
-      toolbarbutton.setAttribute("aria-label", "Notification");
-      toolbarbutton.setAttribute("aria-describedby", message.content.target);
       const badge = toolbarbutton.querySelector(".toolbarbutton-badge");
-      toolbarbutton.setAttribute("badged", true);
       badge.classList.add("feature-callout");
-      badge.setAttribute("aria-label", "Notification");
-      badge.setAttribute("aria-describedby", message.content.target);
+      toolbarbutton.setAttribute("badged", true);
+      // If we have additional aria-label information for the notification
+      // we add this content to the hidden `toolbarbutton-text` node.
+      // We then use `aria-labelledby` to link this description to the button
+      // that received the notification badge.
+      if (message.content["aria-label"]) {
+        toolbarbutton.setAttribute(
+          "aria-labelledby",
+          "toolbarbutton-notification-description"
+        );
+        toolbarbutton
+          .querySelector(".toolbarbutton-text")
+          .setAttribute("id", "toolbarbutton-notification-description");
+        document.l10n.setAttributes(
+          toolbarbutton.querySelector(".toolbarbutton-text"),
+          message.content["aria-label"].string_id
+        );
+      }
 
       // `mousedown` event required because of the `onmousedown` defined on
       // the button that prevents `click` events from firing

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -243,10 +243,13 @@ class _ToolbarBadgeHub {
     }
     let toolbarbutton = document.getElementById(message.content.target);
     if (toolbarbutton) {
+      toolbarbutton.setAttribute("aria-label", "Notification");
+      toolbarbutton.setAttribute("aria-describedby", message.content.target);
+      const badge = toolbarbutton.querySelector(".toolbarbutton-badge");
       toolbarbutton.setAttribute("badged", true);
-      toolbarbutton
-        .querySelector(".toolbarbutton-badge")
-        .classList.add("feature-callout");
+      badge.classList.add("feature-callout");
+      badge.setAttribute("aria-label", "Notification");
+      badge.setAttribute("aria-describedby", message.content.target);
 
       // `mousedown` event required because of the `onmousedown` defined on
       // the button that prevents `click` events from firing

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -151,6 +151,10 @@ class _ToolbarBadgeHub {
     }
   }
 
+  maybeInsertFTL(win) {
+    win.MozXULElement.insertFTLIfNeeded("browser/newtab/asrouter.ftl");
+  }
+
   executeAction({ id, data, message_id }) {
     switch (id) {
       case "show-whatsnew-button":
@@ -260,6 +264,8 @@ class _ToolbarBadgeHub {
       // We then use `aria-labelledby` to link this description to the button
       // that received the notification badge.
       if (message.content.badgeDescription) {
+        // Insert strings as soon as we know we're showing them
+        this.maybeInsertFTL(win);
         toolbarbutton.setAttribute(
           "aria-labelledby",
           `toolbarbutton-notification-description ${message.content.target}`

--- a/locales-src/asrouter.ftl
+++ b/locales-src/asrouter.ftl
@@ -86,6 +86,8 @@ cfr-protections-panel-link-text = Learn more
 
 ## What's New toolbar button and panel
 
+# This string is used by screen readers to offer a text based alternative for
+# the notification icon
 cfr-badge-reader-label-newfeature = New feature:
 
 cfr-whatsnew-button =

--- a/locales-src/asrouter.ftl
+++ b/locales-src/asrouter.ftl
@@ -86,7 +86,7 @@ cfr-protections-panel-link-text = Learn more
 
 ## What's New toolbar button and panel
 
-cfr-badge-reader-label-newfeature = New feature
+cfr-badge-reader-label-newfeature = New feature:
 
 cfr-whatsnew-button =
   .label = What’s New

--- a/locales-src/asrouter.ftl
+++ b/locales-src/asrouter.ftl
@@ -86,6 +86,8 @@ cfr-protections-panel-link-text = Learn more
 
 ## What's New toolbar button and panel
 
+cfr-badge-reader-label-newfeature = New feature
+
 cfr-whatsnew-button =
   .label = What’s New
   .tooltiptext = What’s New

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -1,7 +1,7 @@
 import { _ToolbarBadgeHub } from "lib/ToolbarBadgeHub.jsm";
 import { GlobalOverrider } from "test/unit/utils";
 import { OnboardingMessageProvider } from "lib/OnboardingMessageProvider.jsm";
-import { _ToolbarPanelHub } from "lib/ToolbarPanelHub.jsm";
+import { _ToolbarPanelHub, ToolbarPanelHub } from "lib/ToolbarPanelHub.jsm";
 
 describe("ToolbarBadgeHub", () => {
   let sandbox;
@@ -72,6 +72,7 @@ describe("ToolbarBadgeHub", () => {
     setStringPrefStub = sandbox.stub();
     requestIdleCallbackStub = sandbox.stub().callsFake(fn => fn());
     globals.set({
+      ToolbarPanelHub,
       requestIdleCallback: requestIdleCallbackStub,
       EveryWindow: everyWindowStub,
       PrivateBrowsingUtils: { isBrowserPrivate: isBrowserPrivateStub },

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -23,6 +23,7 @@ describe("ToolbarBadgeHub", () => {
   let clearUserPrefStub;
   let setStringPrefStub;
   let requestIdleCallbackStub;
+  let fakeWindow;
   beforeEach(async () => {
     globals = new GlobalOverrider();
     sandbox = sinon.createSandbox();
@@ -56,7 +57,8 @@ describe("ToolbarBadgeHub", () => {
     clearTimeoutStub = sandbox.stub();
     setTimeoutStub = sandbox.stub();
     setIntervalStub = sandbox.stub();
-    const fakeWindow = {
+    fakeWindow = {
+      MozXULElement: { insertFTLIfNeeded: sandbox.stub() },
       ownerGlobal: {
         gBrowser: {
           selectedBrowser: "browser",
@@ -209,7 +211,7 @@ describe("ToolbarBadgeHub", () => {
         createElement: sandbox.stub().returns(fakeElement),
         l10n: { setAttributes: sandbox.stub() },
       };
-      target = { browser: { ownerDocument: fakeDocument } };
+      target = { ...fakeWindow, browser: { ownerDocument: fakeDocument } };
     });
     it("shouldn't do anything if target element is not found", () => {
       fakeDocument.getElementById.returns(null);

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -290,7 +290,7 @@ describe("ToolbarBadgeHub", () => {
       assert.calledWithExactly(
         fakeDocument.l10n.setAttributes,
         fakeElement,
-        whatsnewMessage.content["aria-label"].string_id
+        whatsnewMessage.content.badgeDescription.string_id
       );
     });
   });


### PR DESCRIPTION
This is one idea for fixing the notification description, posting this for discussion.

I've used the OSX VoiceOver software to test this. The screenshot shows the button description as "What's New New feature": a combination of the button's own description and the element referred to via `aria-labelledby`.

<img width="470" alt="Screenshot 2019-09-27 at 13 05 35" src="https://user-images.githubusercontent.com/810040/65765397-aa597e80-e117-11e9-97af-0ed668aa92ba.png">

The idea is to use the hidden elements associated with any `toolbarbutton` [that has a badge](https://searchfox.org/mozilla-central/rev/f1e99da78fe6c3c68696358dac06aed90f8112d3/toolkit/content/widgets/toolbarbutton.js#110) to hold the button description.
[One issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1576510#c1) described in the bug comment was related to the string needed to describe the notification. I think we have more flexibility here because we can have a set of strings describing various types of badges: new feature, feature callout, hints etc. We can reference any one of these strings in the badge payload and set that description to the `toolbarbutton`.
