### PR TITLE
(nobug) - Add browser and version attribution to ASRouter admin

### DIFF
--- a/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
+++ b/content-src/components/ASRouterAdmin/ASRouterAdmin.jsx
@@ -384,6 +384,8 @@ export class ASRouterAdminInner extends React.PureComponent {
         source: "addons.mozilla.org",
         campaign: "non-fx-button",
         content: "iridium@particlecore.github.io",
+        browserName: "Google Chrome",
+        browserVersion: "70",
       },
     };
   }
@@ -1041,6 +1043,36 @@ export class ASRouterAdminInner extends React.PureComponent {
                 name="content"
                 placeholder="iridium@particlecore.github.io"
                 value={this.state.attributionParameters.content}
+                onChange={this.onChangeAttributionParameters}
+              />{" "}
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <b> Browser </b>
+            </td>
+            <td>
+              {" "}
+              <input
+                type="text"
+                name="browserName"
+                placeholder="Google Chrome"
+                value={this.state.attributionParameters.browserName}
+                onChange={this.onChangeAttributionParameters}
+              />{" "}
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <b> Browser Version </b>
+            </td>
+            <td>
+              {" "}
+              <input
+                type="text"
+                name="browserVersion"
+                placeholder="70"
+                value={this.state.attributionParameters.browserVersion}
                 onChange={this.onChangeAttributionParameters}
               />{" "}
             </td>

--- a/lib/ASRouter.jsm
+++ b/lib/ASRouter.jsm
@@ -1836,9 +1836,9 @@ class _ASRouter {
   /* istanbul ignore next */
   async forceAttribution(data) {
     // Extract the parameters from data that will make up the referrer url
-    const { source, campaign, content } = data;
+    const { source, campaign, content, browserName, browserVersion } = data;
     if (AppConstants.platform === "win") {
-      const attributionData = `source=${source}&campaign=${campaign}&content=${content}`;
+      const attributionData = `source=${source}&campaign=${campaign}&content=${content}&browser=${browserName}&browser_version=${browserVersion}`;
       this._writeAttributionFile(encodeURIComponent(attributionData));
     } else if (AppConstants.platform === "macosx") {
       let appPath = Services.dirsvc.get("GreD", Ci.nsIFile).parent.parent.path;
@@ -1846,7 +1846,7 @@ class _ASRouter {
         Ci.nsIMacAttributionService
       );
 
-      let referrer = `https://www.mozilla.org/anything/?utm_campaign=${campaign}&utm_source=${source}&utm_content=${encodeURIComponent(
+      let referrer = `https://www.mozilla.org/anything/?utm_browser=${encodeURIComponent(browserName)}&utm_browser_version=${browserVersion}&utm_campaign=${campaign}&utm_source=${source}&utm_content=${encodeURIComponent(
         content
       )}`;
 


### PR DESCRIPTION
Created a new branch `chrome-switchers`. We should work/merge work in this branch until https://bugzilla.mozilla.org/show_bug.cgi?id=1406005 merges and we have the final version of the data.

Requires an additional change in m-c to `AttributionCode.jsm` to know about these 2 new fields. 

```
diff --git a/browser/components/attribution/AttributionCode.jsm b/browser/components/attribution/AttributionCode.jsm
index 127827cc18b27..dda8f43ea3f74 100644
--- a/browser/components/attribution/AttributionCode.jsm
+++ b/browser/components/attribution/AttributionCode.jsm
@@ -32,6 +32,8 @@ const ATTR_CODE_KEYS = [
   "content",
   "experiment",
   "variation",
+  "browser",
+  "browser_version",
 ];

 let gCachedAttrData = null;
```

This should add browser and version in asrouter admin `about:newtab#devtools-targeting` -> `Attribution Parameters ` section. This will allow us to do targeting based on these values and we can simulate the onboarding triplets.