### PR TITLE
Bug 1576510 - Redundant impression sent when clicking on 'show protec…

### DIFF
--- a/lib/ToolbarPanelHub.jsm
+++ b/lib/ToolbarPanelHub.jsm
@@ -509,7 +509,7 @@ class _ToolbarPanelHub {
         const messageEl = this._createHeroElement(win, doc, message);
         container.appendChild(messageEl);
         infoButton.addEventListener("click", toggleMessage);
-        this.sendUserEventTelemetry(win, "IMPRESSION", message.id);
+        this.sendUserEventTelemetry(win, "IMPRESSION", message);
       }
     }
     // Message is collapsed by default. If it was never shown before we want

--- a/test/unit/lib/ToolbarPanelHub.test.js
+++ b/test/unit/lib/ToolbarPanelHub.test.js
@@ -699,7 +699,22 @@ describe("ToolbarPanelHub", () => {
       assert.callCount(fakeElementById.toggleAttribute, 6);
     });
     it("should open link on click (separate link element)", async () => {
+      const sendTelemetryStub = sandbox.stub(
+        instance,
+        "sendUserEventTelemetry"
+      );
+      const onboardingMsgs = await OnboardingMessageProvider.getUntranslatedMessages();
+      const msg = onboardingMsgs.find(m => m.template === "protections_panel");
+
       await fakeInsert();
+
+      assert.calledOnce(sendTelemetryStub);
+      assert.calledWithExactly(
+        sendTelemetryStub,
+        fakeWindow,
+        "IMPRESSION",
+        msg
+      );
 
       eventListeners.mouseup();
 


### PR DESCRIPTION
…tion' button

We were incorrectly calling send telemetry with `message.id` instead of `message` and it wasn't covered by tests.