### PR TITLE
Bug 1584625 - browser_aboutwelcome.js mochitest fails when run twice

### DIFF
--- a/test/browser/browser_onboarding_rtamo.js
+++ b/test/browser/browser_onboarding_rtamo.js
@@ -33,8 +33,21 @@ async function setRTAMOOnboarding() {
   ASRouter._updateMessageProviders();
   await ASRouter.loadMessagesFromAllProviders();
 
-  registerCleanupFunction(() => {
+  registerCleanupFunction(async () => {
+    // Separate cleanup methods between mac and windows
+    const { path } = Services.dirsvc.get("GreD", Ci.nsIFile).parent.parent;
+    const attributionSvc = Cc["@mozilla.org/mac-attribution;1"].getService(
+      Ci.nsIMacAttributionService
+    );
+    attributionSvc.setReferrerUrl(path, "", true);
+    // Clear cache call is only possible in a testing environment
+    let env = Cc["@mozilla.org/process/environment;1"].getService(
+      Ci.nsIEnvironment
+    );
+    env.set("XPCSHELL_TEST_PROFILE_DIR", "testing");
     Services.prefs.clearUserPref(BRANCH_PREF);
+    await AttributionCode.deleteFileAsync();
+    AttributionCode._clearCache();
   });
 }
 


### PR DESCRIPTION
The issue is caused by `browser_onboarding_rtamo.js` that doesn't properly cleanup the attribution data. Mochitests use a fresh profile on every run but attribution data is persisted to disk.
Cleanup is different between mac and windows because the APIs are platform specific and `AttributionCode.jsm` doesn't expose a unified API to restore everything. 