### PR TITLE
Bug 1585387 - The font of the hyperlink and button label from the sponsored content cards is wrongly set to "Regular" instead of "Semibold"

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -125,6 +125,7 @@ $excerpt-line-height: 20;
       border-radius: 4px;
       height: 32px;
       font-size: 14px;
+      font-weight: 600;
       padding: 5px 8px 7px;
       border: 0;
       color: $grey-90;
@@ -164,6 +165,7 @@ $excerpt-line-height: 20;
       }
 
       font-size: 15px;
+      font-weight: 600;
       line-height: 24px;
       height: 24px;
       width: auto;


### PR DESCRIPTION
Test steps: https://bugzilla.mozilla.org/show_bug.cgi?id=1585387#c0