### PR TITLE
Bug 1567273 - Enable DE using Discovery Stream

### DIFF
--- a/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
+++ b/content-src/components/DiscoveryStreamBase/DiscoveryStreamBase.jsx
@@ -26,7 +26,7 @@ const ALLOWED_CSS_URL_PREFIXES = [
   "https://img-getpocket.cdn.mozilla.net/",
 ];
 const DUMMY_CSS_SELECTOR = "DUMMY#CSS.SELECTOR";
-let rickRollCache = []; // Cache of random probability values for a spoc position
+let rollCache = []; // Cache of random probability values for a spoc position
 
 /**
  * Validate a CSS declaration. The values are assumed to be normalized by CSSOM.
@@ -264,17 +264,18 @@ export class _DiscoveryStreamBase extends React.PureComponent {
 
   componentWillReceiveProps(oldProps) {
     if (this.props.DiscoveryStream.layout !== oldProps.DiscoveryStream.layout) {
-      rickRollCache = [];
+      rollCache = [];
     }
   }
 
   render() {
     // Select layout render data by adding spocs and position to recommendations
-    const { layoutRender, spocsFill } = selectLayoutRender(
-      this.props.DiscoveryStream,
-      this.props.Prefs.values,
-      rickRollCache
-    );
+    const { layoutRender, spocsFill } = selectLayoutRender({
+      state: this.props.DiscoveryStream,
+      prefs: this.props.Prefs.values,
+      rollCache,
+      lang: this.props.document.documentElement.lang,
+    });
     const { config, spocs, feeds } = this.props.DiscoveryStream;
 
     // Send SPOCS Fill if any. Note that it should not send it again if the same
@@ -412,4 +413,5 @@ export const DiscoveryStreamBase = connect(state => ({
   DiscoveryStream: state.DiscoveryStream,
   Prefs: state.Prefs,
   Sections: state.Sections,
+  document: global.document,
 }))(_DiscoveryStreamBase);

--- a/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage.jsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
+import { FluentOrText } from "content-src/components/FluentOrText/FluentOrText";
 
 export class DSMessage extends React.PureComponent {
   render() {
@@ -17,11 +18,13 @@ export class DSMessage extends React.PureComponent {
             />
           )}
           {this.props.title && (
-            <span className="title-text">{this.props.title}</span>
+            <span className="title-text">
+              <FluentOrText message={this.props.title} />
+            </span>
           )}
           {this.props.link_text && this.props.link_url && (
             <SafeAnchor className="link" url={this.props.link_url}>
-              {this.props.link_text}
+              <FluentOrText message={this.props.link_text} />
             </SafeAnchor>
           )}
         </header>

--- a/content-src/components/DiscoveryStreamComponents/Navigation/Navigation.jsx
+++ b/content-src/components/DiscoveryStreamComponents/Navigation/Navigation.jsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import { SafeAnchor } from "../SafeAnchor/SafeAnchor";
+import { FluentOrText } from "content-src/components/FluentOrText/FluentOrText";
 
 export class Topic extends React.PureComponent {
   render() {
@@ -25,7 +26,11 @@ export class Navigation extends React.PureComponent {
     const header = this.props.header || {};
     return (
       <div className={`ds-navigation ds-navigation-${alignment}`}>
-        {header.title ? <div className="ds-header">{header.title}</div> : null}
+        {header.title ? (
+          <FluentOrText message={header.title}>
+            <div className="ds-header" />
+          </FluentOrText>
+        ) : null}
         <div>
           <ul>
             {links &&

--- a/content-src/lib/selectLayoutRender.js
+++ b/content-src/lib/selectLayoutRender.js
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const selectLayoutRender = (state, prefs, rickRollCache) => {
+export const selectLayoutRender = ({
+  state = {},
+  prefs = {},
+  rollCache = [],
+  lang = "",
+}) => {
   const { layout, feeds, spocs } = state;
   let spocIndexMap = {};
   let bufferRollCache = [];
@@ -23,11 +28,11 @@ export const selectLayoutRender = (state, prefs, rickRollCache) => {
 
       // Cache random number for a position
       let rickRoll;
-      if (!rickRollCache.length) {
+      if (!rollCache.length) {
         rickRoll = Math.random();
         bufferRollCache.push(rickRoll);
       } else {
-        rickRoll = rickRollCache.shift();
+        rickRoll = rollCache.shift();
         bufferRollCache.push(rickRoll);
       }
 
@@ -61,6 +66,10 @@ export const selectLayoutRender = (state, prefs, rickRollCache) => {
 
   if (!prefs["feeds.topsites"]) {
     filterArray.push("TopSites");
+  }
+
+  if (!lang.startsWith("en-")) {
+    filterArray.push("Navigation");
   }
 
   if (!prefs["feeds.section.topstories"]) {
@@ -213,9 +222,9 @@ export const selectLayoutRender = (state, prefs, rickRollCache) => {
 
   const layoutRender = renderLayout();
 
-  // If empty, fill rickRollCache with random probability values from bufferRollCache
-  if (!rickRollCache.length) {
-    rickRollCache.push(...bufferRollCache);
+  // If empty, fill rollCache with random probability values from bufferRollCache
+  if (!rollCache.length) {
+    rollCache.push(...bufferRollCache);
   }
 
   // Generate the payload for the SPOCS Fill ping. Note that a SPOC could be rejected

--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -469,10 +469,11 @@ const PREFS_CONFIG = new Map([
       title: "Configuration for the new pocket new tab",
       getValue: ({ geo, locale }) => {
         // PLEASE NOTE:
-        // hardcoded_layout in `lib/DiscoveryStreamFeed.jsm` only works for en-* and requires refactoring for non english locales
+        // hardcoded_layout in `lib/DiscoveryStreamFeed.jsm` only works for en-* and DE and requires refactoring for other locales
         const dsEnablementMatrix = {
           US: ["en-CA", "en-GB", "en-US"],
           CA: ["en-CA", "en-GB", "en-US"],
+          DE: ["de", "de-DE", "de-AT", "de-CH"],
         };
 
         // Verify that the current geo & locale combination is enabled

--- a/lib/PrefsFeed.jsm
+++ b/lib/PrefsFeed.jsm
@@ -102,6 +102,10 @@ this.PrefsFeed = class PrefsFeed {
       "browser.newtabpage.activity-stream.discoverystream.spocs-endpoint",
       ""
     );
+    let discoveryStreamLangLayoutConfig = Services.prefs.getStringPref(
+      "browser.newtabpage.activity-stream.discoverystream.lang-layout-config",
+      ""
+    );
     values["discoverystream.enabled"] = discoveryStreamEnabled;
     this._prefMap.set("discoverystream.enabled", {
       value: discoveryStreamEnabled,
@@ -115,6 +119,12 @@ this.PrefsFeed = class PrefsFeed {
     values["discoverystream.spocs-endpoint"] = discoveryStreamSpocsEndpoint;
     this._prefMap.set("discoverystream.spocs-endpoint", {
       value: discoveryStreamSpocsEndpoint,
+    });
+    values[
+      "discoverystream.lang-layout-config"
+    ] = discoveryStreamLangLayoutConfig;
+    this._prefMap.set("discoverystream.lang-layout-config", {
+      value: discoveryStreamLangLayoutConfig,
     });
 
     // Set the initial state of all prefs in redux

--- a/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamBase.test.jsx
@@ -109,6 +109,9 @@ describe("<DiscoveryStreamBase>", () => {
             "feeds.topsites": true,
           },
         }}
+        document={{
+          documentElement: { lang: "en-US" },
+        }}
         Sections={[
           {
             id: "topstories",

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSMessage.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSMessage.test.jsx
@@ -1,13 +1,14 @@
 import { DSMessage } from "content-src/components/DiscoveryStreamComponents/DSMessage/DSMessage";
 import React from "react";
 import { SafeAnchor } from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
-import { shallow } from "enzyme";
+import { FluentOrText } from "content-src/components/FluentOrText/FluentOrText";
+import { mount } from "enzyme";
 
 describe("<DSMessage>", () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<DSMessage />);
+    wrapper = mount(<DSMessage />);
   });
 
   it("should render", () => {
@@ -43,6 +44,32 @@ describe("<DSMessage>", () => {
         .at(0)
         .type(),
       SafeAnchor
+    );
+  });
+
+  it("should render a FluentOrText", () => {
+    wrapper.setProps({
+      link_text: "link_text",
+      title: "title",
+      link_url: "https://link_url.com",
+    });
+
+    assert.equal(
+      wrapper
+        .find(".title-text")
+        .children()
+        .at(0)
+        .type(),
+      FluentOrText
+    );
+
+    assert.equal(
+      wrapper
+        .find(".link a")
+        .children()
+        .at(0)
+        .type(),
+      FluentOrText
     );
   });
 });

--- a/test/unit/content-src/components/DiscoveryStreamComponents/Navigation.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/Navigation.test.jsx
@@ -4,13 +4,14 @@ import {
 } from "content-src/components/DiscoveryStreamComponents/Navigation/Navigation";
 import React from "react";
 import { SafeAnchor } from "content-src/components/DiscoveryStreamComponents/SafeAnchor/SafeAnchor";
-import { shallow } from "enzyme";
+import { FluentOrText } from "content-src/components/FluentOrText/FluentOrText";
+import { shallow, mount } from "enzyme";
 
 describe("<Navigation>", () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<Navigation header={{}} />);
+    wrapper = mount(<Navigation header={{}} />);
   });
 
   it("should render", () => {
@@ -21,6 +22,19 @@ describe("<Navigation>", () => {
     wrapper.setProps({ header: { title: "Foo" } });
 
     assert.equal(wrapper.find(".ds-header").text(), "Foo");
+  });
+
+  it("should render a FluentOrText", () => {
+    wrapper.setProps({ header: { title: "Foo" } });
+
+    assert.equal(
+      wrapper
+        .find(".ds-navigation")
+        .children()
+        .at(0)
+        .type(),
+      FluentOrText
+    );
   });
 
   it("should render 2 Topics", () => {

--- a/test/unit/content-src/lib/selectLayoutRender.test.js
+++ b/test/unit/content-src/lib/selectLayoutRender.test.js
@@ -29,20 +29,18 @@ describe("selectLayoutRender", () => {
   });
 
   it("should return an empty array given initial state", () => {
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      prefs: {},
+      rollCache: [],
+    });
     assert.deepEqual(layoutRender, []);
   });
 
   it("should return an empty SPOCS fill array given initial state", () => {
-    const { spocsFill } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { spocsFill } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
     assert.deepEqual(spocsFill, []);
   });
 
@@ -57,11 +55,9 @@ describe("selectLayoutRender", () => {
     });
     store.dispatch({ type: at.DISCOVERY_STREAM_FEEDS_UPDATE });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.lengthOf(layoutRender, 1);
     assert.propertyVal(layoutRender[0], "width", 3);
@@ -80,11 +76,9 @@ describe("selectLayoutRender", () => {
     });
     store.dispatch({ type: at.DISCOVERY_STREAM_FEEDS_UPDATE });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.lengthOf(layoutRender, 1);
     assert.propertyVal(layoutRender[0], "width", 3);
@@ -107,11 +101,9 @@ describe("selectLayoutRender", () => {
     });
     store.dispatch({ type: at.DISCOVERY_STREAM_FEEDS_UPDATE });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.lengthOf(layoutRender, 1);
     assert.propertyVal(layoutRender[0], "width", 3);
@@ -137,11 +129,9 @@ describe("selectLayoutRender", () => {
       data: { lastUpdated: 0, spocs: { spocs: [1, 2, 3] } },
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.lengthOf(layoutRender, 1);
     assert.propertyVal(layoutRender[0], "width", 3);
@@ -167,11 +157,9 @@ describe("selectLayoutRender", () => {
     });
     store.dispatch({ type: at.DISCOVERY_STREAM_FEEDS_UPDATE });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.deepEqual(layoutRender[0].components[0].data, {
       recommendations: [{ id: "bar" }],
@@ -211,11 +199,9 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random").returns(0.1);
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.calledTwice(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -273,11 +259,9 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random").returns(0.1);
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.calledTwice(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -335,11 +319,10 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random");
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      [0.7, 0.3, 0.8]
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      rollCache: [0.7, 0.3, 0.8],
+    });
 
     assert.notCalled(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -404,11 +387,9 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random").returns(0.6);
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.calledTwice(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -468,11 +449,10 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random");
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      [0.4, 0.3]
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      rollCache: [0.4, 0.3],
+    });
 
     assert.notCalled(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -530,11 +510,10 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random");
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      [0.6, 0.7]
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      rollCache: [0.6, 0.7],
+    });
 
     assert.notCalled(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -594,11 +573,10 @@ describe("selectLayoutRender", () => {
     });
     const randomStub = globals.sandbox.stub(global.Math, "random");
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      [0.7, 0.2]
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      rollCache: [0.7, 0.2],
+    });
 
     assert.notCalled(randomStub);
     assert.lengthOf(layoutRender, 1);
@@ -652,11 +630,9 @@ describe("selectLayoutRender", () => {
     });
     store.dispatch({ type: at.DISCOVERY_STREAM_FEEDS_UPDATE });
 
-    const { spocsFill, layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { spocsFill, layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     const { recommendations } = layoutRender[0].components[0].data;
     assert.equal(recommendations.length, 4);
@@ -689,11 +665,9 @@ describe("selectLayoutRender", () => {
       data: { feed: { data: { recommendations: [] } }, url: "foo2.com" },
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.equal(layoutRender[0].components[0].type, "foo1");
     assert.equal(layoutRender[0].components[1].type, "foo2");
@@ -733,11 +707,9 @@ describe("selectLayoutRender", () => {
       data: { feed: { data: { recommendations: [] } }, url: "foo4.com" },
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.equal(layoutRender[0].components[0].type, "foo1");
     assert.equal(layoutRender[0].components[1].type, "foo2");
@@ -780,11 +752,9 @@ describe("selectLayoutRender", () => {
       data: { feed: { data: { recommendations: [] } }, url: "foo4.com" },
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.equal(layoutRender[0].components[0].type, "foo1");
     assert.equal(layoutRender[0].components[1].type, "foo2");
@@ -837,11 +807,9 @@ describe("selectLayoutRender", () => {
       data: fakeSpocsData,
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.deepEqual(layoutRender[0].components[2].data.recommendations[0], {
       name: "rec",
@@ -864,11 +832,10 @@ describe("selectLayoutRender", () => {
       data: { layout: fakeLayout },
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      { "feeds.topsites": true },
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      prefs: { "feeds.topsites": true },
+    });
 
     assert.equal(layoutRender[0].components[0].type, "TopSites");
     assert.equal(layoutRender[1], undefined);
@@ -885,14 +852,41 @@ describe("selectLayoutRender", () => {
       data: { layout: fakeLayout },
     });
 
-    const { layoutRender } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      { "feeds.topsites": true },
-      []
-    );
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      prefs: { "feeds.topsites": true },
+    });
 
     assert.equal(layoutRender[0].components[0].type, "TopSites");
     assert.equal(layoutRender[0].components[1], undefined);
+  });
+  it("should not render a Navigation if not en-*", () => {
+    const fakeLayout = [
+      {
+        width: 3,
+        components: [
+          { type: "Navigation" },
+          { type: "Message" },
+          { type: "TopSites" },
+        ],
+      },
+    ];
+    store.dispatch({
+      type: at.DISCOVERY_STREAM_LAYOUT_UPDATE,
+      data: { layout: fakeLayout },
+    });
+
+    const { layoutRender } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+      prefs: {
+        "feeds.topsites": true,
+        "feeds.section.topstories": true,
+      },
+    });
+
+    assert.equal(layoutRender[0].components[0].type, "Message");
+    assert.equal(layoutRender[0].components[1].type, "TopSites");
+    assert.equal(layoutRender[0].components[2], undefined);
   });
   it("should skip rendering a spoc in position if that spoc is blocked for that session", () => {
     const fakeLayout = [
@@ -930,22 +924,18 @@ describe("selectLayoutRender", () => {
       data: fakeSpocsData,
     });
 
-    const { layoutRender: layout1 } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender: layout1 } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     store.dispatch({
       type: at.DISCOVERY_STREAM_SPOC_BLOCKED,
       data: { url: "https://foo.com" },
     });
 
-    const { layoutRender: layout2 } = selectLayoutRender(
-      store.getState().DiscoveryStream,
-      {},
-      []
-    );
+    const { layoutRender: layout2 } = selectLayoutRender({
+      state: store.getState().DiscoveryStream,
+    });
 
     assert.deepEqual(layout1[0].components[0].data.recommendations[0], {
       name: "spoc",

--- a/test/unit/lib/ActivityStream.test.js
+++ b/test/unit/lib/ActivityStream.test.js
@@ -183,6 +183,70 @@ describe("ActivityStream", () => {
       assert.calledWith(global.Services.prefs.clearUserPref, "oldPrefName");
     });
   });
+  describe("_updateDynamicPrefs Discovery Stream", () => {
+    it("should be true with expected en-US geo and locale", () => {
+      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
+      sandbox.stub(global.Services.prefs, "getStringPref").returns("US");
+      sandbox
+        .stub(global.Services.locale, "appLocaleAsLangTag")
+        .get(() => "en-US");
+
+      as._updateDynamicPrefs();
+
+      assert.isTrue(
+        JSON.parse(PREFS_CONFIG.get("discoverystream.config").value).enabled
+      );
+    });
+    it("should be true with expected en-CA geo and locale", () => {
+      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
+      sandbox.stub(global.Services.prefs, "getStringPref").returns("CA");
+      sandbox
+        .stub(global.Services.locale, "appLocaleAsLangTag")
+        .get(() => "en-CA");
+
+      as._updateDynamicPrefs();
+
+      assert.isTrue(
+        JSON.parse(PREFS_CONFIG.get("discoverystream.config").value).enabled
+      );
+    });
+    it("should be true with expected de geo and locale", () => {
+      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
+      sandbox.stub(global.Services.prefs, "getStringPref").returns("DE");
+      sandbox
+        .stub(global.Services.locale, "appLocaleAsLangTag")
+        .get(() => "de-DE");
+
+      as._updateDynamicPrefs();
+
+      assert.isTrue(
+        JSON.parse(PREFS_CONFIG.get("discoverystream.config").value).enabled
+      );
+    });
+    it("should be false with no geo and locale", () => {
+      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
+      sandbox.stub(global.Services.prefs, "getStringPref").returns("NOGEO");
+
+      as._updateDynamicPrefs();
+
+      assert.isFalse(
+        JSON.parse(PREFS_CONFIG.get("discoverystream.config").value).enabled
+      );
+    });
+    it("should be false with weird geo and locale combination", () => {
+      sandbox.stub(global.Services.prefs, "prefHasUserValue").returns(true);
+      sandbox.stub(global.Services.prefs, "getStringPref").returns("DE");
+      sandbox
+        .stub(global.Services.locale, "appLocaleAsLangTag")
+        .get(() => "en-US");
+
+      as._updateDynamicPrefs();
+
+      assert.isFalse(
+        JSON.parse(PREFS_CONFIG.get("discoverystream.config").value).enabled
+      );
+    });
+  });
   describe("_updateDynamicPrefs topstories default value", () => {
     it("should be false with no geo/locale", () => {
       as._updateDynamicPrefs();


### PR DESCRIPTION
A note, this relies on https://phabricator.services.mozilla.com/D53236 in MC to properly enabled 7 rows in English based locales. So if you happen to be using this patch locally without the above MC patch, you need to create this pref `browser.newtabpage.activity-stream.discoverystream.lang-layout-config` with the value `en`

To test:

1. Setup a profile enabled with DE. You can find help with how to do that here: https://github.com/mozilla/activity-stream/blob/master/docs/v2-system-addon/geo_locale.md
2. Enable Discovery Stream.
3. Load a new tab.

Expected: no spocs, no english strings, no navigation component under cards, and complete new content that's de based. Also check that en-US/en-CA has not changed. Also, DE should only be 1 row of content. You can change the value in `browser.newtabpage.activity-stream.discoverystream.lang-layout-config` to `en,de` to see 7 rows in DE.