### PR TITLE
Bug 1583845 - Fixing CTA button colors

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -123,8 +123,9 @@ $excerpt-line-height: 20;
     .cta-button {
       @include dark-theme-only {
         color: $grey-10;
-        background: $grey-90-30;
+        background: $grey-90-70;
       }
+
       width: 100%;
       margin: 12px 0 4px;
       box-shadow: none;
@@ -137,6 +138,13 @@ $excerpt-line-height: 20;
       color: $grey-90;
       background: $grey-90-10;
 
+      &:hover {
+        @include dark-theme-only {
+          background: $grey-90-50;
+        }
+
+        background: $grey-90-20;
+      }
 
       &:active {
         @include dark-theme-only {
@@ -146,20 +154,13 @@ $excerpt-line-height: 20;
         background: $grey-90-30;
       }
 
-      &:hover {
-        @include dark-theme-only {
-          background: $grey-90-50;
-        }
-
-        background: $grey-90-30;
-      }
-
       &:focus {
         @include dark-theme-only {
-          background: $grey-90-30;
+          background: $grey-90-70;
           box-shadow: 0 0 0 2px $grey-80, 0 0 0 5px $blue-50-50;
         }
 
+        background: $grey-90-10;
         box-shadow: 0 0 0 2px $white, 0 0 0 5px $blue-50-50;
       }
     }

--- a/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/_DSCard.scss
@@ -138,6 +138,16 @@ $excerpt-line-height: 20;
       color: $grey-90;
       background: $grey-90-10;
 
+      &:focus {
+        @include dark-theme-only {
+          background: $grey-90-70;
+          box-shadow: 0 0 0 2px $grey-80, 0 0 0 5px $blue-50-50;
+        }
+
+        background: $grey-90-10;
+        box-shadow: 0 0 0 2px $white, 0 0 0 5px $blue-50-50;
+      }
+
       &:hover {
         @include dark-theme-only {
           background: $grey-90-50;
@@ -152,16 +162,6 @@ $excerpt-line-height: 20;
         }
 
         background: $grey-90-30;
-      }
-
-      &:focus {
-        @include dark-theme-only {
-          background: $grey-90-70;
-          box-shadow: 0 0 0 2px $grey-80, 0 0 0 5px $blue-50-50;
-        }
-
-        background: $grey-90-10;
-        box-shadow: 0 0 0 2px $white, 0 0 0 5px $blue-50-50;
       }
     }
 


### PR DESCRIPTION
Test steps: See https://bugzilla.mozilla.org/show_bug.cgi?id=1583845#c0

**Note:** To see a CTA button you'll need to use this value for `browser.newtabpage.activity-stream.discoverystream.config`

`{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://e5e8374d-fffa-4a77-a604-31603852b6fd.mock.pstmn.io/1583845-layout"}`