### PR TITLE
Bug 1574657: switch taskcluster provisionerId/workerType for community deployment

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,8 +14,8 @@ tasks:
         then: ${event.after}
         else: ${event.pull_request.head.sha}
     in:
-    - provisionerId: aws-provisioner-v1
-      workerType: github-worker
+    - provisionerId: proj-misc
+      workerType: ci
       deadline: ${fromNow('1 day')}
       payload:
         maxRunTime: 7200


### PR DESCRIPTION
Hi!

I work on the Taskcluster team at Mozilla, and I'm writing to let you know about an upcoming change to our deployment of Taskcluster that will affect this project's use of Taskcluster for CI/CD.

We're splitting Taskcluster for Firefox CI and Taskcluster for community projects into separate deployments. The current integration will continue to work through November 9th, at which point this change will be needed for your Taskcluster integration to continue to work.

The first step of the conversion work happened here: https://github.com/mozilla/activity-stream/pull/5288, that PR upgraded the syntax of the taskcluster.yml file and Github integration to [v1](https://docs.taskcluster.net/docs/reference/integrations/github/taskcluster-yml-v1).

There are two next steps:
- changing the Github integration used by this project from Taskcluster to use [community-tc-integration](https://github.com/apps/community-tc-integration/)
- changing the `provisionerId` and `workerType` in your taskcluster.yml - I've done that for you in this PR.

After you swap the Github Integration over, merging this PR should get you in a good state. We have a bug tracking this work [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1574657).

Let me know if you have any questions or need guidance!