### PR TITLE
Bug 1597492 - Add Pocket tile type to Top Story click ping

### DIFF
--- a/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
+++ b/content-src/components/DiscoveryStreamComponents/DSCard/DSCard.jsx
@@ -95,6 +95,7 @@ export class DSCard extends React.PureComponent {
           event: "CLICK",
           source: this.props.type.toUpperCase(),
           action_position: this.props.pos,
+          value: { card_type: this.props.flightId ? "spoc" : "organic" },
         })
       );
 

--- a/content-src/components/DiscoveryStreamComponents/List/List.jsx
+++ b/content-src/components/DiscoveryStreamComponents/List/List.jsx
@@ -30,6 +30,7 @@ export class ListItem extends React.PureComponent {
           event: "CLICK",
           source: this.props.type.toUpperCase(),
           action_position: this.props.pos,
+          value: { card_type: this.props.flightId ? "spoc" : "organic" },
         })
       );
 

--- a/docs/v2-system-addon/data_dictionary.md
+++ b/docs/v2-system-addon/data_dictionary.md
@@ -209,7 +209,7 @@ Schema definitions/validations that can be used for tests can be found in `syste
 | `action` | [Required] Either `activity_stream_event`, `activity_stream_session`, or `activity_stream_performance`. | :one:
 | `addon_version` | [Required] Firefox build ID, i.e. `Services.appinfo.appBuildID`. | :one:
 | `client_id` | [Required] An identifier for this client. | :one:
-| `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search", "spoc") | :one:
+| `card_type` | [Optional] ("bookmark", "pocket", "trending", "pinned", "search", "spoc", "organic") | :one:
 | `search_vendor` | [Optional] the vendor of the search shortcut, one of ("google", "amazon", "wikipedia", "duckduckgo", "bing", etc.). This field only exists when `card_type = "search"` | :one:
 | `date` | [Auto populated by Onyx] The date in YYYY-MM-DD format. | :three:
 | `experiment_id` | [Optional] The unique identifier for a specific experiment. | :one:

--- a/docs/v2-system-addon/data_events.md
+++ b/docs/v2-system-addon/data_events.md
@@ -148,6 +148,29 @@ A user event ping includes some basic metadata (tab id, addon version, etc.) as 
 }
 ```
 
+#### Clicking a top story item
+
+```js
+{
+  "event": "CLICK",
+  "source": "CARDGRID",
+  "action_position": 2,
+  "value": {
+    // "spoc" for sponsored stories, "organic" for regular stories.
+    "card_type": ["organic" | "spoc"],
+  }
+
+  // Basic metadata
+  "action": "activity_stream_event",
+  "page": ["about:newtab" | "about:home" | "about:welcome" | "unknown"],
+  "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",
+  "session_id": "005deed0-e3e4-4c02-a041-17405fd703f6",
+  "addon_version": "20180710100040",
+  "locale": "en-US",
+  "user_prefs": 7
+}
+```
+
 #### Adding a search shortcut
 ```js
 {

--- a/test/schemas/pings.js
+++ b/test/schemas/pings.js
@@ -142,6 +142,7 @@ export const UserEventAction = Joi.object().keys({
           "pocket",
           "search",
           "spoc",
+          "organic",
         ]),
         search_vendor: Joi.valid(["google", "amazon"]),
         has_flow_params: Joi.bool(),

--- a/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/DSCard.test.jsx
@@ -117,6 +117,32 @@ describe("<DSCard>", () => {
           event: "CLICK",
           source: "FOO",
           action_position: 1,
+          value: { card_type: "organic" },
+        })
+      );
+      assert.calledWith(
+        dispatch,
+        ac.ImpressionStats({
+          click: 0,
+          source: "FOO",
+          tiles: [{ id: "fooidx", pos: 1 }],
+        })
+      );
+    });
+
+    it("should set the right card_type on spocs", () => {
+      wrapper.setProps({ id: "fooidx", pos: 1, type: "foo", flightId: 12345 });
+
+      wrapper.instance().onLinkClick();
+
+      assert.calledTwice(dispatch);
+      assert.calledWith(
+        dispatch,
+        ac.UserEvent({
+          event: "CLICK",
+          source: "FOO",
+          action_position: 1,
+          value: { card_type: "spoc" },
         })
       );
       assert.calledWith(
@@ -148,6 +174,7 @@ describe("<DSCard>", () => {
           event: "CLICK",
           source: "FOO",
           action_position: 1,
+          value: { card_type: "organic" },
         })
       );
       assert.calledWith(

--- a/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
+++ b/test/unit/content-src/components/DiscoveryStreamComponents/List.test.jsx
@@ -205,6 +205,32 @@ describe("<ListItem> presentation component", () => {
           event: "CLICK",
           source: "FOO",
           action_position: 1,
+          value: { card_type: "organic" },
+        })
+      );
+      assert.calledWith(
+        dispatch,
+        ac.ImpressionStats({
+          click: 0,
+          source: "FOO",
+          tiles: [{ id: "foo-id", pos: 1 }],
+        })
+      );
+    });
+
+    it("should set the right card_type on spocs", () => {
+      wrapper.setProps({ id: "foo-id", pos: 1, type: "foo", flightId: 12345 });
+
+      wrapper.instance().onLinkClick();
+
+      assert.calledTwice(dispatch);
+      assert.calledWith(
+        dispatch,
+        ac.UserEvent({
+          event: "CLICK",
+          source: "FOO",
+          action_position: 1,
+          value: { card_type: "spoc" },
         })
       );
       assert.calledWith(


### PR DESCRIPTION
This adds a `card_type` field to the `CLICK` ping for Top Stories. Note that this doesn't change the Pocket telemetry (i.e. with `impression_id` and `tile_id`), but the user event ping, which contains `client_id` without `tile_id`. Per bug 1597492, this will be useful for us to study the user engagement of Top Story related experiments. 

This requires a data review.