### PR TITLE
Bug 1589731 - Update targeting for What's New and Firefox accounts badge

### DIFF
--- a/lib/OnboardingMessageProvider.jsm
+++ b/lib/OnboardingMessageProvider.jsm
@@ -465,6 +465,20 @@ const ONBOARDING_MESSAGES = () => [
     trigger: { id: "firstRun" },
   },
   {
+    id: "FXA_ACCOUNTS_BADGE_NEW_USER",
+    template: "toolbar_badge",
+    content: {
+      delay: 10000, // delay for 10 seconds
+      target: "fxa-toolbar-menu-button",
+    },
+    // This message will be evaluated before the What's New toolbar badge
+    // and for profiles newer than 28 days it will be displayed
+    priority: 2,
+    // Never accessed the FxA panel && doesn't use Firefox sync && has FxA enabled
+    targeting: `isFxABadgeEnabled && !hasAccessedFxAPanel && !usesFirefoxSync && isFxAEnabled == true && (currentDate|date - profileAgeCreated) / (1000 * 3600 * 24) < 28`,
+    trigger: { id: "toolbarBadgeUpdate" },
+  },
+  {
     id: "FXA_ACCOUNTS_BADGE",
     template: "toolbar_badge",
     content: {


### PR DESCRIPTION
The requirement was that 
> For new profiles (<= 28 days) the Firefox accounts badge should show first and then the What's New button badge.

We now have (in `priority` order):
  1. FXA_ACCOUNTS_BADGE_NEW_USER - same targeting as FXA_ACCOUNTS_BADGE + profile has to be newer than 28 days so it captures new users
  2. WHATS_NEW_BADGE
  3. FXA_ACCOUNTS_BADGE - everyone that never opened the FxA panel, get triggered if other 2 options are exhausted
