### PR TITLE
(nobug) - Remove earliestFirefoxVersion attribute for causing perform…

### DIFF
--- a/content-src/asrouter/docs/targeting-attributes.md
+++ b/content-src/asrouter/docs/targeting-attributes.md
@@ -36,7 +36,6 @@ Please note that some targeting attributes require stricter controls on the tele
 * [hasPinnedTabs](#haspinnedtabs)
 * [hasAccessedFxAPanel](#hasaccessedfxapanel)
 * [isWhatsNewPanelEnabled](#iswhatsnewpanelenabled)
-* [earliestFirefoxVersion](#earliestfirefoxversion)
 * [isFxABadgeEnabled](#isfxabadgeenabled)
 * [totalBlockedCount](#totalblockedcount)
 * [recentBookmarks](#recentbookmarks)
@@ -500,16 +499,6 @@ Boolean pref that controls if the What's New panel feature is enabled
 
 ```ts
 declare const isWhatsNewPanelEnabled: boolean;
-```
-
-### `earliestFirefoxVersion`
-
-Integer value of the first Firefox version the profile ran on
-
-#### Definition
-
-```ts
-declare const earliestFirefoxVersion: boolean;
 ```
 
 ### `isFxABadgeEnabled`

--- a/lib/ASRouterTargeting.jsm
+++ b/lib/ASRouterTargeting.jsm
@@ -23,13 +23,6 @@ XPCOMUtils.defineLazyModuleGetters(this, {
     "resource://gre/modules/components-utils/FilterExpressions.jsm",
 });
 
-XPCOMUtils.defineLazyServiceGetter(
-  this,
-  "UpdateManager",
-  "@mozilla.org/updates/update-manager;1",
-  "nsIUpdateManager"
-);
-
 XPCOMUtils.defineLazyPreferenceGetter(
   this,
   "cfrFeaturesUserPref",
@@ -453,16 +446,6 @@ const TargetingGetters = {
   },
   get isWhatsNewPanelEnabled() {
     return isWhatsNewPanelEnabled;
-  },
-  get earliestFirefoxVersion() {
-    if (UpdateManager.updateCount) {
-      const earliestFirefoxVersion = UpdateManager.getUpdateAt(
-        UpdateManager.updateCount - 1
-      ).previousAppVersion;
-      return parseInt(earliestFirefoxVersion.match(/\d+/), 10);
-    }
-
-    return null;
   },
   get isFxABadgeEnabled() {
     return isFxABadgeEnabled;


### PR DESCRIPTION
…ance issues

And more generally because detecting version numbers is not a good way to target upgrades.
[Link to backouts when we tried to use this attribute](https://github.com/mozilla/activity-stream/pull/5273#issuecomment-524525961).