### PR TITLE
Bug 1589653 - Provide bookmark object to targeting expression

### DIFF
--- a/lib/ASRouterTriggerListeners.jsm
+++ b/lib/ASRouterTriggerListeners.jsm
@@ -11,6 +11,7 @@ const { XPCOMUtils } = ChromeUtils.import(
 XPCOMUtils.defineLazyModuleGetters(this, {
   PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.jsm",
   EveryWindow: "resource:///modules/EveryWindow.jsm",
+  NewTabUtils: "resource://gre/modules/NewTabUtils.jsm",
 });
 
 const FEW_MINUTES = 15 * 60 * 1000; // 15 mins
@@ -158,6 +159,11 @@ this.ASRouterTriggerListeners = new Map([
           if (browser) {
             this._triggerHandler(browser.gBrowser.selectedBrowser, {
               id: this.id,
+              context: {
+                bookmark: NewTabUtils.activityStreamProvider.getBookmark({
+                  url: new URL(browser.gBrowser.currentURI.spec),
+                }),
+              },
             });
           }
         }

--- a/test/unit/asrouter/ASRouterTriggerListeners.test.js
+++ b/test/unit/asrouter/ASRouterTriggerListeners.test.js
@@ -22,7 +22,8 @@ describe("ASRouterTriggerListeners", () => {
       gBrowser: {
         addTabsProgressListener: sandbox.stub(),
         removeTabsProgressListener: sandbox.stub(),
-        currentURI: { host: "" },
+        currentURI: { host: "", spec: "https://bookmarkedpage.example" },
+        selectedBrowser: {},
       },
       addEventListener: sinon.stub(),
       removeEventListener: sinon.stub(),
@@ -58,7 +59,7 @@ describe("ASRouterTriggerListeners", () => {
         observerStub = sandbox.stub(global.Services.obs, "addObserver");
         sandbox
           .stub(global.Services.wm, "getMostRecentBrowserWindow")
-          .returns({ gBrowser: { selectedBrowser: {} } });
+          .returns(existingWindow);
       });
       afterEach(() => {
         bookmarkedURLListener.uninit();
@@ -85,9 +86,11 @@ describe("ASRouterTriggerListeners", () => {
         );
 
         assert.calledOnce(newTriggerHandler);
-        assert.calledWithExactly(newTriggerHandler, subject, {
-          id: bookmarkedURLListener.id,
-        });
+        const { args } = newTriggerHandler.firstCall;
+        assert.equal(args[0], existingWindow.gBrowser.selectedBrowser);
+        assert.propertyVal(args[1], "id", bookmarkedURLListener.id);
+        assert.property(args[1], "context");
+        assert.property(args[1].context, "bookmark");
       });
     });
   });

--- a/test/unit/unit-entry.js
+++ b/test/unit/unit-entry.js
@@ -148,6 +148,7 @@ const TEST_GLOBAL = {
   NewTabUtils: {
     activityStreamProvider: {
       getTopFrecentSites: () => [],
+      getBookmark: () => Promise.resolve({}),
       executePlacesQuery: async (sql, options) => ({ sql, options }),
     },
   },


### PR DESCRIPTION
The issue is that `bookmark-icon-updated` is also triggered when adding a bookmark not only when visiting a bookmarked URL and this results in showing the message at an undesired time.
I didn't want to make a super specific "opened-already-bookmarked-url" trigger so instead I'm passing in through the `context` parameter of the trigger the `bookmark` object associated with the current url.
This contains:
```
title,
url,
_lastModified_,
...
```
We can then use this information inside of the targeting expression `currentDate|date - bookmark.lastModified > 60 * 60`.
It can potentially allow us to do other interesting messages `bookmark.url in [list of web developer resources]` => show some new devtools feature?