### PR TITLE
Bug 1587926 - Idle callback with dsimage

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSImage/DSImage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSImage/DSImage.jsx
@@ -60,7 +60,7 @@ export class DSImage extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.idleCallbackId = window.requestIdleCallback(
+    this.idleCallbackId = this.props.windowObj.requestIdleCallback(
       this.onIdleCallback.bind(this)
     );
     this.observer = new IntersectionObserver(this.onSeen.bind(this), {
@@ -76,6 +76,9 @@ export class DSImage extends React.PureComponent {
     // Remove observer on unmount
     if (this.observer) {
       this.observer.unobserve(ReactDOM.findDOMNode(this));
+    }
+    if (this.idleCallbackId) {
+      this.props.windowObj.cancelIdleCallback(this.idleCallbackId);
     }
   }
 
@@ -160,4 +163,5 @@ DSImage.defaultProps = {
   extraClassNames: null, // Additional classnames to append to component
   optimize: true, // Measure parent container to request exact sizes
   alt_text: null,
+  windowObj: window, // Added to support unit tests
 };

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSImage.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSImage.test.jsx
@@ -111,4 +111,23 @@ describe("Discovery Stream <DSImage>", () => {
 
     assert.calledOnce(observer.unobserve);
   });
+  describe.only("DSImage with Idle Callback", () => {
+    let wrapper;
+    let windowStub = {
+      requestIdleCallback: sinon.stub().returns(1),
+      cancelIdleCallback: sinon.stub(),
+    };
+    beforeEach(() => {
+      wrapper = mount(<DSImage windowObj={windowStub} />);
+    });
+
+    it("should call requestIdleCallback on componentDidMount", () => {
+      assert.calledOnce(windowStub.requestIdleCallback);
+    });
+
+    it("should call cancelIdleCallback on componentWillUnmount", () => {
+      wrapper.instance().componentWillUnmount();
+      assert.calledOnce(windowStub.cancelIdleCallback);
+    });
+  });
 });

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSImage.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSImage.test.jsx
@@ -111,7 +111,7 @@ describe("Discovery Stream <DSImage>", () => {
 
     assert.calledOnce(observer.unobserve);
   });
-  describe.only("DSImage with Idle Callback", () => {
+  describe("DSImage with Idle Callback", () => {
     let wrapper;
     let windowStub = {
       requestIdleCallback: sinon.stub().returns(1),


### PR DESCRIPTION
1. Set `browser.newtabpage.activity-stream.debug` to true
2. Open a new tab
3. Open about:config
4. Toggle `browser.newtabpage.activity-stream.discoverystream.enabled` on and off, a few times.
5. Check console.

Expected, no errors about setState on unmounted dsimage. "Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method."