### PR TITLE
Bug 1589025 - Displaying privacy modal in correct position

### DIFF
--- a/content-src/asrouter/templates/Trailhead/_Trailhead.scss
+++ b/content-src/asrouter/templates/Trailhead/_Trailhead.scss
@@ -332,7 +332,7 @@
     overflow-y: hidden;
   }
 
-  .modalOverlayInner {
+  .trailhead.modalOverlayInner {
     position: absolute;
   }
 


### PR DESCRIPTION
~~@k88hudson As far as I can tell & observe this isn't causing any regressions, but since the modal is used by trailhead I figured you might be able to give a 2nd opinion there. Positioning is `fixed` by default and this was overriding to `absolute` – unsure why. 🤔~~

Test steps: https://bugzilla.mozilla.org/show_bug.cgi?id=1589025#c0