### PR TITLE
Bug 1597697 - Migrate events ping to the new data pipeline

### DIFF
--- a/lib/TelemetryFeed.jsm
+++ b/lib/TelemetryFeed.jsm
@@ -634,9 +634,25 @@ this.TelemetryFeed = class TelemetryFeed {
   }
 
   sendEvent(event_object) {
-    // As per Bug 1597697, all pings to Tiles are simply stopped here. Though we
-    // leave these pings around so that we could send to another destination or
-    // drop them if needed in the future.
+    switch (event_object.action) {
+      case "activity_stream_user_event":
+        this.sendEventPing(event_object);
+        break;
+    }
+  }
+
+  async sendEventPing(ping) {
+    delete ping.action;
+    ping.client_id = await this.telemetryClientId;
+    if (ping.value && typeof ping.value === "object") {
+      ping.value = JSON.stringify(ping.value);
+    }
+    this.sendStructuredIngestionEvent(
+      ping,
+      STRUCTURED_INGESTION_NAMESPACE_AS,
+      "events",
+      1
+    );
   }
 
   sendUTEvent(event_object, eventFunction) {

--- a/test/unit/lib/TelemetryFeed.test.js
+++ b/test/unit/lib/TelemetryFeed.test.js
@@ -974,16 +974,53 @@ describe("TelemetryFeed", () => {
       assert.propertyVal(ping, "event_context", "foo");
     });
   });
-  describe("#sendEvent", () => {
-    it("should not call PingCentre", async () => {
-      FakePrefs.prototype.prefs.telemetry = true;
-      const event = {};
+  describe("#sendEventPing", () => {
+    it("should call sendStructuredIngestionEvent", async () => {
+      const data = {
+        action: "activity_stream_user_event",
+        event: "CLICK",
+      };
       instance = new TelemetryFeed();
-      sandbox.stub(instance.pingCentre, "sendPing");
+      sandbox.spy(instance, "sendStructuredIngestionEvent");
 
-      await instance.sendEvent(event);
+      await instance.sendEventPing(data);
 
-      assert.notCalled(instance.pingCentre.sendPing);
+      const expectedPayload = {
+        client_id: FAKE_TELEMETRY_ID,
+        event: "CLICK",
+      };
+      assert.calledWith(instance.sendStructuredIngestionEvent, expectedPayload);
+    });
+    it("should stringify value if it is an Object", async () => {
+      const data = {
+        action: "activity_stream_user_event",
+        event: "CLICK",
+        value: { foo: "bar" },
+      };
+      instance = new TelemetryFeed();
+      sandbox.spy(instance, "sendStructuredIngestionEvent");
+
+      await instance.sendEventPing(data);
+
+      const expectedPayload = {
+        client_id: FAKE_TELEMETRY_ID,
+        event: "CLICK",
+        value: JSON.stringify({ foo: "bar" }),
+      };
+      assert.calledWith(instance.sendStructuredIngestionEvent, expectedPayload);
+    });
+  });
+  describe("#sendEvent", () => {
+    it("should call sendEventPing on activity_stream_user_event", () => {
+      FakePrefs.prototype.prefs.telemetry = true;
+      FakePrefs.prototype.prefs[STRUCTURED_INGESTION_TELEMETRY_PREF] = true;
+      const event = { action: "activity_stream_user_event" };
+      instance = new TelemetryFeed();
+      sandbox.spy(instance, "sendEventPing");
+
+      instance.sendEvent(event);
+
+      assert.calledOnce(instance.sendEventPing);
     });
   });
   describe("#sendUTEvent", () => {


### PR DESCRIPTION
This migrates all Event pings in AS/DS to the Structured Ingestion pipeline.

Steps to test:
* Turn on PingCentre logging
* Turn on AS Telemetry as well as Structured Ingestion by flipping "activity-stream.telemetry" and "activity-stream.telemetry.structuredIngestion"
* Click any card on the newtab page, or search in the search box
* You should see events ping logged in the browser console
* You can further check if those pings made to the database by using this [query](https://sql.telemetry.mozilla.org/queries/65254/source), note that you might need to change the date in it.