### PR TITLE
Bug 1585434 - Put ASRouter remote l10n behind the pref

### DIFF
--- a/content-src/asrouter/README.md
+++ b/content-src/asrouter/README.md
@@ -8,6 +8,7 @@ Name | Used for | Type | Example value
 `providers.snippets` | Message provider options for snippets | `Object` | [see below](#message-providers)
 `providers.cfr` | Message provider options for cfr | `Object` | [see below](#message-providers)
 `providers.onboarding` | Message provider options for onboarding | `Object` | [see below](#message-providers)
+`useRemoteL10n` | Controls whether to use the remote Fluent files for l10n, default as `true` | `Boolean` | `[true|false]`
 
 ### Message providers examples
 

--- a/docs/v2-system-addon/remote_cfr.md
+++ b/docs/v2-system-addon/remote_cfr.md
@@ -58,3 +58,6 @@ There should be a "cfr-remote" provider listed.
 
 If your message is published in the staging environment the easiest way to test is using the [Remote Settings Devtools](https://github.com/mozilla/remote-settings-devtools/releases) addon. You can install this by going to `about:debugging` and using the `Load Temporary Addon` feature.
 The devtools allow you to switch your profile between production and staging and takes care of correctly flipping all the required preferences.
+
+## Remote l10n
+By default, all CFR messages are localized with the remote Fluent files hosted in `ms-language-packs` on Remote Settings. For local test and development, you can force ASRouter to use the local Fluent files by flipping the pref `browser.newtabpage.activity-stream.asrouter.useRemoteL10n`.

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -105,6 +105,9 @@ const RS_DOWNLOAD_MAX_RETRIES = 2;
 
 // To observe the app locale change notification.
 const TOPIC_INTL_LOCALE_CHANGED = "intl:app-locales-changed";
+// To observe the pref that controls if ASRouter should use the remote Fluent files for l10n.
+const USE_REMOTE_L10N_PREF =
+  "browser.newtabpage.activity-stream.asrouter.useRemoteL10n";
 
 /**
  * chooseBranch<T> -  Choose an item from a list of "branches" pseudorandomly using a seed / ratio configuration
@@ -759,6 +762,14 @@ class _ASRouter {
     await this._maybeUpdateL10nAttachment();
   }
 
+  observe(aSubject, aTopic, aPrefName) {
+    switch (aPrefName) {
+      case USE_REMOTE_L10N_PREF:
+        CFRPageActions.reloadL10n();
+        break;
+    }
+  }
+
   /**
    * init - Initializes the MessageRouter.
    * It is ready when it has been connected to a RemotePageManager instance.
@@ -833,6 +844,7 @@ class _ASRouter {
     );
 
     Services.obs.addObserver(this._onLocaleChanged, TOPIC_INTL_LOCALE_CHANGED);
+    Services.prefs.addObserver(USE_REMOTE_L10N_PREF, this);
     // sets .initialized to true and resolves .waitForInitialized promise
     this._finishInitializing();
   }
@@ -864,6 +876,7 @@ class _ASRouter {
       this._onLocaleChanged,
       TOPIC_INTL_LOCALE_CHANGED
     );
+    Services.prefs.removeObserver(USE_REMOTE_L10N_PREF, this);
     // If we added any CFR recommendations, they need to be removed
     CFRPageActions.clearRecommendations();
     this._resetInitialization();

--- a/lib/CFRPageActions.jsm
+++ b/lib/CFRPageActions.jsm
@@ -47,6 +47,8 @@ const CATEGORY_ICONS = {
  * profile directory.
  */
 const RS_DOWNLOADED_FILE_SUBDIR = "settings/main/ms-language-packs";
+const USE_REMOTE_L10N_PREF =
+  "browser.newtabpage.activity-stream.asrouter.useRemoteL10n";
 
 /**
  * A WeakMap from browsers to {host, recommendation} pairs. Recommendations are
@@ -118,10 +120,21 @@ class PageAction {
 
   /**
    * Creates a new DOMLocalization instance with the Fluent file from Remote Settings.
-   * Note that it still uses the packaged Fluent file as the fallback if the remote one
-   * is not available.
+   *
+   * Note: it will use the local Fluent file in any of following cases:
+   *   * the remote Fluent file is not available
+   *   * it was told to use the local Fluent file
    */
   _createDOML10n() {
+    if (!Services.prefs.getBoolPref(USE_REMOTE_L10N_PREF, true)) {
+      return new DOMLocalization([
+        "browser/newtab/asrouter.ftl",
+        "browser/branding/brandings.ftl",
+        "browser/branding/sync-brand.ftl",
+        "branding/brand.ftl",
+      ]);
+    }
+
     async function* generateBundles(resourceIds) {
       const appLocale = Services.locale.appLocaleAsBCP47;
       const appLocales = Services.locale.appLocalesAsBCP47;
@@ -160,6 +173,10 @@ class PageAction {
       ],
       generateBundles
     );
+  }
+
+  reloadL10n() {
+    this._l10n = this._createDOML10n();
   }
 
   async showAddressBarNotifier(recommendation, shouldExpand = false) {
@@ -913,6 +930,18 @@ const CFRPageActions = {
     RecommendationMap = new WeakMap();
     this.PageActionMap = PageActionMap;
     this.RecommendationMap = RecommendationMap;
+  },
+
+  /**
+   * Reload the l10n Fluent files for all PageActions
+   */
+  reloadL10n() {
+    for (const win of Services.wm.getEnumerator("navigator:browser")) {
+      if (win.closed || !PageActionMap.has(win)) {
+        continue;
+      }
+      PageActionMap.get(win).reloadL10n();
+    }
   },
 };
 

--- a/test/unit/asrouter/CFRPageActions.test.js
+++ b/test/unit/asrouter/CFRPageActions.test.js
@@ -747,6 +747,42 @@ describe("CFRPageActions", () => {
         );
       });
     });
+
+    describe("#_createDOML10n", () => {
+      let domL10nStub;
+      beforeEach(() => {
+        domL10nStub = sandbox.stub();
+
+        globals.set("DOMLocalization", domL10nStub);
+      });
+      it("should load the remote Fluent file if USE_REMOTE_L10N_PREF is true", () => {
+        sandbox.stub(global.Services.prefs, "getBoolPref").returns(true);
+        pageAction._createDOML10n();
+
+        assert.calledOnce(domL10nStub);
+        const { args } = domL10nStub.firstCall;
+        // The first arg is the resource array, and the second one is the bundle generator.
+        assert.equal(args.length, 2);
+        assert.deepEqual(args[0], [
+          "browser/newtab/asrouter.ftl",
+          "browser/branding/brandings.ftl",
+          "browser/branding/sync-brand.ftl",
+          "branding/brand.ftl",
+        ]);
+      });
+      it("should load the local Fluent file if USE_REMOTE_L10N_PREF is false", () => {
+        sandbox.stub(global.Services.prefs, "getBoolPref").returns(false);
+        pageAction._createDOML10n();
+
+        assert.calledOnce(domL10nStub);
+        assert.calledWith(domL10nStub, [
+          "browser/newtab/asrouter.ftl",
+          "browser/branding/brandings.ftl",
+          "browser/branding/sync-brand.ftl",
+          "branding/brand.ftl",
+        ]);
+      });
+    });
   });
 
   describe("CFRPageActions", () => {
@@ -1065,6 +1101,32 @@ describe("CFRPageActions", () => {
         for (const browser of browsers) {
           assert.isFalse(CFRPageActions.RecommendationMap.has(browser));
         }
+      });
+    });
+
+    describe("reloadL10n", () => {
+      const createFakePageAction = () => ({
+        hideAddressBarNotifier() {},
+        reloadL10n: sandbox.stub(),
+      });
+      const windows = [{}, {}, { closed: true }];
+
+      beforeEach(() => {
+        CFRPageActions.PageActionMap.set(windows[0], createFakePageAction());
+        CFRPageActions.PageActionMap.set(windows[2], createFakePageAction());
+        globals.set({ Services: { wm: { getEnumerator: () => windows } } });
+      });
+
+      it("should call reloadL10n for all the PageActions of any existing, non-closed windows", () => {
+        const pageActions = windows.map(win =>
+          CFRPageActions.PageActionMap.get(win)
+        );
+        CFRPageActions.reloadL10n();
+
+        // Only the first window had a PageAction and wasn't closed
+        assert.calledOnce(pageActions[0].reloadL10n);
+        assert.isUndefined(pageActions[1]);
+        assert.notCalled(pageActions[2].reloadL10n);
       });
     });
   });


### PR DESCRIPTION
This, coupled with this [patch](https://phabricator.services.mozilla.com/D48412), allows us to enable/disable the remote l10n for ASRouter.

What's changed?
* Add a pref observer for `ASRouter`, upon pref changes, it delegates the l10n reload work to `CFRPageActions`. 
* Add a function `reloadL10n` to `PageAction`, by which `CFRPageActions` can reload the l10n file for all the existing pageActions. 