### PR TITLE
Bug 1597697 - Stop sending pings to Tiles data pipeline

### DIFF
--- a/lib/ActivityStream.jsm
+++ b/lib/ActivityStream.jsm
@@ -314,13 +314,6 @@ const PREFS_CONFIG = new Map([
     },
   ],
   [
-    "telemetry.ping.endpoint",
-    {
-      title: "Telemetry server endpoint",
-      value: "https://tiles.services.mozilla.com/v4/links/activity-stream",
-    },
-  ],
-  [
     "section.highlights.includeVisited",
     {
       title:

--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -74,8 +74,6 @@ XPCOMUtils.defineLazyServiceGetters(this, {
 });
 
 const ACTIVITY_STREAM_ID = "activity-stream";
-const ACTIVITY_STREAM_ENDPOINT_PREF =
-  "browser.newtabpage.activity-stream.telemetry.ping.endpoint";
 const DOMWINDOW_OPENED_TOPIC = "domwindowopened";
 const DOMWINDOW_UNLOAD_TOPIC = "unload";
 const TAB_PINNED_EVENT = "TabPinned";
@@ -257,10 +255,7 @@ this.TelemetryFeed = class TelemetryFeed {
    */
   get pingCentre() {
     Object.defineProperty(this, "pingCentre", {
-      value: new PingCentre({
-        topic: ACTIVITY_STREAM_ID,
-        overrideEndpointPref: ACTIVITY_STREAM_ENDPOINT_PREF,
-      }),
+      value: new PingCentre({ topic: ACTIVITY_STREAM_ID }),
     });
     return this.pingCentre;
   }
@@ -420,7 +415,6 @@ this.TelemetryFeed = class TelemetryFeed {
         source,
         tiles: impressionSets[source],
       });
-      this.sendEvent(payload);
       this.sendStructuredIngestionEvent(
         payload,
         STRUCTURED_INGESTION_NAMESPACE_AS,
@@ -453,7 +447,6 @@ this.TelemetryFeed = class TelemetryFeed {
         tiles,
         loaded: tiles.length,
       });
-      this.sendEvent(payload);
       this.sendStructuredIngestionEvent(
         payload,
         STRUCTURED_INGESTION_NAMESPACE_AS,
@@ -641,9 +634,9 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   sendEvent(event_object) {
-    if (this.telemetryEnabled) {
-      this.pingCentre.sendPing(event_object, { filter: ACTIVITY_STREAM_ID });
-    }
+    // As per Bug 1597697, all pings to Tiles are simply stopped here. Though we
+    // leave these pings around so that we could send to another destination or
+    // drop them if needed in the future.
   }
 
   sendUTEvent(event_object, eventFunction) {
@@ -686,7 +679,6 @@ this.TelemetryFeed = class TelemetryFeed {
       au.getPortIdOfSender(action),
       action.data
     );
-    this.sendEvent(payload);
     this.sendStructuredIngestionEvent(
       payload,
       STRUCTURED_INGESTION_NAMESPACE_AS,

--- a/test/unit/lib/TelemetryFeed.test.js
+++ b/test/unit/lib/TelemetryFeed.test.js
@@ -975,7 +975,7 @@ describe("TelemetryFeed", () => {
     });
   });
   describe("#sendEvent", () => {
-    it("should call PingCentre", async () => {
+    it("should not call PingCentre", async () => {
       FakePrefs.prototype.prefs.telemetry = true;
       const event = {};
       instance = new TelemetryFeed();
@@ -983,7 +983,7 @@ describe("TelemetryFeed", () => {
 
       await instance.sendEvent(event);
 
-      assert.calledWith(instance.pingCentre.sendPing, event);
+      assert.notCalled(instance.pingCentre.sendPing);
     });
   });
   describe("#sendUTEvent", () => {
@@ -1255,7 +1255,7 @@ describe("TelemetryFeed", () => {
       assert.calledWith(sendEvent, eventCreator.returnValue);
     });
     it("should send an event on a TELEMETRY_IMPRESSION_STATS action", () => {
-      const sendEvent = sandbox.stub(instance, "sendEvent");
+      const sendEvent = sandbox.stub(instance, "sendStructuredIngestionEvent");
       const eventCreator = sandbox.stub(instance, "createImpressionStats");
       const tiles = [{ id: 10001 }, { id: 10002 }, { id: 10003 }];
       const action = ac.ImpressionStats({ source: "POCKET", tiles });
@@ -1438,7 +1438,7 @@ describe("TelemetryFeed", () => {
       assert.notCalled(spy);
     });
     it("should send impression pings if there is impression data", () => {
-      const spy = sandbox.spy(instance, "sendEvent");
+      const spy = sandbox.spy(instance, "sendStructuredIngestionEvent");
       const session = {
         impressionSets: {
           source_foo: [{ id: 1, pos: 0 }, { id: 2, pos: 1 }],
@@ -1459,7 +1459,7 @@ describe("TelemetryFeed", () => {
       assert.notCalled(spy);
     });
     it("should send loaded content pings if there is loaded content data", () => {
-      const spy = sandbox.spy(instance, "sendEvent");
+      const spy = sandbox.spy(instance, "sendStructuredIngestionEvent");
       const session = {
         loadedContentSets: {
           source_foo: [{ id: 1, pos: 0 }, { id: 2, pos: 1 }],

--- a/test/unit/ping-centre/PingCentre.test.js
+++ b/test/unit/ping-centre/PingCentre.test.js
@@ -18,7 +18,6 @@ const prefInitHook = function() {
   fakePrefs = this; // eslint-disable-line consistent-this
 };
 
-const FAKE_TELEMETRY_ID = "foo123";
 const FAKE_UPDATE_CHANNEL = "beta";
 const FAKE_LOCALE = "en-US";
 const FAKE_ACTIVE_EXPERIMENTS = {
@@ -47,9 +46,6 @@ describe("PingCentre", () => {
       .stub(global.Services.locale, "appLocaleAsLangTag")
       .get(() => FAKE_LOCALE);
     globals.set("fetch", fetchStub);
-    globals.set("ClientID", {
-      getClientID: sandbox.spy(async () => FAKE_TELEMETRY_ID),
-    });
     globals.set("TelemetryEnvironment", {
       getActiveExperiments: sandbox.spy(() => FAKE_ACTIVE_EXPERIMENTS),
       currentEnvironment: {
@@ -67,11 +63,6 @@ describe("PingCentre", () => {
   afterEach(() => {
     globals.restore();
     FakePrefs.prototype.prefs = {};
-  });
-
-  it("should add .telemetryClientId from the ClientID module", async () => {
-    tSender = new PingCentre({ topic: "activity-stream" });
-    assert.equal(await tSender.telemetryClientId, FAKE_TELEMETRY_ID);
   });
 
   it("should construct the Prefs object", () => {
@@ -281,31 +272,6 @@ describe("PingCentre", () => {
         .returns(FAKE_BROWSER_SEARCH_REGION);
       let region = tSender._getRegion();
       assert.equal(region, FAKE_BROWSER_SEARCH_REGION);
-    });
-  });
-
-  describe("#_createPing", () => {
-    it("should create a ping with expected properties", async () => {
-      tSender = new PingCentre({ topic: "activity-stream" });
-      const ping = await tSender._createPing(fakePingJSON);
-
-      const EXPECTED_SHIELD_STRING =
-        "pref-flip-quantum-css-style-r1-1381147:stylo;nightly-nothing-burger-1-pref:Control;";
-      let EXPECTED_RESULT = Object.assign(
-        {
-          locale: FAKE_LOCALE,
-          topic: "activity-stream",
-          client_id: FAKE_TELEMETRY_ID,
-          version: "69.0a1",
-          release_channel: FAKE_UPDATE_CHANNEL,
-        },
-        fakePingJSON
-      );
-      EXPECTED_RESULT.shield_id = EXPECTED_SHIELD_STRING;
-      EXPECTED_RESULT.profile_creation_date = FAKE_PROFILE_CREATION_DATE;
-      EXPECTED_RESULT.region = "UNSET";
-
-      assert.equal(JSON.stringify(ping), JSON.stringify(EXPECTED_RESULT));
     });
   });
 

--- a/test/unit/ping-centre/PingCentre.test.js
+++ b/test/unit/ping-centre/PingCentre.test.js
@@ -4,7 +4,6 @@
 import { FakePrefs, GlobalOverrider } from "test/unit/utils";
 import { PingCentre, PingCentreConstants } from "ping-centre/PingCentre.jsm";
 const {
-  PRODUCTION_ENDPOINT_PREF,
   FHR_UPLOAD_ENABLED_PREF,
   TELEMETRY_PREF,
   LOGGING_PREF,
@@ -22,7 +21,6 @@ const prefInitHook = function() {
 const FAKE_TELEMETRY_ID = "foo123";
 const FAKE_UPDATE_CHANNEL = "beta";
 const FAKE_LOCALE = "en-US";
-const FAKE_AS_ENDPOINT_PREF = "some.as.endpoint.pref";
 const FAKE_ACTIVE_EXPERIMENTS = {
   "pref-flip-quantum-css-style-r1-1381147": { branch: "stylo" },
   "nightly-nothing-burger-1-pref": { branch: "Control" },
@@ -35,10 +33,7 @@ describe("PingCentre", () => {
   let tSender;
   let sandbox;
   let fetchStub;
-  const fakeEndpointUrl = "http://127.0.0.1/stuff";
   const fakePingJSON = { action: "fake_action", monkey: 1 };
-  const fakeFetchHttpErrorResponse = { ok: false, status: 400 };
-  const fakeFetchSuccessResponse = { ok: true, status: 200 };
 
   beforeEach(() => {
     globals = new GlobalOverrider();
@@ -80,29 +75,14 @@ describe("PingCentre", () => {
   });
 
   it("should construct the Prefs object", () => {
-    tSender = new PingCentre({
-      topic: "activity-stream",
-      overrideEndpointPref: fakeEndpointUrl,
-    });
+    tSender = new PingCentre({ topic: "activity-stream" });
 
     assert.calledOnce(global.Services.prefs.getBranch);
   });
 
   it("should throw when topic is not specified", () => {
     assert.throws(() => {
-      tSender = new PingCentre({ overrideEndpointPref: fakeEndpointUrl });
-    });
-  });
-
-  describe("setting the telemetry endpoint", () => {
-    beforeEach(() => {
-      globals.set("AppConstants", { MOZ_UPDATE_CHANNEL: "release" });
-      FakePrefs.prototype.prefs[PRODUCTION_ENDPOINT_PREF] = fakeEndpointUrl;
-    });
-
-    it("should correctly set endpoint based on topic", () => {
-      tSender = new PingCentre({ topic: "onboarding" });
-      assert.equal(tSender._pingEndpoint, fakeEndpointUrl);
+      tSender = new PingCentre();
     });
   });
 
@@ -118,10 +98,7 @@ describe("PingCentre", () => {
       FakePrefs.prototype.prefs[TELEMETRY_PREF] = p.enabledPref;
       FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = p.fhrPref;
 
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
 
       assert.equal(tSender.enabled, p.result);
     }
@@ -140,10 +117,7 @@ describe("PingCentre", () => {
         FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
         FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = true;
 
-        tSender = new PingCentre({
-          topic: "activity-stream",
-          overrideEndpointPref: fakeEndpointUrl,
-        });
+        tSender = new PingCentre({ topic: "activity-stream" });
         assert.propertyVal(tSender, "enabled", true);
       });
 
@@ -159,10 +133,7 @@ describe("PingCentre", () => {
         FakePrefs.prototype.prefs = {};
         FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = true;
         FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
-        tSender = new PingCentre({
-          topic: "activity-stream",
-          overrideEndpointPref: fakeEndpointUrl,
-        });
+        tSender = new PingCentre({ topic: "activity-stream" });
 
         assert.propertyVal(tSender, "enabled", false);
       });
@@ -179,10 +150,7 @@ describe("PingCentre", () => {
         FakePrefs.prototype.prefs = {};
         FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
         FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = true;
-        tSender = new PingCentre({
-          topic: "activity-stream",
-          overrideEndpointPref: fakeEndpointUrl,
-        });
+        tSender = new PingCentre({ topic: "activity-stream" });
         assert.propertyVal(tSender, "enabled", true);
       });
 
@@ -198,10 +166,7 @@ describe("PingCentre", () => {
         FakePrefs.prototype.prefs = {};
         FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = false;
         FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
-        tSender = new PingCentre({
-          topic: "activity-stream",
-          overrideEndpointPref: fakeEndpointUrl,
-        });
+        tSender = new PingCentre({ topic: "activity-stream" });
 
         assert.propertyVal(tSender, "enabled", false);
       });
@@ -216,10 +181,7 @@ describe("PingCentre", () => {
 
   describe("#_createExperimentsString", () => {
     beforeEach(() => {
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: FAKE_AS_ENDPOINT_PREF,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
     });
 
     function testExperimentString(experimentString, activeExperiments, filter) {
@@ -245,10 +207,7 @@ describe("PingCentre", () => {
     it("should apply filter to experiment list", () => {
       const FILTER = "boop";
 
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: FAKE_AS_ENDPOINT_PREF,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
 
       let expString = tSender._createExperimentsString(
         FAKE_ACTIVE_EXPERIMENTS,
@@ -276,10 +235,7 @@ describe("PingCentre", () => {
     let getStub;
 
     beforeEach(() => {
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: FAKE_AS_ENDPOINT_PREF,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
     });
 
     afterEach(() => {
@@ -374,117 +330,15 @@ describe("PingCentre", () => {
     });
   });
 
-  describe("#sendPing()", () => {
-    let prefStub;
-    let getStub;
-
-    beforeEach(() => {
-      FakePrefs.prototype.prefs = {};
-      FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = true;
-      FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
-      FakePrefs.prototype.prefs[FAKE_AS_ENDPOINT_PREF] = fakeEndpointUrl;
-
-      prefStub = sinon
-        .stub(global.Services.prefs, "prefHasUserValue")
-        .returns(true);
-      getStub = sinon
-        .stub(global.Services.prefs, "getStringPref")
-        .returns(FAKE_BROWSER_SEARCH_REGION);
-
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: FAKE_AS_ENDPOINT_PREF,
-      });
-    });
-
-    afterEach(() => {
-      prefStub.restore();
-      getStub.restore();
-    });
-
-    it("should not send if the PingCentre is disabled", async () => {
-      FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
-
-      await tSender.sendPing(fakePingJSON);
-
-      assert.notCalled(fetchStub);
-    });
-
-    it("should POST given ping data to telemetry.ping.endpoint pref w/fetch", async () => {
-      fetchStub.resolves(fakeFetchSuccessResponse);
-      await tSender.sendPing(fakePingJSON);
-
-      const EXPECTED_SHIELD_STRING =
-        "pref-flip-quantum-css-style-r1-1381147:stylo;nightly-nothing-burger-1-pref:Control;";
-      let EXPECTED_RESULT = Object.assign(
-        {
-          locale: FAKE_LOCALE,
-          topic: "activity-stream",
-          client_id: FAKE_TELEMETRY_ID,
-          version: "69.0a1",
-          release_channel: FAKE_UPDATE_CHANNEL,
-        },
-        fakePingJSON
-      );
-      EXPECTED_RESULT.shield_id = EXPECTED_SHIELD_STRING;
-      EXPECTED_RESULT.profile_creation_date = FAKE_PROFILE_CREATION_DATE;
-      EXPECTED_RESULT.region = FAKE_BROWSER_SEARCH_REGION;
-
-      assert.calledOnce(fetchStub);
-      assert.calledWithExactly(fetchStub, fakeEndpointUrl, {
-        method: "POST",
-        body: JSON.stringify(EXPECTED_RESULT),
-        credentials: "omit",
-      });
-    });
-
-    it("should log HTTP failures using Cu.reportError", async () => {
-      fetchStub.resolves(fakeFetchHttpErrorResponse);
-
-      await tSender.sendPing(fakePingJSON);
-
-      assert.called(Cu.reportError);
-    });
-
-    it("should log an error using Cu.reportError if fetch rejects", async () => {
-      fetchStub.rejects("Oh noes!");
-
-      await tSender.sendPing(fakePingJSON);
-
-      assert.called(Cu.reportError);
-    });
-
-    it("should log if logging is on && if action is not activity_stream_performance", async () => {
-      globals.sandbox.stub(global.Services.console, "logStringMessage");
-      FakePrefs.prototype.prefs = {};
-      FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = true;
-      FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
-      FakePrefs.prototype.prefs[LOGGING_PREF] = true;
-      fetchStub.resolves(fakeFetchSuccessResponse);
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
-
-      await tSender.sendPing(fakePingJSON);
-
-      assert.called(global.Services.console.logStringMessage); // eslint-disable-line no-console
-    });
-  });
-
   describe("#sendStructuredIngestionPing()", () => {
     let prefStub;
     let getStub;
+    const fakeEndpointUrl = "https://fake-endpoint.com";
 
     beforeEach(() => {
       FakePrefs.prototype.prefs = {};
       FakePrefs.prototype.prefs[FHR_UPLOAD_ENABLED_PREF] = true;
       FakePrefs.prototype.prefs[TELEMETRY_PREF] = true;
-      FakePrefs.prototype.prefs[FAKE_AS_ENDPOINT_PREF] = fakeEndpointUrl;
 
       prefStub = sinon
         .stub(global.Services.prefs, "prefHasUserValue")
@@ -494,10 +348,7 @@ describe("PingCentre", () => {
         .returns(FAKE_BROWSER_SEARCH_REGION);
       sandbox.stub(PingCentre, "_sendInGzip").resolves();
 
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: FAKE_AS_ENDPOINT_PREF,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
     });
 
     afterEach(() => {
@@ -507,10 +358,7 @@ describe("PingCentre", () => {
 
     it("should not send if the PingCentre is disabled", async () => {
       FakePrefs.prototype.prefs[TELEMETRY_PREF] = false;
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
 
       await tSender.sendStructuredIngestionPing(fakePingJSON, fakeEndpointUrl);
 
@@ -551,10 +399,7 @@ describe("PingCentre", () => {
 
   describe("#uninit()", () => {
     it("should remove the telemetry pref listener", () => {
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
       assert.property(fakePrefs.observers, TELEMETRY_PREF);
 
       tSender.uninit();
@@ -563,10 +408,7 @@ describe("PingCentre", () => {
     });
 
     it("should remove the fhrpref listener", () => {
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
       assert.property(fakePrefs.observers, FHR_UPLOAD_ENABLED_PREF);
 
       tSender.uninit();
@@ -587,10 +429,7 @@ describe("PingCentre", () => {
       globals.sandbox
         .stub(FakePrefs.prototype, "removeObserver")
         .throws("Some Error");
-      tSender = new PingCentre({
-        topic: "activity-stream",
-        overrideEndpointPref: fakeEndpointUrl,
-      });
+      tSender = new PingCentre({ topic: "activity-stream" });
 
       tSender.uninit();
 
@@ -603,10 +442,7 @@ describe("PingCentre", () => {
       it("should change this.logging from false to true", () => {
         FakePrefs.prototype.prefs = {};
         FakePrefs.prototype.prefs[LOGGING_PREF] = false;
-        tSender = new PingCentre({
-          topic: "activity-stream",
-          overrideEndpointPref: fakeEndpointUrl,
-        });
+        tSender = new PingCentre({ topic: "activity-stream" });
         assert.propertyVal(tSender, "logging", false);
 
         fakePrefs.setBoolPref(LOGGING_PREF, true);


### PR DESCRIPTION
This is the part 2 of https://phabricator.services.mozilla.com/D53875, which shuts off all the telemetry in Activity/Discovery Stream to Tiles data pipeline.