### PR TITLE
Bug 1578579 - Add telemetry for ad privacy info

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSPrivacyModal/DSPrivacyModal.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSPrivacyModal/DSPrivacyModal.jsx
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
+import { actionCreators as ac } from "common/Actions.jsm";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
 import { ModalOverlayWrapper } from "content-src/asrouter/components/ModalOverlay/ModalOverlay";
 
@@ -10,6 +11,16 @@ export class DSPrivacyModal extends React.PureComponent {
   constructor(props) {
     super(props);
     this.closeModal = this.closeModal.bind(this);
+    this.onLinkClick = this.onLinkClick.bind(this);
+  }
+
+  onLinkClick(event) {
+    this.props.dispatch(
+      ac.UserEvent({
+        event: "CLICK_PRIVACY_INFO_LINK",
+        source: "DS_PRIVACY_MODAL",
+      })
+    );
   }
 
   closeModal() {
@@ -28,7 +39,10 @@ export class DSPrivacyModal extends React.PureComponent {
         <div className="privacy-notice">
           <h3 data-l10n-id="newtab-privacy-modal-header" />
           <p data-l10n-id="newtab-privacy-modal-paragraph" />
-          <SafeAnchor url="https://www.mozilla.org/en-US/privacy/firefox/">
+          <SafeAnchor
+            onLinkClick={this.onLinkClick}
+            url="https://www.mozilla.org/en-US/privacy/firefox/"
+          >
             <span data-l10n-id="newtab-privacy-modal-link" />
           </SafeAnchor>
         </div>

--- a/content-src/components/DiscoveryStreamComponents/DSPrivacyModal/DSPrivacyModal.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSPrivacyModal/DSPrivacyModal.jsx
@@ -17,7 +17,7 @@ export class DSPrivacyModal extends React.PureComponent {
   onLinkClick(event) {
     this.props.dispatch(
       ac.UserEvent({
-        event: "CLICK_PRIVACY_INFO_LINK",
+        event: "CLICK_PRIVACY_INFO",
         source: "DS_PRIVACY_MODAL",
       })
     );

--- a/content-src/lib/link-menu-options.js
+++ b/content-src/lib/link-menu-options.js
@@ -28,6 +28,7 @@ export const LinkMenuOptions = {
     action: {
       type: at.SHOW_PRIVACY_INFO,
     },
+    userEvent: "SHOW_PRIVACY_INFO",
   }),
   RemoveBookmark: site => ({
     id: "newtab-menu-remove-bookmark",

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -192,7 +192,7 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 
 ```js
 {
-  "event": "CLICK_PRIVACY_INFO_LINK",
+  "event": "CLICK_PRIVACY_INFO",
   "source": "DS_PRIVACY_MODAL",
 
   // Basic metadata

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -169,6 +169,43 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 }
 ```
 
+#### Showing privacy information
+
+```js
+{
+  "event": "SHOW_PRIVACY_INFO",
+  "source": "TOP_SITES",
+  "action_position": 2,
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7
+}
+```
+
+#### Clicking on privacy information link
+
+```js
+{
+  "event": "CLICK_PRIVACY_INFO_LINK",
+  "source": "DS_PRIVACY_MODAL",
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7
+}
+```
+
 #### Deleting a search shortcut
 ```js
 {

--- a/test/schemas/pings.js
+++ b/test/schemas/pings.js
@@ -120,6 +120,8 @@ export const UserEventAction = Joi.object().keys({
         "ARCHIVE_FROM_POCKET",
         "SKIPPED_SIGNIN",
         "SUBMIT_EMAIL",
+        "SHOW_PRIVACY_INFO",
+        "CLICK_PRIVACY_INFO_LINK",
       ]).required(),
       source: Joi.valid(["TOP_SITES", "TOP_STORIES", "HIGHLIGHTS"]),
       action_position: Joi.number().integer(),

--- a/test/schemas/pings.js
+++ b/test/schemas/pings.js
@@ -121,7 +121,7 @@ export const UserEventAction = Joi.object().keys({
         "SKIPPED_SIGNIN",
         "SUBMIT_EMAIL",
         "SHOW_PRIVACY_INFO",
-        "CLICK_PRIVACY_INFO_LINK",
+        "CLICK_PRIVACY_INFO",
       ]).required(),
       source: Joi.valid(["TOP_SITES", "TOP_STORIES", "HIGHLIGHTS"]),
       action_position: Joi.number().integer(),

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSPrivacyModal.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSPrivacyModal.test.jsx
@@ -36,7 +36,7 @@ describe("Discovery Stream <DSPrivacyModal>", () => {
     assert.calledWith(
       dispatch,
       ac.UserEvent({
-        event: "CLICK_PRIVACY_INFO_LINK",
+        event: "CLICK_PRIVACY_INFO",
         source: "DS_PRIVACY_MODAL",
       })
     );

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSPrivacyModal.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSPrivacyModal.test.jsx
@@ -1,11 +1,20 @@
 import { DSPrivacyModal } from "content-src/components/DiscoveryStreamComponents/DSPrivacyModal/DSPrivacyModal";
 import { shallow, mount } from "enzyme";
+import { actionCreators as ac } from "common/Actions.jsm";
 import React from "react";
 
 describe("Discovery Stream <DSPrivacyModal>", () => {
   let sandbox;
+  let dispatch;
+  let wrapper;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    dispatch = sandbox.stub();
+    wrapper = shallow(<DSPrivacyModal dispatch={dispatch} />);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it("should contain a privacy notice", () => {
@@ -16,10 +25,20 @@ describe("Discovery Stream <DSPrivacyModal>", () => {
   });
 
   it("should call dispatch when modal is closed", () => {
-    let dispatch = sandbox.stub();
-    let wrapper = shallow(<DSPrivacyModal dispatch={dispatch} />);
-
     wrapper.instance().closeModal();
     assert.calledOnce(dispatch);
+  });
+
+  it("should call dispatch with the correct events", () => {
+    wrapper.instance().onLinkClick();
+
+    assert.calledOnce(dispatch);
+    assert.calledWith(
+      dispatch,
+      ac.UserEvent({
+        event: "CLICK_PRIVACY_INFO_LINK",
+        source: "DS_PRIVACY_MODAL",
+      })
+    );
   });
 });


### PR DESCRIPTION
You can verify the new telemetry by enabling the telemetry [logging](https://github.com/mozilla/activity-stream/blob/master/content-src/asrouter/docs/debugging-docs.md#how-to-test-telemetry-pings).