### PR TITLE
Bug 1588524 - The 'What's New' toolbar button is redisplayed after br…

### DIFF
--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -184,7 +184,6 @@ class _ToolbarBadgeHub {
         "mousedown",
         this.removeAllNotifications
       );
-      event.target.removeEventListener("click", this.removeAllNotifications);
       event.target.removeEventListener("keypress", this.removeAllNotifications);
       // If we have an event it means the user interacted with the badge
       // we should send telemetry
@@ -262,8 +261,7 @@ class _ToolbarBadgeHub {
       // `mousedown` event required because of the `onmousedown` defined on
       // the button that prevents `click` events from firing
       toolbarbutton.addEventListener("mousedown", this.removeAllNotifications);
-      // `click` and `keypress` events required for keyboard accessibility
-      toolbarbutton.addEventListener("click", this.removeAllNotifications);
+      // `keypress` event required for keyboard accessibility
       toolbarbutton.addEventListener("keypress", this.removeAllNotifications);
       this.state = { notification: { id: message.id } };
 

--- a/lib/ToolbarBadgeHub.jsm
+++ b/lib/ToolbarBadgeHub.jsm
@@ -185,6 +185,7 @@ class _ToolbarBadgeHub {
         this.removeAllNotifications
       );
       event.target.removeEventListener("click", this.removeAllNotifications);
+      event.target.removeEventListener("keypress", this.removeAllNotifications);
       // If we have an event it means the user interacted with the badge
       // we should send telemetry
       if (this.state.notification) {
@@ -261,8 +262,9 @@ class _ToolbarBadgeHub {
       // `mousedown` event required because of the `onmousedown` defined on
       // the button that prevents `click` events from firing
       toolbarbutton.addEventListener("mousedown", this.removeAllNotifications);
-      // `click` event required for keyboard accessibility
+      // `click` and `keypress` events required for keyboard accessibility
       toolbarbutton.addEventListener("click", this.removeAllNotifications);
+      toolbarbutton.addEventListener("keypress", this.removeAllNotifications);
       this.state = { notification: { id: message.id } };
 
       return toolbarbutton;

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -239,15 +239,10 @@ describe("ToolbarBadgeHub", () => {
     it("should attach a cb on the notification", () => {
       instance.addToolbarNotification(target, fxaMessage);
 
-      assert.calledThrice(fakeElement.addEventListener);
+      assert.calledTwice(fakeElement.addEventListener);
       assert.calledWithExactly(
         fakeElement.addEventListener,
         "mousedown",
-        instance.removeAllNotifications
-      );
-      assert.calledWithExactly(
-        fakeElement.addEventListener,
-        "click",
         instance.removeAllNotifications
       );
       assert.calledWithExactly(
@@ -533,15 +528,10 @@ describe("ToolbarBadgeHub", () => {
 
       instance.removeAllNotifications(fakeEvent);
 
-      assert.calledThrice(fakeEvent.target.removeEventListener);
+      assert.calledTwice(fakeEvent.target.removeEventListener);
       assert.calledWithExactly(
         fakeEvent.target.removeEventListener,
         "mousedown",
-        instance.removeAllNotifications
-      );
-      assert.calledWithExactly(
-        fakeEvent.target.removeEventListener,
-        "click",
         instance.removeAllNotifications
       );
       assert.calledWithExactly(
@@ -568,15 +558,10 @@ describe("ToolbarBadgeHub", () => {
 
       instance.removeAllNotifications(fakeEvent);
 
-      assert.calledThrice(fakeEvent.target.removeEventListener);
+      assert.calledTwice(fakeEvent.target.removeEventListener);
       assert.calledWithExactly(
         fakeEvent.target.removeEventListener,
         "mousedown",
-        instance.removeAllNotifications
-      );
-      assert.calledWithExactly(
-        fakeEvent.target.removeEventListener,
-        "click",
         instance.removeAllNotifications
       );
       assert.calledWithExactly(

--- a/test/unit/lib/ToolbarBadgeHub.test.js
+++ b/test/unit/lib/ToolbarBadgeHub.test.js
@@ -239,7 +239,7 @@ describe("ToolbarBadgeHub", () => {
     it("should attach a cb on the notification", () => {
       instance.addToolbarNotification(target, fxaMessage);
 
-      assert.calledTwice(fakeElement.addEventListener);
+      assert.calledThrice(fakeElement.addEventListener);
       assert.calledWithExactly(
         fakeElement.addEventListener,
         "mousedown",
@@ -248,6 +248,11 @@ describe("ToolbarBadgeHub", () => {
       assert.calledWithExactly(
         fakeElement.addEventListener,
         "click",
+        instance.removeAllNotifications
+      );
+      assert.calledWithExactly(
+        fakeElement.addEventListener,
+        "keypress",
         instance.removeAllNotifications
       );
     });
@@ -528,7 +533,7 @@ describe("ToolbarBadgeHub", () => {
 
       instance.removeAllNotifications(fakeEvent);
 
-      assert.calledTwice(fakeEvent.target.removeEventListener);
+      assert.calledThrice(fakeEvent.target.removeEventListener);
       assert.calledWithExactly(
         fakeEvent.target.removeEventListener,
         "mousedown",
@@ -537,6 +542,11 @@ describe("ToolbarBadgeHub", () => {
       assert.calledWithExactly(
         fakeEvent.target.removeEventListener,
         "click",
+        instance.removeAllNotifications
+      );
+      assert.calledWithExactly(
+        fakeEvent.target.removeEventListener,
+        "keypress",
         instance.removeAllNotifications
       );
     });
@@ -558,7 +568,7 @@ describe("ToolbarBadgeHub", () => {
 
       instance.removeAllNotifications(fakeEvent);
 
-      assert.calledTwice(fakeEvent.target.removeEventListener);
+      assert.calledThrice(fakeEvent.target.removeEventListener);
       assert.calledWithExactly(
         fakeEvent.target.removeEventListener,
         "mousedown",
@@ -567,6 +577,11 @@ describe("ToolbarBadgeHub", () => {
       assert.calledWithExactly(
         fakeEvent.target.removeEventListener,
         "click",
+        instance.removeAllNotifications
+      );
+      assert.calledWithExactly(
+        fakeEvent.target.removeEventListener,
+        "keypress",
         instance.removeAllNotifications
       );
     });


### PR DESCRIPTION
…owser restart if it was previously accessed using keyboard navigation

I was able to verify the same behavior as in the bug report: the keypress events are different between mac and windows. Our `click` event listener was enough on mac to handle keyboard access but on windows this never triggered. Added a specific `keypress` event listener.