### PR TITLE
Bug 1594173 - Add Ad Privacy Info Modal to Top Sites Tile

### DIFF
--- a/content-src/components/TopSites/TopSitesConstants.js
+++ b/content-src/components/TopSites/TopSitesConstants.js
@@ -20,6 +20,7 @@ export const TOP_SITES_SPOC_CONTEXT_MENU_OPTIONS = [
   "OpenInPrivateWindow",
   "Separator",
   "BlockUrl",
+  "ShowPrivacyInfo",
 ];
 // the special top site for search shortcut experiment can only have the option to unpin (which removes) the topsite
 export const TOP_SITES_SEARCH_SHORTCUTS_CONTEXT_MENU_OPTIONS = [


### PR DESCRIPTION
To test:

1. Update `browser.newtabpage.activity-stream.discoverystream.endpoints` with `https://,http://`
2. Update `browser.newtabpage.activity-stream.discoverystream.config` with `{"api_key_pref":"extensions.pocket.oAuthConsumerKey","collapsible":true,"enabled":true,"show_spocs":true,"hardcoded_layout":false,"personalized":false,"layout_endpoint":"https://5ad1b408-b40a-4a49-b6ec-27473d192df0.mock.pstmn.io"}`
3. Click the three dot context menu on Netflix top site. You should see "Our sponsors & your privacy". Clicking it should show privacy modal.